### PR TITLE
perf(intro-hub): unblock React.memo on My Servers screen (#221)

### DIFF
--- a/src/components/IntroHub/MyServersPanel.tsx
+++ b/src/components/IntroHub/MyServersPanel.tsx
@@ -35,6 +35,23 @@ const HEALTH_SCAN_CHUNK_DELAY_MS = 180;
 const DRAG_SENTINEL_TOP = -1;
 const DRAG_SENTINEL_BOTTOM = -2;
 
+// Pre-allocated lucide-react icon elements for the right-click context menu.
+// Without these constants the menu allocates a fresh JSX element per item per
+// right-click. Not a hot path on its own but it stacks with the other
+// per-render allocations on the My Servers screen (issue #221).
+const MENU_ICON_CONNECT      = <Play size={14} />;
+const MENU_ICON_DISCONNECT   = <LogOut size={14} className="text-amber-500" />;
+const MENU_ICON_EDIT         = <Edit2 size={14} />;
+const MENU_ICON_RENAME       = <PencilLine size={14} />;
+const MENU_ICON_COPY         = <Copy size={14} />;
+const MENU_ICON_FAVORITE     = <Star size={14} />;
+const MENU_ICON_CROSS_SRC    = <ArrowUpRight size={14} className="text-indigo-500" />;
+const MENU_ICON_CROSS_DEST   = <ArrowDownLeft size={14} className="text-emerald-500" />;
+const MENU_ICON_HEALTH       = <Activity size={14} />;
+const MENU_ICON_SPEED        = <Gauge size={14} />;
+const MENU_ICON_MOUNT        = <HardDrive size={14} />;
+const MENU_ICON_DELETE       = <Trash2 size={14} />;
+
 /** Load credential from vault with retry if store not ready */
 const getCredentialWithRetry = async (account: string, maxRetries = 3): Promise<string> => {
     for (let attempt = 0; attempt < maxRetries; attempt++) {
@@ -559,20 +576,26 @@ export function MyServersPanel({
         }
     }, [dragIdx]);
 
-    const handleDragStart = useCallback((idx: number) => (e: React.DragEvent) => {
+    // Drag handlers used to be higher-order functions (`(idx) => (e) => ...`),
+    // which produced a fresh closure per card per render and silently
+    // defeated the `React.memo()` on `ServerCard` and `MyServersTableRow`.
+    // They now take `(idx, e)` as a single signature, so the parent passes
+    // a stable reference and the children rebind to their own row index
+    // internally via `useCallback`. See issue #221.
+    const handleDragStart = useCallback((idx: number, e: React.DragEvent) => {
         setDragIdx(idx);
         e.dataTransfer.effectAllowed = 'move';
         e.dataTransfer.setData('text/plain', idx.toString());
     }, []);
 
-    const handleDragEnter = useCallback((idx: number) => (e: React.DragEvent) => {
+    const handleDragEnter = useCallback((idx: number, e: React.DragEvent) => {
         e.preventDefault();
         e.dataTransfer.dropEffect = 'move';
         maybeAutoScrollWhileDrag(e.clientY);
         setOverIdx(idx);
     }, [maybeAutoScrollWhileDrag]);
 
-    const handleDragOver = useCallback((idx: number) => (e: React.DragEvent) => {
+    const handleDragOver = useCallback((idx: number, e: React.DragEvent) => {
         e.preventDefault();
         e.dataTransfer.dropEffect = 'move';
         maybeAutoScrollWhileDrag(e.clientY);
@@ -585,7 +608,7 @@ export function MyServersPanel({
     // complains about temporal dead zone access.
     const insertEdgesRef = useRef({ insertStartIdx: 0, insertEndIdx: 0 });
 
-    const handleDrop = useCallback((idx: number) => (e: React.DragEvent) => {
+    const handleDrop = useCallback((idx: number, e: React.DragEvent) => {
         e.preventDefault();
         if (dragIdx === null) { setDragIdx(null); setOverIdx(null); return; }
         const { insertStartIdx: insStart, insertEndIdx: insEnd } = insertEdgesRef.current;
@@ -627,11 +650,38 @@ export function MyServersPanel({
         return () => window.removeEventListener('keydown', onKeyDown);
     }, [dragIdx]);
 
+    // Pre-compute lowercased search blobs keyed by server id. Without this
+    // cache `getServerSearchText` (which builds a string from 5 server
+    // fields) ran on every server on every keystroke, multiplying string
+    // allocations and LowerCase work needlessly. Issue #221.
+    const serverSearchTexts = useMemo(
+        () => new Map(servers.map(s => [s.id, getServerSearchText(s)])),
+        [servers],
+    );
+
+    // O(1) lookup for "where does this server sit in the full `servers`
+    // array". Replaces O(N) `findIndex` calls inside per-card render,
+    // which compounded to O(N^2) on every parent re-render. Issue #221.
+    const serverIndexMap = useMemo(
+        () => new Map(servers.map((s, i) => [s.id, i])),
+        [servers],
+    );
+
+    // O(1) lookup for the cross-profile selection role of a given server.
+    // Replaces a per-card `Array.indexOf` over `crossProfileSelection`.
+    // Issue #221.
+    const crossProfileRoleMap = useMemo((): Map<string, 'source' | 'destination'> => {
+        const m = new Map<string, 'source' | 'destination'>();
+        if (crossProfileSelection[0]) m.set(crossProfileSelection[0], 'source');
+        if (crossProfileSelection[1]) m.set(crossProfileSelection[1], 'destination');
+        return m;
+    }, [crossProfileSelection]);
+
     const filteredServers = useMemo(() => {
         let result = servers;
         if (searchQuery.trim()) {
             const q = searchQuery.toLowerCase();
-            result = result.filter((server) => getServerSearchText(server).includes(q));
+            result = result.filter((server) => (serverSearchTexts.get(server.id) ?? '').includes(q));
         }
         if (activeFilter === 'favorites') {
             result = result.filter(s => favorites.has(s.id));
@@ -642,18 +692,17 @@ export function MyServersPanel({
             }
         }
         return result;
-    }, [servers, searchQuery, activeFilter, favorites]);
+    }, [servers, searchQuery, activeFilter, favorites, serverSearchTexts]);
 
     const { insertStartIdx, insertEndIdx } = useMemo(() => {
         if (filteredServers.length === 0) {
             return { insertStartIdx: 0, insertEndIdx: servers.length };
         }
-        const firstVisible = servers.findIndex((s) => s.id === filteredServers[0].id);
-        const lastVisible = servers.findIndex((s) => s.id === filteredServers[filteredServers.length - 1].id);
-        const safeFirst = firstVisible >= 0 ? firstVisible : 0;
-        const safeLast = lastVisible >= 0 ? lastVisible : Math.max(servers.length - 1, 0);
-        return { insertStartIdx: safeFirst, insertEndIdx: safeLast + 1 };
-    }, [filteredServers, servers]);
+        const firstVisible = serverIndexMap.get(filteredServers[0].id) ?? 0;
+        const lastVisible = serverIndexMap.get(filteredServers[filteredServers.length - 1].id)
+            ?? Math.max(servers.length - 1, 0);
+        return { insertStartIdx: firstVisible, insertEndIdx: lastVisible + 1 };
+    }, [filteredServers, servers, serverIndexMap]);
 
     // Keep the drop-handler ref in sync with the memoized edges.
     useEffect(() => {
@@ -1064,7 +1113,7 @@ export function MyServersPanel({
         const isFav = favorites.has(server.id);
         const hasActiveSession = activeProfileIds?.has(server.id) ?? false;
         const items: ContextMenuItem[] = [
-            { label: t('common.connect'), icon: <Play size={14} />, action: () => handleConnect(server) },
+            { label: t('common.connect'), icon: MENU_ICON_CONNECT, action: () => handleConnect(server) },
         ];
         if (hasActiveSession && onDisconnectProfile) {
             // Issue #222: Disconnect entry surfaces only when at least one
@@ -1072,39 +1121,39 @@ export function MyServersPanel({
             // the actual connection state instead of showing a no-op entry.
             items.push({
                 label: t('common.disconnect'),
-                icon: <LogOut size={14} className="text-amber-500" />,
+                icon: MENU_ICON_DISCONNECT,
                 action: () => { void onDisconnectProfile(server.id); },
             });
         }
         items.push(
-            { label: t('common.edit'), icon: <Edit2 size={14} />, action: () => onEdit(server) },
-            { label: t('introHub.renameWithHotkey'), icon: <PencilLine size={14} />, action: () => handleRenameStart(server) },
-            { label: t('common.copy'), icon: <Copy size={14} />, action: () => handleDuplicate(server) },
-            { label: isFav ? t('introHub.removeFavorite') : t('introHub.addFavorite'), icon: <Star size={14} />, action: () => toggleFavorite(server.id) },
+            { label: t('common.edit'), icon: MENU_ICON_EDIT, action: () => onEdit(server) },
+            { label: t('introHub.renameWithHotkey'), icon: MENU_ICON_RENAME, action: () => handleRenameStart(server) },
+            { label: t('common.copy'), icon: MENU_ICON_COPY, action: () => handleDuplicate(server) },
+            { label: isFav ? t('introHub.removeFavorite') : t('introHub.addFavorite'), icon: MENU_ICON_FAVORITE, action: () => toggleFavorite(server.id) },
         );
         if (onOpenCrossProfile && servers.length > 1) {
             items.push({
                 label: t('introHub.setAsCrossProfileSource'),
-                icon: <ArrowUpRight size={14} className="text-indigo-500" />,
+                icon: MENU_ICON_CROSS_SRC,
                 action: () => setAsCrossProfileSource(server.id),
                 divider: true,
             });
             items.push({
                 label: t('introHub.setAsCrossProfileDestination'),
-                icon: <ArrowDownLeft size={14} className="text-emerald-500" />,
+                icon: MENU_ICON_CROSS_DEST,
                 action: () => setAsCrossProfileDestination(server.id),
             });
         }
         items.push(
-            { label: t('healthCheck.title'), icon: <Activity size={14} />, action: () => setHealthCheckTarget(server.id), divider: true },
+            { label: t('healthCheck.title'), icon: MENU_ICON_HEALTH, action: () => setHealthCheckTarget(server.id), divider: true },
             {
                 label: t('speedTest.title'),
-                icon: <Gauge size={14} />,
+                icon: MENU_ICON_SPEED,
                 action: () => setSpeedTestTarget(server.id),
                 disabled: !supportsSpeedTest(server),
             },
-            { label: t('mountManager.openMountAction'), icon: <HardDrive size={14} />, action: () => handleOpenMount(server) },
-            { label: t('common.delete'), icon: <Trash2 size={14} />, action: () => handleDelete(server), danger: true },
+            { label: t('mountManager.openMountAction'), icon: MENU_ICON_MOUNT, action: () => handleOpenMount(server) },
+            { label: t('common.delete'), icon: MENU_ICON_DELETE, action: () => handleDelete(server), danger: true },
         );
         showContextMenu(e, items);
     }, [t, handleConnect, onEdit, handleDuplicate, handleDelete, handleRenameStart, toggleFavorite, favorites, showContextMenu, onOpenCrossProfile, setAsCrossProfileSource, setAsCrossProfileDestination, servers.length, handleOpenMount, activeProfileIds, onDisconnectProfile]);
@@ -1210,18 +1259,17 @@ export function MyServersPanel({
                         {canDrag && dragIdx !== null && (
                             <div
                                 className={`col-span-full h-6 rounded-md border-2 border-dashed transition-colors ${overIdx === DRAG_SENTINEL_TOP ? 'border-blue-500 bg-blue-100/60 dark:bg-blue-900/30' : 'border-transparent'}`}
-                                onDragEnter={handleDragEnter(DRAG_SENTINEL_TOP)}
-                                onDragOver={handleDragOver(DRAG_SENTINEL_TOP)}
-                                onDrop={handleDrop(DRAG_SENTINEL_TOP)}
+                                onDragEnter={(e) => handleDragEnter(DRAG_SENTINEL_TOP, e)}
+                                onDragOver={(e) => handleDragOver(DRAG_SENTINEL_TOP, e)}
+                                onDrop={(e) => handleDrop(DRAG_SENTINEL_TOP, e)}
                             />
                         )}
                         {filteredServers.map((server) => {
                             // Resolve the real index in the full `servers` array so drag-reorder
-                            // works correctly even with a filter or search applied.
-                            const realIdx = servers.findIndex(s => s.id === server.id);
-                            const selectionIndex = crossProfileSelection.indexOf(server.id);
-                            const selectionRole: 'source' | 'destination' | null =
-                                selectionIndex === 0 ? 'source' : selectionIndex === 1 ? 'destination' : null;
+                            // works correctly even with a filter or search applied. O(1) via the
+                            // pre-computed maps (issue #221) instead of per-card linear scans.
+                            const realIdx = serverIndexMap.get(server.id) ?? -1;
+                            const selectionRole = crossProfileRoleMap.get(server.id) ?? null;
                             // Always read the cached status: in detailed layout it
                             // drives the 16px radial; in compact it powers the small
                             // overlay dot on the icon (T-HEALTH-CIRCLES).
@@ -1248,10 +1296,11 @@ export function MyServersPanel({
                                     isDraggable={canDrag}
                                     isDragging={dragIdx === realIdx}
                                     isDragTarget={overIdx === realIdx && dragIdx !== null && dragIdx !== realIdx}
-                                    onDragStart={canDrag ? handleDragStart(realIdx) : undefined}
-                                    onDragEnter={canDrag ? handleDragEnter(realIdx) : undefined}
-                                    onDragOver={canDrag ? handleDragOver(realIdx) : undefined}
-                                    onDrop={canDrag ? handleDrop(realIdx) : undefined}
+                                    dragIndex={realIdx}
+                                    onDragStart={canDrag ? handleDragStart : undefined}
+                                    onDragEnter={canDrag ? handleDragEnter : undefined}
+                                    onDragOver={canDrag ? handleDragOver : undefined}
+                                    onDrop={canDrag ? handleDrop : undefined}
                                     onDragEnd={canDrag ? handleDragEnd : undefined}
                                     selectionRole={selectionRole}
                                     onSelect={servers.length > 1 ? handleSelectServer : undefined}
@@ -1266,9 +1315,9 @@ export function MyServersPanel({
                         {canDrag && dragIdx !== null && (
                             <div
                                 className={`col-span-full h-6 rounded-md border-2 border-dashed transition-colors ${overIdx === DRAG_SENTINEL_BOTTOM ? 'border-blue-500 bg-blue-100/60 dark:bg-blue-900/30' : 'border-transparent'}`}
-                                onDragEnter={handleDragEnter(DRAG_SENTINEL_BOTTOM)}
-                                onDragOver={handleDragOver(DRAG_SENTINEL_BOTTOM)}
-                                onDrop={handleDrop(DRAG_SENTINEL_BOTTOM)}
+                                onDragEnter={(e) => handleDragEnter(DRAG_SENTINEL_BOTTOM, e)}
+                                onDragOver={(e) => handleDragOver(DRAG_SENTINEL_BOTTOM, e)}
+                                onDrop={(e) => handleDrop(DRAG_SENTINEL_BOTTOM, e)}
                             />
                         )}
                     </div>
@@ -1289,9 +1338,9 @@ export function MyServersPanel({
                     {canDrag && dragIdx !== null && (
                         <div
                             className={`mx-2 mt-2 h-5 rounded-md border-2 border-dashed transition-colors ${overIdx === DRAG_SENTINEL_TOP ? 'border-blue-500 bg-blue-100/60 dark:bg-blue-900/30' : 'border-transparent'}`}
-                            onDragEnter={handleDragEnter(DRAG_SENTINEL_TOP)}
-                            onDragOver={handleDragOver(DRAG_SENTINEL_TOP)}
-                            onDrop={handleDrop(DRAG_SENTINEL_TOP)}
+                            onDragEnter={(e) => handleDragEnter(DRAG_SENTINEL_TOP, e)}
+                            onDragOver={(e) => handleDragOver(DRAG_SENTINEL_TOP, e)}
+                            onDrop={(e) => handleDrop(DRAG_SENTINEL_TOP, e)}
                         />
                     )}
                     <MyServersTable
@@ -1334,9 +1383,9 @@ export function MyServersPanel({
                     {canDrag && dragIdx !== null && (
                         <div
                             className={`mx-2 mb-2 h-5 rounded-md border-2 border-dashed transition-colors ${overIdx === DRAG_SENTINEL_BOTTOM ? 'border-blue-500 bg-blue-100/60 dark:bg-blue-900/30' : 'border-transparent'}`}
-                            onDragEnter={handleDragEnter(DRAG_SENTINEL_BOTTOM)}
-                            onDragOver={handleDragOver(DRAG_SENTINEL_BOTTOM)}
-                            onDrop={handleDrop(DRAG_SENTINEL_BOTTOM)}
+                            onDragEnter={(e) => handleDragEnter(DRAG_SENTINEL_BOTTOM, e)}
+                            onDragOver={(e) => handleDragOver(DRAG_SENTINEL_BOTTOM, e)}
+                            onDrop={(e) => handleDrop(DRAG_SENTINEL_BOTTOM, e)}
                         />
                     )}
                     </div>

--- a/src/components/IntroHub/MyServersTable.tsx
+++ b/src/components/IntroHub/MyServersTable.tsx
@@ -44,10 +44,10 @@ interface MyServersTableProps {
     canDrag: boolean;
     dragIdx: number | null;
     overIdx: number | null;
-    onDragStart: (idx: number) => (e: React.DragEvent) => void;
-    onDragEnter: (idx: number) => (e: React.DragEvent) => void;
-    onDragOver: (idx: number) => (e: React.DragEvent) => void;
-    onDrop: (idx: number) => (e: React.DragEvent) => void;
+    onDragStart: (idx: number, e: React.DragEvent) => void;
+    onDragEnter: (idx: number, e: React.DragEvent) => void;
+    onDragOver: (idx: number, e: React.DragEvent) => void;
+    onDrop: (idx: number, e: React.DragEvent) => void;
     onDragEnd: () => void;
     crossProfileSelection: string[];
     onSelect: (server: ServerProfile) => void;
@@ -292,10 +292,11 @@ export function MyServersTable({
                                 isDraggable={canDrag}
                                 isDragging={dragIdx === realIdx}
                                 isDragTarget={overIdx === realIdx && dragIdx !== null && dragIdx !== realIdx}
-                                onDragStart={canDrag ? onDragStart(realIdx) : undefined}
-                                onDragEnter={canDrag ? onDragEnter(realIdx) : undefined}
-                                onDragOver={canDrag ? onDragOver(realIdx) : undefined}
-                                onDrop={canDrag ? onDrop(realIdx) : undefined}
+                                dragIndex={realIdx}
+                                onDragStart={canDrag ? onDragStart : undefined}
+                                onDragEnter={canDrag ? onDragEnter : undefined}
+                                onDragOver={canDrag ? onDragOver : undefined}
+                                onDrop={canDrag ? onDrop : undefined}
                                 onDragEnd={canDrag ? onDragEnd : undefined}
                                 dragDisabledTitle={dragDisabledTitle}
                                 selectionRole={selectionRole}

--- a/src/components/IntroHub/MyServersTableRow.tsx
+++ b/src/components/IntroHub/MyServersTableRow.tsx
@@ -44,10 +44,14 @@ interface MyServersTableRowProps {
     isDraggable?: boolean;
     isDragging?: boolean;
     isDragTarget?: boolean;
-    onDragStart?: (e: React.DragEvent) => void;
-    onDragEnter?: (e: React.DragEvent) => void;
-    onDragOver?: (e: React.DragEvent) => void;
-    onDrop?: (e: React.DragEvent) => void;
+    /** Position of this row in the parent's `servers` array. Lets the row
+     *  bind the four parent drag callbacks to its own index without
+     *  forcing the parent to re-curry on every render (issue #221). */
+    dragIndex?: number;
+    onDragStart?: (idx: number, e: React.DragEvent) => void;
+    onDragEnter?: (idx: number, e: React.DragEvent) => void;
+    onDragOver?: (idx: number, e: React.DragEvent) => void;
+    onDrop?: (idx: number, e: React.DragEvent) => void;
     onDragEnd?: () => void;
     dragDisabledTitle?: string;
     selectionRole?: 'source' | 'destination' | null;
@@ -85,6 +89,7 @@ export const MyServersTableRow = React.memo(function MyServersTableRow({
     isDraggable,
     isDragging,
     isDragTarget,
+    dragIndex,
     onDragStart,
     onDragEnter,
     onDragOver,
@@ -115,6 +120,27 @@ export const MyServersTableRow = React.memo(function MyServersTableRow({
     const handleMouseEnter = onHoverChange ? () => onHoverChange(server) : undefined;
     const handleMouseLeave = onHoverChange ? () => onHoverChange(null) : undefined;
     const handleRetry = onRetryHealth ? () => onRetryHealth(server) : undefined;
+
+    // Bind the parent's stable `(idx, e) => void` drag callbacks to this
+    // row's `dragIndex` so the bound references survive parent re-renders.
+    // This is what restores the `React.memo()` skip on rows whose own data
+    // did not change (issue #221).
+    const handleRowDragStart = React.useCallback(
+        (e: React.DragEvent) => { if (typeof dragIndex === 'number') onDragStart?.(dragIndex, e); },
+        [onDragStart, dragIndex],
+    );
+    const handleRowDragEnter = React.useCallback(
+        (e: React.DragEvent) => { if (typeof dragIndex === 'number') onDragEnter?.(dragIndex, e); },
+        [onDragEnter, dragIndex],
+    );
+    const handleRowDragOver = React.useCallback(
+        (e: React.DragEvent) => { if (typeof dragIndex === 'number') onDragOver?.(dragIndex, e); },
+        [onDragOver, dragIndex],
+    );
+    const handleRowDrop = React.useCallback(
+        (e: React.DragEvent) => { if (typeof dragIndex === 'number') onDrop?.(dragIndex, e); },
+        [onDrop, dragIndex],
+    );
     const radialTitle = healthStatus
         ? t(`introHub.health.${healthStatus}`)
             + (healthLatencyMs && healthStatus !== 'pending' && healthStatus !== 'down' ? ` · ${healthLatencyMs}ms` : '')
@@ -241,7 +267,7 @@ export const MyServersTableRow = React.memo(function MyServersTableRow({
                         // area generous (whole index column) without nesting a
                         // tiny div inside. The tr keeps drop-side handlers.
                         draggable={isDraggable}
-                        onDragStart={isDraggable ? onDragStart : undefined}
+                        onDragStart={isDraggable && onDragStart ? handleRowDragStart : undefined}
                         onDragEnd={isDraggable ? onDragEnd : undefined}
                         className={`${cellClass} text-right text-[11px] tabular-nums text-gray-400 dark:text-gray-500 ${isDraggable ? 'cursor-grab active:cursor-grabbing' : ''}`}
                         title={dragDisabledTitle || (isDraggable ? t('introHub.table.dragToReorder') : undefined)}
@@ -422,9 +448,9 @@ export const MyServersTableRow = React.memo(function MyServersTableRow({
             // in the index cell (WebKitGTK doesn't reliably fire dragstart on
             // <tr>). The row keeps the drop-side handlers so users can drop
             // anywhere along the row.
-            onDragEnter={onDragEnter}
-            onDragOver={onDragOver}
-            onDrop={onDrop}
+            onDragEnter={onDragEnter ? handleRowDragEnter : undefined}
+            onDragOver={onDragOver ? handleRowDragOver : undefined}
+            onDrop={onDrop ? handleRowDrop : undefined}
             onClick={handleRowClick}
             onContextMenu={(e) => onContextMenu?.(e, server)}
             onMouseEnter={handleMouseEnter}

--- a/src/components/IntroHub/ServerCard.tsx
+++ b/src/components/IntroHub/ServerCard.tsx
@@ -259,10 +259,16 @@ interface ServerCardProps {
     isDraggable?: boolean;
     isDragging?: boolean;
     isDragTarget?: boolean;
-    onDragStart?: (e: React.DragEvent) => void;
-    onDragEnter?: (e: React.DragEvent) => void;
-    onDragOver?: (e: React.DragEvent) => void;
-    onDrop?: (e: React.DragEvent) => void;
+    /** Position of this card in the parent's `servers` array. Passed as a
+     *  separate prop, instead of being curried into each drag handler at
+     *  the call site, so the four handler references stay stable across
+     *  parent re-renders and `React.memo()` actually skips re-rendering
+     *  cards whose own data did not change (issue #221). */
+    dragIndex?: number;
+    onDragStart?: (idx: number, e: React.DragEvent) => void;
+    onDragEnter?: (idx: number, e: React.DragEvent) => void;
+    onDragOver?: (idx: number, e: React.DragEvent) => void;
+    onDrop?: (idx: number, e: React.DragEvent) => void;
     onDragEnd?: () => void;
     /** Cross-Profile Transfer selection role for this card. */
     selectionRole?: 'source' | 'destination' | null;
@@ -398,6 +404,7 @@ export const ServerCard = React.memo(function ServerCard({
     isDraggable,
     isDragging,
     isDragTarget,
+    dragIndex,
     onDragStart,
     onDragEnter,
     onDragOver,
@@ -474,15 +481,36 @@ export const ServerCard = React.memo(function ServerCard({
         });
     }, [server, credentialsMasked, hideUsername]);
 
+    // Bind the parent's stable `(idx, e) => void` drag handlers to this
+    // card's `dragIndex` once per (handler, index) change instead of on
+    // every parent render. This is what makes `React.memo` actually skip
+    // re-rendering unchanged cards (issue #221).
+    const handleCardDragStart = React.useCallback(
+        (e: React.DragEvent) => { if (typeof dragIndex === 'number') onDragStart?.(dragIndex, e); },
+        [onDragStart, dragIndex],
+    );
+    const handleCardDragEnter = React.useCallback(
+        (e: React.DragEvent) => { if (typeof dragIndex === 'number') onDragEnter?.(dragIndex, e); },
+        [onDragEnter, dragIndex],
+    );
+    const handleCardDragOver = React.useCallback(
+        (e: React.DragEvent) => { if (typeof dragIndex === 'number') onDragOver?.(dragIndex, e); },
+        [onDragOver, dragIndex],
+    );
+    const handleCardDrop = React.useCallback(
+        (e: React.DragEvent) => { if (typeof dragIndex === 'number') onDrop?.(dragIndex, e); },
+        [onDrop, dragIndex],
+    );
+
     // ===== GRID VIEW =====
     return (
         <div
             data-my-server-card
             draggable={isDraggable}
-            onDragStart={onDragStart}
-            onDragEnter={onDragEnter}
-            onDragOver={onDragOver}
-            onDrop={onDrop}
+            onDragStart={onDragStart ? handleCardDragStart : undefined}
+            onDragEnter={onDragEnter ? handleCardDragEnter : undefined}
+            onDragOver={onDragOver ? handleCardDragOver : undefined}
+            onDrop={onDrop ? handleCardDrop : undefined}
             onDragEnd={onDragEnd}
             onClick={handleCardClick}
             className={`group relative bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-750 border rounded-lg p-3.5 transition-colors shadow-sm dark:shadow-md ${isDraggable ? 'cursor-grab active:cursor-grabbing' : ''} ${onSelect ? 'cursor-pointer' : ''} ${isDragging ? 'opacity-40 scale-[0.97] shadow-lg ring-2 ring-blue-400/50 border-blue-400' : 'border-gray-100 dark:border-gray-700/50 hover:border-blue-200 dark:hover:border-blue-500/30'} ${isDragTarget ? '!border-blue-500 !border-2 bg-blue-50 dark:bg-blue-900/30 shadow-inner' : ''} ${selectionRingClass}`}


### PR DESCRIPTION
## Summary

Five concrete optimisations on the home grid and table view that together let `React.memo` skip re-rendering server cards whose own data did not change.

1. Stable drag callbacks (signature change `(idx, e) => void` + `dragIndex` prop).
2. `servers.findIndex` replaced with a `useMemo`'d `Map<id, index>`.
3. `crossProfileSelection.indexOf` replaced with a `useMemo`'d `Map<id, role>`.
4. Search-text cache (`useMemo`'d `Map<id, lowercased>`).
5. Pre-allocated context menu icons.

TypeScript clean. No behavioural change. Most visible on slower hardware and WebView2 builds where the prior allocation pattern compounded into perceptible input lag.

## Reporter

@raelb (Windows 10, v3.8.3 video showing input lag)

## Test plan

- [ ] Reporter confirms responsiveness on next build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized server drag-and-drop reordering and search performance through improved handler efficiency and memoized caching.
  * Streamlined server management context menu structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/axpdev-lab/aeroftp/pull/255?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->