### PR TITLE
fix: allow webdav connect when root propfind returns 405

### DIFF
--- a/src-tauri/src/providers/webdav.rs
+++ b/src-tauri/src/providers/webdav.rs
@@ -1178,6 +1178,33 @@ impl StorageProvider for WebDavProvider {
             StatusCode::FORBIDDEN => Err(ProviderError::AuthenticationFailed(
                 "Invalid credentials".to_string(),
             )),
+            StatusCode::METHOD_NOT_ALLOWED => {
+                tracing::debug!(
+                    "[WebDAV] PROPFIND / returned 405, retrying with OPTIONS for capability check"
+                );
+
+                let options_response = self
+                    .request(Method::OPTIONS, "/")
+                    .send()
+                    .await
+                    .map_err(|e| ProviderError::ConnectionFailed(e.to_string()))?;
+
+                let options_status = options_response.status();
+                if options_status.is_success() {
+                    self.connected = true;
+                    if let Some(ref initial_path) = self.config.initial_path {
+                        if !initial_path.is_empty() {
+                            self.current_path = initial_path.clone();
+                        }
+                    }
+                    Ok(())
+                } else {
+                    Err(ProviderError::ConnectionFailed(format!(
+                        "Server returned status: {}",
+                        options_status
+                    )))
+                }
+            }
             status => Err(ProviderError::ConnectionFailed(format!(
                 "Server returned status: {}",
                 status


### PR DESCRIPTION
Fixes #95

Some WebDAV servers return 405 for PROPFIND / even though WebDAV is available. The connect handshake now falls back to OPTIONS when the initial PROPFIND gets 405, so valid endpoints can still connect.

Greetings, saschabuehrle