### PR TITLE
fix: release v3.8.5 follow-ups (#229 #231 #232)

### DIFF
--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -19071,9 +19071,9 @@ fn cmd_alias_toggle(name: &str, bin_dir: Option<&Path>, format: OutputFormat) ->
                 print_error(
                     format,
                     &format!("cannot resolve current executable: {}", e),
-                    5,
+                    2,
                 );
-                return 5;
+                return 2;
             }
         };
         let bin_dir = match bin_dir

--- a/src-tauri/src/providers/filen/mod.rs
+++ b/src-tauri/src/providers/filen/mod.rs
@@ -799,18 +799,29 @@ impl StorageProvider for FilenProvider {
             .as_ref()
             .map(|k| k.expose_secret().trim().to_string())
             .filter(|k| !k.is_empty());
+        let api_key_path = configured_api_key.is_some();
 
         let encrypted_master_keys: Option<String> = if let Some(api_key) = configured_api_key {
             self.api_key = SecretString::from(api_key);
             filen_log("connect: API-key path, skipping /v3/login (no 2FA window)");
-            // Best-effort: recover the canonical master-keys history. If the
-            // call fails, derived_master_key alone still decrypts everything
-            // encrypted under the current password.
+            // The API-key path replaces /v3/login, so we must obtain and
+            // decrypt the canonical master-keys ring here. A partial ring
+            // would silently break decryption for files encrypted under
+            // previously-rotated keys.
             match self.fetch_master_keys_blob(&derived_master_key).await {
-                Ok(blob) => blob,
+                Ok(Some(blob)) => Some(blob),
+                Ok(None) => {
+                    filen_log("connect: /v3/user/masterKeys returned no blob");
+                    return Err(ProviderError::AuthenticationFailed(
+                        "Filen returned no master keys; reconnect with the account password to refresh the ring".to_string(),
+                    ));
+                }
                 Err(e) => {
                     filen_log(&format!("connect: /v3/user/masterKeys failed: {}", e));
-                    None
+                    return Err(ProviderError::AuthenticationFailed(format!(
+                        "Cannot load Filen master keys via API key ({}); reconnect with the account password to refresh the ring",
+                        e
+                    )));
                 }
             }
         } else {
@@ -872,19 +883,30 @@ impl StorageProvider for FilenProvider {
         ));
         if let Some(blob) = encrypted_master_keys {
             filen_log(&format!("master_keys blob len={}", blob.len()));
-            if let Some(decrypted) = Self::try_decrypt_aes_gcm(&blob, &derived_master_key) {
-                let decrypted_keys: Vec<SecretString> = decrypted
-                    .split('|')
-                    .map(|s| SecretString::from(s.to_string()))
-                    .collect();
-                // Check if derived_master_key is already present
-                let already_present = decrypted_keys
-                    .iter()
-                    .any(|k| k.expose_secret() == derived_master_key);
-                self.master_keys = decrypted_keys;
-                if !already_present {
-                    self.master_keys
-                        .push(SecretString::from(derived_master_key));
+            match Self::try_decrypt_aes_gcm(&blob, &derived_master_key) {
+                Some(decrypted) => {
+                    let decrypted_keys: Vec<SecretString> = decrypted
+                        .split('|')
+                        .map(|s| SecretString::from(s.to_string()))
+                        .collect();
+                    // Check if derived_master_key is already present
+                    let already_present = decrypted_keys
+                        .iter()
+                        .any(|k| k.expose_secret() == derived_master_key);
+                    self.master_keys = decrypted_keys;
+                    if !already_present {
+                        self.master_keys
+                            .push(SecretString::from(derived_master_key));
+                    }
+                }
+                None if api_key_path => {
+                    filen_log("connect: master_keys blob decrypt failed on API-key path");
+                    return Err(ProviderError::AuthenticationFailed(
+                        "Cannot decrypt Filen master keys with the account password; reconnect to refresh the ring".to_string(),
+                    ));
+                }
+                None => {
+                    filen_log("connect: master_keys blob decrypt failed; proceeding with derived_master_key only");
                 }
             }
         }

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -259,7 +259,7 @@
             "totpSecretHelp": "2FA gizli anahtarınızı bir kez kaydedin. AeroFTP, bir kimlik doğrulayıcı uygulama gibi her yeniden bağlanmada 6 haneli kodu otomatik olarak üretir.",
             "filenApiKey": "Filen CLI API anahtarı (isteğe bağlı)",
             "filenApiKeyPlaceholder": "Filen CLI'den API anahtarı",
-            "filenApiKeyHelp": "Her yeniden bağlanışta 2FA kodunu atlamak için Filen CLI profilinizdeki API anahtarını yapıştırın. Hesap parolası yine de gereklidir: dosyalarınızı uçtan uca şifresini çözer.",
+            "filenApiKeyHelp": "Her yeniden bağlanışta 2FA kodunu atlamak için Filen CLI profilinizdeki API anahtarını yapıştırın. Hesap parolası yine de gereklidir: dosyalarınızın uçtan uca şifresini çözer.",
             "manualTotalStorage": "Toplam depolama (manuel)",
             "manualTotalStoragePlaceholder": "ör. 10 GB, 500 GB, 2 TB",
             "manualTotalStorageHint": "İsteğe bağlı. Kota API'si olmayan (FTP, S3, WebDAV) veya yalnızca kullanılan alanı bildiren (Backblaze B2) arka uçlar için plan veya hesap sınırı. Sağlayıcının kendi toplam değeri her zaman önceliklidir.",

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -1359,11 +1359,12 @@ export const PROVIDERS: ProviderConfig[] = [
         },
         features: { shareLink: false, sync: true },
         healthCheckUrl: 'https://webdav.pcloud.com',
-        helpUrl: 'https://www.pcloud.com',
+        helpUrl: 'https://help.pcloud.com/article/webdav',
         signupUrl: 'https://www.pcloud.com',
         setupInstructions: [
             'Use your pCloud account email as the username',
             'Use your regular pCloud login password',
+            'The default server https://webdav.pcloud.com serves the US data region',
             'European region accounts: change the server to https://ewebdav.pcloud.com',
             'On the first connection pCloud may email a "New login attempt. Is this you?" confirmation: approve it to continue',
             'That confirmation email is sent by team@pcloud.com: ignore any lookalike sender',


### PR DESCRIPTION
Three CodeRabbit follow-ups surfaced post-merge on PR #227 and PR #228.
Bundled so v3.8.5 can ship the Filen API-key + pCloud WebDAV work without
the silent-degrade hazard from #229, the polish gaps from #231, or the
mis-mapped exit code from #232 still on the books.

### Commits

- `d2733619` fix(cli): correct exit code for current_exe() resolve failure
- `72604fad` fix(providers): polish pCloud WebDAV preset and Turkish help text
- `b0909f2e` fix(filen): surface incomplete masterKeys ring as connect error

### `d2733619` CLI exit-code 5 -> 2 (closes #232)

`cmd_alias_toggle` returned exit code 5 (reserved for the config-error
class) when `std::env::current_exe()` failed. Map both the `print_error`
argument and the function return to 2 (path error), aligning with the
rest of the CLI exit-code taxonomy. One-line semantic correction, no
behaviour change to the alias toggle path itself.

### `72604fad` pCloud WebDAV polish + Turkish grammar (closes #231)

Three CodeRabbit nitpicks on the new `pcloud-webdav` registry preset and
the Filen API-key help string from PR #228:

- `helpUrl` was the generic homepage. Point at
  `https://help.pcloud.com/article/webdav`, the canonical pCloud
  WebDAV article.
- `setupInstructions` mentioned the European endpoint but left the
  default ambiguous. Add an explicit line that
  `https://webdav.pcloud.com` serves the US data region.
- `filenApiKeyHelp` in `tr.json` had a double-marked accusative
  (`dosyalarınızı uçtan uca şifresini çözer`). Switch to the genitive
  (`dosyalarınızın`) so the second clause reads naturally.

### `b0909f2e` Filen master-keys ring silent degrade (closes #229)

The optional Filen CLI API-key path skips POST `/v3/login` and recovers
the encrypted master-keys blob from POST `/v3/user/masterKeys` instead.
Previously every failure mode on that recovery (network/HTTP error,
empty blob, decrypt failure) silently degraded the session to a single
`derived_master_key`. For accounts with a password-rotation history the
older keys remained missing, so `connect()` reported success while
later file operations failed to decrypt anything encrypted under a
prior key.

Convert the three silent-fallback branches into `AuthenticationFailed`
returns when the API-key path is in use. Each error message tells the
user to reconnect with the account password so `/v3/login` can refresh
the full ring. Preserve the existing best-effort decrypt fallback for
the password path, where `/v3/login` already guarantees a usable
session even when older blobs cannot be decoded.

### Verification

- `npm run typecheck` clean
- `cargo check --lib --bin aeroftp` clean
- `cargo check --bin aeroftp-cli` clean
- `npm run i18n:validate` 46/46 locales clean, zero placeholders

Rebased on `main` at `1051314f` (post macOS CI pin). No conflicts.

### Out of scope

- #230 (Filen API key persisted in `ProviderOptions`) requires a vault
  migration and UI work, slated for v3.8.6 or roadmap.
- #233 / #234 sit behind the DAG transfer-engine env flags (default
  OFF). Both are pre-flag-flip Phase 4 work, not release-blocking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CLI error exit code handling
  * Strengthened Filen provider authentication validation for API-key connections

* **Documentation**
  * Updated Turkish localization text
  * Enhanced pCloud WebDAV setup instructions with server region clarification

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/axpdev-lab/aeroftp/pull/236?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->