### PR TITLE
ci(smoke): isolated upload-artifact@v7 smoke test (gates #149)

### DIFF
--- a/.github/workflows/smoke-upload-artifact-v7.yml
+++ b/.github/workflows/smoke-upload-artifact-v7.yml
@@ -1,0 +1,74 @@
+name: smoke-upload-artifact-v7
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/smoke-upload-artifact-v7.yml'
+  workflow_dispatch:
+
+jobs:
+  upload:
+    name: upload (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, ubuntu-24.04, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Generate dummy payload
+        shell: bash
+        run: |
+          mkdir -p out
+          echo "smoke test for upload-artifact@v7 on ${{ matrix.os }}" > out/dummy.txt
+          python -c "open('out/binary.bin', 'wb').write(b'X' * 1024 * 1024)"
+          ls -la out/
+
+      - name: Upload artifact (v7)
+        uses: actions/upload-artifact@v7
+        with:
+          name: smoke-${{ matrix.os }}
+          path: out/
+          retention-days: 1
+          if-no-files-found: error
+
+  verify:
+    name: download + verify
+    needs: upload
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ./downloaded
+
+      - name: Verify each artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          fail=0
+          for d in downloaded/smoke-*; do
+            echo "=== $d ==="
+            ls -la "$d"
+            if [ ! -f "$d/dummy.txt" ]; then
+              echo "FAIL: dummy.txt missing in $d"
+              fail=1
+              continue
+            fi
+            if [ ! -f "$d/binary.bin" ]; then
+              echo "FAIL: binary.bin missing in $d"
+              fail=1
+              continue
+            fi
+            size=$(stat -c%s "$d/binary.bin" 2>/dev/null || stat -f%z "$d/binary.bin")
+            if [ "$size" != "1048576" ]; then
+              echo "FAIL: binary.bin size is $size, expected 1048576"
+              fail=1
+              continue
+            fi
+            echo "PASS: $d"
+          done
+          if [ "$fail" -ne 0 ]; then
+            echo "Smoke test FAILED"
+            exit 1
+          fi
+          echo "Smoke test PASSED on all matrix runners"


### PR DESCRIPTION
## Goal

Decide whether [#149](https://github.com/axpdev-lab/aeroftp/pull/149) (\`actions/upload-artifact\` v4 -> v7) is safe to merge into the main release pipeline.

CI green on #149 alone is not enough. v6 bumped runtime to Node 24, v7 switched to ESM. Three majors are skipped in one bump, and the actual upload at tag push time is not exercised on a regular push CI run.

## What this PR does

Adds \`.github/workflows/smoke-upload-artifact-v7.yml\`, an isolated workflow that:

1. Generates a 1 MiB binary plus a text marker on each matrix runner
2. Uploads with \`actions/upload-artifact@v7\` and \`if-no-files-found: error\`
3. Downloads everything back in a verify job
4. Asserts presence and exact size of each artifact

Matrix runners covered:

- \`ubuntu-22.04\` (current pipeline OS for Linux release)
- \`ubuntu-24.04\` (target for the Snap rework tracked in #164)
- \`windows-latest\`
- \`macos-latest\`

Triggers: \`pull_request\` on the workflow file itself (so this PR runs it automatically) and \`workflow_dispatch\` for manual re-runs from the Actions UI.

## Decision matrix

- **All four matrix runners pass** -> merge #149 with confidence, optionally keep this workflow in main as a regression guard for future \`upload-artifact\` major bumps
- **One or more runners fail** -> close #149, leave a comment with the failure mode, wait for upstream patch
- **Pass on 22.04 only** -> still merge #149 (current pipeline), but flag as warning for the #164 rework

## Out of scope

- No change to the release pipeline itself
- No change to AeroFTP code
- No change to Dependabot config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated testing workflow to validate artifact upload and download functionality across multiple operating systems including Windows, macOS, and Linux variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->