### PR TITLE
feat(transfer): DAG transfer engine convergence (phases 1-3)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1786,9 +1786,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.3"
+version = "0.7.0-rc.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a0d26b245348befa0c121944541476763dcc46ede886c88f9d12e1697d27c3"
+checksum = "96dacf199529fb801ae62a9aafdc01b189e9504c0d1ee1512a4c16bcd8666a93"
 dependencies = [
  "cpubits",
  "ctutils",
@@ -1825,11 +1825,11 @@ dependencies = [
 
 [[package]]
 name = "crypto-primes"
-version = "0.7.0"
+version = "0.7.0-pre.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21f41f23de7d24cdbda7f0c4d9c0351f99a4ceb258ef30e5c1927af8987ffe5a"
+checksum = "6081ce8b60c0e533e2bba42771b94eb6149052115f4179744d5779883dc98583"
 dependencies = [
- "crypto-bigint 0.7.3",
+ "crypto-bigint 0.7.0-rc.28",
  "libm",
  "rand_core 0.10.1",
 ]
@@ -2509,16 +2509,16 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.17"
+version = "0.17.0-rc.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4bf51f0534ed6e59a0f2f26272b64ba55c470133f8424c2adfd1c4d59d9988"
+checksum = "91bbdd377139884fafcad8dc43a760a3e1e681aa26db910257fa6535b70e1829"
 dependencies = [
  "der 0.8.0",
  "digest 0.11.2",
- "elliptic-curve 0.14.0-rc.31",
+ "elliptic-curve 0.14.0-rc.28",
  "rfc6979 0.5.0-rc.5",
  "signature 3.0.0-rc.10",
- "spki 0.8.0",
+ "spki 0.8.0-rc.4",
  "zeroize",
 ]
 
@@ -2602,12 +2602,12 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.31"
+version = "0.14.0-rc.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b148a81cede8f4023248f980cffdf7611c46f2add469c6980e815b7c5b764ba5"
+checksum = "bde7860544606d222fd6bd6d9f9a0773321bf78072a637e1d560a058c0031978"
 dependencies = [
  "base16ct 1.0.0",
- "crypto-bigint 0.7.3",
+ "crypto-bigint 0.7.0-rc.28",
  "crypto-common 0.2.1",
  "digest 0.11.2",
  "hkdf 0.13.0",
@@ -4214,17 +4214,17 @@ checksum = "25f8a978272e3cbdf4768f7363eb1c8e1e6ba63c52a3ed05e29e222da4aec7cb"
 dependencies = [
  "argon2",
  "bcrypt-pbkdf",
- "crypto-bigint 0.7.3",
- "ecdsa 0.17.0-rc.17",
+ "crypto-bigint 0.7.0-rc.28",
+ "ecdsa 0.17.0-rc.16",
  "ed25519-dalek 3.0.0-pre.6",
  "hex",
  "hmac 0.13.0",
  "num-bigint-dig",
- "p256 0.14.0-rc.9",
- "p384 0.14.0-rc.9",
+ "p256 0.14.0-rc.7",
+ "p384 0.14.0-rc.7",
  "p521",
  "rand_core 0.10.1",
- "rsa 0.10.0-rc.17",
+ "rsa 0.10.0-rc.16",
  "sec1 0.8.1",
  "sha1 0.11.0",
  "sha2 0.11.0",
@@ -5124,9 +5124,9 @@ dependencies = [
 
 [[package]]
 name = "ml-kem"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04437cb1a66c0b78740927b76cc61f218344b9f6ef3dd430e283274a718ef0e9"
+checksum = "8198b5db27ac9773534c371751a59dc18aec8b80aa141e69abfdd1dec2e3f78c"
 dependencies = [
  "hybrid-array",
  "kem",
@@ -5992,14 +5992,14 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.14.0-rc.9"
+version = "0.14.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b97e3bf0465157ae90975ff52dbeb1362ba618924878c9f74c25baa27a65f9a"
+checksum = "018bfbb86e05fd70a83e985921241035ee09fcd369c4a2c3680b389a01d2ad28"
 dependencies = [
- "ecdsa 0.17.0-rc.17",
- "elliptic-curve 0.14.0-rc.31",
+ "ecdsa 0.17.0-rc.16",
+ "elliptic-curve 0.14.0-rc.28",
  "primefield",
- "primeorder 0.14.0-rc.9",
+ "primeorder 0.14.0-rc.7",
  "sha2 0.11.0",
 ]
 
@@ -6017,29 +6017,29 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.14.0-rc.9"
+version = "0.14.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "437f30ebcb1e16ff48acead5f08bd69fbcdbc82421687bb48af5c315a0bfab03"
+checksum = "8c91df688211f5957dbe2ab599dcbcaade8d6d3cdc15c5b350d350d7d07ce423"
 dependencies = [
- "ecdsa 0.17.0-rc.17",
- "elliptic-curve 0.14.0-rc.31",
+ "ecdsa 0.17.0-rc.16",
+ "elliptic-curve 0.14.0-rc.28",
  "fiat-crypto 0.3.0",
  "primefield",
- "primeorder 0.14.0-rc.9",
+ "primeorder 0.14.0-rc.7",
  "sha2 0.11.0",
 ]
 
 [[package]]
 name = "p521"
-version = "0.14.0-rc.9"
+version = "0.14.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e9fd792bab86ecf6249561752fb5a413511f999887107dd054bbda5143743d7"
+checksum = "de6cd9451de522549d36cc78a1b45a699a3d55a872e8ea0c8f0318e502d99e2c"
 dependencies = [
  "base16ct 1.0.0",
- "ecdsa 0.17.0-rc.17",
- "elliptic-curve 0.14.0-rc.31",
+ "ecdsa 0.17.0-rc.16",
+ "elliptic-curve 0.14.0-rc.28",
  "primefield",
- "primeorder 0.14.0-rc.9",
+ "primeorder 0.14.0-rc.7",
  "sha2 0.11.0",
 ]
 
@@ -6493,7 +6493,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "986d2e952779af96ea048f160fd9194e1751b4faea78bcf3ceb456efe008088e"
 dependencies = [
  "der 0.8.0",
- "spki 0.8.0",
+ "spki 0.8.0-rc.4",
 ]
 
 [[package]]
@@ -6525,7 +6525,7 @@ dependencies = [
  "rand_core 0.10.1",
  "scrypt 0.12.0",
  "sha2 0.11.0",
- "spki 0.8.0",
+ "spki 0.8.0-rc.4",
 ]
 
 [[package]]
@@ -6549,7 +6549,7 @@ dependencies = [
  "der 0.8.0",
  "pkcs5 0.8.0-rc.13",
  "rand_core 0.10.1",
- "spki 0.8.0",
+ "spki 0.8.0-rc.4",
 ]
 
 [[package]]
@@ -6714,11 +6714,11 @@ dependencies = [
 
 [[package]]
 name = "primefield"
-version = "0.14.0-rc.9"
+version = "0.14.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b52e6ee42db392378a95622b463c9740631171d1efce43fa445a569c1600cb6"
+checksum = "93401c13cc7ff24684571cfca9d3cf9ebabfaf3d4b7b9963ade41ec54da196b5"
 dependencies = [
- "crypto-bigint 0.7.3",
+ "crypto-bigint 0.7.0-rc.28",
  "crypto-common 0.2.1",
  "rand_core 0.10.1",
  "rustcrypto-ff",
@@ -6737,11 +6737,11 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-rc.9"
+version = "0.14.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0556580e42c19833f5d232aca11a7687a503ee41f937b54f5ae1d50fc2a6a36a"
+checksum = "a0c5c8a39bcd764bfedf456e8d55e115fe86dda3e0f555371849f2a41cbc9706"
 dependencies = [
- "elliptic-curve 0.14.0-rc.31",
+ "elliptic-curve 0.14.0-rc.28",
 ]
 
 [[package]]
@@ -6864,7 +6864,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -7624,12 +7624,12 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.10.0-rc.17"
+version = "0.10.0-rc.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ed3e93fc7e473e464b9726f4759659e72bc8665e4b8ea227547024f416d905"
+checksum = "6fb9fd8c1edd9e6a2693623baf0fe77ff05ce022a5d7746900ffc38a15c233de"
 dependencies = [
  "const-oid 0.10.2",
- "crypto-bigint 0.7.3",
+ "crypto-bigint 0.7.0-rc.28",
  "crypto-primes",
  "digest 0.11.2",
  "pkcs1 0.8.0-rc.4",
@@ -7637,7 +7637,7 @@ dependencies = [
  "rand_core 0.10.1",
  "sha2 0.11.0",
  "signature 3.0.0-rc.10",
- "spki 0.8.0",
+ "spki 0.8.0-rc.4",
  "zeroize",
 ]
 
@@ -7667,47 +7667,58 @@ dependencies = [
 
 [[package]]
 name = "russh"
-version = "0.60.1"
+version = "0.60.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d937f3f4a79bffd67fc12fd437785effdfc8b94edc89ab90392f9ac9e11cc9fc"
+checksum = "324b92f459d3e42da294e14e8eb150d2215fcfb7c966838bc1127cd68bc05a0d"
 dependencies = [
+ "aead 0.6.0-rc.10",
  "aes 0.8.4",
+ "aes 0.9.0",
+ "aes-gcm 0.11.0-rc.3",
  "aws-lc-rs",
  "bitflags 2.11.0",
  "block-padding 0.3.3",
  "byteorder",
  "bytes",
  "cbc 0.1.2",
+ "cbc 0.2.0",
  "cipher 0.5.1",
- "crypto-bigint 0.7.3",
+ "crypto-bigint 0.7.0-rc.28",
+ "ctr 0.10.0",
  "ctr 0.9.2",
  "curve25519-dalek 5.0.0-pre.6",
  "data-encoding",
  "delegate",
  "der 0.8.0",
  "digest 0.10.7",
- "ecdsa 0.17.0-rc.17",
+ "ecdsa 0.17.0-rc.16",
  "ed25519-dalek 3.0.0-pre.6",
- "elliptic-curve 0.14.0-rc.31",
+ "elliptic-curve 0.14.0-rc.28",
  "enum_dispatch",
  "flate2",
  "futures",
  "generic-array 1.3.5",
  "getrandom 0.2.17",
+ "ghash 0.6.0",
  "hex-literal",
+ "hkdf 0.13.0",
  "hmac 0.12.1",
+ "hmac 0.13.0",
  "inout 0.1.4",
  "internal-russh-forked-ssh-key",
  "internal-russh-num-bigint",
+ "keccak",
  "log",
  "md5",
  "ml-kem",
  "module-lattice",
- "p256 0.14.0-rc.9",
- "p384 0.14.0-rc.9",
+ "num-bigint",
+ "p256 0.14.0-rc.7",
+ "p384 0.14.0-rc.7",
  "p521",
  "pageant",
  "pbkdf2 0.12.2",
+ "pbkdf2 0.13.0",
  "pkcs1 0.8.0-rc.4",
  "pkcs5 0.8.0-rc.13",
  "pkcs8 0.11.0-rc.11",
@@ -7715,14 +7726,19 @@ dependencies = [
  "rand 0.10.1",
  "rand_core 0.10.1",
  "ring",
- "rsa 0.10.0-rc.17",
+ "rsa 0.10.0-rc.16",
  "russh-cryptovec",
  "russh-util",
+ "salsa20 0.11.0",
+ "scrypt 0.12.0",
  "sec1 0.8.1",
  "sha1 0.10.6",
+ "sha1 0.11.0",
  "sha2 0.10.9",
+ "sha2 0.11.0",
+ "sha3",
  "signature 3.0.0-rc.10",
- "spki 0.8.0",
+ "spki 0.8.0-rc.4",
  "ssh-encoding",
  "subtle",
  "thiserror 2.0.18",
@@ -7734,9 +7750,9 @@ dependencies = [
 
 [[package]]
 name = "russh-cryptovec"
-version = "0.59.0"
+version = "0.60.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36140e8a20297bc2e8338807c3d9ca911f7fa49d7539cbcd6d48d3befd70efd8"
+checksum = "37cb4d0360bdd8935392a306d8b5edb539cc455b30e8bf13dd213a0cf7879b40"
 dependencies = [
  "log",
  "nix 0.31.2",
@@ -8859,7 +8875,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8941,9 +8957,9 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.8.0"
+version = "0.8.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+checksum = "8baeff88f34ed0691978ec34440140e1572b68c7dd4a495fd14a3dc1944daa80"
 dependencies = [
  "base64ct",
  "der 0.8.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -139,7 +139,7 @@ mime_guess = "2"
 
 # SFTP Support (Sprint 3 - v1.3.0)
 # SFTP channel writes: see sftp-upload-0byte-bug.md in memory
-russh = { version = "0.60.1", features = ["ring"] }
+russh = { version = "0.60.3", features = ["ring"] }
 russh-sftp = "2.1"
 ssh2 = { version = "0.9.5", features = ["vendored-openssl"] }
 

--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -4755,6 +4755,48 @@ async fn upload_with_resume(
     provider.upload(local_path, remote_path, progress_cb).await
 }
 
+/// DAG-ENGINE phase 1: run a plain single-file CLI transfer through the graph
+/// engine.
+///
+/// Reached only with the `transfer_engine_dag_single_file` flag on and only
+/// for the plain leaf (`!cli.partial`, so neither `download_with_resume` nor
+/// `upload_with_resume` would take a resume branch and the legacy leaf is a
+/// bare `provider.download` / `provider.upload`). The owned provider is
+/// briefly wrapped in an `Arc<Mutex<_>>` so the DAG transfer node can reach it
+/// from its spawned task, then handed back to the caller for the disconnect.
+/// The CLI renders progress through the `indicatif` callback and prints its
+/// own result line, so the graph runs with a `NoopDagObserver`.
+async fn cli_run_single_file_dag(
+    provider: Box<dyn StorageProvider>,
+    direction: ftp_client_gui_lib::transfer_dag::TransferDirection,
+    remote: &str,
+    local: &str,
+    progress_cb: Option<Box<dyn Fn(u64, u64) + Send>>,
+) -> (Box<dyn StorageProvider>, Result<(), ProviderError>) {
+    let arc = Arc::new(tokio::sync::Mutex::new(Some(provider)));
+    let built = ftp_client_gui_lib::transfer_dag::TransferDagBuilder::single_file(direction);
+    let report = Arc::new(AtomicU64::new(0));
+    let observer: Arc<dyn ftp_client_gui_lib::transfer_dag::DagObserver> =
+        Arc::new(ftp_client_gui_lib::transfer_dag::NoopDagObserver);
+    let result = ftp_client_gui_lib::transfer_dag_single_file::execute_single_file_dag(
+        &built,
+        Arc::clone(&arc),
+        remote.to_string(),
+        local.to_string(),
+        None,
+        progress_cb,
+        observer,
+        report,
+    )
+    .await;
+    let provider = arc
+        .lock()
+        .await
+        .take()
+        .expect("provider is returned by the single-file DAG");
+    (provider, result)
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn download_transfer_task(
     url: &str,
@@ -14318,7 +14360,28 @@ async fn cmd_get(
         }
     }
 
-    match download_with_resume(&mut *provider, remote, local_path, cli, progress_cb).await {
+    // DAG-ENGINE phase 1: route the plain classic single-file download
+    // through the graph engine when the flag is on. `--partial` keeps the
+    // legacy `download_with_resume` (its resume branch is not the plain
+    // leaf); with the flag off the legacy call runs verbatim.
+    let dl_result = if ftp_client_gui_lib::transfer_dag_single_file::dag_single_file_enabled()
+        && !cli.partial
+    {
+        let (returned, res) = cli_run_single_file_dag(
+            provider,
+            ftp_client_gui_lib::transfer_dag::TransferDirection::Download,
+            remote,
+            local_path,
+            progress_cb,
+        )
+        .await;
+        provider = returned;
+        res
+    } else {
+        download_with_resume(&mut *provider, remote, local_path, cli, progress_cb).await
+    };
+
+    match dl_result {
         Ok(()) => {
             let elapsed = start.elapsed();
             let file_size = std::fs::metadata(local_path).map(|m| m.len()).unwrap_or(0);
@@ -15504,7 +15567,28 @@ async fn cmd_put(
         }
     }
 
-    match upload_with_resume(&mut *provider, local, remote_path, cli, progress_cb).await {
+    // DAG-ENGINE phase 1: route the plain classic single-file upload through
+    // the graph engine when the flag is on. `--partial` keeps the legacy
+    // `upload_with_resume` (its resume branch is not the plain leaf); with the
+    // flag off the legacy call runs verbatim.
+    let up_result = if ftp_client_gui_lib::transfer_dag_single_file::dag_single_file_enabled()
+        && !cli.partial
+    {
+        let (returned, res) = cli_run_single_file_dag(
+            provider,
+            ftp_client_gui_lib::transfer_dag::TransferDirection::Upload,
+            remote_path,
+            local,
+            progress_cb,
+        )
+        .await;
+        provider = returned;
+        res
+    } else {
+        upload_with_resume(&mut *provider, local, remote_path, cli, progress_cb).await
+    };
+
+    match up_result {
         Ok(()) => {
             session_transfer_add(file_size);
             let elapsed = start.elapsed();

--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -19068,11 +19068,18 @@ fn cmd_alias_toggle(name: &str, bin_dir: Option<&Path>, format: OutputFormat) ->
         let exe = match std::env::current_exe() {
             Ok(path) => path,
             Err(e) => {
-                print_error(format, &format!("cannot resolve current executable: {}", e), 5);
+                print_error(
+                    format,
+                    &format!("cannot resolve current executable: {}", e),
+                    5,
+                );
                 return 5;
             }
         };
-        let bin_dir = match bin_dir.map(|p| p.to_path_buf()).map_or_else(default_opt_in_bin_dir, Ok) {
+        let bin_dir = match bin_dir
+            .map(|p| p.to_path_buf())
+            .map_or_else(default_opt_in_bin_dir, Ok)
+        {
             Ok(path) => path,
             Err(e) => {
                 print_error(format, &e, 5);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -136,6 +136,7 @@ mod sync_scheduler;
 mod sync_versioning;
 mod totp;
 pub mod transfer_dag;
+pub mod transfer_dag_single_file;
 pub mod transfer_domain;
 pub mod transfer_event_sink;
 pub mod transfer_orchestrator;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -136,7 +136,9 @@ mod sync_scheduler;
 mod sync_versioning;
 mod totp;
 pub mod transfer_dag;
+pub mod transfer_dag_batch;
 pub mod transfer_dag_single_file;
+pub mod transfer_dag_sync;
 pub mod transfer_domain;
 pub mod transfer_event_sink;
 pub mod transfer_orchestrator;
@@ -396,10 +398,9 @@ fn drain_expired_overlay_sessions(
 /// a match at login.
 #[tauri::command]
 fn preview_provider_totp(secret: String) -> Result<serde_json::Value, String> {
-    let (code, seconds_remaining) = providers::totp_helper::generate_totp_code_with_ttl(
-        &secrecy::SecretString::from(secret),
-    )
-    .map_err(|e| e.to_string())?;
+    let (code, seconds_remaining) =
+        providers::totp_helper::generate_totp_code_with_ttl(&secrecy::SecretString::from(secret))
+            .map_err(|e| e.to_string())?;
     Ok(serde_json::json!({
         "code": code,
         "seconds_remaining": seconds_remaining,
@@ -14028,10 +14029,8 @@ pub fn run() {
                     let meta = std::fs::symlink_metadata(&canonical);
                     if meta.map(|m| m.is_file()).unwrap_or(false) {
                         if let Some(window) = app.get_webview_window("main") {
-                            let _ = window.emit(
-                                "servers-open-file",
-                                canonical.to_string_lossy().to_string(),
-                            );
+                            let _ = window
+                                .emit("servers-open-file", canonical.to_string_lossy().to_string());
                         }
                     }
                 }

--- a/src-tauri/src/local_sync.rs
+++ b/src-tauri/src/local_sync.rs
@@ -339,7 +339,9 @@ pub async fn local_sync_run(
                     report.error_messages.push(format!(
                         "verify {}: {}",
                         rel_str,
-                        verify.message.unwrap_or_else(|| "policy not satisfied".to_string()),
+                        verify
+                            .message
+                            .unwrap_or_else(|| "policy not satisfied".to_string()),
                     ));
                     entry_status = "error";
                 }

--- a/src-tauri/src/provider_commands.rs
+++ b/src-tauri/src/provider_commands.rs
@@ -1263,17 +1263,16 @@ pub async fn provider_download_file(
                     segments, filename, file_size
                 );
                 let cancel = tokio_util::sync::CancellationToken::new();
-                let outcome =
-                    crate::provider_transfer_executor::run_provider_segmented_download(
-                        provider.as_ref(),
-                        &remote_path,
-                        &local_path,
-                        file_size,
-                        segments,
-                        progress_cb.take(),
-                        cancel,
-                    )
-                    .await;
+                let outcome = crate::provider_transfer_executor::run_provider_segmented_download(
+                    provider.as_ref(),
+                    &remote_path,
+                    &local_path,
+                    file_size,
+                    segments,
+                    progress_cb.take(),
+                    cancel,
+                )
+                .await;
                 if let Err(ref e) = outcome {
                     warn!(
                         "Segmented download failed, falling back to single-stream: {}",

--- a/src-tauri/src/provider_commands.rs
+++ b/src-tauri/src/provider_commands.rs
@@ -7,7 +7,7 @@
 // Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
 
 use serde::{Deserialize, Serialize};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use tauri::{AppHandle, Emitter, State};
 use tokio::sync::Mutex;
@@ -23,8 +23,9 @@ use crate::providers::{
     RemoteEntry, ShareLinkCapabilities, ShareLinkOptions, ShareLinkResult, SharePermission,
     StorageInfo, StorageProvider,
 };
+use crate::transfer_dag::{DagObserver, TransferDagBuilder};
 use crate::transfer_domain::{TransferBatchConfig, TransferDirection, TransferEntry};
-use crate::transfer_event_sink::{AppHandleSink, TransferEventSink};
+use crate::transfer_event_sink::{AppHandleSink, GuiDagObserver, TransferEventSink};
 use crate::transfer_orchestrator::{execute_batch, ProgressObserver, TransferBatch};
 use crate::transfer_settings::{
     resolve_provider_transfer_settings, ResolvedTransferSettings, TransferSettingsInput,
@@ -905,6 +906,146 @@ pub async fn provider_pwd(state: State<'_, ProviderState>) -> Result<String, Str
         .map_err(|e| format!("Failed to get working directory: {}", e))
 }
 
+/// DAG-ENGINE phase 1: run a plain single-file download through the graph
+/// engine and emit the GUI completion / error events.
+///
+/// Reached only with the `transfer_engine_dag_single_file` flag on and only
+/// for the plain classic leaf (no delta consumed the transfer, no segmented
+/// engine ran, no resume offset). The `"start"` and `"progress"` events were
+/// already emitted by the shared pre-DAG code and the per-byte callback; this
+/// function owns only the terminal `"complete"` (via [`GuiDagObserver`]) and
+/// `"error"` (emitted here, where the typed error is in hand) events. The
+/// emitted events are byte-identical with the legacy single-file path.
+#[allow(clippy::too_many_arguments)]
+async fn run_dag_download_leaf(
+    app: AppHandle,
+    provider: Arc<Mutex<Option<Box<dyn StorageProvider>>>>,
+    transfer_id: String,
+    filename: String,
+    remote_path: String,
+    local_path: String,
+    modified: Option<String>,
+    progress_cb: Option<Box<dyn Fn(u64, u64) + Send>>,
+    file_size: u64,
+    delta_fallback_reason: Option<String>,
+) -> Result<String, String> {
+    let built = TransferDagBuilder::single_file(crate::transfer_dag::TransferDirection::Download);
+    // Seed with the discovered remote size; the transfer node overwrites it
+    // with the real on-disk size once the download succeeds.
+    let report_size = Arc::new(AtomicU64::new(file_size));
+    let sink: Arc<dyn TransferEventSink> = Arc::new(AppHandleSink::new(app.clone()));
+    let observer: Arc<dyn DagObserver> = Arc::new(GuiDagObserver::new(
+        sink,
+        transfer_id.clone(),
+        filename.clone(),
+        "download".to_string(),
+        built.emit_progress,
+        Arc::clone(&report_size),
+        delta_fallback_reason,
+    ));
+
+    match crate::transfer_dag_single_file::execute_single_file_dag(
+        &built,
+        provider,
+        remote_path,
+        local_path,
+        modified,
+        progress_cb,
+        observer,
+        report_size,
+    )
+    .await
+    {
+        Ok(()) => {
+            info!("Download completed: {}", filename);
+            Ok(format!("Downloaded: {}", filename))
+        }
+        Err(e) => {
+            let _ = app.emit(
+                "transfer_event",
+                crate::TransferEvent {
+                    event_type: "error".to_string(),
+                    transfer_id,
+                    filename: filename.clone(),
+                    direction: "download".to_string(),
+                    message: Some(format!("Download failed: {}", e)),
+                    progress: None,
+                    path: None,
+                    delta_stats: None,
+                    fallback_reason: None,
+                },
+            );
+            Err(format!("Download failed: {}", e))
+        }
+    }
+}
+
+/// DAG-ENGINE phase 1: run a plain single-file upload through the graph
+/// engine and emit the GUI completion / error events. The upload mirror of
+/// [`run_dag_download_leaf`]; GitHub keeps its dedicated commit-based path.
+#[allow(clippy::too_many_arguments)]
+async fn run_dag_upload_leaf(
+    app: AppHandle,
+    provider: Arc<Mutex<Option<Box<dyn StorageProvider>>>>,
+    transfer_id: String,
+    filename: String,
+    local_path: String,
+    remote_path: String,
+    progress_cb: Option<Box<dyn Fn(u64, u64) + Send>>,
+    file_size: u64,
+    delta_fallback_reason: Option<String>,
+) -> Result<String, String> {
+    let built = TransferDagBuilder::single_file(crate::transfer_dag::TransferDirection::Upload);
+    // The upload node does not touch the report size: the local file size is
+    // the value the legacy completion event reports.
+    let report_size = Arc::new(AtomicU64::new(file_size));
+    let sink: Arc<dyn TransferEventSink> = Arc::new(AppHandleSink::new(app.clone()));
+    let observer: Arc<dyn DagObserver> = Arc::new(GuiDagObserver::new(
+        sink,
+        transfer_id.clone(),
+        filename.clone(),
+        "upload".to_string(),
+        built.emit_progress,
+        Arc::clone(&report_size),
+        delta_fallback_reason,
+    ));
+
+    match crate::transfer_dag_single_file::execute_single_file_dag(
+        &built,
+        provider,
+        remote_path,
+        local_path,
+        None,
+        progress_cb,
+        observer,
+        report_size,
+    )
+    .await
+    {
+        Ok(()) => {
+            info!("Upload completed: {}", filename);
+            Ok(format!("Uploaded: {}", filename))
+        }
+        Err(e) => {
+            let _ = app.emit(
+                "transfer_event",
+                crate::TransferEvent {
+                    event_type: "error".to_string(),
+                    transfer_id,
+                    filename: filename.clone(),
+                    direction: "upload".to_string(),
+                    message: Some(format!("Upload failed: {}", e)),
+                    progress: None,
+                    path: None,
+                    delta_stats: None,
+                    fallback_reason: None,
+                },
+            );
+            Err(format!("Upload failed: {}", e))
+        }
+    }
+}
+
 /// Download a file from the remote server
 #[allow(clippy::too_many_arguments)]
 #[tauri::command]
@@ -1195,6 +1336,34 @@ pub async fn provider_download_file(
                 },
             );
         }));
+    }
+
+    // DAG-ENGINE phase 1: route the plain classic single-file leaf through
+    // the graph engine when the flag is on. The segmented engine and a resume
+    // offset keep their legacy code: they are not the plain leaf. With the
+    // flag off this branch is never entered and the legacy path below runs
+    // verbatim, so flag-off is provably diff-0.
+    if crate::transfer_dag_single_file::dag_single_file_enabled()
+        && segmented_result.is_none()
+        && partial_offset == 0
+    {
+        let provider_arc = Arc::clone(&state.provider);
+        // Release the command-level guard so the DAG transfer node can lock
+        // the same provider mutex from its spawned task.
+        drop(provider_lock);
+        return run_dag_download_leaf(
+            app,
+            provider_arc,
+            transfer_id,
+            filename,
+            remote_path,
+            local_path,
+            modified,
+            progress_cb,
+            file_size,
+            delta_fallback_reason,
+        )
+        .await;
     }
 
     let result = if let Some(Ok(())) = &segmented_result {
@@ -2369,6 +2538,30 @@ pub async fn provider_upload_file(
                 delta_fallback_reason = delta_result.fallback_reason;
             }
         }
+    }
+
+    // DAG-ENGINE phase 1: route the plain classic single-file upload through
+    // the graph engine when the flag is on. GitHub keeps its dedicated
+    // commit-based upload (a different API shape, not the plain leaf). With
+    // the flag off this branch is never entered and the legacy path below
+    // runs verbatim.
+    if crate::transfer_dag_single_file::dag_single_file_enabled()
+        && provider.provider_type() != ProviderType::GitHub
+    {
+        let provider_arc = Arc::clone(&state.provider);
+        drop(provider_lock);
+        return run_dag_upload_leaf(
+            app,
+            provider_arc,
+            transfer_id,
+            filename,
+            local_path,
+            remote_path,
+            progress_cb,
+            file_size,
+            delta_fallback_reason,
+        )
+        .await;
     }
 
     let result = if provider.provider_type() == ProviderType::GitHub {

--- a/src-tauri/src/provider_transfer_executor.rs
+++ b/src-tauri/src/provider_transfer_executor.rs
@@ -14,7 +14,9 @@ use tracing::warn;
 use crate::providers::{
     ProviderListExecutorKind, ProviderTransferExecutorKind, ProviderType, StorageProvider,
 };
-use crate::transfer_dag::{Capability, TransferSessionLease, TransferSessionPoolHandle};
+use crate::transfer_dag::{
+    Capability, TransferCapabilities, TransferSessionLease, TransferSessionPoolHandle,
+};
 use crate::transfer_domain::{
     transfer_failure_kind_from_sync, user_facing_transfer_failure_message, TransferEntry,
     TransferFailure, TransferOutcome,
@@ -89,7 +91,11 @@ pub fn provider_segmented_download_eligible(
 
     // Capability gate 2: provider must advertise strict concurrent
     // range download (the post-PD-CLI-CONV-E honest flag).
-    if primary.transfer_capabilities().strict_concurrent_range_download != Capability::Supported {
+    if primary
+        .transfer_capabilities()
+        .strict_concurrent_range_download
+        != Capability::Supported
+    {
         return None;
     }
 
@@ -268,8 +274,7 @@ pub async fn run_provider_segmented_download(
             Ok(())
         }
         Ok(ConcurrentRangeOutcome::ServerIgnoredRange) => Err(
-            "segmented download: server ignored Range; falling back to single-stream"
-                .to_string(),
+            "segmented download: server ignored Range; falling back to single-stream".to_string(),
         ),
         Err(e) => Err(format!("segmented download: {}", e)),
     }
@@ -380,21 +385,27 @@ impl ProviderListSessionModel {
     }
 }
 
-pub async fn resolve_provider_executor_session_model(
-    provider: &Arc<Mutex<Option<Box<dyn StorageProvider>>>>,
+/// Decide the transfer session model purely from a provider's transfer
+/// capabilities and declared executor kind (DAG-ENGINE F3-T06).
+///
+/// This is the executor-kind decision extracted as a pure function: no async,
+/// no mutex lock, no I/O. `can_clone` is the one fact a probe must supply
+/// (`clone_for_transfer().is_ok()`), and `advertised_max_sessions` is the
+/// provider's fallback lease count when the capabilities do not pin one.
+///
+/// The decision is byte-identical to the previous inline logic; isolating it
+/// makes the capability-driven choice unit-testable without a live provider.
+pub fn resolve_session_model(
+    provider_type: ProviderType,
+    caps: &TransferCapabilities,
+    executor_kind: ProviderTransferExecutorKind,
+    can_clone: bool,
+    advertised_max_sessions: u16,
     max_concurrent: usize,
 ) -> ProviderExecutorSessionModel {
-    let provider_lock = provider.lock().await;
-    let Some(provider) = provider_lock.as_ref() else {
-        return ProviderExecutorSessionModel::locked(None);
-    };
-
-    let provider_type = provider.provider_type();
-    let caps = provider.transfer_capabilities();
-    let executor_kind = provider.transfer_executor_kind();
     let scheduler_can_parallelize = caps.file_parallel == Capability::Supported
         && caps.session_pool == Capability::Supported
-        && provider.clone_for_transfer().is_ok();
+        && can_clone;
 
     if !scheduler_can_parallelize {
         return ProviderExecutorSessionModel::locked(Some(provider_type));
@@ -402,7 +413,7 @@ pub async fn resolve_provider_executor_session_model(
 
     let max_leases = caps
         .max_file_slots
-        .unwrap_or_else(|| provider.transfer_executor_max_sessions())
+        .unwrap_or(advertised_max_sessions)
         .max(1) as usize;
     let max_leases = max_leases.min(max_concurrent.max(1)).max(1);
 
@@ -429,6 +440,28 @@ pub async fn resolve_provider_executor_session_model(
             ProviderExecutorSessionModel::locked(Some(provider_type))
         }
     }
+}
+
+/// Thin async wrapper over [`resolve_session_model`]: locks the provider,
+/// gathers the capability inputs and the `clone_for_transfer` probe, then
+/// delegates the decision to the pure function.
+pub async fn resolve_provider_executor_session_model(
+    provider: &Arc<Mutex<Option<Box<dyn StorageProvider>>>>,
+    max_concurrent: usize,
+) -> ProviderExecutorSessionModel {
+    let provider_lock = provider.lock().await;
+    let Some(provider) = provider_lock.as_ref() else {
+        return ProviderExecutorSessionModel::locked(None);
+    };
+
+    resolve_session_model(
+        provider.provider_type(),
+        &provider.transfer_capabilities(),
+        provider.transfer_executor_kind(),
+        provider.clone_for_transfer().is_ok(),
+        provider.transfer_executor_max_sessions(),
+        max_concurrent,
+    )
 }
 
 pub async fn resolve_provider_list_session_model(
@@ -685,7 +718,6 @@ impl ProviderDownloadExecutor {
             )),
         }
     }
-
 
     /// Try the segmented (intra-file range) download path. Returns
     /// `None` when the path is not applicable — the caller falls
@@ -1301,5 +1333,127 @@ mod tests {
 
         assert_eq!(pool.capacity().kind, SessionLeaseKind::HttpList);
         assert_eq!(pool.capacity().max_leases, 3);
+    }
+
+    // ---- F3-T06: pure executor-kind resolver --------------------------------
+
+    /// Capabilities that advertise a real parallel session pool.
+    fn parallel_caps() -> TransferCapabilities {
+        TransferCapabilities {
+            file_parallel: Capability::Supported,
+            session_pool: Capability::Supported,
+            ..TransferCapabilities::default()
+        }
+    }
+
+    #[test]
+    fn resolve_session_model_locks_when_not_parallelizable() {
+        // file_parallel Unsupported: locked regardless of the executor kind.
+        let model = resolve_session_model(
+            ProviderType::S3,
+            &TransferCapabilities::default(),
+            ProviderTransferExecutorKind::HttpClonePool,
+            true,
+            8,
+            4,
+        );
+        assert!(matches!(
+            model,
+            ProviderExecutorSessionModel::LockedSingle { .. }
+        ));
+    }
+
+    #[test]
+    fn resolve_session_model_locks_when_clone_is_unavailable() {
+        // The capabilities advertise a pool, but the clone probe failed.
+        let model = resolve_session_model(
+            ProviderType::Ftp,
+            &parallel_caps(),
+            ProviderTransferExecutorKind::FtpConnectionPool,
+            false,
+            8,
+            4,
+        );
+        assert!(matches!(
+            model,
+            ProviderExecutorSessionModel::LockedSingle { .. }
+        ));
+    }
+
+    #[test]
+    fn resolve_session_model_clamps_http_clone_leases_to_max_concurrent() {
+        let caps = TransferCapabilities {
+            max_file_slots: Some(8),
+            ..parallel_caps()
+        };
+        let model = resolve_session_model(
+            ProviderType::S3,
+            &caps,
+            ProviderTransferExecutorKind::HttpClonePool,
+            true,
+            8,
+            3,
+        );
+        match model {
+            ProviderExecutorSessionModel::HttpClonePool { max_leases, .. } => {
+                assert_eq!(max_leases, 3, "user max_concurrent caps the lease count");
+            }
+            other => panic!("expected HttpClonePool, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_session_model_keeps_sftp_and_ftp_kinds_distinct() {
+        let caps = TransferCapabilities {
+            max_file_slots: Some(4),
+            ..parallel_caps()
+        };
+        let sftp = resolve_session_model(
+            ProviderType::Sftp,
+            &caps,
+            ProviderTransferExecutorKind::SftpConnectionPool,
+            true,
+            4,
+            8,
+        );
+        assert!(matches!(
+            sftp,
+            ProviderExecutorSessionModel::SftpConnectionPool { max_leases: 4, .. }
+        ));
+        let ftp = resolve_session_model(
+            ProviderType::Ftp,
+            &caps,
+            ProviderTransferExecutorKind::FtpConnectionPool,
+            true,
+            4,
+            8,
+        );
+        assert!(matches!(
+            ftp,
+            ProviderExecutorSessionModel::FtpConnectionPool { max_leases: 4, .. }
+        ));
+    }
+
+    #[test]
+    fn resolve_session_model_falls_back_to_advertised_sessions_without_caps_slots() {
+        // max_file_slots None: the provider's advertised count is the source.
+        let caps = TransferCapabilities {
+            max_file_slots: None,
+            ..parallel_caps()
+        };
+        let model = resolve_session_model(
+            ProviderType::S3,
+            &caps,
+            ProviderTransferExecutorKind::HttpClonePool,
+            true,
+            6,
+            16,
+        );
+        match model {
+            ProviderExecutorSessionModel::HttpClonePool { max_leases, .. } => {
+                assert_eq!(max_leases, 6, "advertised session count is the fallback");
+            }
+            other => panic!("expected HttpClonePool, got {other:?}"),
+        }
     }
 }

--- a/src-tauri/src/providers/ftp.rs
+++ b/src-tauri/src/providers/ftp.rs
@@ -1025,6 +1025,14 @@ impl StorageProvider for FtpProvider {
         use suppaftp::types::FileType;
         use tokio::io::AsyncReadExt;
 
+        // PD-FTP-1: a `clone_for_transfer()` pool worker starts unconnected
+        // and carries only the spec; it must dial its own control+data
+        // connection on the first transfer. `download()` and `read_range()`
+        // already do this; `upload()` omitted it, so every clone-pool upload
+        // (folder upload, multi-file batch via the executor) failed with
+        // `NotConnected`. A no-op when the provider is already connected.
+        self.ensure_connected().await?;
+
         // Capture before the &mut self borrow below; needed later to decide
         // whether to insert the TLS-drain sleep.
         let tls_active = !matches!(self.config.tls_mode, FtpTlsMode::None);

--- a/src-tauri/src/providers/ftp.rs
+++ b/src-tauri/src/providers/ftp.rs
@@ -955,6 +955,11 @@ impl StorageProvider for FtpProvider {
         use tokio::io::AsyncReadExt;
         let limit = super::MAX_DOWNLOAD_TO_BYTES;
 
+        // PD-FTP-1: dial the connection so an in-memory read works on a
+        // `clone_for_transfer()` pool worker too, symmetric with the
+        // streaming `download()`. A no-op when already connected.
+        self.ensure_connected().await?;
+
         let stream = self.stream_mut()?;
 
         // Check file size first if server supports SIZE command
@@ -1297,6 +1302,13 @@ impl StorageProvider for FtpProvider {
         on_progress: Option<Box<dyn Fn(u64, u64) + Send>>,
     ) -> Result<(), ProviderError> {
         use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt as _};
+
+        // PD-FTP-1: the transfer executor calls `resume_download()` instead of
+        // `download()` whenever a retry carries a partial offset, so a resumed
+        // download on a `clone_for_transfer()` pool worker hit `NotConnected`.
+        // Dial the connection first, symmetric with `download()`/`upload()`/
+        // `read_range()`. A no-op when already connected.
+        self.ensure_connected().await?;
 
         let stream = self.stream_mut()?;
 

--- a/src-tauri/src/providers/multi_thread.rs
+++ b/src-tauri/src/providers/multi_thread.rs
@@ -418,11 +418,13 @@ where
 /// `max_parallel`, exactly mirroring the JoinSet semaphore. The temp file is
 /// pre-allocated by the caller, so the only real dependency is satisfied
 /// before the graph runs and a Plan/Preallocate node would add nothing but a
-/// serial point: the graph is an honest pure fan-out. Observer is no-op and
-/// the AIMD controller is `None`: 1d migrates the executor only, diff-0;
-/// adaptivity on this path is a later concern. Outcome, error variant and
-/// cancel semantics are identical to [`run_ranges_via_joinset`]; only the
-/// scheduling differs (which diff-0 explicitly does not constrain).
+/// serial point: the graph is an honest pure fan-out. Observer is no-op; the
+/// AIMD controller (F3-T05) starts every class at its honest ceiling, so a
+/// congestion-free download dispatches identically to the prior `None` and
+/// only shrinks the in-flight range set under a real congestion signal.
+/// Outcome, error variant and cancel semantics are identical to
+/// [`run_ranges_via_joinset`]; only the scheduling differs (which diff-0
+/// explicitly does not constrain).
 pub(crate) async fn run_ranges_via_graph<W, WFut>(
     ranges: &[(u64, u64)],
     temp_path: &Path,
@@ -441,7 +443,8 @@ where
     use crate::transfer_dag::executor::{execute_dag, DagNodeRunner, NodeFuture, NodeOutcome};
     use crate::transfer_dag::graph::{TransferDag, TransferNode, TransferNodeKind};
     use crate::transfer_dag::{
-        DagObserver, NoopDagObserver, ResourceRequest, TransferBudget, TransferResourceManager,
+        AimdConfig, AimdController, DagObserver, NoopDagObserver, ResourceRequest, TransferBudget,
+        TransferResourceManager,
     };
     use std::sync::atomic::AtomicBool;
     use std::sync::Mutex;
@@ -465,6 +468,17 @@ where
         disk_write_slots: slots,
         ..TransferBudget::from_file_slots(1)
     });
+
+    // AIMD backpressure (F3-T05). The controller's per-class ceilings are the
+    // budget above, and every class starts at its ceiling: a download with no
+    // congestion dispatches every range immediately, identical to the prior
+    // `None`. It only ever shrinks the Chunk/Http dispatch target when a range
+    // fails with a genuine congestion signal (429/503/timeout/reset), where a
+    // smaller in-flight set is the safer, faster choice.
+    let aimd = Arc::new(AimdController::from_budget(
+        &manager.budget(),
+        AimdConfig::default(),
+    ));
 
     let ranges: Arc<Vec<(u64, u64)>> = Arc::new(ranges.to_vec());
     let aggregate = Arc::new(AtomicU64::new(0));
@@ -543,7 +557,7 @@ where
         &manager,
         runner,
         Arc::new(NoopDagObserver) as Arc<dyn DagObserver>,
-        None,
+        Some(aimd),
     )
     .await;
 

--- a/src-tauri/src/providers/totp_helper.rs
+++ b/src-tauri/src/providers/totp_helper.rs
@@ -31,9 +31,7 @@ pub fn generate_totp_code(secret: &SecretString) -> Result<String, ProviderError
 /// diagnostic that shows the live code + 30s countdown next to the saved
 /// secret field, so the user can confirm AeroFTP derives the same code as
 /// their authenticator app (issue #128).
-pub fn generate_totp_code_with_ttl(
-    secret: &SecretString,
-) -> Result<(String, u64), ProviderError> {
+pub fn generate_totp_code_with_ttl(secret: &SecretString) -> Result<(String, u64), ProviderError> {
     let totp = build_totp(secret)?;
     let code = totp
         .generate_current()

--- a/src-tauri/src/sync.rs
+++ b/src-tauri/src/sync.rs
@@ -426,14 +426,17 @@ impl SyncProgressSink for NoopProgressSink {
     fn on_file_done(&mut self, _rel: &str, _outcome: &FileOutcome) {}
 }
 
-enum SyncTreeAction {
+// `pub(crate)`: the DAG-ENGINE phase-2 sync routing module
+// (`transfer_dag_sync`) reuses the planning decision types verbatim so the
+// graph path stays decision-equivalent to the legacy `sync_tree_core` loop.
+pub(crate) enum SyncTreeAction {
     Copy,
     Skip(String),
 }
 
-struct SyncTreeDecision {
-    action: SyncTreeAction,
-    decision_policy: DeltaPolicy,
+pub(crate) struct SyncTreeDecision {
+    pub(crate) action: SyncTreeAction,
+    pub(crate) decision_policy: DeltaPolicy,
 }
 
 #[derive(Clone, Copy)]
@@ -444,10 +447,10 @@ struct SyncFileMeta<'a> {
 }
 
 #[derive(Clone, Copy)]
-struct SyncTransferSpec<'a> {
-    rel: &'a str,
-    total: u64,
-    decision_policy: DeltaPolicy,
+pub(crate) struct SyncTransferSpec<'a> {
+    pub(crate) rel: &'a str,
+    pub(crate) total: u64,
+    pub(crate) decision_policy: DeltaPolicy,
     /// Policy originally requested by the caller. Kept distinct from
     /// `decision_policy` because the decide layer may downgrade the policy
     /// when required data is missing (e.g. `Hash` falls back to `Mtime` if
@@ -455,7 +458,7 @@ struct SyncTransferSpec<'a> {
     /// (P1-T01) is consulted on this field, not on `decision_policy`, so
     /// the native attempt fires if and only if the user explicitly asked
     /// for `Delta`.
-    requested_policy: DeltaPolicy,
+    pub(crate) requested_policy: DeltaPolicy,
 }
 
 /// Action to perform during sync
@@ -926,6 +929,24 @@ pub async fn sync_tree_core(
     opts: &SyncOptions,
     sink: &mut dyn SyncProgressSink,
 ) -> SyncReport {
+    // DAG-ENGINE phase 2 (F2-T07b): with the sync flag on, route a real
+    // (non-dry-run) sync through the shared graph engine instead of this
+    // hand-rolled interleaved decide/perform loop. Dry-run always stays on
+    // the legacy path below: it must never build or execute a DAG, so the
+    // dry-run plan is structurally guaranteed free of any mutating graph.
+    // Default OFF, so the legacy path is the default and a rollback is a
+    // runtime toggle, never a revert.
+    if crate::transfer_dag_sync::should_route_sync_to_dag(opts.dry_run) {
+        return crate::transfer_dag_sync::execute_sync_dag(
+            provider,
+            local_root,
+            remote_root,
+            opts,
+            sink,
+        )
+        .await;
+    }
+
     let start = std::time::Instant::now();
     sink.on_phase(SyncPhase::Scanning);
     let locals = scan_local_tree(local_root, &opts.scan);
@@ -1178,7 +1199,7 @@ pub async fn sync_tree_core(
     report
 }
 
-fn decide_upload(
+pub(crate) fn decide_upload(
     local_entry: &crate::sync_core::LocalEntry,
     remote_entry: Option<&crate::sync_core::RemoteEntry>,
     policy: DeltaPolicy,
@@ -1218,7 +1239,7 @@ fn decide_upload(
     }
 }
 
-fn decide_download(
+pub(crate) fn decide_download(
     remote_entry: &crate::sync_core::RemoteEntry,
     local_entry: Option<&crate::sync_core::LocalEntry>,
     policy: DeltaPolicy,
@@ -1443,7 +1464,7 @@ fn parse_scan_mtime(raw: &str) -> Option<chrono::DateTime<Utc>> {
         })
 }
 
-fn apply_sync_tree_outcome(
+pub(crate) fn apply_sync_tree_outcome(
     report: &mut SyncReport,
     rel: &str,
     operation: &'static str,
@@ -1512,7 +1533,7 @@ fn apply_sync_tree_outcome(
     sink.on_file_done(rel, &outcome);
 }
 
-async fn perform_upload(
+pub(crate) async fn perform_upload(
     provider: &mut Box<dyn StorageProvider>,
     local_root: &str,
     remote_root: &str,
@@ -1656,7 +1677,7 @@ async fn perform_upload(
 // tunables with intrinsic transfer attributes (rel/total/policy), so
 // the lint is suppressed here rather than refactored away.
 #[allow(clippy::too_many_arguments)]
-async fn perform_download(
+pub(crate) async fn perform_download(
     provider: &mut Box<dyn StorageProvider>,
     local_root: &str,
     remote_root: &str,
@@ -1852,7 +1873,7 @@ async fn sync_download_transfer(
         .map_err(|e| e.to_string())
 }
 
-async fn perform_remote_delete(
+pub(crate) async fn perform_remote_delete(
     provider: &mut Box<dyn StorageProvider>,
     remote_root: &str,
     rel: &str,
@@ -1875,7 +1896,7 @@ async fn perform_remote_delete(
     }
 }
 
-fn perform_local_delete(
+pub(crate) fn perform_local_delete(
     local_root: &str,
     rel: &str,
     decision_policy: DeltaPolicy,
@@ -1944,7 +1965,7 @@ fn mkdir_error_is_idempotent(err: &ProviderError) -> bool {
     }
 }
 
-async fn ensure_remote_dir(provider: &mut Box<dyn StorageProvider>, dir: &str) {
+pub(crate) async fn ensure_remote_dir(provider: &mut Box<dyn StorageProvider>, dir: &str) {
     // Walk the parent chain top-down. A failure on an intermediate level
     // (e.g. mkdir on `/mnt` denied because the user has no write access on
     // the SFTP root) must NOT short-circuit the chain: the leaf mkdir may

--- a/src-tauri/src/sync_core/scan.rs
+++ b/src-tauri/src/sync_core/scan.rs
@@ -94,7 +94,11 @@ fn rel_from_abs(abs_path: &str, root: &str) -> Option<String> {
     let p = abs_path.trim_matches('/');
     let r = root.trim_matches('/');
     if r.is_empty() {
-        return if p.is_empty() { None } else { Some(p.to_string()) };
+        return if p.is_empty() {
+            None
+        } else {
+            Some(p.to_string())
+        };
     }
     if p == r {
         // The scan root itself, not a child entry.
@@ -170,8 +174,7 @@ async fn try_recursive_fastpath(
     remote_root: &str,
     opts: &ScanOptions,
 ) -> Option<Vec<RemoteEntry>> {
-    let listing =
-        crate::used_scan::provider_list_recursive_fastpath(provider, remote_root).await?;
+    let listing = crate::used_scan::provider_list_recursive_fastpath(provider, remote_root).await?;
     if !listing.structured_paths {
         return None;
     }

--- a/src-tauri/src/transfer_dag/adaptive.rs
+++ b/src-tauri/src/transfer_dag/adaptive.rs
@@ -34,7 +34,7 @@ use std::time::{Duration, Instant};
 
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
-use super::resources::ResourceRequest;
+use super::resources::{ResourceRequest, TransferBudget};
 
 /// Resource classes the controller manages in v1 (decision D1). Checker,
 /// disk, and hash slots stay static and are intentionally absent.
@@ -228,10 +228,20 @@ impl DynamicSemaphore {
 /// Tuning for the AIMD controller. Defaults are prudent; tests inject short
 /// or zero windows. `cooldown` blocks any increase after a decrease;
 /// `healthy_window` is the minimum quiet interval before each `+1`.
+///
+/// `recovery_window` is the guard band against oscillation (decision F3-T09):
+/// after a congestion event the controller will not let additive increase
+/// climb straight back to the concurrency level that triggered congestion. It
+/// caps regrowth one slot below that level until a full `recovery_window` of
+/// uninterrupted quiet has elapsed, at which point the cap relaxes back to the
+/// honest ceiling. A zero `recovery_window` disables the guard band (the cap
+/// relaxes on the first healthy note), which is the pre-F3-T09 behaviour and
+/// is what unit tests of the bare additive mechanism opt into.
 #[derive(Debug, Clone, Copy)]
 pub struct AimdConfig {
     pub cooldown: Duration,
     pub healthy_window: Duration,
+    pub recovery_window: Duration,
 }
 
 impl Default for AimdConfig {
@@ -239,6 +249,9 @@ impl Default for AimdConfig {
         Self {
             cooldown: Duration::from_secs(5),
             healthy_window: Duration::from_secs(5),
+            // Long enough that a provider's rate-limit window has demonstrably
+            // cleared before AIMD risks the level that congested it again.
+            recovery_window: Duration::from_secs(30),
         }
     }
 }
@@ -249,6 +262,12 @@ struct ClassState {
     target: usize,
     cooldown_until: Option<Instant>,
     healthy_since: Option<Instant>,
+    /// Guard band (F3-T09): the highest target additive increase may reach.
+    /// Starts at `ceiling`; a congestion event drops it one below the level
+    /// that congested; a full `recovery_window` of quiet relaxes it back.
+    regrowth_cap: usize,
+    /// Instant of the most recent congestion event, for the recovery timer.
+    last_congestion: Option<Instant>,
 }
 
 impl ClassState {
@@ -262,6 +281,8 @@ impl ClassState {
             target: ceiling,
             cooldown_until: None,
             healthy_since: None,
+            regrowth_cap: ceiling,
+            last_congestion: None,
         }
     }
 }
@@ -296,6 +317,20 @@ impl AimdController {
         }
     }
 
+    /// Build a controller whose per-class ceilings are the honest effective
+    /// budget (F3-T05). Every class starts at its ceiling — AIMD is
+    /// decrease-biased — so a run with no congestion dispatches exactly as if
+    /// no controller were wired.
+    pub fn from_budget(budget: &TransferBudget, config: AimdConfig) -> Self {
+        Self::new(
+            budget.file_slots.max(1) as usize,
+            budget.chunk_slots.max(1) as usize,
+            budget.http_slots.max(1) as usize,
+            budget.api_slots.max(1) as usize,
+            config,
+        )
+    }
+
     fn state(&self, class: AdaptiveClass) -> &Mutex<ClassState> {
         match class {
             AdaptiveClass::File => &self.file,
@@ -307,27 +342,50 @@ impl AimdController {
 
     /// Multiplicative decrease: halve the target (floor 1) and arm a cooldown
     /// that blocks any increase until it elapses.
+    ///
+    /// The guard band (F3-T09) also records the concurrency level that
+    /// congested and drops `regrowth_cap` one slot below it, so additive
+    /// increase cannot immediately climb back into the same congestion.
     pub fn on_congestion(&self, class: AdaptiveClass) {
+        let now = Instant::now();
         let mut st = self.state(class).lock().expect("aimd mutex poisoned");
+        let level_at_congestion = st.target;
         st.target = (st.target / 2).max(1);
         st.sem.set_live(st.target);
-        st.cooldown_until = Some(Instant::now() + self.config.cooldown);
+        st.cooldown_until = Some(now + self.config.cooldown);
         st.healthy_since = None;
+        // Ratchet the regrowth cap down: never above one slot below the level
+        // that just congested, and a repeated congestion only tightens it.
+        st.regrowth_cap = level_at_congestion
+            .saturating_sub(1)
+            .max(1)
+            .min(st.regrowth_cap);
+        st.last_congestion = Some(now);
     }
 
     /// Note a healthy completion. After a quiet `healthy_window` with no
     /// congestion and no active cooldown, additively increase by one (never
-    /// above the ceiling).
+    /// above the ceiling, and never above the [`AimdConfig::recovery_window`]
+    /// guard band until the band has relaxed).
     pub fn note_healthy(&self, class: AdaptiveClass) {
         let now = Instant::now();
         let mut st = self.state(class).lock().expect("aimd mutex poisoned");
+        // Guard band relaxation: a full recovery window of quiet since the
+        // last congestion lifts the regrowth cap back to the honest ceiling.
+        if let Some(congested_at) = st.last_congestion {
+            if now.duration_since(congested_at) >= self.config.recovery_window {
+                st.regrowth_cap = st.ceiling;
+                st.last_congestion = None;
+            }
+        }
         if let Some(until) = st.cooldown_until {
             if now < until {
                 return;
             }
             st.cooldown_until = None;
         }
-        if st.target >= st.ceiling {
+        let growth_cap = st.ceiling.min(st.regrowth_cap);
+        if st.target >= growth_cap {
             return;
         }
         match st.healthy_since {
@@ -503,6 +561,7 @@ mod tests {
         let cfg = AimdConfig {
             cooldown: Duration::from_secs(3600),
             healthy_window: Duration::from_secs(0),
+            recovery_window: Duration::from_secs(0),
         };
         let ctrl = AimdController::new(8, 1, 1, 1, cfg);
         ctrl.on_congestion(AdaptiveClass::File);
@@ -518,11 +577,13 @@ mod tests {
 
     #[tokio::test]
     async fn aimd_additive_increase_after_quiet_window_capped_at_ceiling() {
-        // No cooldown, zero healthy window: each pair of notes yields +1, but
-        // never above the ceiling.
+        // No cooldown, zero healthy/recovery window: each pair of notes yields
+        // +1, but never above the ceiling. A zero recovery window disables the
+        // guard band so this test exercises the bare additive mechanism.
         let cfg = AimdConfig {
             cooldown: Duration::from_secs(0),
             healthy_window: Duration::from_secs(0),
+            recovery_window: Duration::from_secs(0),
         };
         let ctrl = AimdController::new(3, 1, 1, 1, cfg);
         ctrl.on_congestion(AdaptiveClass::File); // 3 -> 1 (floor)
@@ -550,5 +611,91 @@ mod tests {
         );
         let held = ctrl.acquire(&req).await;
         assert_eq!(held.len(), 2, "chunk + http permits, not file/api");
+    }
+
+    #[tokio::test]
+    async fn guard_band_blocks_regrowth_to_the_congested_level() {
+        // A long recovery window keeps the guard band armed: additive
+        // increase may climb back up but must stop one slot below the level
+        // that congested, never re-entering the same congestion.
+        let cfg = AimdConfig {
+            cooldown: Duration::from_secs(0),
+            healthy_window: Duration::from_secs(0),
+            recovery_window: Duration::from_secs(3600),
+        };
+        let ctrl = AimdController::new(8, 1, 1, 1, cfg);
+        ctrl.on_congestion(AdaptiveClass::File); // 8 -> 4, regrowth cap -> 7
+        assert_eq!(ctrl.target(AdaptiveClass::File), 4);
+        for _ in 0..40 {
+            ctrl.note_healthy(AdaptiveClass::File);
+        }
+        assert_eq!(
+            ctrl.target(AdaptiveClass::File),
+            7,
+            "guard band holds regrowth one slot below the congested level"
+        );
+    }
+
+    #[tokio::test]
+    async fn guard_band_relaxes_after_recovery_window() {
+        // A zero recovery window relaxes the guard band on the first healthy
+        // note, so additive increase may climb all the way to the ceiling.
+        let cfg = AimdConfig {
+            cooldown: Duration::from_secs(0),
+            healthy_window: Duration::from_secs(0),
+            recovery_window: Duration::from_secs(0),
+        };
+        let ctrl = AimdController::new(8, 1, 1, 1, cfg);
+        ctrl.on_congestion(AdaptiveClass::File); // 8 -> 4
+        for _ in 0..40 {
+            ctrl.note_healthy(AdaptiveClass::File);
+        }
+        assert_eq!(
+            ctrl.target(AdaptiveClass::File),
+            8,
+            "a relaxed guard band lets regrowth reach the honest ceiling"
+        );
+    }
+
+    #[tokio::test]
+    async fn guard_band_ratchets_down_on_repeated_congestion() {
+        let cfg = AimdConfig {
+            cooldown: Duration::from_secs(0),
+            healthy_window: Duration::from_secs(0),
+            recovery_window: Duration::from_secs(3600),
+        };
+        let ctrl = AimdController::new(16, 1, 1, 1, cfg);
+        ctrl.on_congestion(AdaptiveClass::File); // 16 -> 8, cap -> 15
+        for _ in 0..40 {
+            ctrl.note_healthy(AdaptiveClass::File);
+        }
+        assert_eq!(ctrl.target(AdaptiveClass::File), 15);
+        ctrl.on_congestion(AdaptiveClass::File); // 15 -> 7, cap -> 14
+        for _ in 0..40 {
+            ctrl.note_healthy(AdaptiveClass::File);
+        }
+        assert_eq!(
+            ctrl.target(AdaptiveClass::File),
+            14,
+            "a second congestion tightens the guard band further"
+        );
+    }
+
+    #[test]
+    fn from_budget_seeds_per_class_ceilings_from_the_effective_budget() {
+        let budget = TransferBudget {
+            file_slots: 6,
+            chunk_slots: 3,
+            http_slots: 9,
+            api_slots: 2,
+            ..TransferBudget::default()
+        };
+        let ctrl = AimdController::from_budget(&budget, AimdConfig::default());
+        // Every class starts at its ceiling: a no-congestion run is identical
+        // to having no controller at all.
+        assert_eq!(ctrl.target(AdaptiveClass::File), 6);
+        assert_eq!(ctrl.target(AdaptiveClass::Chunk), 3);
+        assert_eq!(ctrl.target(AdaptiveClass::Http), 9);
+        assert_eq!(ctrl.target(AdaptiveClass::Api), 2);
     }
 }

--- a/src-tauri/src/transfer_dag/builder.rs
+++ b/src-tauri/src/transfer_dag/builder.rs
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+//! `TransferDagBuilder`: shared construction of production transfer graphs.
+//!
+//! DAG-ENGINE phase 1 converges the single-file download and upload paths,
+//! GUI and CLI, onto one [`TransferDag`] shape so every surface schedules the
+//! same node graph through [`execute_dag`](super::executor::execute_dag).
+//!
+//! The single-file graph is a linear chain. A single file transfer is
+//! inherently sequential (discover before acquire before transfer before
+//! verify ...), so routing it through the DAG buys not parallelism but
+//! structural uniformity with the batch and sync graphs (phase 2) and a
+//! single observability surface, instead of a hand-rolled orchestration per
+//! call site.
+//!
+//! Node responsibilities, in phase 1:
+//!
+//! - `DiscoverRemote` / `DiscoverLocal`: resolve the transfer size (a remote
+//!   `size()` call, or a local `metadata()` read).
+//! - `AcquireResource`: structural anchor. A no-op in phase 1; phase 3 hooks
+//!   the resume-checkpoint fetch here.
+//! - `DownloadFile` / `UploadFile`: the real I/O. The only node that carries a
+//!   scarce resource ([`ResourceRequest::file_transfer`]).
+//! - `VerifyChecksum`: structural anchor. A no-op in phase 1 (the legacy
+//!   single-file path does not verify); phase 3 makes it real behind the
+//!   `server_checksum` capability.
+//! - `PreserveMetadata`: restore the remote mtime on a downloaded file. A
+//!   no-op on the upload direction.
+//! - `CommitTemp`: structural anchor. A no-op in phase 1 because every
+//!   provider's own `download` / `upload` already performs the atomic
+//!   `.aerotmp` finalize internally (since v3.0.5); phase 3 may host an
+//!   explicit resume-checkpoint commit here.
+//! - `EmitProgress`: emit the terminal completion event.
+//!
+//! Temp-file cleanup on failure is intentionally NOT a graph node. The
+//! ready-frontier executor aborts on the first failed node and drains the
+//! in-flight set; it never dispatches a node whose dependency failed, so a
+//! `CleanupTemp` node could not run on the failure path. Cleanup stays an
+//! RAII concern of the transfer runner (the provider's own `.aerotmp` guard),
+//! which is the honest place for it.
+
+use super::graph::{TransferDag, TransferNodeKind};
+use super::resources::ResourceRequest;
+
+/// Transfer direction for [`TransferDagBuilder::single_file`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransferDirection {
+    Download,
+    Upload,
+}
+
+/// A built single-file transfer graph plus the id of every node, so a runner
+/// can bind each [`TransferNodeKind`] to its action without re-scanning the
+/// graph. Every kind appears exactly once in a single-file graph, so a runner
+/// may equally match on [`TransferNodeKind`] directly; the ids are kept for
+/// callers and tests that prefer an explicit handle.
+#[derive(Debug, Clone)]
+pub struct SingleFileDag {
+    /// The graph, ready for [`execute_dag`](super::executor::execute_dag).
+    pub dag: TransferDag,
+    /// The direction this graph was built for.
+    pub direction: TransferDirection,
+    /// `DiscoverRemote` (download) or `DiscoverLocal` (upload).
+    pub discover: usize,
+    /// `AcquireResource`.
+    pub acquire: usize,
+    /// `DownloadFile` (download) or `UploadFile` (upload): the I/O node.
+    pub transfer: usize,
+    /// `VerifyChecksum`.
+    pub verify: usize,
+    /// `PreserveMetadata`.
+    pub preserve_metadata: usize,
+    /// `CommitTemp`.
+    pub commit: usize,
+    /// `EmitProgress`: the terminal node.
+    pub emit_progress: usize,
+}
+
+/// Stateless constructor of shared production transfer graphs.
+pub struct TransferDagBuilder;
+
+impl TransferDagBuilder {
+    /// Build the single-file transfer graph for `direction`.
+    ///
+    /// Seven nodes, a linear chain:
+    /// `Discover{Remote|Local}` → `AcquireResource` → `{Download|Upload}File`
+    /// → `VerifyChecksum` → `PreserveMetadata` → `CommitTemp` → `EmitProgress`.
+    ///
+    /// Only the transfer node carries a scarce resource
+    /// ([`ResourceRequest::file_transfer`]); every other node is a metadata
+    /// or structural step with no resource request, so they never contend on
+    /// the shared semaphores and the graph cannot deadlock against its own
+    /// budget.
+    pub fn single_file(direction: TransferDirection) -> SingleFileDag {
+        let mut dag = TransferDag::default();
+
+        let (discover_kind, transfer_kind) = match direction {
+            TransferDirection::Download => (
+                TransferNodeKind::DiscoverRemote,
+                TransferNodeKind::DownloadFile,
+            ),
+            TransferDirection::Upload => {
+                (TransferNodeKind::DiscoverLocal, TransferNodeKind::UploadFile)
+            }
+        };
+
+        let discover = dag.add_node(discover_kind, vec![], ResourceRequest::default());
+        let acquire = dag.add_node(
+            TransferNodeKind::AcquireResource,
+            vec![discover],
+            ResourceRequest::default(),
+        );
+        let transfer = dag.add_node(transfer_kind, vec![acquire], ResourceRequest::file_transfer());
+        let verify = dag.add_node(
+            TransferNodeKind::VerifyChecksum,
+            vec![transfer],
+            ResourceRequest::default(),
+        );
+        let preserve_metadata = dag.add_node(
+            TransferNodeKind::PreserveMetadata,
+            vec![verify],
+            ResourceRequest::default(),
+        );
+        let commit = dag.add_node(
+            TransferNodeKind::CommitTemp,
+            vec![preserve_metadata],
+            ResourceRequest::default(),
+        );
+        let emit_progress = dag.add_node(
+            TransferNodeKind::EmitProgress,
+            vec![commit],
+            ResourceRequest::default(),
+        );
+
+        SingleFileDag {
+            dag,
+            direction,
+            discover,
+            acquire,
+            transfer,
+            verify,
+            preserve_metadata,
+            commit,
+            emit_progress,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transfer_dag::executor::{execute_dag, DagNodeRunner, NodeFuture, NodeOutcome};
+    use crate::transfer_dag::graph::TransferNode;
+    use crate::transfer_dag::observer::NoopDagObserver;
+    use crate::transfer_dag::resources::{TransferBudget, TransferResourceManager};
+    use std::sync::Arc;
+
+    #[test]
+    fn download_graph_has_seven_nodes_in_order() {
+        let built = TransferDagBuilder::single_file(TransferDirection::Download);
+        let nodes = built.dag.nodes();
+
+        assert_eq!(nodes.len(), 7);
+        assert_eq!(nodes[0].kind, TransferNodeKind::DiscoverRemote);
+        assert_eq!(nodes[1].kind, TransferNodeKind::AcquireResource);
+        assert_eq!(nodes[2].kind, TransferNodeKind::DownloadFile);
+        assert_eq!(nodes[3].kind, TransferNodeKind::VerifyChecksum);
+        assert_eq!(nodes[4].kind, TransferNodeKind::PreserveMetadata);
+        assert_eq!(nodes[5].kind, TransferNodeKind::CommitTemp);
+        assert_eq!(nodes[6].kind, TransferNodeKind::EmitProgress);
+    }
+
+    #[test]
+    fn upload_graph_swaps_only_the_discover_and_transfer_kinds() {
+        let built = TransferDagBuilder::single_file(TransferDirection::Upload);
+        let nodes = built.dag.nodes();
+
+        assert_eq!(nodes.len(), 7);
+        assert_eq!(nodes[0].kind, TransferNodeKind::DiscoverLocal);
+        assert_eq!(nodes[1].kind, TransferNodeKind::AcquireResource);
+        assert_eq!(nodes[2].kind, TransferNodeKind::UploadFile);
+        assert_eq!(nodes[3].kind, TransferNodeKind::VerifyChecksum);
+        assert_eq!(nodes[4].kind, TransferNodeKind::PreserveMetadata);
+        assert_eq!(nodes[5].kind, TransferNodeKind::CommitTemp);
+        assert_eq!(nodes[6].kind, TransferNodeKind::EmitProgress);
+    }
+
+    #[test]
+    fn nodes_form_a_strict_linear_chain() {
+        let built = TransferDagBuilder::single_file(TransferDirection::Download);
+        let nodes = built.dag.nodes();
+
+        assert_eq!(nodes[0].depends_on, Vec::<usize>::new());
+        for i in 1..nodes.len() {
+            assert_eq!(
+                nodes[i].depends_on,
+                vec![i - 1],
+                "node {i} must depend solely on node {}",
+                i - 1
+            );
+        }
+    }
+
+    #[test]
+    fn named_ids_match_node_positions() {
+        let built = TransferDagBuilder::single_file(TransferDirection::Download);
+
+        assert_eq!(built.discover, 0);
+        assert_eq!(built.acquire, 1);
+        assert_eq!(built.transfer, 2);
+        assert_eq!(built.verify, 3);
+        assert_eq!(built.preserve_metadata, 4);
+        assert_eq!(built.commit, 5);
+        assert_eq!(built.emit_progress, 6);
+    }
+
+    #[test]
+    fn only_the_transfer_node_carries_a_scarce_resource() {
+        let built = TransferDagBuilder::single_file(TransferDirection::Upload);
+        let nodes = built.dag.nodes();
+
+        for node in nodes {
+            if node.id == built.transfer {
+                assert_eq!(node.resources, ResourceRequest::file_transfer());
+            } else {
+                assert_eq!(
+                    node.resources,
+                    ResourceRequest::default(),
+                    "node {} ({:?}) must not reserve a resource",
+                    node.id,
+                    node.kind
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn built_graph_runs_to_completion_on_the_executor() {
+        // The graph must be schedulable end-to-end: a noop runner over a
+        // minimal budget completes all seven nodes in dependency order.
+        let built = TransferDagBuilder::single_file(TransferDirection::Download);
+        let runner: Arc<dyn DagNodeRunner> = Arc::new(|_node: TransferNode| -> NodeFuture {
+            Box::pin(async { NodeOutcome::Completed })
+        });
+        let manager = TransferResourceManager::new(TransferBudget::from_file_slots(1));
+
+        let summary = execute_dag(
+            &built.dag,
+            &manager,
+            runner,
+            Arc::new(NoopDagObserver),
+            None,
+        )
+        .await
+        .expect("single-file graph must schedule cleanly");
+
+        assert_eq!(summary.nodes_completed, 7);
+        assert_eq!(summary.nodes_failed, 0);
+    }
+}

--- a/src-tauri/src/transfer_dag/builder.rs
+++ b/src-tauri/src/transfer_dag/builder.rs
@@ -40,8 +40,19 @@
 //! RAII concern of the transfer runner (the provider's own `.aerotmp` guard),
 //! which is the honest place for it.
 
+use super::capabilities::TransferCapabilities;
 use super::graph::{TransferDag, TransferNodeKind};
 use super::resources::ResourceRequest;
+
+/// Multipart chunk size used when a provider advertises `multipart_upload` but
+/// does not state a `preferred_chunk_size`. 8 MiB balances part count against
+/// per-part request overhead.
+const DEFAULT_MULTIPART_CHUNK_SIZE: u64 = 8 * 1024 * 1024;
+
+/// Hard cap on the number of `UploadPart` nodes a multipart graph may carry.
+/// Mirrors the S3 multipart-upload limit so a pathological chunk size cannot
+/// produce a graph with hundreds of thousands of nodes.
+const MAX_MULTIPART_PARTS: usize = 10_000;
 
 /// Transfer direction for [`TransferDagBuilder::single_file`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -77,6 +88,224 @@ pub struct SingleFileDag {
     pub emit_progress: usize,
 }
 
+/// One file to include in a batch transfer graph.
+///
+/// The builder only needs a stable key and direction. Runtime paths, sizes,
+/// retry policy, and provider handles stay with the runner that binds node ids
+/// to real I/O. `key` is intentionally opaque here: GUI batch callers may use
+/// a transfer entry id, while sync callers should use the relative path plus
+/// action when a plain relative path is ambiguous.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BatchDagItem {
+    pub key: String,
+    pub direction: TransferDirection,
+}
+
+impl BatchDagItem {
+    pub fn new(key: impl Into<String>, direction: TransferDirection) -> Self {
+        Self {
+            key: key.into(),
+            direction,
+        }
+    }
+}
+
+/// Node ids for one file sub-DAG inside a batch graph.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BatchFileDag {
+    pub key: String,
+    pub direction: TransferDirection,
+    pub discover: usize,
+    pub acquire: usize,
+    pub transfer: usize,
+    pub verify: usize,
+    pub preserve_metadata: usize,
+    pub commit: usize,
+    /// Terminal node for the file. Fase 2 journal observers attach durable
+    /// per-file completion to this id, never to the raw transfer node.
+    pub emit_progress: usize,
+}
+
+/// A built multi-file transfer graph plus per-file terminal metadata.
+#[derive(Debug, Clone)]
+pub struct BatchDag {
+    pub dag: TransferDag,
+    pub files: Vec<BatchFileDag>,
+}
+
+/// A planned sync action that can be represented in the transfer DAG.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SyncDagAction {
+    Upload,
+    Download,
+    DeleteLocal,
+    DeleteRemote,
+    Skip,
+    KeepBoth,
+}
+
+impl SyncDagAction {
+    fn transfer_direction(self) -> Option<TransferDirection> {
+        match self {
+            Self::Upload => Some(TransferDirection::Upload),
+            Self::Download => Some(TransferDirection::Download),
+            Self::DeleteLocal | Self::DeleteRemote | Self::Skip | Self::KeepBoth => None,
+        }
+    }
+}
+
+/// One entry in a sync plan.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SyncDagItem {
+    pub key: String,
+    pub action: SyncDagAction,
+}
+
+impl SyncDagItem {
+    pub fn new(key: impl Into<String>, action: SyncDagAction) -> Self {
+        Self {
+            key: key.into(),
+            action,
+        }
+    }
+}
+
+/// Node ids for one transfer-producing sync plan entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SyncFileDag {
+    pub key: String,
+    pub plan_index: usize,
+    pub action: SyncDagAction,
+    pub direction: TransferDirection,
+    pub acquire: usize,
+    pub transfer: usize,
+    pub verify: usize,
+    pub preserve_metadata: usize,
+    pub commit: usize,
+    /// Terminal node for the sync file. Fase 2 journal observers attach
+    /// durable completion to this id.
+    pub emit_progress: usize,
+}
+
+/// A built sync graph plus global discovery/compare ids and per-file
+/// transfer terminal metadata.
+#[derive(Debug, Clone)]
+pub struct SyncDag {
+    pub dag: TransferDag,
+    pub discover_local: usize,
+    pub discover_remote: usize,
+    pub compare: usize,
+    pub files: Vec<SyncFileDag>,
+}
+
+impl SyncDag {
+    /// Terminal-to-journal mapping when the legacy journal entries preserve
+    /// the same order as the sync plan passed to [`TransferDagBuilder::from_sync_plan`].
+    pub fn journal_terminals_for_plan_order(&self) -> Vec<super::observer::SyncJournalTerminal> {
+        self.files
+            .iter()
+            .map(|file| {
+                super::observer::SyncJournalTerminal::new(file.emit_progress, file.plan_index)
+            })
+            .collect()
+    }
+}
+
+/// Capability-derived shaping decisions for one file's transfer graph
+/// (DAG-ENGINE phase 3). Resolved once from a provider's
+/// [`TransferCapabilities`] and the file size; the builder reads it to decide
+/// how many transfer nodes to emit and what each one reserves.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TransferGraphProfile {
+    /// Number of upload parts. `1` is a single `UploadFile`; `> 1` fans the
+    /// transfer core out into that many parallel `UploadPart` nodes. Always
+    /// `1` on the download direction (multipart is an upload-only concept).
+    pub upload_parts: usize,
+    /// `true` when the provider can resume the transfer from a checkpoint, so
+    /// the `AcquireResource` node fetches the saved offset and the transfer
+    /// starts from there. The graph shape is unchanged; the runner reads it.
+    pub resume: bool,
+    /// Extra `api_slots` every API-bound transfer node reserves. `1` for
+    /// providers that advertise `rate_limited_api`, `0` otherwise: it lets the
+    /// shared `api_slots` budget (and the AIMD `Api` class) throttle the
+    /// API-bound providers without touching transport-bound ones.
+    pub api_slots: u16,
+}
+
+impl TransferGraphProfile {
+    /// Resolve the profile for `direction` from a provider's capabilities and
+    /// the known `file_size` (used only to size the multipart part count).
+    pub fn resolve(
+        direction: TransferDirection,
+        caps: &TransferCapabilities,
+        file_size: u64,
+    ) -> Self {
+        let api_slots = u16::from(caps.rate_limited_api.is_available());
+        let resume = match direction {
+            TransferDirection::Download => caps.resume_download,
+            TransferDirection::Upload => caps.resume_upload,
+        }
+        .is_available();
+
+        let upload_parts =
+            if direction == TransferDirection::Upload && caps.multipart_upload.is_available() {
+                let chunk = caps
+                    .preferred_chunk_size
+                    .filter(|size| *size > 0)
+                    .unwrap_or(DEFAULT_MULTIPART_CHUNK_SIZE);
+                let parts = file_size.div_ceil(chunk).max(1);
+                (parts as usize).clamp(1, MAX_MULTIPART_PARTS)
+            } else {
+                1
+            };
+
+        Self {
+            upload_parts,
+            resume,
+            api_slots,
+        }
+    }
+}
+
+/// A built capability-shaped single-file graph. Unlike [`SingleFileDag`] the
+/// transfer core is a `Vec`: one node for a plain transfer, or N `UploadPart`
+/// nodes for a multipart upload. `VerifyChecksum` joins every transfer node so
+/// it cannot run until the last part lands.
+#[derive(Debug, Clone)]
+pub struct ShapedFileDag {
+    pub dag: TransferDag,
+    pub direction: TransferDirection,
+    pub profile: TransferGraphProfile,
+    pub discover: usize,
+    pub acquire: usize,
+    /// The transfer core: one `DownloadFile` / `UploadFile`, or N `UploadPart`.
+    pub transfer: Vec<usize>,
+    pub verify: usize,
+    pub preserve_metadata: usize,
+    pub commit: usize,
+    pub emit_progress: usize,
+}
+
+/// A built capability-shaped copy graph. When the provider advertises
+/// `server_side_copy` the transfer core collapses into a single
+/// [`TransferNodeKind::ServerSideCopy`] node (the server moves the bytes, no
+/// disk I/O); otherwise it degrades honestly to a `DownloadFile` followed by
+/// an `UploadFile`.
+#[derive(Debug, Clone)]
+pub struct CopyDag {
+    pub dag: TransferDag,
+    /// `true` when the core is a single `ServerSideCopy` node.
+    pub server_side: bool,
+    pub discover: usize,
+    pub acquire: usize,
+    /// One `ServerSideCopy` node, or a `DownloadFile` then an `UploadFile`.
+    pub copy: Vec<usize>,
+    pub verify: usize,
+    pub preserve_metadata: usize,
+    pub commit: usize,
+    pub emit_progress: usize,
+}
+
 /// Stateless constructor of shared production transfer graphs.
 pub struct TransferDagBuilder;
 
@@ -94,27 +323,167 @@ impl TransferDagBuilder {
     /// budget.
     pub fn single_file(direction: TransferDirection) -> SingleFileDag {
         let mut dag = TransferDag::default();
+        let ids = append_single_file_chain(&mut dag, direction);
 
-        let (discover_kind, transfer_kind) = match direction {
-            TransferDirection::Download => (
-                TransferNodeKind::DiscoverRemote,
-                TransferNodeKind::DownloadFile,
-            ),
-            TransferDirection::Upload => {
-                (TransferNodeKind::DiscoverLocal, TransferNodeKind::UploadFile)
-            }
+        SingleFileDag {
+            dag,
+            direction,
+            discover: ids.discover,
+            acquire: ids.acquire,
+            transfer: ids.transfer,
+            verify: ids.verify,
+            preserve_metadata: ids.preserve_metadata,
+            commit: ids.commit,
+            emit_progress: ids.emit_progress,
+        }
+    }
+
+    /// Build a multi-file batch graph by merging one single-file sub-DAG per
+    /// item into the same [`TransferDag`].
+    ///
+    /// The sub-DAGs are intentionally independent: their discover/acquire
+    /// prefixes can enter the ready frontier together, while the real transfer
+    /// nodes all carry [`ResourceRequest::file_transfer`]. A single
+    /// [`TransferResourceManager`](super::resources::TransferResourceManager)
+    /// shared by the executor is therefore the only file-level concurrency
+    /// governor, matching the Fase 2 `file_slots` contract.
+    pub fn from_batch(items: &[BatchDagItem]) -> BatchDag {
+        let mut dag = TransferDag::default();
+        let mut files = Vec::with_capacity(items.len());
+
+        for item in items {
+            let ids = append_single_file_chain(&mut dag, item.direction);
+            files.push(BatchFileDag {
+                key: item.key.clone(),
+                direction: item.direction,
+                discover: ids.discover,
+                acquire: ids.acquire,
+                transfer: ids.transfer,
+                verify: ids.verify,
+                preserve_metadata: ids.preserve_metadata,
+                commit: ids.commit,
+                emit_progress: ids.emit_progress,
+            });
+        }
+
+        BatchDag { dag, files }
+    }
+
+    /// Build a sync-session graph.
+    ///
+    /// Sync has one global discovery/compare prefix:
+    /// `DiscoverLocal` and `DiscoverRemote` run independently, then `Compare`
+    /// joins them. Every transfer-producing plan entry hangs below `Compare`
+    /// as a per-file chain beginning at `AcquireResource`; delete/skip entries
+    /// do not produce file-transfer nodes in this Fase 2 slice.
+    pub fn from_sync_plan(plan: &[SyncDagItem]) -> SyncDag {
+        let mut dag = TransferDag::default();
+        let discover_local = dag.add_node(
+            TransferNodeKind::DiscoverLocal,
+            vec![],
+            ResourceRequest::default(),
+        );
+        let discover_remote = dag.add_node(
+            TransferNodeKind::DiscoverRemote,
+            vec![],
+            ResourceRequest::default(),
+        );
+        let compare = dag.add_node(
+            TransferNodeKind::Compare,
+            vec![discover_local, discover_remote],
+            ResourceRequest::default(),
+        );
+        let mut files = Vec::new();
+
+        for (plan_index, item) in plan.iter().enumerate() {
+            let Some(direction) = item.action.transfer_direction() else {
+                continue;
+            };
+            let ids = append_sync_file_chain(&mut dag, direction, compare);
+            files.push(SyncFileDag {
+                key: item.key.clone(),
+                plan_index,
+                action: item.action,
+                direction,
+                acquire: ids.acquire,
+                transfer: ids.transfer,
+                verify: ids.verify,
+                preserve_metadata: ids.preserve_metadata,
+                commit: ids.commit,
+                emit_progress: ids.emit_progress,
+            });
+        }
+
+        SyncDag {
+            dag,
+            discover_local,
+            discover_remote,
+            compare,
+            files,
+        }
+    }
+
+    /// Build a capability-shaped single-file graph (DAG-ENGINE phase 3).
+    ///
+    /// The graph reads the provider's [`TransferCapabilities`] and the file
+    /// size through [`TransferGraphProfile`]:
+    ///
+    /// - `multipart_upload` available on an upload large enough for more than
+    ///   one part: the transfer core fans out into N `UploadPart` nodes, each
+    ///   reserving one `chunk_slot`, so the shared chunk budget governs how
+    ///   many parts upload at once.
+    /// - `rate_limited_api` available: every transfer node also reserves one
+    ///   `api_slot`, exposing it to the shared API budget and the AIMD `Api`
+    ///   class.
+    /// - `resume_*` available: recorded on the profile so the runner's
+    ///   `AcquireResource` node fetches the checkpoint; the graph shape is
+    ///   unchanged.
+    ///
+    /// With a capability set that advertises none of the above this produces
+    /// the same seven-node linear chain as [`Self::single_file`].
+    pub fn shaped_file(
+        direction: TransferDirection,
+        caps: &TransferCapabilities,
+        file_size: u64,
+    ) -> ShapedFileDag {
+        let profile = TransferGraphProfile::resolve(direction, caps, file_size);
+        let mut dag = TransferDag::default();
+
+        let discover_kind = match direction {
+            TransferDirection::Download => TransferNodeKind::DiscoverRemote,
+            TransferDirection::Upload => TransferNodeKind::DiscoverLocal,
         };
-
         let discover = dag.add_node(discover_kind, vec![], ResourceRequest::default());
         let acquire = dag.add_node(
             TransferNodeKind::AcquireResource,
             vec![discover],
             ResourceRequest::default(),
         );
-        let transfer = dag.add_node(transfer_kind, vec![acquire], ResourceRequest::file_transfer());
+
+        let mut transfer = Vec::new();
+        if direction == TransferDirection::Upload && profile.upload_parts > 1 {
+            for _ in 0..profile.upload_parts {
+                transfer.push(dag.add_node(
+                    TransferNodeKind::UploadPart,
+                    vec![acquire],
+                    part_request(profile.api_slots),
+                ));
+            }
+        } else {
+            let transfer_kind = match direction {
+                TransferDirection::Download => TransferNodeKind::DownloadFile,
+                TransferDirection::Upload => TransferNodeKind::UploadFile,
+            };
+            transfer.push(dag.add_node(
+                transfer_kind,
+                vec![acquire],
+                transfer_request(profile.api_slots),
+            ));
+        }
+
         let verify = dag.add_node(
             TransferNodeKind::VerifyChecksum,
-            vec![transfer],
+            transfer.clone(),
             ResourceRequest::default(),
         );
         let preserve_metadata = dag.add_node(
@@ -133,9 +502,10 @@ impl TransferDagBuilder {
             ResourceRequest::default(),
         );
 
-        SingleFileDag {
+        ShapedFileDag {
             dag,
             direction,
+            profile,
             discover,
             acquire,
             transfer,
@@ -144,6 +514,233 @@ impl TransferDagBuilder {
             commit,
             emit_progress,
         }
+    }
+
+    /// Build a capability-shaped copy graph (DAG-ENGINE phase 3, F3-T02).
+    ///
+    /// When `caps.server_side_copy` is available the transfer core is a single
+    /// [`TransferNodeKind::ServerSideCopy`] node: the server moves the bytes,
+    /// so the node reserves only an `api_slot`, never a file or disk slot.
+    /// Otherwise the core degrades honestly to a `DownloadFile` followed by an
+    /// `UploadFile`, the two transfers a non-server-side copy actually needs.
+    pub fn shaped_copy(caps: &TransferCapabilities) -> CopyDag {
+        let api_slots = u16::from(caps.rate_limited_api.is_available());
+        let server_side = caps.server_side_copy.is_available();
+        let mut dag = TransferDag::default();
+
+        let discover = dag.add_node(
+            TransferNodeKind::DiscoverRemote,
+            vec![],
+            ResourceRequest::default(),
+        );
+        let acquire = dag.add_node(
+            TransferNodeKind::AcquireResource,
+            vec![discover],
+            ResourceRequest::default(),
+        );
+
+        let mut copy = Vec::new();
+        if server_side {
+            // A server-side copy is one API operation; it always reserves an
+            // api slot even when the provider does not flag rate limiting.
+            copy.push(dag.add_node(
+                TransferNodeKind::ServerSideCopy,
+                vec![acquire],
+                ResourceRequest {
+                    api_slots: api_slots.max(1),
+                    ..ResourceRequest::default()
+                },
+            ));
+        } else {
+            let download = dag.add_node(
+                TransferNodeKind::DownloadFile,
+                vec![acquire],
+                transfer_request(api_slots),
+            );
+            let upload = dag.add_node(
+                TransferNodeKind::UploadFile,
+                vec![download],
+                transfer_request(api_slots),
+            );
+            copy.push(download);
+            copy.push(upload);
+        }
+
+        let verify = dag.add_node(
+            TransferNodeKind::VerifyChecksum,
+            vec![*copy.last().expect("copy core is never empty")],
+            ResourceRequest::default(),
+        );
+        let preserve_metadata = dag.add_node(
+            TransferNodeKind::PreserveMetadata,
+            vec![verify],
+            ResourceRequest::default(),
+        );
+        let commit = dag.add_node(
+            TransferNodeKind::CommitTemp,
+            vec![preserve_metadata],
+            ResourceRequest::default(),
+        );
+        let emit_progress = dag.add_node(
+            TransferNodeKind::EmitProgress,
+            vec![commit],
+            ResourceRequest::default(),
+        );
+
+        CopyDag {
+            dag,
+            server_side,
+            discover,
+            acquire,
+            copy,
+            verify,
+            preserve_metadata,
+            commit,
+            emit_progress,
+        }
+    }
+}
+
+/// `ResourceRequest` for a whole-file transfer node, optionally rate-limited.
+fn transfer_request(api_slots: u16) -> ResourceRequest {
+    ResourceRequest {
+        file_slots: 1,
+        disk_read_slots: 1,
+        disk_write_slots: 1,
+        api_slots,
+        ..ResourceRequest::default()
+    }
+}
+
+/// `ResourceRequest` for one `UploadPart` node: a chunk slot (so the chunk
+/// budget governs part parallelism) plus a disk read, optionally rate-limited.
+fn part_request(api_slots: u16) -> ResourceRequest {
+    ResourceRequest {
+        chunk_slots: 1,
+        disk_read_slots: 1,
+        api_slots,
+        ..ResourceRequest::default()
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SingleFileNodeIds {
+    discover: usize,
+    acquire: usize,
+    transfer: usize,
+    verify: usize,
+    preserve_metadata: usize,
+    commit: usize,
+    emit_progress: usize,
+}
+
+fn append_single_file_chain(
+    dag: &mut TransferDag,
+    direction: TransferDirection,
+) -> SingleFileNodeIds {
+    let (discover_kind, transfer_kind) = match direction {
+        TransferDirection::Download => (
+            TransferNodeKind::DiscoverRemote,
+            TransferNodeKind::DownloadFile,
+        ),
+        TransferDirection::Upload => (
+            TransferNodeKind::DiscoverLocal,
+            TransferNodeKind::UploadFile,
+        ),
+    };
+
+    let discover = dag.add_node(discover_kind, vec![], ResourceRequest::default());
+    let acquire = dag.add_node(
+        TransferNodeKind::AcquireResource,
+        vec![discover],
+        ResourceRequest::default(),
+    );
+    let transfer = dag.add_node(
+        transfer_kind,
+        vec![acquire],
+        ResourceRequest::file_transfer(),
+    );
+    let verify = dag.add_node(
+        TransferNodeKind::VerifyChecksum,
+        vec![transfer],
+        ResourceRequest::default(),
+    );
+    let preserve_metadata = dag.add_node(
+        TransferNodeKind::PreserveMetadata,
+        vec![verify],
+        ResourceRequest::default(),
+    );
+    let commit = dag.add_node(
+        TransferNodeKind::CommitTemp,
+        vec![preserve_metadata],
+        ResourceRequest::default(),
+    );
+    let emit_progress = dag.add_node(
+        TransferNodeKind::EmitProgress,
+        vec![commit],
+        ResourceRequest::default(),
+    );
+
+    SingleFileNodeIds {
+        discover,
+        acquire,
+        transfer,
+        verify,
+        preserve_metadata,
+        commit,
+        emit_progress,
+    }
+}
+
+fn append_sync_file_chain(
+    dag: &mut TransferDag,
+    direction: TransferDirection,
+    compare: usize,
+) -> SingleFileNodeIds {
+    let transfer_kind = match direction {
+        TransferDirection::Download => TransferNodeKind::DownloadFile,
+        TransferDirection::Upload => TransferNodeKind::UploadFile,
+    };
+
+    let acquire = dag.add_node(
+        TransferNodeKind::AcquireResource,
+        vec![compare],
+        ResourceRequest::default(),
+    );
+    let transfer = dag.add_node(
+        transfer_kind,
+        vec![acquire],
+        ResourceRequest::file_transfer(),
+    );
+    let verify = dag.add_node(
+        TransferNodeKind::VerifyChecksum,
+        vec![transfer],
+        ResourceRequest::default(),
+    );
+    let preserve_metadata = dag.add_node(
+        TransferNodeKind::PreserveMetadata,
+        vec![verify],
+        ResourceRequest::default(),
+    );
+    let commit = dag.add_node(
+        TransferNodeKind::CommitTemp,
+        vec![preserve_metadata],
+        ResourceRequest::default(),
+    );
+    let emit_progress = dag.add_node(
+        TransferNodeKind::EmitProgress,
+        vec![commit],
+        ResourceRequest::default(),
+    );
+
+    SingleFileNodeIds {
+        discover: compare,
+        acquire,
+        transfer,
+        verify,
+        preserve_metadata,
+        commit,
+        emit_progress,
     }
 }
 
@@ -154,7 +751,9 @@ mod tests {
     use crate::transfer_dag::graph::TransferNode;
     use crate::transfer_dag::observer::NoopDagObserver;
     use crate::transfer_dag::resources::{TransferBudget, TransferResourceManager};
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
+    use std::time::Duration;
 
     #[test]
     fn download_graph_has_seven_nodes_in_order() {
@@ -192,9 +791,9 @@ mod tests {
         let nodes = built.dag.nodes();
 
         assert_eq!(nodes[0].depends_on, Vec::<usize>::new());
-        for i in 1..nodes.len() {
+        for (i, node) in nodes.iter().enumerate().skip(1) {
             assert_eq!(
-                nodes[i].depends_on,
+                node.depends_on,
                 vec![i - 1],
                 "node {i} must depend solely on node {}",
                 i - 1
@@ -256,6 +855,473 @@ mod tests {
         .expect("single-file graph must schedule cleanly");
 
         assert_eq!(summary.nodes_completed, 7);
+        assert_eq!(summary.nodes_failed, 0);
+    }
+
+    #[test]
+    fn empty_batch_builds_empty_graph() {
+        let built = TransferDagBuilder::from_batch(&[]);
+
+        assert!(built.dag.nodes().is_empty());
+        assert!(built.files.is_empty());
+    }
+
+    #[test]
+    fn batch_merges_one_subdag_per_item() {
+        let built = TransferDagBuilder::from_batch(&[
+            BatchDagItem::new("a.txt", TransferDirection::Upload),
+            BatchDagItem::new("b.txt", TransferDirection::Download),
+        ]);
+        let nodes = built.dag.nodes();
+
+        assert_eq!(nodes.len(), 14);
+        assert_eq!(built.files.len(), 2);
+        assert_eq!(built.files[0].key, "a.txt");
+        assert_eq!(built.files[0].direction, TransferDirection::Upload);
+        assert_eq!(built.files[0].discover, 0);
+        assert_eq!(built.files[0].transfer, 2);
+        assert_eq!(built.files[0].emit_progress, 6);
+        assert_eq!(
+            nodes[built.files[0].discover].kind,
+            TransferNodeKind::DiscoverLocal
+        );
+        assert_eq!(
+            nodes[built.files[0].transfer].kind,
+            TransferNodeKind::UploadFile
+        );
+
+        assert_eq!(built.files[1].key, "b.txt");
+        assert_eq!(built.files[1].direction, TransferDirection::Download);
+        assert_eq!(built.files[1].discover, 7);
+        assert_eq!(built.files[1].transfer, 9);
+        assert_eq!(built.files[1].emit_progress, 13);
+        assert_eq!(
+            nodes[built.files[1].discover].kind,
+            TransferNodeKind::DiscoverRemote
+        );
+        assert_eq!(
+            nodes[built.files[1].transfer].kind,
+            TransferNodeKind::DownloadFile
+        );
+    }
+
+    #[test]
+    fn batch_subdags_are_independent_but_transfer_nodes_are_scarce() {
+        let built = TransferDagBuilder::from_batch(&[
+            BatchDagItem::new("one", TransferDirection::Upload),
+            BatchDagItem::new("two", TransferDirection::Upload),
+            BatchDagItem::new("three", TransferDirection::Upload),
+        ]);
+        let nodes = built.dag.nodes();
+
+        for file in &built.files {
+            assert!(nodes[file.discover].depends_on.is_empty());
+            assert_eq!(nodes[file.acquire].depends_on, vec![file.discover]);
+            assert_eq!(nodes[file.transfer].depends_on, vec![file.acquire]);
+            assert_eq!(
+                nodes[file.transfer].resources,
+                ResourceRequest::file_transfer()
+            );
+            assert_eq!(nodes[file.emit_progress].depends_on, vec![file.commit]);
+        }
+    }
+
+    #[tokio::test]
+    async fn batch_file_slots_serialize_real_transfer_nodes() {
+        let built = TransferDagBuilder::from_batch(&[
+            BatchDagItem::new("one", TransferDirection::Download),
+            BatchDagItem::new("two", TransferDirection::Download),
+            BatchDagItem::new("three", TransferDirection::Download),
+        ]);
+        let in_flight_transfers = Arc::new(AtomicUsize::new(0));
+        let peak_transfers = Arc::new(AtomicUsize::new(0));
+        let runner: Arc<dyn DagNodeRunner> = {
+            let in_flight_transfers = Arc::clone(&in_flight_transfers);
+            let peak_transfers = Arc::clone(&peak_transfers);
+            Arc::new(move |node: TransferNode| -> NodeFuture {
+                let in_flight_transfers = Arc::clone(&in_flight_transfers);
+                let peak_transfers = Arc::clone(&peak_transfers);
+                Box::pin(async move {
+                    if matches!(
+                        node.kind,
+                        TransferNodeKind::DownloadFile | TransferNodeKind::UploadFile
+                    ) {
+                        let now = in_flight_transfers.fetch_add(1, Ordering::SeqCst) + 1;
+                        peak_transfers.fetch_max(now, Ordering::SeqCst);
+                        tokio::time::sleep(Duration::from_millis(20)).await;
+                        in_flight_transfers.fetch_sub(1, Ordering::SeqCst);
+                    }
+                    NodeOutcome::Completed
+                })
+            })
+        };
+        let manager = TransferResourceManager::new(TransferBudget::from_file_slots(1));
+
+        let summary = execute_dag(
+            &built.dag,
+            &manager,
+            runner,
+            Arc::new(NoopDagObserver),
+            None,
+        )
+        .await
+        .expect("batch graph must schedule cleanly");
+
+        assert_eq!(summary.nodes_completed, 21);
+        assert_eq!(peak_transfers.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn batch_file_slots_allow_transfer_overlap_when_budget_allows() {
+        let built = TransferDagBuilder::from_batch(&[
+            BatchDagItem::new("one", TransferDirection::Upload),
+            BatchDagItem::new("two", TransferDirection::Upload),
+            BatchDagItem::new("three", TransferDirection::Upload),
+        ]);
+        let in_flight_transfers = Arc::new(AtomicUsize::new(0));
+        let peak_transfers = Arc::new(AtomicUsize::new(0));
+        let runner: Arc<dyn DagNodeRunner> = {
+            let in_flight_transfers = Arc::clone(&in_flight_transfers);
+            let peak_transfers = Arc::clone(&peak_transfers);
+            Arc::new(move |node: TransferNode| -> NodeFuture {
+                let in_flight_transfers = Arc::clone(&in_flight_transfers);
+                let peak_transfers = Arc::clone(&peak_transfers);
+                Box::pin(async move {
+                    if matches!(
+                        node.kind,
+                        TransferNodeKind::DownloadFile | TransferNodeKind::UploadFile
+                    ) {
+                        let now = in_flight_transfers.fetch_add(1, Ordering::SeqCst) + 1;
+                        peak_transfers.fetch_max(now, Ordering::SeqCst);
+                        tokio::time::sleep(Duration::from_millis(20)).await;
+                        in_flight_transfers.fetch_sub(1, Ordering::SeqCst);
+                    }
+                    NodeOutcome::Completed
+                })
+            })
+        };
+        let manager = TransferResourceManager::new(TransferBudget::from_file_slots(2));
+
+        execute_dag(
+            &built.dag,
+            &manager,
+            runner,
+            Arc::new(NoopDagObserver),
+            None,
+        )
+        .await
+        .expect("batch graph must schedule cleanly");
+
+        assert_eq!(peak_transfers.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn sync_plan_builds_global_discover_compare_prefix() {
+        let built = TransferDagBuilder::from_sync_plan(&[]);
+        let nodes = built.dag.nodes();
+
+        assert_eq!(nodes.len(), 3);
+        assert_eq!(built.discover_local, 0);
+        assert_eq!(built.discover_remote, 1);
+        assert_eq!(built.compare, 2);
+        assert_eq!(
+            nodes[built.discover_local].kind,
+            TransferNodeKind::DiscoverLocal
+        );
+        assert_eq!(
+            nodes[built.discover_remote].kind,
+            TransferNodeKind::DiscoverRemote
+        );
+        assert_eq!(nodes[built.compare].kind, TransferNodeKind::Compare);
+        assert_eq!(
+            nodes[built.compare].depends_on,
+            vec![built.discover_local, built.discover_remote]
+        );
+        assert!(built.files.is_empty());
+    }
+
+    #[test]
+    fn sync_plan_adds_transfer_chains_under_compare() {
+        let built = TransferDagBuilder::from_sync_plan(&[
+            SyncDagItem::new("upload:a.txt", SyncDagAction::Upload),
+            SyncDagItem::new("download:b.txt", SyncDagAction::Download),
+            SyncDagItem::new("skip:c.txt", SyncDagAction::Skip),
+            SyncDagItem::new("delete:d.txt", SyncDagAction::DeleteRemote),
+        ]);
+        let nodes = built.dag.nodes();
+
+        assert_eq!(built.files.len(), 2);
+        assert_eq!(nodes.len(), 15);
+
+        let upload = &built.files[0];
+        assert_eq!(upload.key, "upload:a.txt");
+        assert_eq!(upload.plan_index, 0);
+        assert_eq!(upload.action, SyncDagAction::Upload);
+        assert_eq!(upload.direction, TransferDirection::Upload);
+        assert_eq!(nodes[upload.acquire].depends_on, vec![built.compare]);
+        assert_eq!(nodes[upload.transfer].kind, TransferNodeKind::UploadFile);
+        assert_eq!(
+            nodes[upload.transfer].resources,
+            ResourceRequest::file_transfer()
+        );
+        assert_eq!(nodes[upload.emit_progress].depends_on, vec![upload.commit]);
+
+        let download = &built.files[1];
+        assert_eq!(download.key, "download:b.txt");
+        assert_eq!(download.plan_index, 1);
+        assert_eq!(download.action, SyncDagAction::Download);
+        assert_eq!(download.direction, TransferDirection::Download);
+        assert_eq!(nodes[download.acquire].depends_on, vec![built.compare]);
+        assert_eq!(
+            nodes[download.transfer].kind,
+            TransferNodeKind::DownloadFile
+        );
+        assert_eq!(
+            nodes[download.transfer].resources,
+            ResourceRequest::file_transfer()
+        );
+        assert_eq!(
+            nodes[download.emit_progress].depends_on,
+            vec![download.commit]
+        );
+    }
+
+    #[test]
+    fn sync_plan_exposes_terminal_to_legacy_journal_indices() {
+        let built = TransferDagBuilder::from_sync_plan(&[
+            SyncDagItem::new("upload:a.txt", SyncDagAction::Upload),
+            SyncDagItem::new("skip:b.txt", SyncDagAction::Skip),
+            SyncDagItem::new("download:c.txt", SyncDagAction::Download),
+        ]);
+
+        let terminals = built.journal_terminals_for_plan_order();
+
+        assert_eq!(terminals.len(), 2);
+        assert_eq!(terminals[0].node_id, built.files[0].emit_progress);
+        assert_eq!(terminals[0].entry_index, 0);
+        assert_eq!(terminals[1].node_id, built.files[1].emit_progress);
+        assert_eq!(terminals[1].entry_index, 2);
+    }
+
+    #[tokio::test]
+    async fn sync_file_slots_limit_only_transfer_nodes_after_compare() {
+        let built = TransferDagBuilder::from_sync_plan(&[
+            SyncDagItem::new("one", SyncDagAction::Upload),
+            SyncDagItem::new("two", SyncDagAction::Download),
+            SyncDagItem::new("three", SyncDagAction::Upload),
+        ]);
+        let in_flight_transfers = Arc::new(AtomicUsize::new(0));
+        let peak_transfers = Arc::new(AtomicUsize::new(0));
+        let runner: Arc<dyn DagNodeRunner> = {
+            let in_flight_transfers = Arc::clone(&in_flight_transfers);
+            let peak_transfers = Arc::clone(&peak_transfers);
+            Arc::new(move |node: TransferNode| -> NodeFuture {
+                let in_flight_transfers = Arc::clone(&in_flight_transfers);
+                let peak_transfers = Arc::clone(&peak_transfers);
+                Box::pin(async move {
+                    if matches!(
+                        node.kind,
+                        TransferNodeKind::DownloadFile | TransferNodeKind::UploadFile
+                    ) {
+                        let now = in_flight_transfers.fetch_add(1, Ordering::SeqCst) + 1;
+                        peak_transfers.fetch_max(now, Ordering::SeqCst);
+                        tokio::time::sleep(Duration::from_millis(20)).await;
+                        in_flight_transfers.fetch_sub(1, Ordering::SeqCst);
+                    }
+                    NodeOutcome::Completed
+                })
+            })
+        };
+        let manager = TransferResourceManager::new(TransferBudget::from_file_slots(1));
+
+        let summary = execute_dag(
+            &built.dag,
+            &manager,
+            runner,
+            Arc::new(NoopDagObserver),
+            None,
+        )
+        .await
+        .expect("sync graph must schedule cleanly");
+
+        assert_eq!(summary.nodes_completed, 21);
+        assert_eq!(peak_transfers.load(Ordering::SeqCst), 1);
+    }
+
+    // ---- Phase 3: capability-shaped graphs --------------------------------
+
+    use crate::transfer_dag::Capability;
+
+    fn caps_multipart(chunk_size: u64) -> TransferCapabilities {
+        TransferCapabilities {
+            multipart_upload: Capability::Supported,
+            preferred_chunk_size: Some(chunk_size),
+            ..TransferCapabilities::default()
+        }
+    }
+
+    #[test]
+    fn shaped_download_is_the_classic_seven_node_chain() {
+        let built = TransferDagBuilder::shaped_file(
+            TransferDirection::Download,
+            &TransferCapabilities::default(),
+            64 * 1024 * 1024,
+        );
+        let nodes = built.dag.nodes();
+
+        assert_eq!(nodes.len(), 7);
+        assert_eq!(built.transfer.len(), 1);
+        assert_eq!(
+            nodes[built.transfer[0]].kind,
+            TransferNodeKind::DownloadFile
+        );
+        assert_eq!(built.profile.upload_parts, 1);
+        assert!(!built.profile.resume);
+        assert_eq!(built.profile.api_slots, 0);
+        assert_eq!(nodes[built.verify].depends_on, built.transfer);
+    }
+
+    #[test]
+    fn shaped_upload_without_multipart_is_a_single_upload_node() {
+        let built = TransferDagBuilder::shaped_file(
+            TransferDirection::Upload,
+            &TransferCapabilities::default(),
+            500 * 1024 * 1024,
+        );
+
+        assert_eq!(built.transfer.len(), 1);
+        assert_eq!(
+            built.dag.nodes()[built.transfer[0]].kind,
+            TransferNodeKind::UploadFile
+        );
+    }
+
+    #[test]
+    fn shaped_upload_with_multipart_fans_out_upload_parts() {
+        // 5 MiB file, 1 MiB parts: five parallel UploadPart nodes.
+        let built = TransferDagBuilder::shaped_file(
+            TransferDirection::Upload,
+            &caps_multipart(1024 * 1024),
+            5 * 1024 * 1024,
+        );
+        let nodes = built.dag.nodes();
+
+        assert_eq!(built.profile.upload_parts, 5);
+        assert_eq!(built.transfer.len(), 5);
+        for &part in &built.transfer {
+            assert_eq!(nodes[part].kind, TransferNodeKind::UploadPart);
+            assert_eq!(nodes[part].depends_on, vec![built.acquire]);
+            assert_eq!(nodes[part].resources.chunk_slots, 1);
+        }
+        // VerifyChecksum joins every part: it cannot run until the last lands.
+        assert_eq!(nodes[built.verify].depends_on, built.transfer);
+        // discover + acquire + 5 parts + verify + preserve + commit + emit.
+        assert_eq!(nodes.len(), 11);
+    }
+
+    #[test]
+    fn shaped_upload_multipart_collapses_when_the_file_fits_one_chunk() {
+        // 512 KiB file, 1 MiB parts: a single UploadFile, no fan-out.
+        let built = TransferDagBuilder::shaped_file(
+            TransferDirection::Upload,
+            &caps_multipart(1024 * 1024),
+            512 * 1024,
+        );
+
+        assert_eq!(built.profile.upload_parts, 1);
+        assert_eq!(built.transfer.len(), 1);
+        assert_eq!(
+            built.dag.nodes()[built.transfer[0]].kind,
+            TransferNodeKind::UploadFile
+        );
+    }
+
+    #[test]
+    fn shaped_profile_marks_resume_from_capabilities() {
+        let caps = TransferCapabilities {
+            resume_download: Capability::Supported,
+            ..TransferCapabilities::default()
+        };
+        let download = TransferDagBuilder::shaped_file(TransferDirection::Download, &caps, 1024);
+        assert!(download.profile.resume);
+        // resume_upload is not advertised: the upload profile stays plain.
+        let upload = TransferDagBuilder::shaped_file(TransferDirection::Upload, &caps, 1024);
+        assert!(!upload.profile.resume);
+    }
+
+    #[test]
+    fn shaped_profile_reserves_api_slot_for_rate_limited_providers() {
+        let caps = TransferCapabilities {
+            rate_limited_api: Capability::Supported,
+            ..TransferCapabilities::default()
+        };
+        let built = TransferDagBuilder::shaped_file(TransferDirection::Download, &caps, 1024);
+
+        assert_eq!(built.profile.api_slots, 1);
+        assert_eq!(built.dag.nodes()[built.transfer[0]].resources.api_slots, 1);
+    }
+
+    #[test]
+    fn shaped_copy_collapses_into_one_server_side_copy_node() {
+        let caps = TransferCapabilities {
+            server_side_copy: Capability::Supported,
+            ..TransferCapabilities::default()
+        };
+        let built = TransferDagBuilder::shaped_copy(&caps);
+        let nodes = built.dag.nodes();
+
+        assert!(built.server_side);
+        assert_eq!(built.copy.len(), 1);
+        assert_eq!(nodes[built.copy[0]].kind, TransferNodeKind::ServerSideCopy);
+        // A server-side copy reserves no file or disk slot, only an api slot.
+        assert_eq!(nodes[built.copy[0]].resources.file_slots, 0);
+        assert_eq!(nodes[built.copy[0]].resources.api_slots, 1);
+        // discover + acquire + copy + verify + preserve + commit + emit.
+        assert_eq!(nodes.len(), 7);
+    }
+
+    #[test]
+    fn shaped_copy_degrades_to_download_then_upload() {
+        let built = TransferDagBuilder::shaped_copy(&TransferCapabilities::default());
+        let nodes = built.dag.nodes();
+
+        assert!(!built.server_side);
+        assert_eq!(built.copy.len(), 2);
+        assert_eq!(nodes[built.copy[0]].kind, TransferNodeKind::DownloadFile);
+        assert_eq!(nodes[built.copy[1]].kind, TransferNodeKind::UploadFile);
+        // The two transfers are a strict chain: upload after download.
+        assert_eq!(nodes[built.copy[1]].depends_on, vec![built.copy[0]]);
+        assert_eq!(nodes[built.verify].depends_on, vec![built.copy[1]]);
+    }
+
+    #[tokio::test]
+    async fn shaped_multipart_graph_runs_to_completion_on_the_executor() {
+        let built = TransferDagBuilder::shaped_file(
+            TransferDirection::Upload,
+            &caps_multipart(1024 * 1024),
+            4 * 1024 * 1024,
+        );
+        let runner: Arc<dyn DagNodeRunner> = Arc::new(|_node: TransferNode| -> NodeFuture {
+            Box::pin(async { NodeOutcome::Completed })
+        });
+        // chunk_slots sized for the four parts to overlap.
+        let manager = TransferResourceManager::new(TransferBudget {
+            chunk_slots: 4,
+            ..TransferBudget::from_file_slots(1)
+        });
+
+        let summary = execute_dag(
+            &built.dag,
+            &manager,
+            runner,
+            Arc::new(NoopDagObserver),
+            None,
+        )
+        .await
+        .expect("multipart graph must schedule cleanly");
+
+        // discover + acquire + 4 parts + verify + preserve + commit + emit.
+        assert_eq!(summary.nodes_completed, 10);
         assert_eq!(summary.nodes_failed, 0);
     }
 }

--- a/src-tauri/src/transfer_dag/executor.rs
+++ b/src-tauri/src/transfer_dag/executor.rs
@@ -741,4 +741,63 @@ mod tests {
         // A not-found failure is not congestion: the target stays put.
         assert_eq!(controller.target(AdaptiveClass::File), 8);
     }
+
+    #[tokio::test]
+    async fn controller_at_ceiling_with_no_congestion_dispatches_like_none() {
+        // F3-T05 non-regression: a controller seeded from the budget starts
+        // every class at its ceiling, so a congestion-free run dispatches
+        // exactly as the prior `None` did. This is the evidence that wiring
+        // `Some(ctrl)` into the production segmented-download path is
+        // behaviourally identical on the happy path.
+        use crate::transfer_dag::adaptive::{AimdConfig, AimdController};
+
+        let build = || {
+            let mut dag = TransferDag::default();
+            for _ in 0..6 {
+                dag.add_node(
+                    TransferNodeKind::DownloadRange,
+                    vec![],
+                    ResourceRequest::range_chunk(),
+                );
+            }
+            dag
+        };
+        let budget = TransferBudget {
+            chunk_slots: 6,
+            http_slots: 6,
+            disk_write_slots: 6,
+            ..TransferBudget::from_file_slots(1)
+        };
+
+        let probe_none = Arc::new(ProbeRunner::default());
+        let summary_none = execute_dag(
+            &build(),
+            &TransferResourceManager::new(budget),
+            runner_arc(Arc::clone(&probe_none)),
+            noop_observer(),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let probe_some = Arc::new(ProbeRunner::default());
+        let controller = Arc::new(AimdController::from_budget(&budget, AimdConfig::default()));
+        let summary_some = execute_dag(
+            &build(),
+            &TransferResourceManager::new(budget),
+            runner_arc(Arc::clone(&probe_some)),
+            noop_observer(),
+            Some(controller),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(summary_none, summary_some);
+        assert_eq!(probe_none.peak(), probe_some.peak());
+        assert_eq!(
+            probe_some.peak(),
+            6,
+            "an at-ceiling controller adds no throttle to a congestion-free run"
+        );
+    }
 }

--- a/src-tauri/src/transfer_dag/graph.rs
+++ b/src-tauri/src/transfer_dag/graph.rs
@@ -17,6 +17,7 @@ pub enum TransferNodeKind {
     DownloadRange,
     UploadFile,
     UploadPart,
+    ServerSideCopy,
     VerifyChecksum,
     PreserveMetadata,
     CommitTemp,

--- a/src-tauri/src/transfer_dag/mod.rs
+++ b/src-tauri/src/transfer_dag/mod.rs
@@ -8,6 +8,7 @@
 //! scheduler, capability model, and resource leases become shared vocabulary.
 
 pub mod adaptive;
+pub mod builder;
 pub mod capabilities;
 pub mod executor;
 pub mod graph;
@@ -20,6 +21,7 @@ pub mod session_pool;
 pub use adaptive::{
     congestion_from_error, AdaptiveClass, AimdConfig, AimdController, CongestionEvent,
 };
+pub use builder::{SingleFileDag, TransferDagBuilder, TransferDirection};
 pub use capabilities::{Capability, TransferCapabilities};
 pub use observer::{DagObserver, NoopDagObserver, ObservedOutcome};
 pub use resources::{ResourceKind, ResourceRequest, TransferBudget, TransferResourceManager};

--- a/src-tauri/src/transfer_dag/mod.rs
+++ b/src-tauri/src/transfer_dag/mod.rs
@@ -15,15 +15,24 @@ pub mod graph;
 pub mod metrics;
 pub mod observer;
 pub mod planner;
+pub mod probe;
 pub mod resources;
 pub mod session_pool;
 
 pub use adaptive::{
     congestion_from_error, AdaptiveClass, AimdConfig, AimdController, CongestionEvent,
 };
-pub use builder::{SingleFileDag, TransferDagBuilder, TransferDirection};
+pub use builder::{
+    BatchDag, BatchDagItem, BatchFileDag, CopyDag, ShapedFileDag, SingleFileDag, SyncDag,
+    SyncDagAction, SyncDagItem, SyncFileDag, TransferDagBuilder, TransferDirection,
+    TransferGraphProfile,
+};
 pub use capabilities::{Capability, TransferCapabilities};
-pub use observer::{DagObserver, NoopDagObserver, ObservedOutcome};
+pub use observer::{
+    DagObserver, NoopDagObserver, ObservedOutcome, OrderedDagObserver, SyncJournalDagObserver,
+    SyncJournalTerminal,
+};
+pub use probe::SessionProbeCache;
 pub use resources::{ResourceKind, ResourceRequest, TransferBudget, TransferResourceManager};
 pub use session_pool::{
     FtpPoolSessionLease, FtpSessionPoolAdapter, SessionLeaseId, SessionLeaseInfo, SessionLeaseKind,

--- a/src-tauri/src/transfer_dag/observer.rs
+++ b/src-tauri/src/transfer_dag/observer.rs
@@ -26,6 +26,9 @@
 
 use super::graph::TransferNodeKind;
 use super::metrics::TransferDagMetrics;
+use crate::sync::{JournalEntryStatus, SyncJournal};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 
 /// Outcome category reported to [`DagObserver::on_node_complete`]. Mirrors the
 /// executor's `NodeOutcome` without coupling the observer to its `String`
@@ -62,6 +65,189 @@ pub trait DagObserver: Send + Sync {
 pub struct NoopDagObserver;
 
 impl DagObserver for NoopDagObserver {}
+
+/// Calls child observers in the order they were provided.
+///
+/// Fase 2 uses this to enforce "durable journal first, visible completion
+/// second": put `SyncJournalDagObserver` before GUI/progress observers.
+pub struct OrderedDagObserver {
+    observers: Vec<Arc<dyn DagObserver>>,
+}
+
+impl OrderedDagObserver {
+    pub fn new(observers: Vec<Arc<dyn DagObserver>>) -> Self {
+        Self { observers }
+    }
+}
+
+impl DagObserver for OrderedDagObserver {
+    fn on_node_start(&self, node_id: usize, kind: TransferNodeKind) {
+        for observer in &self.observers {
+            observer.on_node_start(node_id, kind);
+        }
+    }
+
+    fn on_node_complete(&self, node_id: usize, outcome: ObservedOutcome) {
+        for observer in &self.observers {
+            observer.on_node_complete(node_id, outcome);
+        }
+    }
+
+    fn on_scan_progress(&self, scanned: usize, in_flight: usize) {
+        for observer in &self.observers {
+            observer.on_scan_progress(scanned, in_flight);
+        }
+    }
+
+    fn on_metrics(&self, metrics: &TransferDagMetrics) {
+        for observer in &self.observers {
+            observer.on_metrics(metrics);
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SyncJournalTerminal {
+    pub node_id: usize,
+    pub entry_index: usize,
+    pub bytes_transferred: Option<u64>,
+    pub verified: Option<bool>,
+}
+
+impl SyncJournalTerminal {
+    pub fn new(node_id: usize, entry_index: usize) -> Self {
+        Self {
+            node_id,
+            entry_index,
+            bytes_transferred: None,
+            verified: Some(true),
+        }
+    }
+
+    pub fn with_result(
+        node_id: usize,
+        entry_index: usize,
+        bytes_transferred: u64,
+        verified: bool,
+    ) -> Self {
+        Self {
+            node_id,
+            entry_index,
+            bytes_transferred: Some(bytes_transferred),
+            verified: Some(verified),
+        }
+    }
+}
+
+type PersistSyncJournal = dyn Fn(&SyncJournal) -> Result<(), String> + Send + Sync;
+
+/// Updates and persists the legacy sync journal when a per-file terminal DAG
+/// node completes.
+///
+/// The observer intentionally keys off the terminal per-file node
+/// (`EmitProgress` in the Fase 2 builders), not `UploadFile` / `DownloadFile`,
+/// so durable resume state advances only after verify/metadata/commit nodes
+/// have completed.
+pub struct SyncJournalDagObserver {
+    journal: Arc<Mutex<SyncJournal>>,
+    terminals: HashMap<usize, SyncJournalTerminal>,
+    persist: Arc<PersistSyncJournal>,
+    last_error: Mutex<Option<String>>,
+}
+
+impl SyncJournalDagObserver {
+    pub fn new(journal: Arc<Mutex<SyncJournal>>, terminals: Vec<SyncJournalTerminal>) -> Self {
+        Self::with_persist(journal, terminals, Arc::new(crate::sync::save_sync_journal))
+    }
+
+    pub fn with_persist(
+        journal: Arc<Mutex<SyncJournal>>,
+        terminals: Vec<SyncJournalTerminal>,
+        persist: Arc<PersistSyncJournal>,
+    ) -> Self {
+        Self {
+            journal,
+            terminals: terminals
+                .into_iter()
+                .map(|terminal| (terminal.node_id, terminal))
+                .collect(),
+            persist,
+            last_error: Mutex::new(None),
+        }
+    }
+
+    pub fn journal(&self) -> Arc<Mutex<SyncJournal>> {
+        Arc::clone(&self.journal)
+    }
+
+    pub fn last_error(&self) -> Option<String> {
+        self.last_error
+            .lock()
+            .expect("sync journal observer error mutex poisoned")
+            .clone()
+    }
+}
+
+impl DagObserver for SyncJournalDagObserver {
+    fn on_node_complete(&self, node_id: usize, outcome: ObservedOutcome) {
+        if outcome != ObservedOutcome::Completed {
+            return;
+        }
+
+        let Some(terminal) = self.terminals.get(&node_id) else {
+            return;
+        };
+
+        let persist_result = {
+            let mut journal = self
+                .journal
+                .lock()
+                .expect("sync journal observer journal mutex poisoned");
+            let Some(entry) = journal.entries.get_mut(terminal.entry_index) else {
+                let error = format!(
+                    "Sync journal terminal node {} references missing entry {}",
+                    node_id, terminal.entry_index
+                );
+                *self
+                    .last_error
+                    .lock()
+                    .expect("sync journal observer error mutex poisoned") = Some(error);
+                return;
+            };
+
+            entry.status = JournalEntryStatus::Completed;
+            if let Some(bytes) = terminal.bytes_transferred {
+                entry.bytes_transferred = bytes;
+            }
+            if let Some(verified) = terminal.verified {
+                entry.verified = Some(verified);
+            }
+            journal.completed = journal.entries.iter().all(|entry| {
+                matches!(
+                    entry.status,
+                    JournalEntryStatus::Completed | JournalEntryStatus::Skipped
+                )
+            });
+
+            (self.persist)(&journal)
+        };
+
+        match persist_result {
+            Ok(()) => {
+                *self
+                    .last_error
+                    .lock()
+                    .expect("sync journal observer error mutex poisoned") = None;
+            }
+            Err(error) => {
+                *self
+                    .last_error
+                    .lock()
+                    .expect("sync journal observer error mutex poisoned") = Some(error);
+            }
+        }
+    }
+}
 
 /// Aggregates the final metrics snapshot for later inspection. Used by tests
 /// today and by `PD-BENCH-1` to read run totals without an `AppHandle`.
@@ -103,7 +289,7 @@ impl DagObserver for CollectingDagObserver {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Arc;
+    use crate::sync::{CompareDirection, RetryPolicy, SyncJournalEntry, VerifyPolicy};
 
     #[test]
     fn noop_observer_is_object_safe_and_silent() {
@@ -130,5 +316,156 @@ mod tests {
         assert_eq!(obs.scan_progress_calls(), 2);
         assert_eq!(obs.last_scanned(), 40);
         assert_eq!(obs.metrics().range_fallbacks, 2);
+    }
+
+    fn test_journal() -> SyncJournal {
+        let mut journal = SyncJournal::new(
+            "/local".to_string(),
+            "/remote".to_string(),
+            CompareDirection::Bidirectional,
+            RetryPolicy::default(),
+            VerifyPolicy::SizeOnly,
+        );
+        journal.entries.push(SyncJournalEntry {
+            relative_path: "a.txt".to_string(),
+            action: "upload".to_string(),
+            status: JournalEntryStatus::Pending,
+            attempts: 1,
+            last_error: None,
+            verified: None,
+            bytes_transferred: 0,
+        });
+        journal.entries.push(SyncJournalEntry {
+            relative_path: "b.txt".to_string(),
+            action: "download".to_string(),
+            status: JournalEntryStatus::Pending,
+            attempts: 1,
+            last_error: None,
+            verified: None,
+            bytes_transferred: 0,
+        });
+        journal
+    }
+
+    #[test]
+    fn sync_journal_observer_persists_terminal_completion() {
+        let journal = Arc::new(Mutex::new(test_journal()));
+        let persisted = Arc::new(Mutex::new(Vec::new()));
+        let persist: Arc<PersistSyncJournal> = {
+            let persisted = Arc::clone(&persisted);
+            Arc::new(move |journal| {
+                persisted
+                    .lock()
+                    .expect("persisted mutex poisoned")
+                    .push(journal.clone());
+                Ok(())
+            })
+        };
+        let observer = SyncJournalDagObserver::with_persist(
+            Arc::clone(&journal),
+            vec![SyncJournalTerminal::with_result(42, 0, 123, true)],
+            persist,
+        );
+
+        observer.on_node_complete(42, ObservedOutcome::Completed);
+
+        let journal = journal.lock().expect("journal mutex poisoned");
+        assert_eq!(journal.entries[0].status, JournalEntryStatus::Completed);
+        assert_eq!(journal.entries[0].bytes_transferred, 123);
+        assert_eq!(journal.entries[0].verified, Some(true));
+        assert!(!journal.completed, "second entry is still pending");
+
+        let snapshots = persisted.lock().expect("persisted mutex poisoned");
+        assert_eq!(snapshots.len(), 1);
+        assert_eq!(
+            snapshots[0].entries[0].status,
+            JournalEntryStatus::Completed
+        );
+    }
+
+    #[test]
+    fn sync_journal_observer_ignores_non_terminal_or_non_completed_nodes() {
+        let journal = Arc::new(Mutex::new(test_journal()));
+        let persist_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let persist: Arc<PersistSyncJournal> = {
+            let persist_calls = Arc::clone(&persist_calls);
+            Arc::new(move |_| {
+                persist_calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Ok(())
+            })
+        };
+        let observer = SyncJournalDagObserver::with_persist(
+            Arc::clone(&journal),
+            vec![SyncJournalTerminal::new(42, 0)],
+            persist,
+        );
+
+        observer.on_node_complete(41, ObservedOutcome::Completed);
+        observer.on_node_complete(42, ObservedOutcome::Failed);
+
+        assert_eq!(
+            journal.lock().expect("journal mutex poisoned").entries[0].status,
+            JournalEntryStatus::Pending
+        );
+        assert_eq!(persist_calls.load(std::sync::atomic::Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn sync_journal_observer_records_persist_error() {
+        let journal = Arc::new(Mutex::new(test_journal()));
+        let observer = SyncJournalDagObserver::with_persist(
+            journal,
+            vec![SyncJournalTerminal::new(42, 0)],
+            Arc::new(|_| Err("disk full".to_string())),
+        );
+
+        observer.on_node_complete(42, ObservedOutcome::Completed);
+
+        assert_eq!(observer.last_error(), Some("disk full".to_string()));
+    }
+
+    struct TraceObserver {
+        trace: Arc<Mutex<Vec<&'static str>>>,
+        label: &'static str,
+    }
+
+    impl DagObserver for TraceObserver {
+        fn on_node_complete(&self, _node_id: usize, _outcome: ObservedOutcome) {
+            self.trace
+                .lock()
+                .expect("trace mutex poisoned")
+                .push(self.label);
+        }
+    }
+
+    #[test]
+    fn ordered_observer_preserves_journal_before_visible_completion() {
+        let trace = Arc::new(Mutex::new(Vec::new()));
+        let journal = Arc::new(Mutex::new(test_journal()));
+        let persist: Arc<PersistSyncJournal> = {
+            let trace = Arc::clone(&trace);
+            Arc::new(move |_| {
+                trace.lock().expect("trace mutex poisoned").push("journal");
+                Ok(())
+            })
+        };
+        let journal_observer: Arc<dyn DagObserver> =
+            Arc::new(SyncJournalDagObserver::with_persist(
+                journal,
+                vec![SyncJournalTerminal::new(42, 0)],
+                persist,
+            ));
+        let visible_observer: Arc<dyn DagObserver> = Arc::new(TraceObserver {
+            trace: Arc::clone(&trace),
+            label: "visible",
+        });
+        let ordered = OrderedDagObserver::new(vec![journal_observer, visible_observer]);
+
+        ordered.on_node_complete(42, ObservedOutcome::Completed);
+
+        assert_eq!(
+            trace.lock().expect("trace mutex poisoned").as_slice(),
+            ["journal", "visible"]
+        );
     }
 }

--- a/src-tauri/src/transfer_dag/probe.rs
+++ b/src-tauri/src/transfer_dag/probe.rs
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+//! Session-scoped probe cache for [`Capability::SupportedAfterProbe`].
+//!
+//! Some capabilities cannot be answered from static provider metadata: WebDAV
+//! and Koofr advertise range download only `SupportedAfterProbe`, because the
+//! honest answer needs a one-byte `Range` request against the live server.
+//!
+//! Re-probing once per file in a 100-file transfer would add 100 wasted round
+//! trips. [`SessionProbeCache`] memoises each probe by key for the lifetime of
+//! one transfer session: the probe closure runs at most once per key even when
+//! many file graphs resolve the same capability concurrently, because every
+//! key is backed by a [`tokio::sync::OnceCell`].
+//!
+//! The cache is deliberately provider-free: it stores only `bool` results
+//! against opaque string keys, so the builder and the runner can share it
+//! without the graph engine depending on any provider type.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::sync::{Arc, Mutex};
+
+use tokio::sync::OnceCell;
+
+use super::capabilities::Capability;
+
+/// Memoises capability probe results for one transfer session.
+///
+/// Construct one [`SessionProbeCache`] per session, share it as `Arc`, and
+/// resolve every `SupportedAfterProbe` capability through it. Distinct keys
+/// probe independently; the same key probes exactly once.
+#[derive(Default)]
+pub struct SessionProbeCache {
+    cells: Mutex<HashMap<String, Arc<OnceCell<bool>>>>,
+}
+
+impl SessionProbeCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The `OnceCell` for `key`, created on first use.
+    fn cell(&self, key: &str) -> Arc<OnceCell<bool>> {
+        let mut cells = self.cells.lock().expect("probe cache mutex poisoned");
+        Arc::clone(
+            cells
+                .entry(key.to_string())
+                .or_insert_with(|| Arc::new(OnceCell::new())),
+        )
+    }
+
+    /// Resolve `key`, running `probe` at most once for the session.
+    ///
+    /// Concurrent callers for the same key all observe the single result: the
+    /// first to arrive runs `probe`, the rest await its completion. A later
+    /// call returns the cached value without touching `probe` at all.
+    pub async fn resolve<F, Fut>(&self, key: &str, probe: F) -> bool
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = bool>,
+    {
+        let cell = self.cell(key);
+        *cell.get_or_init(probe).await
+    }
+
+    /// Resolve a [`Capability`] to a concrete `bool`.
+    ///
+    /// `Supported` and `Experimental` are available without a probe;
+    /// `Unsupported` is not; only `SupportedAfterProbe` runs (and caches) the
+    /// `probe` closure. `probe` is never even constructed by the caller's hot
+    /// path when the capability is statically known — pass it as a closure.
+    pub async fn resolve_capability<F, Fut>(
+        &self,
+        key: &str,
+        capability: Capability,
+        probe: F,
+    ) -> bool
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = bool>,
+    {
+        match capability {
+            Capability::Supported | Capability::Experimental => true,
+            Capability::Unsupported => false,
+            Capability::SupportedAfterProbe => self.resolve(key, probe).await,
+        }
+    }
+
+    /// Number of distinct keys probed so far. Diagnostic only.
+    pub fn probed_keys(&self) -> usize {
+        self.cells
+            .lock()
+            .expect("probe cache mutex poisoned")
+            .values()
+            .filter(|cell| cell.initialized())
+            .count()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[tokio::test]
+    async fn resolve_runs_the_probe_exactly_once_under_concurrency() {
+        let cache = Arc::new(SessionProbeCache::new());
+        let runs = Arc::new(AtomicUsize::new(0));
+
+        let mut tasks = Vec::new();
+        for _ in 0..16 {
+            let cache = Arc::clone(&cache);
+            let runs = Arc::clone(&runs);
+            tasks.push(tokio::spawn(async move {
+                cache
+                    .resolve("webdav:range", || async move {
+                        runs.fetch_add(1, Ordering::SeqCst);
+                        tokio::task::yield_now().await;
+                        true
+                    })
+                    .await
+            }));
+        }
+
+        for task in tasks {
+            assert!(task.await.unwrap(), "every caller sees the probe result");
+        }
+        assert_eq!(
+            runs.load(Ordering::SeqCst),
+            1,
+            "16 concurrent callers must trigger exactly one probe"
+        );
+        assert_eq!(cache.probed_keys(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_later_call_returns_the_cached_value_without_probing() {
+        let cache = SessionProbeCache::new();
+        let runs = AtomicUsize::new(0);
+
+        let first = cache
+            .resolve("k", || async {
+                runs.fetch_add(1, Ordering::SeqCst);
+                false
+            })
+            .await;
+        let second = cache
+            .resolve("k", || async {
+                runs.fetch_add(1, Ordering::SeqCst);
+                true // a different result the cache must never reach
+            })
+            .await;
+
+        assert!(!first);
+        assert!(!second, "the cached false wins over the second closure");
+        assert_eq!(runs.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn distinct_keys_probe_independently() {
+        let cache = SessionProbeCache::new();
+        let runs = AtomicUsize::new(0);
+
+        for key in ["a", "b", "c"] {
+            cache
+                .resolve(key, || async {
+                    runs.fetch_add(1, Ordering::SeqCst);
+                    true
+                })
+                .await;
+        }
+
+        assert_eq!(runs.load(Ordering::SeqCst), 3);
+        assert_eq!(cache.probed_keys(), 3);
+    }
+
+    #[tokio::test]
+    async fn resolve_capability_short_circuits_static_capabilities() {
+        let cache = SessionProbeCache::new();
+        let probe_ran = AtomicUsize::new(0);
+        let probe = || async {
+            probe_ran.fetch_add(1, Ordering::SeqCst);
+            true
+        };
+
+        assert!(
+            cache
+                .resolve_capability("k1", Capability::Supported, probe)
+                .await
+        );
+        assert!(
+            cache
+                .resolve_capability("k2", Capability::Experimental, || async { false })
+                .await
+        );
+        assert!(
+            !cache
+                .resolve_capability("k3", Capability::Unsupported, || async { true })
+                .await
+        );
+        assert_eq!(
+            probe_ran.load(Ordering::SeqCst),
+            0,
+            "static capabilities never construct or run the probe"
+        );
+        assert_eq!(cache.probed_keys(), 0);
+    }
+
+    #[tokio::test]
+    async fn resolve_capability_probes_only_for_supported_after_probe() {
+        let cache = SessionProbeCache::new();
+        let probe_ran = AtomicUsize::new(0);
+
+        let resolved = cache
+            .resolve_capability("webdav:range", Capability::SupportedAfterProbe, || async {
+                probe_ran.fetch_add(1, Ordering::SeqCst);
+                true
+            })
+            .await;
+
+        assert!(resolved);
+        assert_eq!(probe_ran.load(Ordering::SeqCst), 1);
+    }
+}

--- a/src-tauri/src/transfer_dag_batch.rs
+++ b/src-tauri/src/transfer_dag_batch.rs
@@ -1,0 +1,584 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+//! DAG-ENGINE phase 2: the multi-file batch transfer path through `execute_dag`.
+//!
+//! [`crate::transfer_orchestrator::execute_batch`] is the single chokepoint
+//! for every multi-file transfer in the app: GUI drag&drop, GUI file-list
+//! batch operations, the FTP batch path in `lib.rs`, the CLI file-level batch,
+//! and cross-profile transfers. This module is the flag-gated bridge that
+//! routes that one chokepoint through the shared graph engine instead of the
+//! hand-rolled `JoinSet` sliding window.
+//!
+//! ## Scope
+//!
+//! [`execute_batch_dag`] builds one [`BatchDag`](crate::transfer_dag::BatchDag)
+//! from the batch entries (one seven-node single-file sub-DAG per file) and
+//! runs it through [`execute_dag`]. The graph's single
+//! [`TransferResourceManager`] is the only file-level concurrency governor, so
+//! `max_concurrent` flows in through `TransferBatchConfig::transfer_budget()`
+//! exactly as the legacy path consumes it (F2-T03).
+//!
+//! The real per-file I/O is unchanged: every transfer node calls the same
+//! [`TransferExecutor::execute_with_session`] the legacy path called, holding
+//! the same per-file session lease from the same `executor.session_pool(..)`.
+//! Only the *scheduling* moves onto the graph; the bytes on the wire and the
+//! emitted `transfer_batch_*` events are byte-identical.
+//!
+//! ## Byte-identical contract
+//!
+//! - `emit_batch_started` / `emit_batch_progress` (one per transferred file) /
+//!   `emit_batch_completed` are emitted with the same payloads as the legacy
+//!   orchestrator.
+//! - A failed file does NOT abort the batch. The legacy executor records the
+//!   failure in the progress snapshot and proceeds to the next entry, so each
+//!   transfer node always reports [`NodeOutcome::Completed`] to the graph
+//!   executor; the failure lives only in the [`BatchProgressSnapshot`].
+//! - Cancellation leaves the remaining files untouched and unaccounted,
+//!   mirroring the legacy task that returns early after `cancel` is observed.
+//!
+//! ## Feature flag
+//!
+//! Gated by [`dag_batch_enabled`], read from [`DAG_BATCH_ENV`], default OFF.
+//! With the flag off, not one byte of this module executes and `execute_batch`
+//! runs its legacy path verbatim. The flag is a runtime toggle (not a
+//! recompile) so the parity harness can measure flag-OFF vs flag-ON in a
+//! single build, the same pattern as the phase-1 single-file flag.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Instant;
+
+use tokio::sync::Mutex;
+
+use crate::transfer_dag::executor::{execute_dag, DagNodeRunner, NodeFuture, NodeOutcome};
+use crate::transfer_dag::graph::{TransferNode, TransferNodeKind};
+use crate::transfer_dag::{
+    AimdConfig, AimdController, BatchDagItem, DagObserver, NoopDagObserver, TransferDagBuilder,
+    TransferDirection, TransferResourceManager,
+};
+use crate::transfer_domain::{
+    BatchProgressSnapshot, TransferBatchResult, TransferDirection as DomainTransferDirection,
+    TransferOutcome,
+};
+use crate::transfer_event_sink::TransferEventSink;
+use crate::transfer_orchestrator::{ProgressObserver, TransferBatch, TransferExecutor};
+
+/// Environment variable that gates the phase-2 batch DAG path.
+///
+/// Recognised truthy values (case-insensitive, trimmed): `1`, `true`, `on`,
+/// `yes`. Anything else, including an unset variable, leaves the path OFF.
+pub const DAG_BATCH_ENV: &str = "AEROFTP_TRANSFER_ENGINE_DAG_BATCH";
+
+/// Returns `true` when the batch DAG path is enabled for this process.
+///
+/// Default OFF: a phased migration enters production behind a flag so a
+/// rollback is a toggle, never a revert (DAG-ENGINE plan, principle 2).
+pub fn dag_batch_enabled() -> bool {
+    std::env::var(DAG_BATCH_ENV)
+        .ok()
+        .map(|raw| flag_value_is_on(&raw))
+        .unwrap_or(false)
+}
+
+/// Parses one environment-variable value into the on/off flag state.
+fn flag_value_is_on(raw: &str) -> bool {
+    matches!(
+        raw.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "on" | "yes"
+    )
+}
+
+/// Run a multi-file batch transfer through the graph engine.
+///
+/// A drop-in replacement for [`crate::transfer_orchestrator::execute_batch`]:
+/// same arguments, same [`TransferBatchResult`]. Reached only with the
+/// [`DAG_BATCH_ENV`] flag on; the legacy `JoinSet` path is untouched and stays
+/// the default.
+pub async fn execute_batch_dag<E>(
+    sink: Arc<dyn TransferEventSink>,
+    batch: TransferBatch,
+    executor: Arc<E>,
+    cancel: Arc<AtomicBool>,
+    progress_observer: Option<ProgressObserver>,
+) -> TransferBatchResult
+where
+    E: TransferExecutor + Send + Sync + 'static,
+{
+    let started_at = Instant::now();
+    let TransferBatch {
+        id,
+        display_name,
+        direction,
+        config,
+        entries,
+    } = batch;
+    let total = entries.len() as u32;
+    let dag_direction = match direction {
+        DomainTransferDirection::Download => TransferDirection::Download,
+        DomainTransferDirection::Upload => TransferDirection::Upload,
+    };
+
+    sink.emit_batch_started(serde_json::json!({
+        "batch_id": id,
+        "display_name": display_name,
+        "direction": direction,
+        "total": total,
+    }));
+
+    let progress = Arc::new(Mutex::new(BatchProgressSnapshot {
+        total,
+        bytes_total: entries.iter().map(|entry| entry.size).sum(),
+        ..BatchProgressSnapshot::default()
+    }));
+
+    // One seven-node single-file sub-DAG per entry, merged into one graph.
+    let items: Vec<BatchDagItem> = entries
+        .iter()
+        .map(|entry| BatchDagItem::new(entry.id.clone(), dag_direction))
+        .collect();
+    let built = TransferDagBuilder::from_batch(&items);
+
+    // The builder preserves entry order, so `built.files[i]` is `entries[i]`.
+    // Map the per-file transfer node id back to its entry index.
+    let mut node_to_entry: HashMap<usize, usize> = HashMap::with_capacity(built.files.len());
+    for (index, file) in built.files.iter().enumerate() {
+        node_to_entry.insert(file.transfer, index);
+    }
+
+    let entries = Arc::new(entries);
+    let node_to_entry = Arc::new(node_to_entry);
+    let max_concurrent = config.max_concurrent.max(1) as usize;
+    let session_pool = Arc::new(executor.session_pool(max_concurrent));
+    let resource_manager = TransferResourceManager::new(config.transfer_budget());
+
+    // AIMD backpressure (F3-T05). The controller's File ceiling is the batch
+    // `file_slots` budget and starts there, so a congestion-free batch
+    // dispatches every file exactly as before; when a file fails with a
+    // genuine congestion signal the File dispatch target halves, throttling
+    // the remaining files instead of hammering an overloaded server.
+    let aimd = Arc::new(AimdController::from_budget(
+        &resource_manager.budget(),
+        AimdConfig::default(),
+    ));
+
+    let runner: Arc<dyn DagNodeRunner> = {
+        let sink = Arc::clone(&sink);
+        let executor = Arc::clone(&executor);
+        let cancel = Arc::clone(&cancel);
+        let progress = Arc::clone(&progress);
+        let entries = Arc::clone(&entries);
+        let node_to_entry = Arc::clone(&node_to_entry);
+        let session_pool = Arc::clone(&session_pool);
+        Arc::new(move |node: TransferNode| -> NodeFuture {
+            let sink = Arc::clone(&sink);
+            let executor = Arc::clone(&executor);
+            let cancel = Arc::clone(&cancel);
+            let progress = Arc::clone(&progress);
+            let progress_observer = progress_observer.clone();
+            let entries = Arc::clone(&entries);
+            let node_to_entry = Arc::clone(&node_to_entry);
+            let session_pool = Arc::clone(&session_pool);
+            Box::pin(async move {
+                // Only the real transfer node does I/O; every structural node
+                // (discover / acquire / verify / preserve / commit / emit) is
+                // a no-op anchor, exactly like the single-file bridge.
+                if !matches!(
+                    node.kind,
+                    TransferNodeKind::DownloadFile | TransferNodeKind::UploadFile
+                ) {
+                    return NodeOutcome::Completed;
+                }
+                let Some(&entry_index) = node_to_entry.get(&node.id) else {
+                    return NodeOutcome::Completed;
+                };
+                let entry = entries[entry_index].clone();
+
+                // Cancellation: a cancelled batch leaves the remaining files
+                // untouched and unaccounted, mirroring the legacy task that
+                // returns early. The node still completes so the graph drains.
+                if cancel.load(Ordering::Relaxed) {
+                    return NodeOutcome::Completed;
+                }
+
+                let session_lease = match session_pool.acquire().await {
+                    Ok(lease) => lease,
+                    Err(error) => {
+                        tracing::warn!("Transfer session acquisition failed: {}", error);
+                        return NodeOutcome::Completed;
+                    }
+                };
+
+                if cancel.load(Ordering::Relaxed) {
+                    return NodeOutcome::Completed;
+                }
+
+                {
+                    let mut snapshot = progress.lock().await;
+                    snapshot.active += 1;
+                }
+
+                let outcome = executor
+                    .execute_with_session(entry.clone(), session_lease)
+                    .await;
+
+                let snapshot_clone = {
+                    let mut snapshot = progress.lock().await;
+                    snapshot.active = snapshot.active.saturating_sub(1);
+                    match &outcome {
+                        TransferOutcome::Success => {
+                            snapshot.completed += 1;
+                            snapshot.bytes_transferred += entry.size;
+                        }
+                        TransferOutcome::Skipped { .. } => {
+                            snapshot.skipped += 1;
+                        }
+                        TransferOutcome::Failed(_) => {
+                            snapshot.failed += 1;
+                        }
+                    }
+                    snapshot.clone()
+                };
+
+                sink.emit_batch_progress(&snapshot_clone);
+                if let Some(observer) = progress_observer {
+                    observer(snapshot_clone);
+                }
+
+                // A failed file must NOT abort the batch: the legacy executor
+                // records the failure and proceeds to the next entry. The node
+                // therefore always reports Completed; the failure lives only in
+                // the progress snapshot.
+                NodeOutcome::Completed
+            })
+        })
+    };
+
+    let observer: Arc<dyn DagObserver> = Arc::new(NoopDagObserver);
+    if let Err(error) =
+        execute_dag(&built.dag, &resource_manager, runner, observer, Some(aimd)).await
+    {
+        // The runner never returns Failed, so a graph error here means an
+        // executor-level fault (panic, semaphore closed). Surface it and still
+        // build the honest result from whatever the snapshot recorded.
+        tracing::warn!("Batch transfer graph stopped early: {}", error);
+    }
+
+    let snapshot = progress.lock().await.clone();
+    let batch_result = TransferBatchResult {
+        completed: snapshot.completed,
+        skipped: snapshot.skipped,
+        failed: snapshot.failed,
+        total: snapshot.total,
+        cancelled: cancel.load(Ordering::Relaxed),
+        duration_ms: started_at.elapsed().as_millis() as u64,
+    };
+
+    sink.emit_batch_completed(&batch_result);
+
+    batch_result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transfer_dag::TransferSessionPoolHandle;
+    use crate::transfer_domain::{
+        TransferBatchConfig, TransferEntry, TransferFailure, TransferFailureKind,
+    };
+    use crate::TransferEvent;
+    use async_trait::async_trait;
+    use std::collections::HashSet;
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+    use std::sync::Mutex as StdMutex;
+    use std::time::Duration;
+
+    #[test]
+    fn flag_recognises_truthy_values_case_insensitively() {
+        for on in ["1", "true", "TRUE", "On", "yes", " yes ", "Yes"] {
+            assert!(flag_value_is_on(on), "{on:?} must be on");
+        }
+    }
+
+    #[test]
+    fn flag_rejects_falsey_and_garbage_values() {
+        for off in ["0", "false", "off", "no", "", "  ", "enabled", "2", "y"] {
+            assert!(!flag_value_is_on(off), "{off:?} must be off");
+        }
+    }
+
+    #[test]
+    fn flag_is_off_when_env_is_unset() {
+        std::env::remove_var(DAG_BATCH_ENV);
+        assert!(!dag_batch_enabled());
+    }
+
+    /// A `TransferExecutor` whose outcome per entry is scripted, with peak
+    /// concurrency tracking and a configurable session-pool capacity.
+    struct MockExecutor {
+        fail: HashSet<String>,
+        skip: HashSet<String>,
+        executed: StdMutex<Vec<String>>,
+        in_flight: AtomicUsize,
+        peak: AtomicUsize,
+        session_capacity: usize,
+    }
+
+    impl MockExecutor {
+        fn new(session_capacity: usize) -> Self {
+            Self {
+                fail: HashSet::new(),
+                skip: HashSet::new(),
+                executed: StdMutex::new(Vec::new()),
+                in_flight: AtomicUsize::new(0),
+                peak: AtomicUsize::new(0),
+                session_capacity,
+            }
+        }
+
+        fn executed(&self) -> Vec<String> {
+            self.executed.lock().unwrap().clone()
+        }
+
+        fn peak(&self) -> usize {
+            self.peak.load(AtomicOrdering::SeqCst)
+        }
+    }
+
+    #[async_trait]
+    impl TransferExecutor for MockExecutor {
+        async fn execute(&self, entry: TransferEntry) -> TransferOutcome {
+            let now = self.in_flight.fetch_add(1, AtomicOrdering::SeqCst) + 1;
+            self.peak.fetch_max(now, AtomicOrdering::SeqCst);
+            tokio::time::sleep(Duration::from_millis(15)).await;
+            self.in_flight.fetch_sub(1, AtomicOrdering::SeqCst);
+            self.executed.lock().unwrap().push(entry.id.clone());
+
+            if self.fail.contains(&entry.id) {
+                TransferOutcome::Failed(TransferFailure {
+                    kind: TransferFailureKind::Unknown,
+                    message: "mock failure".to_string(),
+                    retryable: false,
+                })
+            } else if self.skip.contains(&entry.id) {
+                TransferOutcome::Skipped {
+                    reason: "mock skip".to_string(),
+                }
+            } else {
+                TransferOutcome::Success
+            }
+        }
+
+        fn session_pool(&self, max_concurrent: usize) -> TransferSessionPoolHandle {
+            TransferSessionPoolHandle::http_clone(
+                "mock",
+                self.session_capacity.min(max_concurrent).max(1),
+            )
+        }
+    }
+
+    /// A sink that counts the three batch-lifecycle events.
+    #[derive(Default)]
+    struct CountingSink {
+        started: AtomicUsize,
+        progress: AtomicUsize,
+        completed: AtomicUsize,
+    }
+
+    impl TransferEventSink for CountingSink {
+        fn emit_transfer_event(&self, _event: TransferEvent) {}
+        fn emit_batch_started(&self, _payload: serde_json::Value) {
+            self.started.fetch_add(1, AtomicOrdering::SeqCst);
+        }
+        fn emit_batch_progress(&self, _snapshot: &BatchProgressSnapshot) {
+            self.progress.fetch_add(1, AtomicOrdering::SeqCst);
+        }
+        fn emit_batch_completed(&self, _result: &TransferBatchResult) {
+            self.completed.fetch_add(1, AtomicOrdering::SeqCst);
+        }
+    }
+
+    fn entry(id: &str, size: u64) -> TransferEntry {
+        TransferEntry {
+            id: id.to_string(),
+            display_name: id.to_string(),
+            remote_path: format!("/remote/{id}"),
+            local_path: format!("/local/{id}"),
+            size,
+            modified: None,
+        }
+    }
+
+    fn batch(entries: Vec<TransferEntry>, max_concurrent: u32) -> TransferBatch {
+        TransferBatch {
+            id: "batch-1".to_string(),
+            display_name: "Test batch".to_string(),
+            direction: DomainTransferDirection::Download,
+            config: TransferBatchConfig {
+                max_concurrent,
+                max_retries: 0,
+                timeout_ms: 30_000,
+            },
+            entries,
+        }
+    }
+
+    #[tokio::test]
+    async fn batch_dag_executes_every_entry_and_counts_outcomes() {
+        let mut executor = MockExecutor::new(1);
+        executor.fail.insert("c".to_string());
+        executor.skip.insert("b".to_string());
+        let executor = Arc::new(executor);
+        let sink = Arc::new(CountingSink::default());
+
+        let result = execute_batch_dag(
+            Arc::clone(&sink) as Arc<dyn TransferEventSink>,
+            batch(vec![entry("a", 100), entry("b", 200), entry("c", 300)], 1),
+            Arc::clone(&executor),
+            Arc::new(AtomicBool::new(false)),
+            None,
+        )
+        .await;
+
+        assert_eq!(result.total, 3);
+        assert_eq!(result.completed, 1);
+        assert_eq!(result.skipped, 1);
+        assert_eq!(result.failed, 1);
+        assert!(!result.cancelled);
+        assert_eq!(executor.executed().len(), 3);
+        // Lifecycle events: one start, one completed, one progress per file.
+        assert_eq!(sink.started.load(AtomicOrdering::SeqCst), 1);
+        assert_eq!(sink.completed.load(AtomicOrdering::SeqCst), 1);
+        assert_eq!(sink.progress.load(AtomicOrdering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn batch_dag_failed_file_does_not_abort_remaining() {
+        let mut executor = MockExecutor::new(1);
+        // The first entry fails; the remaining two must still transfer.
+        executor.fail.insert("first".to_string());
+        let executor = Arc::new(executor);
+
+        let result = execute_batch_dag(
+            Arc::new(CountingSink::default()) as Arc<dyn TransferEventSink>,
+            batch(
+                vec![entry("first", 10), entry("second", 20), entry("third", 30)],
+                1,
+            ),
+            Arc::clone(&executor),
+            Arc::new(AtomicBool::new(false)),
+            None,
+        )
+        .await;
+
+        assert_eq!(result.failed, 1);
+        assert_eq!(result.completed, 2);
+        let executed = executor.executed();
+        assert_eq!(executed.len(), 3, "a failed file must not abort the batch");
+        assert!(executed.contains(&"second".to_string()));
+        assert!(executed.contains(&"third".to_string()));
+    }
+
+    #[tokio::test]
+    async fn batch_dag_respects_file_slot_concurrency() {
+        // file_slots = 2 (from max_concurrent), session pool wide enough: the
+        // graph's resource manager is the binding limit, peak must be 2.
+        let executor = Arc::new(MockExecutor::new(8));
+        let result = execute_batch_dag(
+            Arc::new(CountingSink::default()) as Arc<dyn TransferEventSink>,
+            batch(
+                vec![entry("a", 1), entry("b", 1), entry("c", 1), entry("d", 1)],
+                2,
+            ),
+            Arc::clone(&executor),
+            Arc::new(AtomicBool::new(false)),
+            None,
+        )
+        .await;
+
+        assert_eq!(result.completed, 4);
+        assert_eq!(executor.peak(), 2, "file_slots=2 must cap concurrency at 2");
+    }
+
+    #[tokio::test]
+    async fn batch_dag_serializes_when_one_file_slot() {
+        let executor = Arc::new(MockExecutor::new(8));
+        let result = execute_batch_dag(
+            Arc::new(CountingSink::default()) as Arc<dyn TransferEventSink>,
+            batch(vec![entry("a", 1), entry("b", 1), entry("c", 1)], 1),
+            Arc::clone(&executor),
+            Arc::new(AtomicBool::new(false)),
+            None,
+        )
+        .await;
+
+        assert_eq!(result.completed, 3);
+        assert_eq!(executor.peak(), 1, "file_slots=1 must force serialization");
+    }
+
+    #[tokio::test]
+    async fn batch_dag_cancellation_skips_transfers() {
+        let executor = Arc::new(MockExecutor::new(1));
+        let result = execute_batch_dag(
+            Arc::new(CountingSink::default()) as Arc<dyn TransferEventSink>,
+            batch(vec![entry("a", 1), entry("b", 1)], 1),
+            Arc::clone(&executor),
+            Arc::new(AtomicBool::new(true)),
+            None,
+        )
+        .await;
+
+        assert!(result.cancelled);
+        assert_eq!(result.completed, 0);
+        assert_eq!(result.failed, 0);
+        assert!(
+            executor.executed().is_empty(),
+            "a pre-cancelled batch transfers nothing"
+        );
+    }
+
+    #[tokio::test]
+    async fn batch_dag_empty_batch_emits_lifecycle_and_zero_result() {
+        let executor = Arc::new(MockExecutor::new(1));
+        let sink = Arc::new(CountingSink::default());
+        let result = execute_batch_dag(
+            Arc::clone(&sink) as Arc<dyn TransferEventSink>,
+            batch(vec![], 1),
+            Arc::clone(&executor),
+            Arc::new(AtomicBool::new(false)),
+            None,
+        )
+        .await;
+
+        assert_eq!(result.total, 0);
+        assert_eq!(result.completed, 0);
+        assert!(executor.executed().is_empty());
+        assert_eq!(sink.started.load(AtomicOrdering::SeqCst), 1);
+        assert_eq!(sink.completed.load(AtomicOrdering::SeqCst), 1);
+        assert_eq!(sink.progress.load(AtomicOrdering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn batch_dag_progress_observer_fires_once_per_file() {
+        let executor = Arc::new(MockExecutor::new(1));
+        let observed = Arc::new(AtomicUsize::new(0));
+        let progress_observer: ProgressObserver = {
+            let observed = Arc::clone(&observed);
+            Arc::new(move |_snapshot| {
+                observed.fetch_add(1, AtomicOrdering::SeqCst);
+            })
+        };
+
+        execute_batch_dag(
+            Arc::new(CountingSink::default()) as Arc<dyn TransferEventSink>,
+            batch(vec![entry("a", 1), entry("b", 1)], 1),
+            Arc::clone(&executor),
+            Arc::new(AtomicBool::new(false)),
+            Some(progress_observer),
+        )
+        .await;
+
+        assert_eq!(observed.load(AtomicOrdering::SeqCst), 2);
+    }
+}

--- a/src-tauri/src/transfer_dag_single_file.rs
+++ b/src-tauri/src/transfer_dag_single_file.rs
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+//! DAG-ENGINE phase 1: the single-file transfer path through `execute_dag`.
+//!
+//! [`crate::transfer_dag`] is the pure, provider-free graph engine. This
+//! module is the thin provider-coupled bridge that binds the seven-node
+//! single-file graph produced by [`TransferDagBuilder::single_file`] to a real
+//! [`StorageProvider`]: it is the [`DagNodeRunner`] for the single-file shape.
+//!
+//! ## Scope
+//!
+//! Phase 1 routes the *plain classic single-file leaf* of a download or upload
+//! through the graph engine. It deliberately does NOT replace the delta,
+//! intra-file segmented, resume, or GitHub-commit paths: those keep their
+//! legacy code. The GUI ([`crate::provider_commands`]) and CLI (`aeroftp_cli`)
+//! entry points run their delta / segmented / resume logic exactly as before
+//! and hand only the plain leaf to [`execute_single_file_dag`]. The result is
+//! byte-identical: the same `provider.download` / `provider.upload` call, the
+//! same per-byte progress callback, behind a graph schedule.
+//!
+//! ## Feature flag
+//!
+//! The whole path is gated by [`dag_single_file_enabled`], read from the
+//! [`DAG_SINGLE_FILE_ENV`] environment variable, default OFF. With the flag
+//! off, not one byte of this module executes and the legacy path is verbatim.
+//! The flag is a runtime toggle (not a recompile) so the parity harness can
+//! measure flag-OFF vs flag-ON in a single build.
+//!
+//! ## Node bindings
+//!
+//! For the linear seven-node single-file graph the runner binds:
+//!
+//! - `DiscoverRemote` / `DiscoverLocal`: no-op. The transfer size is already
+//!   resolved by the shared legacy pre-DAG code; re-resolving it here would
+//!   add a wire round-trip and break the byte-identical-on-the-wire contract.
+//! - `AcquireResource`: no-op (phase 3 hooks the resume-checkpoint fetch).
+//! - `DownloadFile` / `UploadFile`: the one real I/O node. It carries the only
+//!   scarce resource and runs `provider.download` / `provider.upload` with the
+//!   caller's progress callback.
+//! - `VerifyChecksum`: no-op in phase 1 (the legacy single-file path does not
+//!   verify).
+//! - `PreserveMetadata`: restores the remote mtime on a downloaded file; a
+//!   no-op on the upload direction.
+//! - `CommitTemp`: no-op (the provider's own `.aerotmp` finalize is internal).
+//! - `EmitProgress`: no-op terminal node; its completion is the signal a
+//!   [`DagObserver`] maps onto the GUI "complete" event.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
+
+use tokio::sync::Mutex;
+
+use crate::providers::{ProviderError, StorageProvider};
+use crate::transfer_dag::executor::{execute_dag, DagNodeRunner, NodeFuture, NodeOutcome};
+use crate::transfer_dag::graph::{TransferNode, TransferNodeKind};
+use crate::transfer_dag::{
+    DagObserver, SingleFileDag, TransferBudget, TransferDirection, TransferResourceManager,
+};
+
+/// Environment variable that gates the phase-1 single-file DAG path.
+///
+/// Recognised truthy values (case-insensitive, trimmed): `1`, `true`, `on`,
+/// `yes`. Anything else, including an unset variable, leaves the path OFF.
+pub const DAG_SINGLE_FILE_ENV: &str = "AEROFTP_TRANSFER_ENGINE_DAG_SINGLE_FILE";
+
+/// A per-byte transfer progress callback, as accepted by
+/// [`StorageProvider::download`] / [`StorageProvider::upload`].
+pub type ProgressCallback = Box<dyn Fn(u64, u64) + Send>;
+
+/// The connected-provider handle shared between the GUI command state and the
+/// spawned DAG node tasks. `Option` because a session may be disconnected.
+pub type SharedProvider = Arc<Mutex<Option<Box<dyn StorageProvider>>>>;
+
+/// Returns `true` when the single-file DAG path is enabled for this process.
+///
+/// Default OFF: a phased migration enters production behind a flag so a
+/// rollback is a toggle, never a revert (DAG-ENGINE plan, principle 2).
+pub fn dag_single_file_enabled() -> bool {
+    std::env::var(DAG_SINGLE_FILE_ENV)
+        .ok()
+        .map(|raw| flag_value_is_on(&raw))
+        .unwrap_or(false)
+}
+
+/// Parses one environment-variable value into the on/off flag state.
+fn flag_value_is_on(raw: &str) -> bool {
+    matches!(
+        raw.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "on" | "yes"
+    )
+}
+
+/// Run a plain single-file transfer through the graph engine.
+///
+/// `built` is the seven-node graph from [`TransferDagBuilder::single_file`];
+/// the caller builds it once so it can also read `built.emit_progress` to
+/// construct an observer. `provider` is locked by the `DownloadFile` /
+/// `UploadFile` node from its spawned task: the caller MUST NOT hold a guard
+/// on the same mutex across this call or the node would deadlock.
+///
+/// On the download direction the actual on-disk size after a successful
+/// transfer is stored into `report_size` (the observer reports it in the
+/// completion event); on the upload direction `report_size` is left at the
+/// value the caller seeded it with. The typed [`ProviderError`] of a failed
+/// transfer is recovered and returned, so the caller keeps its exact error
+/// classification (CLI exit codes, GUI error strings) unchanged.
+#[allow(clippy::too_many_arguments)]
+pub async fn execute_single_file_dag(
+    built: &SingleFileDag,
+    provider: SharedProvider,
+    remote_path: String,
+    local_path: String,
+    modified: Option<String>,
+    progress_cb: Option<ProgressCallback>,
+    observer: Arc<dyn DagObserver>,
+    report_size: Arc<AtomicU64>,
+) -> Result<(), ProviderError> {
+    let direction = built.direction;
+    let remote: Arc<str> = Arc::from(remote_path.as_str());
+    let local: Arc<str> = Arc::from(local_path.as_str());
+    let modified: Option<Arc<str>> = modified.as_deref().map(Arc::from);
+    // The progress callback is consumed once, by the transfer node; the slot
+    // makes the runner closure `Fn` (it can hand the callback out without the
+    // closure itself being `FnOnce`).
+    let progress_slot: Arc<StdMutex<Option<ProgressCallback>>> =
+        Arc::new(StdMutex::new(progress_cb));
+    // The executor only surfaces a stringified `DagExecutionError`; the typed
+    // provider error is stashed here so the caller keeps exact error semantics.
+    let first_error: Arc<StdMutex<Option<ProviderError>>> = Arc::new(StdMutex::new(None));
+
+    let runner: Arc<dyn DagNodeRunner> = {
+        let provider = Arc::clone(&provider);
+        let remote = Arc::clone(&remote);
+        let local = Arc::clone(&local);
+        let modified = modified.clone();
+        let progress_slot = Arc::clone(&progress_slot);
+        let first_error = Arc::clone(&first_error);
+        let report_size = Arc::clone(&report_size);
+        Arc::new(move |node: TransferNode| -> NodeFuture {
+            let provider = Arc::clone(&provider);
+            let remote = Arc::clone(&remote);
+            let local = Arc::clone(&local);
+            let modified = modified.clone();
+            let progress_slot = Arc::clone(&progress_slot);
+            let first_error = Arc::clone(&first_error);
+            let report_size = Arc::clone(&report_size);
+            Box::pin(async move {
+                match node.kind {
+                    TransferNodeKind::DownloadFile => {
+                        let cb = progress_slot.lock().expect("progress slot poisoned").take();
+                        let mut guard = provider.lock().await;
+                        let Some(p) = guard.as_mut() else {
+                            return record_failure(
+                                &first_error,
+                                ProviderError::NotConnected,
+                            );
+                        };
+                        match p.download(&remote, &local, cb).await {
+                            Ok(()) => {
+                                // Report the real on-disk size; fall back to the
+                                // caller-seeded value if the stat fails.
+                                if let Ok(meta) = std::fs::metadata(&*local) {
+                                    report_size.store(meta.len(), Ordering::SeqCst);
+                                }
+                                NodeOutcome::Completed
+                            }
+                            Err(e) => record_failure(&first_error, e),
+                        }
+                    }
+                    TransferNodeKind::UploadFile => {
+                        let cb = progress_slot.lock().expect("progress slot poisoned").take();
+                        let mut guard = provider.lock().await;
+                        let Some(p) = guard.as_mut() else {
+                            return record_failure(
+                                &first_error,
+                                ProviderError::NotConnected,
+                            );
+                        };
+                        match p.upload(&local, &remote, cb).await {
+                            Ok(()) => NodeOutcome::Completed,
+                            Err(e) => record_failure(&first_error, e),
+                        }
+                    }
+                    TransferNodeKind::PreserveMetadata => {
+                        if direction == TransferDirection::Download {
+                            crate::preserve_remote_mtime(&local, modified.as_deref());
+                        }
+                        NodeOutcome::Completed
+                    }
+                    // DiscoverRemote / DiscoverLocal / AcquireResource /
+                    // VerifyChecksum / CommitTemp / EmitProgress: structural
+                    // anchors, no-ops in phase 1. A single-file graph never
+                    // produces any other kind.
+                    _ => NodeOutcome::Completed,
+                }
+            })
+        })
+    };
+
+    // A single-file transfer needs exactly one file slot; the other six nodes
+    // request nothing, so the graph cannot deadlock against its own budget.
+    let manager = TransferResourceManager::new(TransferBudget::from_file_slots(1));
+
+    match execute_dag(&built.dag, &manager, runner, observer, None).await {
+        Ok(_summary) => Ok(()),
+        Err(dag_err) => Err(first_error
+            .lock()
+            .expect("first-error slot poisoned")
+            .take()
+            .unwrap_or_else(|| ProviderError::TransferFailed(dag_err.to_string()))),
+    }
+}
+
+/// Stash the typed error for the caller and return the matching node failure.
+fn record_failure(
+    first_error: &Arc<StdMutex<Option<ProviderError>>>,
+    error: ProviderError,
+) -> NodeOutcome {
+    let message = error.to_string();
+    let mut slot = first_error.lock().expect("first-error slot poisoned");
+    if slot.is_none() {
+        *slot = Some(error);
+    }
+    NodeOutcome::Failed(message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flag_recognises_truthy_values_case_insensitively() {
+        for on in ["1", "true", "TRUE", "On", "yes", " yes ", "Yes"] {
+            assert!(flag_value_is_on(on), "{on:?} must be on");
+        }
+    }
+
+    #[test]
+    fn flag_rejects_falsey_and_garbage_values() {
+        for off in ["0", "false", "off", "no", "", "  ", "enabled", "2", "y"] {
+            assert!(!flag_value_is_on(off), "{off:?} must be off");
+        }
+    }
+
+    #[test]
+    fn flag_is_off_when_env_is_unset() {
+        // The test runner does not set the variable; default must be OFF.
+        std::env::remove_var(DAG_SINGLE_FILE_ENV);
+        assert!(!dag_single_file_enabled());
+    }
+}

--- a/src-tauri/src/transfer_dag_single_file.rs
+++ b/src-tauri/src/transfer_dag_single_file.rs
@@ -55,7 +55,8 @@ use crate::providers::{ProviderError, StorageProvider};
 use crate::transfer_dag::executor::{execute_dag, DagNodeRunner, NodeFuture, NodeOutcome};
 use crate::transfer_dag::graph::{TransferNode, TransferNodeKind};
 use crate::transfer_dag::{
-    DagObserver, SingleFileDag, TransferBudget, TransferDirection, TransferResourceManager,
+    AimdConfig, AimdController, DagObserver, SingleFileDag, TransferBudget, TransferDirection,
+    TransferResourceManager,
 };
 
 /// Environment variable that gates the phase-1 single-file DAG path.
@@ -151,10 +152,7 @@ pub async fn execute_single_file_dag(
                         let cb = progress_slot.lock().expect("progress slot poisoned").take();
                         let mut guard = provider.lock().await;
                         let Some(p) = guard.as_mut() else {
-                            return record_failure(
-                                &first_error,
-                                ProviderError::NotConnected,
-                            );
+                            return record_failure(&first_error, ProviderError::NotConnected);
                         };
                         match p.download(&remote, &local, cb).await {
                             Ok(()) => {
@@ -172,10 +170,7 @@ pub async fn execute_single_file_dag(
                         let cb = progress_slot.lock().expect("progress slot poisoned").take();
                         let mut guard = provider.lock().await;
                         let Some(p) = guard.as_mut() else {
-                            return record_failure(
-                                &first_error,
-                                ProviderError::NotConnected,
-                            );
+                            return record_failure(&first_error, ProviderError::NotConnected);
                         };
                         match p.upload(&local, &remote, cb).await {
                             Ok(()) => NodeOutcome::Completed,
@@ -202,7 +197,18 @@ pub async fn execute_single_file_dag(
     // request nothing, so the graph cannot deadlock against its own budget.
     let manager = TransferResourceManager::new(TransferBudget::from_file_slots(1));
 
-    match execute_dag(&built.dag, &manager, runner, observer, None).await {
+    // AIMD backpressure (F3-T05), wired on every DAG transfer surface for
+    // uniformity. The controller starts each class at its ceiling, so a
+    // congestion-free single-file transfer dispatches exactly as before; the
+    // File ceiling of 1 cannot shrink, so today this is structurally inert,
+    // but the Api class becomes live once a capability-shaped graph reserves
+    // an api slot on a rate-limited provider.
+    let aimd = Arc::new(AimdController::from_budget(
+        &manager.budget(),
+        AimdConfig::default(),
+    ));
+
+    match execute_dag(&built.dag, &manager, runner, observer, Some(aimd)).await {
         Ok(_summary) => Ok(()),
         Err(dag_err) => Err(first_error
             .lock()

--- a/src-tauri/src/transfer_dag_sync.rs
+++ b/src-tauri/src/transfer_dag_sync.rs
@@ -1,0 +1,985 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+//! DAG-ENGINE phase 2: the sync-session transfer path through `execute_dag`.
+//!
+//! [`crate::sync::sync_tree_core`] is the shared sync engine: the MCP
+//! `sync_tree` tool and the `sync_core` re-export both run through it. This
+//! module is the flag-gated bridge that routes that engine through the shared
+//! graph engine instead of its hand-rolled interleaved decide/perform loop.
+//!
+//! ## Shape of the sync graph
+//!
+//! A sync session has one global discovery prefix
+//! (`DiscoverLocal` + `DiscoverRemote` -> `Compare`) and one per-file transfer
+//! chain below `Compare` for every upload/download the plan resolved. The
+//! graph is static, so the scan and the compare must finish *before* the
+//! graph can be built: the discover/compare nodes are structural anchors,
+//! and the real scan happens in [`execute_sync_dag`]'s planning phase.
+//!
+//! ## What this actually buys
+//!
+//! A sync drives a single provider connection, so the per-file transfers are
+//! serial by nature (`file_slots = 1`). Routing them through the graph does
+//! not add transfer parallelism; it buys:
+//!
+//! - **Parallel discovery.** The local filesystem walk and the network-bound
+//!   remote scan overlap (blocking thread + provider task), instead of
+//!   running back to back. This is the one real throughput win.
+//! - **Structural uniformity** with the single-file (phase 1) and batch
+//!   (phase 2) graphs: one scheduler, one observability surface, and the
+//!   foundation phase 3 needs to make capability-aware nodes (server-side
+//!   copy, multipart, resume, AIMD) benefit sync for free.
+//! - **A provably non-mutating dry-run.** Dry-run never reaches this module:
+//!   the [`crate::sync::sync_tree_core`] guard excludes it, so the dry-run
+//!   plan output cannot build or execute a graph by construction.
+//!
+//! ## Byte-identical contract
+//!
+//! The per-file decisions are computed by the same pure `decide_upload` /
+//! `decide_download` the legacy core uses, from the same pre-transfer scan
+//! snapshots, so the plan is decision-equivalent. The real per-file I/O is
+//! the same `perform_upload` / `perform_download`, holding the same single
+//! delta-sync batch session across files.
+//!
+//! The contract is counter-based, the same precedent the phase-2 batch path
+//! set: identical [`SyncReport`] counters, the same set of `on_file_*` sink
+//! events (one per file), the same delta-batch session metrics, the same
+//! journal format. One deliberate, documented difference: skip events are
+//! emitted in the planning order up front, then the transfers, then the
+//! orphan deletes; the legacy core interleaves skips with transfers in scan
+//! order. Same events, same counts, grouped by phase instead of interleaved.
+//!
+//! ## Feature flag
+//!
+//! Gated by [`dag_sync_enabled`], read from [`DAG_SYNC_ENV`], default OFF.
+//! With the flag off, not one byte of this module executes and
+//! `sync_tree_core` runs its legacy path verbatim. The flag is a runtime
+//! toggle (not a recompile), the same pattern as the phase-1 single-file and
+//! phase-2 batch flags.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Instant;
+
+use tokio::sync::{mpsc, oneshot};
+
+use crate::delta_transport::DeltaBatch;
+use crate::providers::StorageProvider;
+use crate::sync::{
+    apply_sync_tree_outcome, decide_download, decide_upload, ensure_remote_dir, perform_download,
+    perform_local_delete, perform_remote_delete, perform_upload, DeltaPolicy, FileOutcome,
+    SyncDirection, SyncOptions, SyncPhase, SyncProgressSink, SyncReport, SyncTransferSpec,
+    SyncTreeAction,
+};
+use crate::sync_core::scan::{scan_local_tree, scan_remote_tree, LocalEntry, RemoteEntry};
+use crate::transfer_dag::executor::{execute_dag, DagNodeRunner, NodeFuture, NodeOutcome};
+use crate::transfer_dag::graph::{TransferNode, TransferNodeKind};
+use crate::transfer_dag::{
+    AimdConfig, AimdController, DagObserver, NoopDagObserver, SyncDagAction, SyncDagItem,
+    TransferBudget, TransferDagBuilder, TransferResourceManager,
+};
+
+/// Environment variable that gates the phase-2 sync DAG path.
+///
+/// Recognised truthy values (case-insensitive, trimmed): `1`, `true`, `on`,
+/// `yes`. Anything else, including an unset variable, leaves the path OFF.
+pub const DAG_SYNC_ENV: &str = "AEROFTP_TRANSFER_ENGINE_DAG_SYNC";
+
+/// Bounded capacity of the transfer-job channel. With `file_slots = 1` only
+/// one transfer node ever holds the slot, so at most one job is in flight;
+/// the buffer is pure headroom and the sender never blocks.
+const JOB_CHANNEL_CAPACITY: usize = 32;
+
+/// Returns `true` when the sync DAG path is enabled for this process.
+///
+/// Default OFF: a phased migration enters production behind a flag so a
+/// rollback is a toggle, never a revert (DAG-ENGINE plan, principle 2).
+pub fn dag_sync_enabled() -> bool {
+    std::env::var(DAG_SYNC_ENV)
+        .ok()
+        .map(|raw| flag_value_is_on(&raw))
+        .unwrap_or(false)
+}
+
+/// Whether a sync call should route through the graph engine.
+///
+/// `true` requires both the flag on and a non-dry-run sync. Dry-run always
+/// returns `false`: the dry-run plan must never build or execute a mutating
+/// graph, and gating it here makes that a structural guarantee rather than a
+/// convention buried in the executor.
+pub fn should_route_sync_to_dag(dry_run: bool) -> bool {
+    !dry_run && dag_sync_enabled()
+}
+
+/// Parses one environment-variable value into the on/off flag state.
+fn flag_value_is_on(raw: &str) -> bool {
+    matches!(
+        raw.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "on" | "yes"
+    )
+}
+
+/// One resolved transfer in a sync plan, in plan order.
+struct PlannedTransfer {
+    rel: String,
+    /// `"upload"` or `"download"`: the operation label the legacy core
+    /// passes to `apply_sync_tree_outcome`.
+    op: &'static str,
+    total: u64,
+    decision_policy: DeltaPolicy,
+}
+
+/// One resolved skip in a sync plan.
+struct PlannedSkip {
+    rel: String,
+    /// `"upload"` or `"download"`: the operation label, identical to the
+    /// legacy core's `apply_sync_tree_outcome` call for a skipped file.
+    apply_op: &'static str,
+    reason: String,
+    decision_policy: DeltaPolicy,
+}
+
+/// One resolved orphan deletion in a sync plan.
+struct PlannedDelete {
+    rel: String,
+    /// `"delete_remote"` or `"delete_local"`.
+    op: &'static str,
+}
+
+/// The fully resolved plan of a sync session, computed before any transfer.
+struct SyncDagPlan {
+    transfers: Vec<PlannedTransfer>,
+    skips: Vec<PlannedSkip>,
+    deletes: Vec<PlannedDelete>,
+}
+
+/// Resolve a sync session into an ordered plan from the pre-transfer scan
+/// snapshots.
+///
+/// This mirrors the two-pass structure of [`crate::sync::sync_tree_core`]
+/// (upload pass over `locals`, download pass over `remotes`, then orphan
+/// deletes) but collects the decisions instead of performing them inline.
+/// The decision functions `decide_upload` / `decide_download` are pure and
+/// read only the scan snapshots, so collecting the whole plan up front is
+/// decision-equivalent to the legacy interleaved loop.
+fn plan_sync_dag(
+    locals: &[LocalEntry],
+    remotes: &[RemoteEntry],
+    opts: &SyncOptions,
+) -> SyncDagPlan {
+    use std::collections::{HashMap as Map, HashSet};
+
+    let mut seen_local: HashSet<String> = HashSet::new();
+    let mut seen_remote: HashSet<String> = HashSet::new();
+    // In direction=Both, a download is suppressed only for paths the upload
+    // pass actually resolved with a Copy; a plain upload Skip must not
+    // suppress a later download decision.
+    let mut upload_resolved_for_both: HashSet<String> = HashSet::new();
+    let local_by_path: Map<&str, &LocalEntry> = locals
+        .iter()
+        .map(|entry| (entry.rel_path.as_str(), entry))
+        .collect();
+    let remote_by_path: Map<&str, &RemoteEntry> = remotes
+        .iter()
+        .map(|entry| (entry.rel_path.as_str(), entry))
+        .collect();
+
+    let mut transfers: Vec<PlannedTransfer> = Vec::new();
+    let mut skips: Vec<PlannedSkip> = Vec::new();
+
+    if matches!(opts.direction, SyncDirection::Upload | SyncDirection::Both) {
+        for local_entry in locals {
+            if !seen_local.insert(local_entry.rel_path.clone()) {
+                continue;
+            }
+            let remote_entry = remote_by_path.get(local_entry.rel_path.as_str()).copied();
+            let decision = decide_upload(
+                local_entry,
+                remote_entry,
+                opts.delta_policy,
+                opts.conflict_mode,
+            );
+            match decision.action {
+                SyncTreeAction::Copy => {
+                    if matches!(opts.direction, SyncDirection::Both) {
+                        upload_resolved_for_both.insert(local_entry.rel_path.clone());
+                    }
+                    transfers.push(PlannedTransfer {
+                        rel: local_entry.rel_path.clone(),
+                        op: "upload",
+                        total: local_entry.size,
+                        decision_policy: decision.decision_policy,
+                    });
+                }
+                SyncTreeAction::Skip(reason) => {
+                    skips.push(PlannedSkip {
+                        rel: local_entry.rel_path.clone(),
+                        apply_op: "upload",
+                        reason,
+                        decision_policy: decision.decision_policy,
+                    });
+                }
+            }
+        }
+    }
+
+    if matches!(
+        opts.direction,
+        SyncDirection::Download | SyncDirection::Both
+    ) {
+        for remote_entry in remotes {
+            if !seen_remote.insert(remote_entry.rel_path.clone()) {
+                continue;
+            }
+            let handled_by_upload = matches!(opts.direction, SyncDirection::Both)
+                && upload_resolved_for_both.contains(&remote_entry.rel_path);
+            let decision = decide_download(
+                remote_entry,
+                local_by_path.get(remote_entry.rel_path.as_str()).copied(),
+                opts.delta_policy,
+                opts.conflict_mode,
+                handled_by_upload,
+            );
+            match decision.action {
+                SyncTreeAction::Copy => {
+                    transfers.push(PlannedTransfer {
+                        rel: remote_entry.rel_path.clone(),
+                        op: "download",
+                        total: remote_entry.size,
+                        decision_policy: decision.decision_policy,
+                    });
+                }
+                SyncTreeAction::Skip(reason) => {
+                    skips.push(PlannedSkip {
+                        rel: remote_entry.rel_path.clone(),
+                        apply_op: "download",
+                        reason,
+                        decision_policy: decision.decision_policy,
+                    });
+                }
+            }
+        }
+    }
+
+    let mut deletes: Vec<PlannedDelete> = Vec::new();
+    if opts.delete_orphans {
+        match opts.direction {
+            SyncDirection::Upload => {
+                for remote_entry in remotes {
+                    if !local_by_path.contains_key(remote_entry.rel_path.as_str()) {
+                        deletes.push(PlannedDelete {
+                            rel: remote_entry.rel_path.clone(),
+                            op: "delete_remote",
+                        });
+                    }
+                }
+            }
+            SyncDirection::Download => {
+                for local_entry in locals {
+                    if !remote_by_path.contains_key(local_entry.rel_path.as_str()) {
+                        deletes.push(PlannedDelete {
+                            rel: local_entry.rel_path.clone(),
+                            op: "delete_local",
+                        });
+                    }
+                }
+            }
+            SyncDirection::Both => {}
+        }
+    }
+
+    SyncDagPlan {
+        transfers,
+        skips,
+        deletes,
+    }
+}
+
+/// A transfer node handing one planned file off to the serial driver.
+struct TransferJob {
+    /// Index into [`SyncDagPlan::transfers`].
+    transfer_index: usize,
+    /// Resolved once the driver has performed the transfer.
+    ack: oneshot::Sender<()>,
+}
+
+/// Build the node runner for a sync graph.
+///
+/// Every structural node (discover / compare / acquire / verify / preserve /
+/// commit / emit) is a no-op anchor. Only the real `DownloadFile` /
+/// `UploadFile` nodes carry work: each one looks up its plan index, hands a
+/// [`TransferJob`] to the driver, and waits for the acknowledgement before
+/// reporting completion, so the graph's `EmitProgress` terminal fires only
+/// after the real transfer finished.
+///
+/// A node always reports [`NodeOutcome::Completed`]: a failed file is
+/// recorded in the [`SyncReport`] by the driver, never on the graph, exactly
+/// like the phase-2 batch path. The graph therefore never aborts mid-sync.
+fn build_sync_runner(
+    node_to_index: Arc<HashMap<usize, usize>>,
+    job_tx: mpsc::Sender<TransferJob>,
+) -> Arc<dyn DagNodeRunner> {
+    Arc::new(move |node: TransferNode| -> NodeFuture {
+        let node_to_index = Arc::clone(&node_to_index);
+        let job_tx = job_tx.clone();
+        Box::pin(async move {
+            if !matches!(
+                node.kind,
+                TransferNodeKind::DownloadFile | TransferNodeKind::UploadFile
+            ) {
+                return NodeOutcome::Completed;
+            }
+            let Some(&transfer_index) = node_to_index.get(&node.id) else {
+                return NodeOutcome::Completed;
+            };
+            let (ack_tx, ack_rx) = oneshot::channel::<()>();
+            if job_tx
+                .send(TransferJob {
+                    transfer_index,
+                    ack: ack_tx,
+                })
+                .await
+                .is_err()
+            {
+                // The driver is gone; nothing more this node can do.
+                return NodeOutcome::Completed;
+            }
+            let _ = ack_rx.await;
+            NodeOutcome::Completed
+        })
+    })
+}
+
+/// Drain the transfer-job channel, performing each file serially.
+///
+/// Runs on the `execute_sync_dag` task itself (not spawned), so it can hold
+/// the borrowed provider, delta batch, report and sink that the graph's
+/// spawned nodes cannot. The loop ends when every sender drops: that happens
+/// when `execute_dag` finishes its body and releases the runner, which is
+/// the only thing the channel needs to terminate cleanly.
+#[allow(clippy::too_many_arguments)]
+async fn drive_sync_transfers(
+    mut job_rx: mpsc::Receiver<TransferJob>,
+    provider: &mut Box<dyn StorageProvider>,
+    delta_batch: &mut Option<Box<dyn DeltaBatch>>,
+    report: &mut SyncReport,
+    sink: &mut dyn SyncProgressSink,
+    transfers: &[PlannedTransfer],
+    local_root: &str,
+    remote_root: &str,
+    download_segments: u32,
+    requested_policy: DeltaPolicy,
+) {
+    while let Some(job) = job_rx.recv().await {
+        let transfer = &transfers[job.transfer_index];
+        let spec = SyncTransferSpec {
+            rel: &transfer.rel,
+            total: transfer.total,
+            decision_policy: transfer.decision_policy,
+            requested_policy,
+        };
+        let outcome = match transfer.op {
+            "upload" => {
+                perform_upload(
+                    provider,
+                    local_root,
+                    remote_root,
+                    spec,
+                    false,
+                    sink,
+                    delta_batch,
+                )
+                .await
+            }
+            _ => {
+                perform_download(
+                    provider,
+                    local_root,
+                    remote_root,
+                    spec,
+                    download_segments,
+                    false,
+                    sink,
+                    delta_batch,
+                )
+                .await
+            }
+        };
+        apply_sync_tree_outcome(
+            report,
+            &transfer.rel,
+            transfer.op,
+            outcome,
+            transfer.decision_policy,
+            sink,
+        );
+        let _ = job.ack.send(());
+    }
+}
+
+/// Run a full sync session through the graph engine.
+///
+/// A drop-in replacement for [`crate::sync::sync_tree_core`]: same arguments,
+/// same [`SyncReport`]. Reached only with [`should_route_sync_to_dag`] true,
+/// i.e. the [`DAG_SYNC_ENV`] flag on and a non-dry-run sync; the legacy
+/// interleaved path stays the default.
+pub async fn execute_sync_dag(
+    provider: &mut Box<dyn StorageProvider>,
+    local_root: &str,
+    remote_root: &str,
+    opts: &SyncOptions,
+    sink: &mut dyn SyncProgressSink,
+) -> SyncReport {
+    let start = Instant::now();
+
+    // Phase 1: Scanning. The local filesystem walk runs on a blocking thread
+    // while the network-bound remote scan runs on the provider, so the two
+    // overlap instead of running back to back.
+    sink.on_phase(SyncPhase::Scanning);
+    let local_handle = {
+        let root = local_root.to_string();
+        let scan_opts = opts.scan.clone();
+        tokio::task::spawn_blocking(move || scan_local_tree(&root, &scan_opts))
+    };
+    let remotes = scan_remote_tree(provider, remote_root, &opts.scan).await;
+    let locals = local_handle.await.unwrap_or_default();
+
+    // Phase 2: Planning. Decisions read only the pre-transfer scan
+    // snapshots, so resolving the whole plan up front is decision-equivalent
+    // to the legacy interleaved decide/perform loop.
+    sink.on_phase(SyncPhase::Planning);
+    let mut report = SyncReport {
+        dry_run: opts.dry_run,
+        direction: Some(opts.direction),
+        delta_policy: Some(opts.delta_policy),
+        ..SyncReport::default()
+    };
+    let plan = plan_sync_dag(&locals, &remotes, opts);
+
+    // Phase 3: Executing.
+    sink.on_phase(SyncPhase::Executing);
+
+    // Mirror the legacy gate: create the remote root only for an
+    // upload-bearing sync that actually has local files to push. Running
+    // this after the scans (rather than before the remote scan, as the
+    // legacy core does) is decision-equivalent: `scan_remote_tree` already
+    // tolerates a missing directory by returning an empty listing.
+    if !locals.is_empty() && matches!(opts.direction, SyncDirection::Upload | SyncDirection::Both) {
+        ensure_remote_dir(provider, remote_root).await;
+    }
+
+    // Skips carry no I/O: emit them up front in plan order, before the
+    // transfer graph runs.
+    for skip in &plan.skips {
+        sink.on_file_start(&skip.rel, 0, "skip", skip.decision_policy);
+        apply_sync_tree_outcome(
+            &mut report,
+            &skip.rel,
+            skip.apply_op,
+            FileOutcome::Skipped {
+                reason: skip.reason.clone(),
+            },
+            skip.decision_policy,
+            sink,
+        );
+    }
+
+    // Open the delta-sync batch once for the whole session: a single SSH
+    // session reused across every eligible file, exactly like the legacy
+    // core. `None` when delta policy is off or the provider is not
+    // delta-eligible.
+    let mut delta_batch: Option<Box<dyn DeltaBatch>> =
+        if matches!(opts.delta_policy, DeltaPolicy::Delta) {
+            crate::delta_sync_rsync::open_delta_batch(provider.as_mut()).await
+        } else {
+            None
+        };
+
+    if !plan.transfers.is_empty() {
+        // One sync graph: a global DiscoverLocal/DiscoverRemote -> Compare
+        // prefix, then a per-file transfer chain for every upload/download.
+        let sync_items: Vec<SyncDagItem> = plan
+            .transfers
+            .iter()
+            .map(|transfer| {
+                let action = match transfer.op {
+                    "upload" => SyncDagAction::Upload,
+                    _ => SyncDagAction::Download,
+                };
+                SyncDagItem::new(transfer.rel.clone(), action)
+            })
+            .collect();
+        let sync_dag = TransferDagBuilder::from_sync_plan(&sync_items);
+
+        // The builder preserves plan order, so `files[i]` is `transfers[i]`.
+        let node_to_index: Arc<HashMap<usize, usize>> = Arc::new(
+            sync_dag
+                .files
+                .iter()
+                .enumerate()
+                .map(|(index, file)| (file.transfer, index))
+                .collect(),
+        );
+
+        let (job_tx, job_rx) = mpsc::channel::<TransferJob>(JOB_CHANNEL_CAPACITY);
+        let runner = build_sync_runner(node_to_index, job_tx);
+        // A sync drives one provider connection: file_slots = 1 keeps the
+        // transfer nodes strictly serial, matching the single delta-batch
+        // session and the legacy core.
+        let manager = TransferResourceManager::new(TransferBudget::from_file_slots(1));
+        let observer: Arc<dyn DagObserver> = Arc::new(NoopDagObserver);
+        // AIMD backpressure (F3-T05). file_slots = 1 means the File class
+        // cannot shrink, so this is structurally inert today; it is wired for
+        // uniformity with the batch and single-file surfaces and so the Api
+        // class becomes live once a sync connection pool lands (Fase 3).
+        let aimd = Arc::new(AimdController::from_budget(
+            &manager.budget(),
+            AimdConfig::default(),
+        ));
+
+        // The graph scheduling (spawned) and the real I/O driver (borrowing
+        // the provider) run concurrently on this task. The driver loop ends
+        // when `execute_dag` finishes its body and drops the runner, which
+        // closes the job channel.
+        let dag_result = {
+            let dag_future = execute_dag(&sync_dag.dag, &manager, runner, observer, Some(aimd));
+            let driver_future = drive_sync_transfers(
+                job_rx,
+                provider,
+                &mut delta_batch,
+                &mut report,
+                sink,
+                &plan.transfers,
+                local_root,
+                remote_root,
+                opts.download_segments,
+                opts.delta_policy,
+            );
+            let (dag_result, ()) = tokio::join!(dag_future, driver_future);
+            dag_result
+        };
+        if let Err(error) = dag_result {
+            // The runner never reports Failed, so a graph error here is an
+            // executor-level fault. Surface it; the report still reflects
+            // whatever the driver recorded.
+            tracing::warn!("Sync transfer graph stopped early: {}", error);
+        }
+    }
+
+    // Orphan deletion runs after every transfer, while the delta batch is
+    // still open, exactly like the legacy core.
+    for delete in &plan.deletes {
+        let outcome = match delete.op {
+            "delete_remote" => {
+                perform_remote_delete(
+                    provider,
+                    remote_root,
+                    &delete.rel,
+                    opts.delta_policy,
+                    false,
+                    sink,
+                )
+                .await
+            }
+            _ => perform_local_delete(local_root, &delete.rel, opts.delta_policy, false, sink),
+        };
+        apply_sync_tree_outcome(
+            &mut report,
+            &delete.rel,
+            delete.op,
+            outcome,
+            opts.delta_policy,
+            sink,
+        );
+    }
+
+    // Finalize the delta batch and surface the session-reuse metrics,
+    // identical to the legacy core.
+    if let Some(batch) = delta_batch.take() {
+        match batch.finalize().await {
+            Ok(stats) => {
+                tracing::info!(
+                    "sync.delta: batch finalize ok: files_transferred={}, session_count={}, bytes_on_wire={}, partial={}",
+                    stats.files_transferred,
+                    stats.session_count,
+                    stats.bytes_on_wire,
+                    stats.partial,
+                );
+                report.delta_session_count = Some(stats.session_count);
+                report.delta_bytes_on_wire = Some(stats.bytes_on_wire);
+                report.delta_batch_files = Some(stats.files_transferred);
+            }
+            Err(e) => {
+                tracing::warn!("sync.delta: batch finalize failed: {e}");
+            }
+        }
+    }
+
+    report.elapsed_secs = start.elapsed().as_secs_f64();
+    sink.on_phase(SyncPhase::Done);
+    report
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sync::{
+        CompareDirection, JournalEntryStatus, RetryPolicy, SyncJournal, SyncJournalEntry,
+        VerifyPolicy,
+    };
+    use crate::transfer_dag::observer::SyncJournalDagObserver;
+    use crate::transfer_dag::{NoopDagObserver, OrderedDagObserver};
+    use std::sync::Mutex as StdMutex;
+    use std::time::Duration;
+
+    // ---- flag parsing -----------------------------------------------------
+
+    #[test]
+    fn flag_recognises_truthy_values_case_insensitively() {
+        for on in ["1", "true", "TRUE", "On", "yes", " yes ", "Yes"] {
+            assert!(flag_value_is_on(on), "{on:?} must be on");
+        }
+    }
+
+    #[test]
+    fn flag_rejects_falsey_and_garbage_values() {
+        for off in ["0", "false", "off", "no", "", "  ", "enabled", "2", "y"] {
+            assert!(!flag_value_is_on(off), "{off:?} must be off");
+        }
+    }
+
+    /// Single env-touching test: no other test in this module reads the env
+    /// var, so this cannot race them.
+    #[test]
+    fn routing_respects_flag_and_dry_run() {
+        std::env::remove_var(DAG_SYNC_ENV);
+        assert!(!dag_sync_enabled());
+        assert!(!should_route_sync_to_dag(false));
+        assert!(!should_route_sync_to_dag(true));
+
+        std::env::set_var(DAG_SYNC_ENV, "1");
+        assert!(dag_sync_enabled());
+        // A real sync routes; a dry-run never does, even with the flag on.
+        assert!(should_route_sync_to_dag(false));
+        assert!(
+            !should_route_sync_to_dag(true),
+            "dry-run must never route to the mutating graph"
+        );
+
+        std::env::remove_var(DAG_SYNC_ENV);
+    }
+
+    // ---- plan_sync_dag ----------------------------------------------------
+
+    fn local(rel: &str, size: u64) -> LocalEntry {
+        LocalEntry {
+            rel_path: rel.to_string(),
+            size,
+            mtime: None,
+            sha256: None,
+        }
+    }
+
+    fn remote(rel: &str, size: u64) -> RemoteEntry {
+        RemoteEntry {
+            rel_path: rel.to_string(),
+            size,
+            mtime: None,
+            checksum_alg: None,
+            checksum_hex: None,
+        }
+    }
+
+    fn opts(direction: SyncDirection) -> SyncOptions {
+        SyncOptions {
+            direction,
+            delta_policy: DeltaPolicy::SizeOnly,
+            dry_run: false,
+            delete_orphans: false,
+            conflict_mode: crate::sync::ConflictMode::Newer,
+            scan: Default::default(),
+            download_segments: 1,
+        }
+    }
+
+    #[test]
+    fn plan_uploads_new_file_and_skips_identical() {
+        let locals = vec![local("new.txt", 10), local("same.txt", 20)];
+        let remotes = vec![remote("same.txt", 20)];
+        let plan = plan_sync_dag(&locals, &remotes, &opts(SyncDirection::Upload));
+
+        assert_eq!(plan.transfers.len(), 1);
+        assert_eq!(plan.transfers[0].rel, "new.txt");
+        assert_eq!(plan.transfers[0].op, "upload");
+        assert_eq!(plan.transfers[0].total, 10);
+        assert_eq!(plan.skips.len(), 1);
+        assert_eq!(plan.skips[0].rel, "same.txt");
+        assert_eq!(plan.skips[0].apply_op, "upload");
+        assert!(plan.deletes.is_empty());
+    }
+
+    #[test]
+    fn plan_downloads_new_remote_file_only() {
+        let locals = vec![local("here.txt", 5)];
+        let remotes = vec![remote("here.txt", 5), remote("only-remote.txt", 99)];
+        let plan = plan_sync_dag(&locals, &remotes, &opts(SyncDirection::Download));
+
+        assert_eq!(plan.transfers.len(), 1);
+        assert_eq!(plan.transfers[0].rel, "only-remote.txt");
+        assert_eq!(plan.transfers[0].op, "download");
+        // The upload pass never runs in download direction.
+        assert!(plan.transfers.iter().all(|t| t.op == "download"));
+    }
+
+    #[test]
+    fn plan_both_direction_resolves_conflict_via_upload_then_skips_download() {
+        // A file on both sides with different sizes: the upload pass resolves
+        // it (ConflictMode::Newer always copies), and the download pass must
+        // then skip it as already handled.
+        let locals = vec![local("conflict.txt", 100)];
+        let remotes = vec![remote("conflict.txt", 50)];
+        let plan = plan_sync_dag(&locals, &remotes, &opts(SyncDirection::Both));
+
+        assert_eq!(plan.transfers.len(), 1);
+        assert_eq!(plan.transfers[0].op, "upload");
+        assert_eq!(plan.transfers[0].rel, "conflict.txt");
+        assert_eq!(plan.skips.len(), 1);
+        assert_eq!(plan.skips[0].apply_op, "download");
+        assert_eq!(plan.skips[0].rel, "conflict.txt");
+    }
+
+    #[test]
+    fn plan_keeps_uploads_before_downloads_in_plan_order() {
+        let locals = vec![local("up-only.txt", 1)];
+        let remotes = vec![remote("down-only.txt", 2)];
+        let plan = plan_sync_dag(&locals, &remotes, &opts(SyncDirection::Both));
+
+        assert_eq!(plan.transfers.len(), 2);
+        assert_eq!(plan.transfers[0].op, "upload");
+        assert_eq!(plan.transfers[1].op, "download");
+    }
+
+    #[test]
+    fn plan_delete_orphans_marks_the_right_side_per_direction() {
+        let locals = vec![local("keep.txt", 1), local("local-orphan.txt", 1)];
+        let remotes = vec![remote("keep.txt", 1), remote("remote-orphan.txt", 1)];
+
+        let mut upload = opts(SyncDirection::Upload);
+        upload.delete_orphans = true;
+        let plan = plan_sync_dag(&locals, &remotes, &upload);
+        assert_eq!(plan.deletes.len(), 1);
+        assert_eq!(plan.deletes[0].rel, "remote-orphan.txt");
+        assert_eq!(plan.deletes[0].op, "delete_remote");
+
+        let mut download = opts(SyncDirection::Download);
+        download.delete_orphans = true;
+        let plan = plan_sync_dag(&locals, &remotes, &download);
+        assert_eq!(plan.deletes.len(), 1);
+        assert_eq!(plan.deletes[0].rel, "local-orphan.txt");
+        assert_eq!(plan.deletes[0].op, "delete_local");
+
+        // Bidirectional sync resolves orphans as transfers, never deletes.
+        let mut both = opts(SyncDirection::Both);
+        both.delete_orphans = true;
+        let plan = plan_sync_dag(&locals, &remotes, &both);
+        assert!(plan.deletes.is_empty());
+    }
+
+    #[test]
+    fn plan_deduplicates_repeated_scan_entries() {
+        let locals = vec![local("dup.txt", 7), local("dup.txt", 7)];
+        let plan = plan_sync_dag(&locals, &[], &opts(SyncDirection::Upload));
+        assert_eq!(
+            plan.transfers.len(),
+            1,
+            "a repeated scan path is planned once"
+        );
+    }
+
+    // ---- runner + driver mechanics ---------------------------------------
+
+    #[tokio::test]
+    async fn sync_runner_drives_every_transfer_exactly_once() {
+        let items = vec![
+            SyncDagItem::new("a.txt", SyncDagAction::Upload),
+            SyncDagItem::new("b.txt", SyncDagAction::Download),
+            SyncDagItem::new("c.txt", SyncDagAction::Upload),
+        ];
+        let sync_dag = TransferDagBuilder::from_sync_plan(&items);
+        let node_to_index: Arc<HashMap<usize, usize>> = Arc::new(
+            sync_dag
+                .files
+                .iter()
+                .enumerate()
+                .map(|(index, file)| (file.transfer, index))
+                .collect(),
+        );
+
+        let (job_tx, mut job_rx) = mpsc::channel::<TransferJob>(JOB_CHANNEL_CAPACITY);
+        let runner = build_sync_runner(node_to_index, job_tx);
+        let manager = TransferResourceManager::new(TransferBudget::from_file_slots(1));
+        let observer: Arc<dyn DagObserver> = Arc::new(NoopDagObserver);
+
+        let seen: Arc<StdMutex<Vec<usize>>> = Arc::new(StdMutex::new(Vec::new()));
+        let driver = {
+            let seen = Arc::clone(&seen);
+            async move {
+                while let Some(job) = job_rx.recv().await {
+                    seen.lock().unwrap().push(job.transfer_index);
+                    let _ = job.ack.send(());
+                }
+            }
+        };
+        let dag_future = execute_dag(&sync_dag.dag, &manager, runner, observer, None);
+        let (dag_result, ()) = tokio::join!(dag_future, driver);
+
+        let summary = dag_result.expect("sync graph must schedule cleanly");
+        // 3 prefix nodes + 3 files x 6 chain nodes.
+        assert_eq!(summary.nodes_completed, 21);
+        let mut seen = seen.lock().unwrap().clone();
+        seen.sort_unstable();
+        assert_eq!(seen, vec![0, 1, 2], "every transfer is driven exactly once");
+    }
+
+    #[tokio::test]
+    async fn sync_runner_handles_an_empty_plan() {
+        let sync_dag = TransferDagBuilder::from_sync_plan(&[]);
+        let node_to_index: Arc<HashMap<usize, usize>> = Arc::new(HashMap::new());
+        let (job_tx, mut job_rx) = mpsc::channel::<TransferJob>(JOB_CHANNEL_CAPACITY);
+        let runner = build_sync_runner(node_to_index, job_tx);
+        let manager = TransferResourceManager::new(TransferBudget::from_file_slots(1));
+        let observer: Arc<dyn DagObserver> = Arc::new(NoopDagObserver);
+
+        let driver = async move {
+            let mut jobs = 0usize;
+            while job_rx.recv().await.is_some() {
+                jobs += 1;
+            }
+            jobs
+        };
+        let dag_future = execute_dag(&sync_dag.dag, &manager, runner, observer, None);
+        let (dag_result, jobs) = tokio::join!(dag_future, driver);
+
+        assert_eq!(jobs, 0, "an empty sync plan hands off no transfer jobs");
+        // Only the 3 global discover/compare prefix nodes.
+        assert_eq!(dag_result.unwrap().nodes_completed, 3);
+    }
+
+    // ---- journal observer interop (F2-T10) -------------------------------
+
+    fn journal_with_pending(paths: &[(&str, &str)]) -> SyncJournal {
+        let mut journal = SyncJournal::new(
+            "/local".to_string(),
+            "/remote".to_string(),
+            CompareDirection::Bidirectional,
+            RetryPolicy::default(),
+            VerifyPolicy::SizeOnly,
+        );
+        for (rel, action) in paths {
+            journal.entries.push(SyncJournalEntry {
+                relative_path: rel.to_string(),
+                action: action.to_string(),
+                status: JournalEntryStatus::Pending,
+                attempts: 1,
+                last_error: None,
+                verified: None,
+                bytes_transferred: 0,
+            });
+        }
+        journal
+    }
+
+    #[tokio::test]
+    async fn sync_journal_observer_completes_entries_over_the_sync_graph() {
+        // The sync graph's per-file EmitProgress terminals must drive the
+        // legacy journal to completion, in plan order, so a journal written
+        // by the DAG path is interoperable with the legacy resume logic.
+        let items = vec![
+            SyncDagItem::new("up.txt", SyncDagAction::Upload),
+            SyncDagItem::new("down.txt", SyncDagAction::Download),
+        ];
+        let sync_dag = TransferDagBuilder::from_sync_plan(&items);
+        let terminals = sync_dag.journal_terminals_for_plan_order();
+        assert_eq!(terminals.len(), 2);
+
+        let journal = Arc::new(std::sync::Mutex::new(journal_with_pending(&[
+            ("up.txt", "upload"),
+            ("down.txt", "download"),
+        ])));
+        let persisted = Arc::new(std::sync::Mutex::new(0u32));
+        let persist = {
+            let persisted = Arc::clone(&persisted);
+            Arc::new(move |_journal: &SyncJournal| {
+                *persisted.lock().unwrap() += 1;
+                Ok(())
+            })
+        };
+        let journal_observer =
+            SyncJournalDagObserver::with_persist(Arc::clone(&journal), terminals, persist);
+        // "Journal durable first, visible completion second": the journal
+        // observer is composed ahead of any visible observer.
+        let observer: Arc<dyn DagObserver> = Arc::new(OrderedDagObserver::new(vec![
+            Arc::new(journal_observer) as Arc<dyn DagObserver>,
+            Arc::new(NoopDagObserver) as Arc<dyn DagObserver>,
+        ]));
+
+        let runner: Arc<dyn DagNodeRunner> = Arc::new(|_node: TransferNode| -> NodeFuture {
+            Box::pin(async { NodeOutcome::Completed })
+        });
+        let manager = TransferResourceManager::new(TransferBudget::from_file_slots(1));
+        execute_dag(&sync_dag.dag, &manager, runner, observer, None)
+            .await
+            .expect("sync graph must schedule cleanly");
+
+        let journal = journal.lock().unwrap();
+        assert!(
+            journal
+                .entries
+                .iter()
+                .all(|entry| entry.status == JournalEntryStatus::Completed),
+            "every journal entry must be marked completed"
+        );
+        assert!(
+            journal.completed,
+            "a fully transferred journal is completed"
+        );
+        assert!(
+            !journal.has_resumable_entries(),
+            "a completed journal has nothing to resume"
+        );
+        assert!(*persisted.lock().unwrap() >= 1, "the journal was persisted");
+    }
+
+    #[test]
+    fn partial_journal_stays_resumable_for_the_legacy_path() {
+        // A journal interrupted mid-run (flag ON) keeps the standard
+        // Pending/Completed split, so the legacy path (flag OFF) resumes it.
+        let mut journal = journal_with_pending(&[("a.txt", "upload"), ("b.txt", "upload")]);
+        journal.entries[0].status = JournalEntryStatus::Completed;
+        assert!(
+            journal.has_resumable_entries(),
+            "a half-finished journal is resumable regardless of which engine wrote it"
+        );
+    }
+
+    // ---- graph build cost (F2-T12) ---------------------------------------
+
+    #[test]
+    fn sync_graph_build_cost_is_well_under_50ms() {
+        // The watch loop rebuilds the sync graph every cycle; the build must
+        // stay far below the filesystem-watcher cooldown.
+        let items: Vec<SyncDagItem> = (0..1000)
+            .map(|i| SyncDagItem::new(format!("file-{i}.bin"), SyncDagAction::Upload))
+            .collect();
+        let start = Instant::now();
+        let sync_dag = TransferDagBuilder::from_sync_plan(&items);
+        let elapsed = start.elapsed();
+
+        assert_eq!(sync_dag.files.len(), 1000);
+        assert!(
+            elapsed < Duration::from_millis(50),
+            "1000-file sync graph build took {elapsed:?}, budget is 50ms"
+        );
+    }
+}

--- a/src-tauri/src/transfer_dag_sync.rs
+++ b/src-tauri/src/transfer_dag_sync.rs
@@ -69,8 +69,8 @@ use crate::providers::StorageProvider;
 use crate::sync::{
     apply_sync_tree_outcome, decide_download, decide_upload, ensure_remote_dir, perform_download,
     perform_local_delete, perform_remote_delete, perform_upload, DeltaPolicy, FileOutcome,
-    SyncDirection, SyncOptions, SyncPhase, SyncProgressSink, SyncReport, SyncTransferSpec,
-    SyncTreeAction,
+    SyncDirection, SyncError, SyncOptions, SyncPhase, SyncProgressSink, SyncReport,
+    SyncTransferSpec, SyncTreeAction,
 };
 use crate::sync_core::scan::{scan_local_tree, scan_remote_tree, LocalEntry, RemoteEntry};
 use crate::transfer_dag::executor::{execute_dag, DagNodeRunner, NodeFuture, NodeOutcome};
@@ -443,7 +443,24 @@ pub async fn execute_sync_dag(
         tokio::task::spawn_blocking(move || scan_local_tree(&root, &scan_opts))
     };
     let remotes = scan_remote_tree(provider, remote_root, &opts.scan).await;
-    let locals = local_handle.await.unwrap_or_default();
+    // `scan_local_tree` itself returns a `Vec` (best-effort, mirroring
+    // `scan_remote_tree`), so the only way the join returns `Err` is a panic
+    // inside the blocking thread. `.unwrap_or_default()` would silently turn
+    // that panic into an empty local listing, which then drives a "no
+    // uploads needed" decision through the planner: the run would report
+    // success while the local side was never scanned. Surface the panic as
+    // a hard `SyncError` on the report so the caller sees the failure;
+    // keep `locals` empty so the remote-only side of the run still proceeds.
+    let (locals, local_scan_panic) = match local_handle.await {
+        Ok(entries) => (entries, None),
+        Err(join_err) => {
+            eprintln!(
+                "[execute_sync_dag] local scan task failed: {}",
+                join_err
+            );
+            (Vec::new(), Some(join_err.to_string()))
+        }
+    };
 
     // Phase 2: Planning. Decisions read only the pre-transfer scan
     // snapshots, so resolving the whole plan up front is decision-equivalent
@@ -455,6 +472,14 @@ pub async fn execute_sync_dag(
         delta_policy: Some(opts.delta_policy),
         ..SyncReport::default()
     };
+    if let Some(msg) = local_scan_panic {
+        report.errors.push(SyncError {
+            rel_path: local_root.to_string(),
+            operation: "scan",
+            message: format!("local scan task failed: {}", msg),
+            decision_policy: opts.delta_policy,
+        });
+    }
     let plan = plan_sync_dag(&locals, &remotes, opts);
 
     // Phase 3: Executing.

--- a/src-tauri/src/transfer_domain.rs
+++ b/src-tauri/src/transfer_domain.rs
@@ -5,6 +5,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::transfer_dag::TransferBudget;
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum TransferDirection {
@@ -55,6 +57,17 @@ impl Default for TransferBatchConfig {
             max_retries: 0,
             timeout_ms: 30_000,
         }
+    }
+}
+
+impl TransferBatchConfig {
+    /// Build the DAG budget used by the batch scheduler.
+    ///
+    /// GUI `Settings.maxConcurrentTransfers` arrives at the backend as
+    /// `max_concurrent`; this method is the explicit handoff into
+    /// `TransferBudget::file_slots`.
+    pub fn transfer_budget(&self) -> TransferBudget {
+        TransferBudget::from_file_slots(self.max_concurrent.min(u16::MAX as u32) as u16)
     }
 }
 
@@ -136,5 +149,27 @@ mod tests {
     fn exposes_redacted_user_facing_message() {
         let message = user_facing_transfer_failure_message(&TransferFailureKind::PermissionDenied);
         assert_eq!(message, "Permission denied during transfer");
+    }
+
+    #[test]
+    fn batch_config_maps_max_concurrent_to_dag_file_slots() {
+        let config = TransferBatchConfig {
+            max_concurrent: 6,
+            max_retries: 0,
+            timeout_ms: 30_000,
+        };
+
+        assert_eq!(config.transfer_budget().file_slots, 6);
+    }
+
+    #[test]
+    fn batch_config_floors_dag_file_slots_to_one() {
+        let config = TransferBatchConfig {
+            max_concurrent: 0,
+            max_retries: 0,
+            timeout_ms: 30_000,
+        };
+
+        assert_eq!(config.transfer_budget().file_slots, 1);
     }
 }

--- a/src-tauri/src/transfer_event_sink.rs
+++ b/src-tauri/src/transfer_event_sink.rs
@@ -192,7 +192,10 @@ impl DagObserver for GuiDagObserver {
         if node_id != self.emit_progress_node_id {
             return;
         }
-        if !matches!(outcome, ObservedOutcome::Completed | ObservedOutcome::Fallback) {
+        if !matches!(
+            outcome,
+            ObservedOutcome::Completed | ObservedOutcome::Fallback
+        ) {
             return;
         }
         let size = self.report_size.load(Ordering::SeqCst);

--- a/src-tauri/src/transfer_event_sink.rs
+++ b/src-tauri/src/transfer_event_sink.rs
@@ -18,6 +18,11 @@
 //! Mirrors the [`crate::ai_core::EventSink`] precedent already used to make
 //! the AI streaming path sink-agnostic for CLI/MCP.
 
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use crate::transfer_dag::graph::TransferNodeKind;
+use crate::transfer_dag::{DagObserver, ObservedOutcome};
 use crate::transfer_domain::{BatchProgressSnapshot, TransferBatchResult};
 use crate::TransferEvent;
 
@@ -103,6 +108,110 @@ impl TransferEventSink for NoopTransferSink {
     fn emit_transfer_event(&self, _event: TransferEvent) {}
 }
 
+/// Format a byte count the way the legacy single-file `transfer_event`
+/// completion message does: one decimal, MB above 1 MiB, KB below. Kept
+/// character-for-character identical so the GUI completion text is unchanged
+/// whether the legacy path or the DAG path produced it.
+fn format_complete_size(bytes: u64) -> String {
+    if bytes > 1_048_576 {
+        format!("{:.1} MB", bytes as f64 / 1_048_576.0)
+    } else {
+        format!("{:.1} KB", bytes as f64 / 1024.0)
+    }
+}
+
+/// [`DagObserver`] adapter that emits the GUI single-file **completion**
+/// event when a single-file transfer graph reaches its terminal node.
+///
+/// ## Why only the completion event
+///
+/// The DAG-ENGINE phase-1 routing keeps the single-file `transfer_event`
+/// stream byte-identical with the legacy path:
+///
+/// - `"start"` is emitted by the shared pre-DAG legacy code (it must precede
+///   the delta attempt), so the observer must NOT emit it again.
+/// - `"progress"` is emitted by the same per-byte callback handed straight to
+///   `provider.download` / `provider.upload`, so it never routes through the
+///   observer either.
+/// - `"error"` carries the failure message, but [`DagObserver::on_node_complete`]
+///   intentionally drops the failure payload (it is observer-object-safe and
+///   allocation-free). The routing layer holds the typed [`crate::providers::ProviderError`]
+///   and emits `"error"` itself, exactly as it owns the `"cancelled"` decision.
+/// - `"complete"` is the one event with no upstream emitter on the DAG path:
+///   the terminal `EmitProgress` node completing is precisely "the transfer
+///   finished successfully". That is what this observer maps.
+///
+/// The completion event is built character-for-character like the legacy one
+/// (`"({size} in 0s)"`, MB/KB via [`format_complete_size`], the original
+/// `fallback_reason`), so a frontend cannot tell the two paths apart.
+pub struct GuiDagObserver {
+    sink: Arc<dyn TransferEventSink>,
+    transfer_id: String,
+    filename: String,
+    /// `"download"` or `"upload"`.
+    direction: String,
+    /// Id of the terminal `EmitProgress` node in the single-file graph
+    /// (`SingleFileDag::emit_progress`). Its completion is the success signal.
+    emit_progress_node_id: usize,
+    /// Size to report in the completion message. The download transfer node
+    /// stores the real on-disk size here; the upload caller seeds it with the
+    /// known local size.
+    report_size: Arc<AtomicU64>,
+    /// Carried verbatim into the completion event: a non-`None` value means an
+    /// earlier delta attempt fell back silently to the classic transfer.
+    fallback_reason: Option<String>,
+}
+
+impl GuiDagObserver {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        sink: Arc<dyn TransferEventSink>,
+        transfer_id: String,
+        filename: String,
+        direction: String,
+        emit_progress_node_id: usize,
+        report_size: Arc<AtomicU64>,
+        fallback_reason: Option<String>,
+    ) -> Self {
+        Self {
+            sink,
+            transfer_id,
+            filename,
+            direction,
+            emit_progress_node_id,
+            report_size,
+            fallback_reason,
+        }
+    }
+}
+
+impl DagObserver for GuiDagObserver {
+    fn on_node_complete(&self, node_id: usize, outcome: ObservedOutcome) {
+        // Only the terminal node completing means the whole single-file graph
+        // succeeded: every upstream node is its transitive dependency.
+        if node_id != self.emit_progress_node_id {
+            return;
+        }
+        if !matches!(outcome, ObservedOutcome::Completed | ObservedOutcome::Fallback) {
+            return;
+        }
+        let size = self.report_size.load(Ordering::SeqCst);
+        self.sink.emit_transfer_event(TransferEvent {
+            event_type: "complete".to_string(),
+            transfer_id: self.transfer_id.clone(),
+            filename: self.filename.clone(),
+            direction: self.direction.clone(),
+            message: Some(format!("({} in 0s)", format_complete_size(size))),
+            progress: None,
+            path: None,
+            delta_stats: None,
+            fallback_reason: self.fallback_reason.clone(),
+        });
+    }
+
+    fn on_node_start(&self, _node_id: usize, _kind: TransferNodeKind) {}
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -130,5 +239,138 @@ mod tests {
         sink.emit_transfer_event(sample_event());
         let cloned = Arc::clone(&sink);
         cloned.emit_transfer_event(sample_event());
+    }
+
+    /// Test sink: records every emitted `transfer_event` for assertions.
+    #[derive(Default)]
+    struct RecordingSink {
+        events: std::sync::Mutex<Vec<TransferEvent>>,
+    }
+
+    impl RecordingSink {
+        fn events(&self) -> Vec<TransferEvent> {
+            self.events.lock().unwrap().clone()
+        }
+    }
+
+    impl TransferEventSink for RecordingSink {
+        fn emit_transfer_event(&self, event: TransferEvent) {
+            self.events.lock().unwrap().push(event);
+        }
+    }
+
+    fn gui_observer(
+        sink: Arc<RecordingSink>,
+        direction: &str,
+        emit_progress_node_id: usize,
+        report_size: Arc<AtomicU64>,
+        fallback_reason: Option<String>,
+    ) -> GuiDagObserver {
+        GuiDagObserver::new(
+            sink as Arc<dyn TransferEventSink>,
+            "pdl-123".to_string(),
+            "f.bin".to_string(),
+            direction.to_string(),
+            emit_progress_node_id,
+            report_size,
+            fallback_reason,
+        )
+    }
+
+    #[test]
+    fn gui_observer_emits_complete_only_on_the_terminal_node() {
+        let sink = Arc::new(RecordingSink::default());
+        let obs = gui_observer(
+            Arc::clone(&sink),
+            "download",
+            6,
+            Arc::new(AtomicU64::new(2_097_152)),
+            None,
+        );
+
+        // Non-terminal completions emit nothing.
+        for node_id in 0..6 {
+            obs.on_node_complete(node_id, ObservedOutcome::Completed);
+        }
+        assert!(sink.events().is_empty(), "only the terminal node emits");
+
+        // The terminal node completing emits exactly one "complete" event.
+        obs.on_node_complete(6, ObservedOutcome::Completed);
+        let events = sink.events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_type, "complete");
+        assert_eq!(events[0].transfer_id, "pdl-123");
+        assert_eq!(events[0].direction, "download");
+        // 2 MiB formats as MB with one decimal, "in 0s" suffix.
+        assert_eq!(events[0].message.as_deref(), Some("(2.0 MB in 0s)"));
+        assert_eq!(events[0].fallback_reason, None);
+    }
+
+    #[test]
+    fn gui_observer_complete_message_uses_kb_below_one_mib() {
+        let sink = Arc::new(RecordingSink::default());
+        let obs = gui_observer(
+            Arc::clone(&sink),
+            "upload",
+            6,
+            Arc::new(AtomicU64::new(512_000)),
+            None,
+        );
+        obs.on_node_complete(6, ObservedOutcome::Completed);
+        let events = sink.events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].direction, "upload");
+        assert_eq!(events[0].message.as_deref(), Some("(500.0 KB in 0s)"));
+    }
+
+    #[test]
+    fn gui_observer_carries_the_delta_fallback_reason() {
+        let sink = Arc::new(RecordingSink::default());
+        let obs = gui_observer(
+            Arc::clone(&sink),
+            "download",
+            6,
+            Arc::new(AtomicU64::new(1024)),
+            Some("rsync binary not found on remote".to_string()),
+        );
+        obs.on_node_complete(6, ObservedOutcome::Completed);
+        let events = sink.events();
+        assert_eq!(
+            events[0].fallback_reason.as_deref(),
+            Some("rsync binary not found on remote"),
+        );
+    }
+
+    #[test]
+    fn gui_observer_stays_silent_on_a_failed_terminal_outcome() {
+        // A failed terminal node must not produce a "complete" event; the
+        // routing layer owns the "error" event because it holds the message.
+        let sink = Arc::new(RecordingSink::default());
+        let obs = gui_observer(
+            Arc::clone(&sink),
+            "download",
+            6,
+            Arc::new(AtomicU64::new(1024)),
+            None,
+        );
+        obs.on_node_complete(6, ObservedOutcome::Failed);
+        assert!(sink.events().is_empty());
+    }
+
+    #[test]
+    fn gui_observer_start_is_a_silent_noop() {
+        // "start" is emitted by the shared legacy code before the DAG runs;
+        // the observer must not duplicate it.
+        let sink = Arc::new(RecordingSink::default());
+        let obs = gui_observer(
+            Arc::clone(&sink),
+            "download",
+            6,
+            Arc::new(AtomicU64::new(1024)),
+            None,
+        );
+        obs.on_node_start(0, TransferNodeKind::DiscoverRemote);
+        obs.on_node_start(6, TransferNodeKind::EmitProgress);
+        assert!(sink.events().is_empty());
     }
 }

--- a/src-tauri/src/transfer_orchestrator.rs
+++ b/src-tauri/src/transfer_orchestrator.rs
@@ -15,8 +15,7 @@ use tokio::sync::Mutex;
 use tokio::task::JoinSet;
 
 use crate::transfer_dag::{
-    ResourceRequest, TransferBudget, TransferResourceManager, TransferSessionLease,
-    TransferSessionPoolHandle,
+    ResourceRequest, TransferResourceManager, TransferSessionLease, TransferSessionPoolHandle,
 };
 use crate::transfer_domain::{
     BatchProgressSnapshot, TransferBatchConfig, TransferBatchResult, TransferDirection,
@@ -64,6 +63,21 @@ pub async fn execute_batch<E>(
 where
     E: TransferExecutor + Send + Sync + 'static,
 {
+    // DAG-ENGINE phase 2 (F2-T07): with the batch flag on, schedule the whole
+    // batch through the shared graph engine instead of this hand-rolled
+    // sliding window. Default OFF, so the legacy path below is the default and
+    // a rollback is a runtime toggle, never a revert.
+    if crate::transfer_dag_batch::dag_batch_enabled() {
+        return crate::transfer_dag_batch::execute_batch_dag(
+            sink,
+            batch,
+            executor,
+            cancel,
+            progress_observer,
+        )
+        .await;
+    }
+
     let started_at = Instant::now();
     let total = batch.entries.len() as u32;
     let progress = Arc::new(Mutex::new(BatchProgressSnapshot {
@@ -71,9 +85,7 @@ where
         bytes_total: batch.entries.iter().map(|entry| entry.size).sum(),
         ..BatchProgressSnapshot::default()
     }));
-    let resource_manager = Arc::new(TransferResourceManager::new(
-        TransferBudget::from_file_slots(batch.config.max_concurrent.max(1) as u16),
-    ));
+    let resource_manager = Arc::new(TransferResourceManager::new(batch.config.transfer_budget()));
     let max_concurrent = batch.config.max_concurrent.max(1) as usize;
     let session_pool = Arc::new(executor.session_pool(max_concurrent));
     let mut join_set = JoinSet::new();

--- a/src-tauri/src/transfer_queue_scan.rs
+++ b/src-tauri/src/transfer_queue_scan.rs
@@ -9,14 +9,14 @@
 // changing its byte-identical output. UX spec: see APPENDIX-TRANSFER-QUEUE
 // `tasks/TQ-1_UX-spec.md` section 4.
 
-use crate::AppState;
 use crate::ftp::{FtpManager, RemoteFile};
 use crate::provider_commands::ProviderState;
 use crate::providers::{RemoteEntry, StorageProvider};
+use crate::AppState;
 use serde::Serialize;
 use std::collections::VecDeque;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use tauri::State;
 use tracing::{debug, warn};
 
@@ -132,20 +132,14 @@ pub async fn walk_remote_ftp(
         }
 
         if let Err(e) = ftp_manager.change_dir(&current_dir).await {
-            warn!(
-                "transfer_queue_scan: cannot enter {}: {}",
-                current_dir, e
-            );
+            warn!("transfer_queue_scan: cannot enter {}: {}", current_dir, e);
             continue;
         }
 
         let files: Vec<RemoteFile> = match ftp_manager.list_files().await {
             Ok(f) => f,
             Err(e) => {
-                warn!(
-                    "transfer_queue_scan: cannot list {}: {}",
-                    current_dir, e
-                );
+                warn!("transfer_queue_scan: cannot list {}: {}", current_dir, e);
                 continue;
             }
         };

--- a/src-tauri/src/transfer_settings.rs
+++ b/src-tauri/src/transfer_settings.rs
@@ -85,6 +85,15 @@ impl ResolvedTransferSettings {
             backoff_multiplier: 2.0,
         }
     }
+
+    /// Build the DAG budget implied by the resolved concurrency setting.
+    ///
+    /// This keeps the Settings-panel knob (`maxConcurrentTransfers` on the
+    /// frontend, `max_concurrent` in commands) and the graph scheduler's
+    /// `file_slots` vocabulary tied to the same resolved value.
+    pub fn transfer_budget(&self) -> TransferBudget {
+        TransferBudget::from_file_slots(self.max_concurrent.min(u16::MAX as u32) as u16)
+    }
 }
 
 pub fn resolve_transfer_settings(
@@ -219,5 +228,23 @@ mod tests {
 
         assert_eq!(resolved.requested_max_concurrent, 6);
         assert_eq!(resolved.max_concurrent, 2);
+    }
+
+    #[test]
+    fn resolved_settings_budget_uses_effective_max_concurrent() {
+        let resolved = resolve_transfer_settings_for_capabilities(
+            TransferSettingsInput {
+                max_concurrent: Some(6),
+                retry_count: None,
+                timeout_seconds: None,
+                download_segments: None,
+            },
+            &TransferCapabilities {
+                max_file_slots: Some(2),
+                ..TransferCapabilities::default()
+            },
+        );
+
+        assert_eq!(resolved.transfer_budget().file_slots, 2);
     }
 }

--- a/src-tauri/tests/aimd_backpressure.rs
+++ b/src-tauri/tests/aimd_backpressure.rs
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+//! AIMD backpressure integration tests (DAG-ENGINE phase 3, F3-T07).
+//!
+//! These drive the real `execute_dag` scheduler with a wired `AimdController`
+//! against congestion "flapper" runners. They cover the three congestion
+//! classes the controller throttles on (429, 503, request timeout), confirm a
+//! non-congestion failure does not throttle, and prove a congestion shrink
+//! carries into the following run as a genuine concurrency throttle.
+//!
+//! The congestion signal is delivered as the provider error string the real
+//! `congestion_from_error` classifier parses; a mock HTTP server would only
+//! produce the same strings. The live rate-limited validation against a real
+//! provider (Google Drive) is F3-T08, run in the phase-4 validation window.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use ftp_client_gui_lib::transfer_dag::executor::{
+    execute_dag, DagNodeRunner, NodeFuture, NodeOutcome,
+};
+use ftp_client_gui_lib::transfer_dag::graph::{TransferDag, TransferNode, TransferNodeKind};
+use ftp_client_gui_lib::transfer_dag::observer::CollectingDagObserver;
+use ftp_client_gui_lib::transfer_dag::{
+    AimdConfig, AimdController, DagObserver, NoopDagObserver, ResourceRequest, TransferBudget,
+    TransferResourceManager,
+};
+
+/// A one-node graph: a single `DownloadFile` reserving one file slot.
+fn one_file_dag() -> TransferDag {
+    let mut dag = TransferDag::default();
+    dag.add_node(
+        TransferNodeKind::DownloadFile,
+        vec![],
+        ResourceRequest::file_transfer(),
+    );
+    dag
+}
+
+/// A runner whose every node fails with a fixed message.
+fn failing_runner(message: &'static str) -> Arc<dyn DagNodeRunner> {
+    Arc::new(move |_node: TransferNode| -> NodeFuture {
+        Box::pin(async move { NodeOutcome::Failed(message.to_string()) })
+    })
+}
+
+/// Run a one-file graph whose transfer fails with `message`, with an AIMD
+/// controller wired, and return the recorded `backpressure_events` count.
+async fn backpressure_events_for(message: &'static str) -> u32 {
+    let dag = one_file_dag();
+    let manager = TransferResourceManager::new(TransferBudget::from_file_slots(8));
+    let controller = Arc::new(AimdController::from_budget(
+        &manager.budget(),
+        AimdConfig::default(),
+    ));
+    let observer = Arc::new(CollectingDagObserver::default());
+
+    let result = execute_dag(
+        &dag,
+        &manager,
+        failing_runner(message),
+        Arc::clone(&observer) as Arc<dyn DagObserver>,
+        Some(controller),
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "a failed transfer node must surface as a graph error"
+    );
+    observer.metrics().backpressure_events
+}
+
+#[tokio::test]
+async fn aimd_429_flap_records_backpressure() {
+    assert_eq!(
+        backpressure_events_for("HTTP 429 Too Many Requests").await,
+        1,
+        "a 429 is a congestion signal and must record one backpressure event"
+    );
+}
+
+#[tokio::test]
+async fn aimd_503_flap_records_backpressure() {
+    assert_eq!(
+        backpressure_events_for("503 Service Unavailable").await,
+        1,
+        "a 503 is a congestion signal and must record one backpressure event"
+    );
+}
+
+#[tokio::test]
+async fn aimd_timeout_flap_records_backpressure() {
+    assert_eq!(
+        backpressure_events_for("operation timed out after 30s").await,
+        1,
+        "a request timeout is a congestion signal and must record one event"
+    );
+}
+
+#[tokio::test]
+async fn aimd_non_congestion_failure_records_no_backpressure() {
+    // A not-found is a hard error, not congestion: the run still fails, but
+    // AIMD must not throttle on it.
+    assert_eq!(
+        backpressure_events_for("404 not found").await,
+        0,
+        "a non-congestion failure must not record a backpressure event"
+    );
+    assert_eq!(backpressure_events_for("permission denied").await, 0);
+}
+
+#[tokio::test]
+async fn aimd_shrink_from_a_congested_run_throttles_the_next_run() {
+    // A long-window config so a healthy run after congestion cannot regrow
+    // the target inside the test: the shrink is observed as a hard throttle.
+    let cfg = AimdConfig {
+        cooldown: Duration::from_secs(3600),
+        healthy_window: Duration::from_secs(3600),
+        recovery_window: Duration::from_secs(3600),
+    };
+    let budget = TransferBudget::from_file_slots(8);
+    let controller = Arc::new(AimdController::from_budget(&budget, cfg));
+
+    // Run 1: one DownloadFile fails with a 429. The shared controller's File
+    // class halves its dispatch target 8 -> 4.
+    let observer = Arc::new(CollectingDagObserver::default());
+    let run1 = execute_dag(
+        &one_file_dag(),
+        &TransferResourceManager::new(budget),
+        failing_runner("HTTP 429 Too Many Requests"),
+        Arc::clone(&observer) as Arc<dyn DagObserver>,
+        Some(Arc::clone(&controller)),
+    )
+    .await;
+    assert!(run1.is_err());
+    assert_eq!(observer.metrics().backpressure_events, 1);
+
+    // Run 2: eight independent DownloadFile nodes all succeed slowly. The
+    // resource manager budget still allows 8 in flight, but the shrunk
+    // controller caps the File dispatch target at 4 — peak in-flight is 4.
+    let mut dag2 = TransferDag::default();
+    for _ in 0..8 {
+        dag2.add_node(
+            TransferNodeKind::DownloadFile,
+            vec![],
+            ResourceRequest::file_transfer(),
+        );
+    }
+    let in_flight = Arc::new(AtomicUsize::new(0));
+    let peak = Arc::new(AtomicUsize::new(0));
+    let runner: Arc<dyn DagNodeRunner> = {
+        let in_flight = Arc::clone(&in_flight);
+        let peak = Arc::clone(&peak);
+        Arc::new(move |_node: TransferNode| -> NodeFuture {
+            let in_flight = Arc::clone(&in_flight);
+            let peak = Arc::clone(&peak);
+            Box::pin(async move {
+                let now = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                peak.fetch_max(now, Ordering::SeqCst);
+                tokio::time::sleep(Duration::from_millis(40)).await;
+                in_flight.fetch_sub(1, Ordering::SeqCst);
+                NodeOutcome::Completed
+            })
+        })
+    };
+
+    let summary = execute_dag(
+        &dag2,
+        &TransferResourceManager::new(budget),
+        runner,
+        Arc::new(NoopDagObserver) as Arc<dyn DagObserver>,
+        Some(Arc::clone(&controller)),
+    )
+    .await
+    .expect("the healthy second run must complete");
+
+    assert_eq!(summary.nodes_completed, 8);
+    assert_eq!(
+        peak.load(Ordering::SeqCst),
+        4,
+        "the congestion shrink from run 1 throttles run 2 to 4 transfers in flight"
+    );
+}

--- a/src-tauri/tests/dispatcher_exec.rs
+++ b/src-tauri/tests/dispatcher_exec.rs
@@ -57,10 +57,28 @@ fn write_stub(path: &Path, name: &str, exit_code: i32) {
 }
 
 fn run_dispatcher(dispatcher: &Path, arg0: &str, args: &[&str]) -> Output {
-    let mut cmd = Command::new(dispatcher);
-    cmd.arg0(arg0);
-    cmd.args(args);
-    cmd.output().unwrap()
+    // ETXTBSY ("Text file busy", errno 26): the kernel refuses to exec a file
+    // that is open for writing anywhere on the system. The parallel cargo test
+    // runner can transiently hold a writable fd on a just-copied dispatcher
+    // binary (a sibling test's process spawn inherits the fd for the brief
+    // window between fork and the close-on-exec), so a fresh exec can fail for
+    // reasons that are never a real defect. A bounded retry clears it well
+    // within a second.
+    const ETXTBSY: i32 = 26;
+    const MAX_ATTEMPTS: u32 = 50;
+    for attempt in 1..=MAX_ATTEMPTS {
+        let mut cmd = Command::new(dispatcher);
+        cmd.arg0(arg0);
+        cmd.args(args);
+        match cmd.output() {
+            Ok(output) => return output,
+            Err(e) if e.raw_os_error() == Some(ETXTBSY) && attempt < MAX_ATTEMPTS => {
+                std::thread::sleep(std::time::Duration::from_millis(20));
+            }
+            Err(e) => panic!("dispatcher exec failed after {attempt} attempt(s): {e}"),
+        }
+    }
+    unreachable!("retry loop returns an Output or panics")
 }
 
 #[test]

--- a/src-tauri/tests/integration_gtc_wan_segmented.rs
+++ b/src-tauri/tests/integration_gtc_wan_segmented.rs
@@ -1099,7 +1099,11 @@ async fn gtc_dag_sftp_single_file_byte_identical() {
         .await
         .expect("legacy SFTP download");
     let e_legacy = t_legacy.elapsed();
-    assert_eq!(sha256_file(&dst_legacy), src_sha, "legacy SFTP sha mismatch");
+    assert_eq!(
+        sha256_file(&dst_legacy),
+        src_sha,
+        "legacy SFTP sha mismatch"
+    );
 
     // DAG path: the same download routed through execute_single_file_dag.
     let dst_dag = dst_root.join("dag.bin");

--- a/src-tauri/tests/integration_gtc_wan_segmented.rs
+++ b/src-tauri/tests/integration_gtc_wan_segmented.rs
@@ -29,7 +29,9 @@
 #![cfg(unix)]
 
 use std::path::{Path, PathBuf};
-use std::time::Instant;
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use ftp_client_gui_lib::credential_store::CredentialStore;
 use ftp_client_gui_lib::cross_profile_transfer::{
@@ -48,9 +50,13 @@ use ftp_client_gui_lib::sync::{
     sync_tree_core, ConflictMode, DeltaPolicy, NoopProgressSink, SyncDirection, SyncOptions,
 };
 use ftp_client_gui_lib::sync_core::scan::ScanOptions;
-use ftp_client_gui_lib::transfer_dag::Capability;
+use ftp_client_gui_lib::transfer_dag::{
+    Capability, DagObserver, NoopDagObserver, TransferDagBuilder, TransferDirection,
+};
+use ftp_client_gui_lib::transfer_dag_single_file::execute_single_file_dag;
 use secrecy::SecretString;
 use sha2::{Digest, Sha256};
+use tokio::sync::Mutex;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 
@@ -993,6 +999,241 @@ async fn gtc_gui_s3_segmented_byte_identical_vs_single_stream() {
         speedup,
     );
 
+    let _ = base.delete(S3_REMOTE_BIG).await;
+    let _ = base.disconnect().await;
+    let _ = std::fs::remove_dir_all(&dst_root);
+    let _ = std::fs::remove_dir_all(&src_dir);
+}
+
+// ---------------------------------------------------------------------
+// DAG-ENGINE phase 1: single-file convergence
+//
+// These tests prove the byte-identical contract for the flag-on path:
+// `execute_single_file_dag` (the seven-node graph through `execute_dag`)
+// must produce the same bytes as a bare `provider.download`, the legacy
+// flag-off leaf. They are the parity oracle for the phase-1 closure gate.
+//
+// Run:
+// ```bash
+// cargo test --release --test integration_gtc_wan_segmented dag \
+//     -- --ignored --nocapture --test-threads=1
+// ```
+// ---------------------------------------------------------------------
+
+/// Run a plain single-file download through the phase-1 DAG path and hand
+/// the provider back. Mirrors exactly what the flag-on GUI / CLI routing
+/// does for the plain classic leaf: the same `provider.download`, behind
+/// the graph schedule, with a silent observer.
+async fn dag_download_once(
+    provider: Box<dyn StorageProvider>,
+    remote: &str,
+    local: &str,
+) -> (Box<dyn StorageProvider>, Result<(), String>) {
+    let arc = Arc::new(Mutex::new(Some(provider)));
+    let built = TransferDagBuilder::single_file(TransferDirection::Download);
+    let report = Arc::new(AtomicU64::new(0));
+    let observer: Arc<dyn DagObserver> = Arc::new(NoopDagObserver);
+    let res = execute_single_file_dag(
+        &built,
+        Arc::clone(&arc),
+        remote.to_string(),
+        local.to_string(),
+        None,
+        None,
+        observer,
+        report,
+    )
+    .await
+    .map_err(|e| e.to_string());
+    let provider = arc
+        .lock()
+        .await
+        .take()
+        .expect("provider is returned by the single-file DAG");
+    (provider, res)
+}
+
+/// Print one harness-readable parity line for a DAG-vs-legacy cell.
+fn report_dag_cell(label: &str, legacy: Duration, dag: Duration) {
+    let speedup = legacy.as_secs_f64() / dag.as_secs_f64().max(1e-6);
+    let overhead = (dag.as_secs_f64() / legacy.as_secs_f64().max(1e-6) - 1.0) * 100.0;
+    eprintln!(
+        "DAG-ENGINE phase1 {label}: 64MiB legacy {:.2}s  dag {:.2}s  \
+         speedup {:.2}x  dag-overhead {:+.1}%  byte-id=YES",
+        legacy.as_secs_f64(),
+        dag.as_secs_f64(),
+        speedup,
+        overhead,
+    );
+}
+
+#[tokio::test]
+#[ignore = "live WAN: DAG-ENGINE phase-1 SFTP single-file byte-identity (vault required)"]
+async fn gtc_dag_sftp_single_file_byte_identical() {
+    let Some(creds) = load_sftp_creds() else {
+        eprintln!("SKIP: SFTP credentials unavailable in vault");
+        return;
+    };
+
+    let src_dir = std::env::temp_dir().join("gtc-dag-sftp-src");
+    let _ = std::fs::remove_dir_all(&src_dir);
+    std::fs::create_dir_all(&src_dir).unwrap();
+    let src = src_dir.join("64MiB.bin");
+    std::fs::write(&src, random_buf(0xDA9D_5F11, FILE_BYTES)).unwrap();
+    let src_sha = sha256_file(&src);
+
+    let mut base = SftpProvider::new(sftp_config(creds));
+    base.connect().await.expect("base SFTP connect");
+    seed_remote(&mut base, &src).await.expect("seed SFTP");
+
+    let dst_root = std::env::temp_dir().join("gtc-dag-sftp-dst");
+    let _ = std::fs::remove_dir_all(&dst_root);
+    std::fs::create_dir_all(&dst_root).unwrap();
+
+    // Legacy baseline: a bare provider.download (the flag-off leaf).
+    let dst_legacy = dst_root.join("legacy.bin");
+    let mut legacy = base.clone_for_transfer().expect("clone SFTP legacy worker");
+    let t_legacy = Instant::now();
+    legacy
+        .download(REMOTE_BIG, dst_legacy.to_str().unwrap(), None)
+        .await
+        .expect("legacy SFTP download");
+    let e_legacy = t_legacy.elapsed();
+    assert_eq!(sha256_file(&dst_legacy), src_sha, "legacy SFTP sha mismatch");
+
+    // DAG path: the same download routed through execute_single_file_dag.
+    let dst_dag = dst_root.join("dag.bin");
+    let dag_worker = base.clone_for_transfer().expect("clone SFTP DAG worker");
+    let t_dag = Instant::now();
+    let (mut dag_worker, res) =
+        dag_download_once(dag_worker, REMOTE_BIG, dst_dag.to_str().unwrap()).await;
+    let e_dag = t_dag.elapsed();
+    res.expect("DAG SFTP download must succeed");
+    assert_eq!(
+        sha256_file(&dst_dag),
+        src_sha,
+        "DAG SFTP download must be byte-identical to the source",
+    );
+
+    report_dag_cell("SFTP @ axpbuntu", e_legacy, e_dag);
+
+    let _ = dag_worker.disconnect().await;
+    let _ = legacy.disconnect().await;
+    let _ = base.delete(REMOTE_BIG).await;
+    let _ = base.disconnect().await;
+    let _ = std::fs::remove_dir_all(&dst_root);
+    let _ = std::fs::remove_dir_all(&src_dir);
+}
+
+#[tokio::test]
+#[ignore = "live WAN: DAG-ENGINE phase-1 FTP single-file byte-identity (vault required)"]
+async fn gtc_dag_ftp_single_file_byte_identical() {
+    let Some(password) = load_ftp_password() else {
+        eprintln!("SKIP: FTP password unavailable in vault");
+        return;
+    };
+
+    let src_dir = std::env::temp_dir().join("gtc-dag-ftp-src");
+    let _ = std::fs::remove_dir_all(&src_dir);
+    std::fs::create_dir_all(&src_dir).unwrap();
+    let src = src_dir.join("64MiB.bin");
+    std::fs::write(&src, random_buf(0xF7B0_0DA6, FILE_BYTES)).unwrap();
+    let src_sha = sha256_file(&src);
+
+    let mut base = FtpProvider::new(ftp_config(password));
+    base.connect().await.expect("base FTP connect");
+    seed_remote_ftp(&mut base, &src).await.expect("seed FTP");
+
+    let dst_root = std::env::temp_dir().join("gtc-dag-ftp-dst");
+    let _ = std::fs::remove_dir_all(&dst_root);
+    std::fs::create_dir_all(&dst_root).unwrap();
+
+    let dst_legacy = dst_root.join("legacy.bin");
+    let mut legacy = base.clone_for_transfer().expect("clone FTP legacy worker");
+    let t_legacy = Instant::now();
+    legacy
+        .download(FTP_REMOTE_BIG, dst_legacy.to_str().unwrap(), None)
+        .await
+        .expect("legacy FTP download");
+    let e_legacy = t_legacy.elapsed();
+    assert_eq!(sha256_file(&dst_legacy), src_sha, "legacy FTP sha mismatch");
+
+    let dst_dag = dst_root.join("dag.bin");
+    let dag_worker = base.clone_for_transfer().expect("clone FTP DAG worker");
+    let t_dag = Instant::now();
+    let (mut dag_worker, res) =
+        dag_download_once(dag_worker, FTP_REMOTE_BIG, dst_dag.to_str().unwrap()).await;
+    let e_dag = t_dag.elapsed();
+    res.expect("DAG FTP download must succeed");
+    assert_eq!(
+        sha256_file(&dst_dag),
+        src_sha,
+        "DAG FTP download must be byte-identical to the source",
+    );
+
+    report_dag_cell("FTP @ axpbuntu", e_legacy, e_dag);
+
+    let _ = dag_worker.disconnect().await;
+    let _ = legacy.disconnect().await;
+    let _ = base.delete(FTP_REMOTE_BIG).await;
+    let _ = base.disconnect().await;
+    let _ = std::fs::remove_dir_all(&dst_root);
+    let _ = std::fs::remove_dir_all(&src_dir);
+}
+
+#[tokio::test]
+#[ignore = "live WAN: DAG-ENGINE phase-1 S3 single-file byte-identity against axpbuntu MinIO (vault required)"]
+async fn gtc_dag_s3_single_file_byte_identical() {
+    let Some(secret) = load_s3_secret() else {
+        eprintln!("SKIP: S3 secret unavailable in vault");
+        return;
+    };
+
+    let src_dir = std::env::temp_dir().join("gtc-dag-s3-src");
+    let _ = std::fs::remove_dir_all(&src_dir);
+    std::fs::create_dir_all(&src_dir).unwrap();
+    let src = src_dir.join("64MiB.bin");
+    std::fs::write(&src, random_buf(0x53D0_0DA6, FILE_BYTES)).unwrap();
+    let src_sha = sha256_file(&src);
+
+    let mut base = S3Provider::new(s3_config(secret)).expect("S3Provider::new");
+    base.connect().await.expect("base S3 connect");
+    let _ = base.delete(S3_REMOTE_BIG).await;
+    base.upload(src.to_str().unwrap(), S3_REMOTE_BIG, None)
+        .await
+        .expect("seed S3 upload");
+
+    let dst_root = std::env::temp_dir().join("gtc-dag-s3-dst");
+    let _ = std::fs::remove_dir_all(&dst_root);
+    std::fs::create_dir_all(&dst_root).unwrap();
+
+    let dst_legacy = dst_root.join("legacy.bin");
+    let mut legacy = base.clone_for_transfer().expect("clone S3 legacy worker");
+    let t_legacy = Instant::now();
+    legacy
+        .download(S3_REMOTE_BIG, dst_legacy.to_str().unwrap(), None)
+        .await
+        .expect("legacy S3 download");
+    let e_legacy = t_legacy.elapsed();
+    assert_eq!(sha256_file(&dst_legacy), src_sha, "legacy S3 sha mismatch");
+
+    let dst_dag = dst_root.join("dag.bin");
+    let dag_worker = base.clone_for_transfer().expect("clone S3 DAG worker");
+    let t_dag = Instant::now();
+    let (mut dag_worker, res) =
+        dag_download_once(dag_worker, S3_REMOTE_BIG, dst_dag.to_str().unwrap()).await;
+    let e_dag = t_dag.elapsed();
+    res.expect("DAG S3 download must succeed");
+    assert_eq!(
+        sha256_file(&dst_dag),
+        src_sha,
+        "DAG S3 download must be byte-identical to the source",
+    );
+
+    report_dag_cell("S3 @ axpbuntu MinIO", e_legacy, e_dag);
+
+    let _ = dag_worker.disconnect().await;
+    let _ = legacy.disconnect().await;
     let _ = base.delete(S3_REMOTE_BIG).await;
     let _ = base.disconnect().await;
     let _ = std::fs::remove_dir_all(&dst_root);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7078,7 +7078,16 @@ interface UpdateVerificationInfo {
     }
 
     const protocol = activeUnifiedRemoteProfile?.protocol;
-    const isProvider = !!protocol && !isFtpProtocol(protocol);
+    // AeroSync runner routing must match how the connection was actually
+    // dialled. A modern FTP/FTPS session lives in `state.provider` (the
+    // StorageProvider impl), exactly like SFTP and the cloud providers, and
+    // the Compare step already uses `usesProviderApi` to pick
+    // `provider_compare_directories`. Computing this with `!isFtpProtocol`
+    // instead flagged FTP as a legacy `ftp_manager` connection, so the runner
+    // sent every transfer through `download_file`/`upload_file` against an
+    // `ftp_manager` that was never connected: every FTP file failed with
+    // "Not connected to server" while S3 (provider path) worked.
+    const isProvider = usesProviderApi(protocol);
 
     // Bandwidth caps come from the CO-3 Sync-tab inputs (localStorage).
     // GAP-9a: Maniac mode ignores them outright (MANIAC_OVERRIDES sets the


### PR DESCRIPTION
This branch lands phases 1 to 3 of the DAG transfer engine convergence plan
(`docs/dev/roadmap/APPENDIX-DAG-ENGINE.md`): single-file, batch and sync
transfers schedule through one shared graph engine, the builder is
capability-aware, and AIMD backpressure is live.

The DAG engine paths are behind env-var feature flags, **default OFF**, so
they are behaviour-neutral for shipped builds until a flag is set; a
rollback is a toggle, never a revert. The branch also carries three plain
FTP bug fixes (see "FTP clone-pool + AeroSync routing fixes" below) that
ship unconditionally and are independent of the DAG flags.

### Commits

- `e853c88c` fix(deps): bump russh to 0.60.3 (GHSA-g9f8-wqj9-fjw5)
- `b855b29c` feat(transfer): add TransferDagBuilder for single-file graphs
- `492373c0` fix(test): retry dispatcher exec on transient ETXTBSY
- `0e1784b3` feat(transfer): route single-file transfers through the DAG engine
- `55675c71` feat(transfer): DAG engine phases 2-3 (batch/sync, capability, AIMD)
- `d91a84e6` fix(ftp): dial the connection before a clone-pool upload
- `b41051bf` fix(ftp): dial the connection before resume-download and in-memory read
- `eb762133` fix(sync): route FTP transfers through the provider API in AeroSync

### Phase 1 — single-file convergence

Single download and upload, GUI and CLI, schedule through `execute_dag` with a
seven-node graph. `GuiDagObserver` maps node lifecycle onto the existing GUI
events byte-identically. Routing is flag-gated; delta / segmented / resume /
GitHub paths stay legacy.

### Phase 2 — batch + sync convergence

- `transfer_dag_batch.rs`: a whole batch routes through
  `TransferDagBuilder::from_batch` + `execute_dag`.
- `transfer_dag_sync.rs`: `sync_tree_core` routes through `from_sync_plan` +
  `execute_dag`; the legacy body stays intact behind a three-line guard.
- The builder gains `from_batch` / `from_sync_plan`; a sync journal observer
  marks per-file terminals; `maxConcurrentTransfers` maps to `file_slots`.

### Phase 3 — capability + AIMD live

- Capability-aware builder: `TransferGraphProfile`, `shaped_file` (multipart
  `UploadPart` fan-out, `api_slots` for rate-limited providers, resume flag),
  `shaped_copy` with the new `ServerSideCopy` node kind.
- AIMD live: `AimdController::from_budget`, wired as `Some(ctrl)` into all four
  production `execute_dag` call sites. Each class starts at its ceiling, so a
  congestion-free run dispatches identically to before.
- AIMD guard band: `AimdConfig.recovery_window` blocks additive increase from
  climbing straight back to the level that congested.
- `SessionProbeCache` memoises `SupportedAfterProbe` results per session.
- `resolve_session_model`: the executor-kind decision extracted to a pure
  function of `TransferCapabilities`.

### Feature flags (all default OFF)

- `AEROFTP_TRANSFER_ENGINE_DAG_SINGLE_FILE`
- `AEROFTP_TRANSFER_ENGINE_DAG_BATCH`
- `AEROFTP_TRANSFER_ENGINE_DAG_SYNC`

### Verification

- `cargo test --lib` 1719 passing, `transfer_dag` 97, `aeroftp-cli` 166.
- Integration 0 failures, including the new `tests/aimd_backpressure.rs`
  (429 / 503 / timeout backpressure scenarios).
- `cargo clippy --lib --tests` and `cargo fmt --check` clean.

### FTP clone-pool + AeroSync routing fixes (not flag-gated)

Three plain FTP bug fixes ride the branch, independent of the DAG engine
and the feature flags. The DAG GUI validation surfaced them but they
reproduce with every flag OFF.

- `d91a84e6` fix(ftp): clone-pool upload. A `clone_for_transfer()` pool
  worker (PD-FTP-1) starts unconnected and carries only the connection
  spec; `download()` and `read_range()` called `ensure_connected()` but
  `upload()` did not. Every file inside an FTP folder upload failed with
  `NotConnected` because folder upload runs through the clone-pool
  executor. Verified green on the lab `.deb`.
- `b41051bf` fix(ftp): clone-pool resume-download + in-memory read.
  Sibling of `d91a84e6`: `resume_download()` (the transfer executor calls
  it on any retry with a partial `.aerotmp` offset) and
  `download_to_bytes()` were the remaining `StorageProvider` methods
  that skipped `ensure_connected()`. Each fix is a single
  `ensure_connected().await?` at the top of the method, no-op when
  already connected, single-stream path unchanged.
- `eb762133` fix(sync): AeroSync runner routing for FTP. AeroSync on
  FTP/FTPS failed every transfer with "Not connected to server" on both
  Linux and Windows; S3 worked. The runner config derived `isProvider`
  from `!isFtpProtocol`, which is false for ftp/ftps, so it sent every
  transfer through the legacy `download_file`/`upload_file` commands
  that operate on `state.ftp_manager`. A modern FTP/FTPS session is
  dialled into `state.provider` exactly like SFTP and the cloud
  providers; the legacy `ftp_manager` was never connected. The Compare
  step of the same dialog already picked its command with
  `usesProviderApi`, as does every other transfer path in `App.tsx`.
  Computing the runner's `isProvider` with `usesProviderApi(protocol)`
  routes FTP through `provider_download_file` / `provider_upload_file`
  / `provider_mkdir` / `provider_set_speed_limit` against the connected
  `state.provider`, identical to S3. Verified green on the lab `.deb`.

### Not yet done (validation window, tracked in the roadmap)

- Manual GUI session on real `.deb` / `.msi` builds with the flags ON.
- `parity_harness` GUI cells, flag ON (F1-T08, F2-T08, F3-T12).
- Live rate-limited backpressure check on a real provider (F3-T08).
- Windows regression check on `d91a84e6` / `eb762133` (folder upload
  FTP + AeroSync FTP). The runner's `.msi` from `55675c71` is green
  (`aimd_backpressure` 5/5, smoke flag ON/OFF, build clean); the three
  FTP fixes will be retested on the real release `.msi` post-merge, not
  on an interim feature-branch build.

### Security

`e853c88c` bumps russh to 0.60.3 for GHSA-g9f8-wqj9-fjw5; merging this should
clear the related Dependabot HIGH alert.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DAG-based transfer engine (single-file, batch, sync) with observable progress and session-aware execution
  * Session probe caching for capability resolution
  * GUI-friendly transfer completion observer and durable sync-journal observer

* **Improvements**
  * AIMD backpressure enhanced with recovery windows and guard bands
  * Transfer concurrency budgeting integrated throughout transfer paths

* **Bug Fixes**
  * FTP pool operations now ensure connections before use
  * Corrected FTP/FTPS classification for sync runs

* **Chores**
  * Updated russh dependency to 0.60.3

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/axpdev-lab/aeroftp/pull/227?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->