### PR TITLE
feat(mega): megacmd df helper for storage quota (#253)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15584,6 +15584,7 @@ pub fn run() {
             provider_commands::provider_import_link,
             provider_commands::provider_compare_directories,
             provider_commands::provider_storage_info,
+            provider_commands::mega_df_query,
             provider_commands::provider_disk_usage,
             provider_commands::provider_calculate_folder_size,
             provider_commands::provider_cancel_folder_size,

--- a/src-tauri/src/profile_loader.rs
+++ b/src-tauri/src/profile_loader.rs
@@ -62,6 +62,18 @@ pub fn insert_profile_option(
 
 /// Copy the entire `options` object from a saved profile into `extra`.
 pub fn apply_profile_options(extra: &mut HashMap<String, String>, profile: &serde_json::Value) {
+    if let Some(provider_id) = profile
+        .get("providerId")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        extra.insert(
+            crate::providers::mega_df::PROVIDER_ID_META_KEY.to_string(),
+            provider_id.to_string(),
+        );
+    }
+
     if let Some(opts) = profile.get("options").and_then(|v| v.as_object()) {
         for (k, v) in opts {
             insert_profile_option(extra, k, v);

--- a/src-tauri/src/provider_commands.rs
+++ b/src-tauri/src/provider_commands.rs
@@ -248,6 +248,8 @@ async fn try_silent_reconnect(
 pub struct ProviderConnectionParams {
     /// Protocol type: "ftp", "ftps", "sftp", "webdav", "s3", "mega", "opendrive"
     pub protocol: String,
+    /// Registry preset id, when connected through a named preset.
+    pub provider_id: Option<String>,
     /// Host/URL (FTP server, WebDAV URL, or S3 endpoint)
     pub server: String,
     /// Port (optional, defaults based on protocol)
@@ -350,6 +352,15 @@ impl ProviderConnectionParams {
         };
 
         let mut extra = std::collections::HashMap::new();
+
+        if let Some(ref provider_id) = self.provider_id {
+            if !provider_id.trim().is_empty() {
+                extra.insert(
+                    crate::providers::mega_df::PROVIDER_ID_META_KEY.to_string(),
+                    provider_id.trim().to_string(),
+                );
+            }
+        }
 
         // Add S3-specific options
         if provider_type == ProviderType::S3 {
@@ -3761,6 +3772,15 @@ pub async fn provider_storage_info(state: State<'_, ProviderState>) -> Result<St
         .storage_info()
         .await
         .map_err(|e| format!("Failed to get storage info: {}", e))
+}
+
+/// Query MEGAcmd quota directly through `mega-df`.
+#[tauri::command]
+pub async fn mega_df_query(profile_id: String) -> Result<(u64, u64), String> {
+    let _ = profile_id;
+    crate::providers::mega_df::mega_df_query()
+        .await
+        .map_err(|e| format!("Failed to query mega-df: {}", e))
 }
 
 /// Get disk usage for a path in bytes
@@ -9700,6 +9720,7 @@ mod tests {
     fn s3_params(path_style: Option<bool>) -> ProviderConnectionParams {
         ProviderConnectionParams {
             protocol: "s3".to_string(),
+            provider_id: None,
             server: "http://localhost".to_string(),
             port: Some(3900),
             username: "access".to_string(),

--- a/src-tauri/src/providers/mega.rs
+++ b/src-tauri/src/providers/mega.rs
@@ -52,37 +52,7 @@ impl MegaCmdProvider {
 
     /// Resolve MEGAcmd executable path (checks PATH and common install locations)
     fn resolve_mega_cmd(cmd: &str) -> String {
-        #[cfg(windows)]
-        {
-            let program_files =
-                std::env::var("ProgramFiles").unwrap_or_else(|_| r"C:\Program Files".to_string());
-            let local_appdata = std::env::var("LOCALAPPDATA").unwrap_or_default();
-            let candidates = [
-                format!(r"{}\MEGAcmd\{}.bat", program_files, cmd),
-                format!(r"{}\MEGAcmd\{}.exe", program_files, cmd),
-                format!(r"{}\MEGAcmd\{}.bat", local_appdata, cmd),
-            ];
-            for candidate in &candidates {
-                if std::path::Path::new(candidate).exists() {
-                    return candidate.clone();
-                }
-            }
-        }
-        #[cfg(target_os = "macos")]
-        {
-            // ARCH-05: Check macOS install locations
-            let candidates = [
-                format!("/Applications/MEGAcmd.app/Contents/MacOS/{}", cmd),
-                format!("/usr/local/bin/{}", cmd),
-                format!("/opt/homebrew/bin/{}", cmd),
-            ];
-            for candidate in &candidates {
-                if std::path::Path::new(candidate).exists() {
-                    return candidate.clone();
-                }
-            }
-        }
-        cmd.to_string()
+        super::mega_df::resolve_mega_cmd(cmd)
     }
 
     /// Classify MEGAcmd stderr into typed ProviderError (ERR-01).
@@ -462,6 +432,10 @@ impl StorageProvider for MegaCmdProvider {
     }
 
     async fn connect(&mut self) -> Result<(), ProviderError> {
+        // SAFETY: mega-df warms up the MEGAcmd Server when it has been quit/
+        // exited. See issue #253.
+        let _ = super::mega_df::mega_df_query().await;
+
         self.current_path = "/".to_string();
 
         // ARCH-01: Check MEGAcmd installation and ARCH-02: ensure daemon is running
@@ -965,36 +939,7 @@ impl StorageProvider for MegaCmdProvider {
     }
 
     async fn storage_info(&mut self) -> Result<StorageInfo, ProviderError> {
-        let output = self.run_mega_cmd_with_reauth("mega-df", &[]).await?;
-
-        // CQ-05: Only parse the "Total" or "Cloud drive" line for storage info
-        let mut used: u64 = 0;
-        let mut total: u64 = 0;
-
-        for line in output.lines() {
-            let line = line.trim();
-            // Look for lines with "of" pattern containing byte counts
-            if let Some(colon_pos) = line.find(':') {
-                let label = line[..colon_pos].trim().to_lowercase();
-                let rest = line[colon_pos + 1..].trim();
-                let parts: Vec<&str> = rest.split_whitespace().collect();
-                // Format: "<used> of <total> ..."
-                if parts.len() >= 3 && parts[1] == "of" {
-                    if let (Ok(u), Ok(t)) = (parts[0].parse::<u64>(), parts[2].parse::<u64>()) {
-                        // Prefer "Total" line; fall back to "Cloud drive"
-                        if label.contains("total") {
-                            used = u;
-                            total = t;
-                            break;
-                        } else if label.contains("cloud drive") {
-                            used = u;
-                            total = t;
-                            // Don't break: a "Total" line may follow
-                        }
-                    }
-                }
-            }
-        }
+        let (used, total) = super::mega_df::mega_df_query().await?;
 
         Ok(StorageInfo {
             used,

--- a/src-tauri/src/providers/mega_df.rs
+++ b/src-tauri/src/providers/mega_df.rs
@@ -1,0 +1,276 @@
+//! Shared MEGAcmd `mega-df` quota helper.
+//!
+//! `mega-df` is useful beyond quota parsing: when the MEGAcmd Server has
+//! been stopped with `quit` or `exit`, invoking any `mega-*` command starts
+//! it again in the background. Issue #253 relies on that warm-up behavior.
+
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+use tokio::process::Command;
+
+use super::ProviderError;
+
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x08000000;
+
+const MEGA_DF_TIMEOUT_SECS: u64 = 30;
+
+/// Metadata key used to carry the GUI registry preset id through ProviderConfig.
+pub const PROVIDER_ID_META_KEY: &str = "_aeroftp_provider_id";
+
+/// Resolve MEGAcmd executable path (checks PATH and common install locations).
+pub(crate) fn resolve_mega_cmd(cmd: &str) -> String {
+    #[cfg(windows)]
+    {
+        let program_files =
+            std::env::var("ProgramFiles").unwrap_or_else(|_| r"C:\Program Files".to_string());
+        let local_appdata = std::env::var("LOCALAPPDATA").unwrap_or_default();
+        let candidates = [
+            format!(r"{}\MEGAcmd\{}.bat", program_files, cmd),
+            format!(r"{}\MEGAcmd\{}.exe", program_files, cmd),
+            format!(r"{}\MEGAcmd\{}.bat", local_appdata, cmd),
+            format!(r"{}\MEGAcmd\{}.exe", local_appdata, cmd),
+        ];
+        for candidate in &candidates {
+            if std::path::Path::new(candidate).exists() {
+                return candidate.clone();
+            }
+        }
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let candidates = [
+            format!("/Applications/MEGAcmd.app/Contents/MacOS/{}", cmd),
+            format!("/usr/local/bin/{}", cmd),
+            format!("/opt/homebrew/bin/{}", cmd),
+        ];
+        for candidate in &candidates {
+            if std::path::Path::new(candidate).exists() {
+                return candidate.clone();
+            }
+        }
+    }
+    cmd.to_string()
+}
+
+/// True for WebDAV presets backed by the local MEGAcmd bridge.
+pub(crate) fn is_megacmd_webdav_provider_id(provider_id: Option<&str>) -> bool {
+    matches!(provider_id, Some("megacmd") | Some("megacmd-webdav"))
+}
+
+/// Query MEGAcmd account quota by spawning `mega-df`.
+pub async fn mega_df_query() -> Result<(u64, u64), ProviderError> {
+    let resolved_cmd = resolve_mega_cmd("mega-df");
+    let mut cmd = Command::new(&resolved_cmd);
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt as _;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+
+    let output = tokio::time::timeout(
+        std::time::Duration::from_secs(MEGA_DF_TIMEOUT_SECS),
+        cmd.output(),
+    )
+    .await
+    .map_err(|_| ProviderError::Timeout)?
+    .map_err(|e| {
+        ProviderError::NotSupported(format!(
+            "mega-df is not available (resolved: {}): {}",
+            resolved_cmd, e
+        ))
+    })?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let detail = if stderr.is_empty() {
+            stdout.trim().to_string()
+        } else {
+            stderr
+        };
+        let lower = detail.to_ascii_lowercase();
+        if lower.contains("not logged in")
+            || lower.contains("not logged-in")
+            || lower.contains("login required")
+        {
+            return Err(ProviderError::AuthenticationFailed(format!(
+                "mega-df: {}",
+                detail
+            )));
+        }
+        return Err(ProviderError::ServerError(format!("mega-df: {}", detail)));
+    }
+
+    parse_mega_df_output(&stdout)
+}
+
+pub(crate) fn parse_mega_df_output(output: &str) -> Result<(u64, u64), ProviderError> {
+    let mut used = None;
+    let mut total = None;
+
+    for raw_line in output.lines() {
+        let line = raw_line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        let (label, rest) = line
+            .split_once(':')
+            .map(|(label, rest)| (label.trim().to_ascii_lowercase(), rest.trim()))
+            .unwrap_or_else(|| (line.to_ascii_lowercase(), line));
+
+        let numbers = integer_tokens(rest);
+        if numbers.is_empty() {
+            continue;
+        }
+
+        let is_used_label = label.contains("used storage")
+            || label.contains("storage used")
+            || (label.contains("used") && !label.contains("total"));
+        let is_total_label = label.contains("total storage")
+            || label.contains("storage total")
+            || label.contains("capacity");
+
+        let rest_lower = rest.to_ascii_lowercase();
+        if rest_lower.contains(" of ")
+            && numbers.len() >= 2
+            && (is_used_label || is_total_label || label == "total")
+        {
+            used = Some(numbers[0]);
+            if let Some((_, after_of)) = rest_lower.split_once(" of ") {
+                if let Some(total_value) = integer_tokens(after_of).first().copied() {
+                    total = Some(total_value);
+                }
+            }
+            continue;
+        }
+
+        let byte_value = number_before_bytes(rest).unwrap_or(numbers[0]);
+
+        if is_used_label {
+            used = Some(byte_value);
+        }
+        if is_total_label {
+            total = Some(byte_value);
+        }
+    }
+
+    let used = used.ok_or_else(|| {
+        ProviderError::ParseError(format!(
+            "Could not parse USED STORAGE from mega-df output: {}",
+            output.trim()
+        ))
+    })?;
+    let total = total.ok_or_else(|| {
+        ProviderError::ParseError(format!(
+            "Could not parse TOTAL STORAGE from mega-df output: {}",
+            output.trim()
+        ))
+    })?;
+
+    Ok((used, total))
+}
+
+fn number_before_bytes(text: &str) -> Option<u64> {
+    let lower = text.to_ascii_lowercase();
+    let bytes_pos = lower.find("bytes")?;
+    integer_tokens(&text[..bytes_pos]).pop()
+}
+
+fn integer_tokens(text: &str) -> Vec<u64> {
+    let mut out = Vec::new();
+    let mut current = String::new();
+
+    for ch in text.chars() {
+        if ch.is_ascii_digit() {
+            current.push(ch);
+        } else if (ch == ',' || ch == '_') && !current.is_empty() {
+            continue;
+        } else if !current.is_empty() {
+            if let Ok(value) = current.parse::<u64>() {
+                out.push(value);
+            }
+            current.clear();
+        }
+    }
+
+    if !current.is_empty() {
+        if let Ok(value) = current.parse::<u64>() {
+            out.push(value);
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_used_and_total_storage_rows() {
+        let output = "\
+USED STORAGE: 5368709120 bytes (5.0 GB)
+TOTAL STORAGE: 21474836480 bytes (20.0 GB)
+";
+        assert_eq!(
+            parse_mega_df_output(output).unwrap(),
+            (5_368_709_120, 21_474_836_480)
+        );
+    }
+
+    #[test]
+    fn parses_total_of_format() {
+        let output = "Total: 5368709120 of 21474836480 bytes used";
+        assert_eq!(
+            parse_mega_df_output(output).unwrap(),
+            (5_368_709_120, 21_474_836_480)
+        );
+    }
+
+    #[test]
+    fn parses_megacmd_stdout_with_total_on_used_storage_row() {
+        let output = "\
+Cloud drive:             313221381 in      17 file(s) and       6 folder(s)
+Inbox:                           0 in       0 file(s) and       0 folder(s)
+Rubbish bin:             535035904 in       3 file(s) and       3 folder(s)
+---------------------------------------------------------------------------
+USED STORAGE:            848257285                   0.03% of 3303903592448
+---------------------------------------------------------------------------
+Total size taken up by file versions:     31457280
+";
+        assert_eq!(
+            parse_mega_df_output(output).unwrap(),
+            (848_257_285, 3_303_903_592_448)
+        );
+    }
+
+    #[test]
+    fn missing_total_is_parse_error() {
+        let err = parse_mega_df_output("USED STORAGE: 5368709120 bytes").unwrap_err();
+        assert!(matches!(err, ProviderError::ParseError(_)));
+        assert!(err.to_string().contains("TOTAL STORAGE"));
+    }
+
+    #[test]
+    fn missing_used_is_parse_error() {
+        let err = parse_mega_df_output("TOTAL STORAGE: 21474836480 bytes").unwrap_err();
+        assert!(matches!(err, ProviderError::ParseError(_)));
+        assert!(err.to_string().contains("USED STORAGE"));
+    }
+
+    #[test]
+    fn empty_output_is_parse_error() {
+        let err = parse_mega_df_output("").unwrap_err();
+        assert!(matches!(err, ProviderError::ParseError(_)));
+    }
+
+    #[test]
+    fn resolves_plain_name_when_binary_is_not_in_known_locations() {
+        let out = resolve_mega_cmd("mega-df");
+        assert!(!out.is_empty());
+        assert!(out.contains("mega-df") || out.ends_with("mega-df"));
+    }
+}

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -46,6 +46,7 @@ pub mod kdrive;
 pub mod koofr;
 pub mod mega;
 pub mod mega_crypto;
+pub mod mega_df;
 pub mod mega_native;
 pub mod multi_thread;
 pub mod oauth1;

--- a/src-tauri/src/providers/types.rs
+++ b/src-tauri/src/providers/types.rs
@@ -348,6 +348,8 @@ pub struct WebDavConfig {
     pub username: String,
     pub password: secrecy::SecretString,
     pub initial_path: Option<String>,
+    /// Registry preset id, when the profile came from a named WebDAV preset.
+    pub provider_id: Option<String>,
     /// Whether to verify TLS certificates (default: true). Set to false for self-signed certs.
     pub verify_cert: bool,
     /// Whether requests should omit Authorization headers.
@@ -429,6 +431,10 @@ impl WebDavConfig {
             username,
             password: secrecy::SecretString::from(config.password.clone().unwrap_or_default()),
             initial_path,
+            provider_id: config
+                .extra
+                .get(super::mega_df::PROVIDER_ID_META_KEY)
+                .cloned(),
             verify_cert,
             anonymous,
         })

--- a/src-tauri/src/providers/webdav.rs
+++ b/src-tauri/src/providers/webdav.rs
@@ -1637,6 +1637,12 @@ impl StorageProvider for WebDavProvider {
     }
 
     async fn connect(&mut self) -> Result<(), ProviderError> {
+        if super::mega_df::is_megacmd_webdav_provider_id(self.config.provider_id.as_deref()) {
+            // SAFETY: mega-df warms up the MEGAcmd Server when it has been quit/
+            // exited. See issue #253.
+            let _ = super::mega_df::mega_df_query().await;
+        }
+
         // A3-03: Warn when using unencrypted HTTP: credentials and data sent in plaintext
         if self.config.url.starts_with("http://") {
             tracing::warn!(
@@ -2592,6 +2598,15 @@ impl StorageProvider for WebDavProvider {
             return Err(ProviderError::NotConnected);
         }
 
+        if super::mega_df::is_megacmd_webdav_provider_id(self.config.provider_id.as_deref()) {
+            let (used, total) = super::mega_df::mega_df_query().await?;
+            return Ok(super::StorageInfo {
+                used,
+                total,
+                free: total.saturating_sub(used),
+            });
+        }
+
         // Koofr WebDAV does not expose RFC 4331 quota properties via PROPFIND
         // (returns 0 / 0). Use the native Koofr REST API instead: it accepts
         // basic auth with the same email + app password used for WebDAV.
@@ -3043,6 +3058,7 @@ mod tests {
             username: "user".to_string(),
             password: secrecy::SecretString::from("pass".to_string()),
             initial_path: None,
+            provider_id: None,
             verify_cert: true,
             anonymous: false,
         }

--- a/src-tauri/tests/dag_webdav_copy.rs
+++ b/src-tauri/tests/dag_webdav_copy.rs
@@ -93,6 +93,7 @@ fn webdav_config(url: String, username: String, password: String) -> WebDavConfi
         username,
         password: SecretString::from(password),
         initial_path: None,
+        provider_id: None,
         verify_cert: true,
         anonymous: false,
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -316,6 +316,19 @@ const stripLegacyNextcloudWebdavRoot = (
   return initialPath;
 };
 
+const isMegaCmdQuotaProfile = (
+  params?: Pick<ConnectionParams, 'protocol' | 'providerId' | 'options'> | null,
+  profile?: Pick<ServerProfile, 'protocol' | 'providerId' | 'options'> | null,
+): boolean => {
+  const protocol = params?.protocol || profile?.protocol;
+  const providerId = params?.providerId || profile?.providerId;
+  const megaMode = params?.options?.mega_mode || profile?.options?.mega_mode;
+  return (
+    (protocol === 'mega' && megaMode === 'megacmd') ||
+    (protocol === 'webdav' && (providerId === 'megacmd' || providerId === 'megacmd-webdav'))
+  );
+};
+
 const Github = ({ size = 24, className = '' }: { size?: number; className?: string }) => (
   <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" className={className}>
     <path fillRule="evenodd" clipRule="evenodd" d="M12.026 2c-5.509 0-9.974 4.465-9.974 9.974 0 4.406 2.857 8.145 6.821 9.465.499.09.679-.217.679-.481 0-.237-.008-.865-.011-1.696-2.775.602-3.361-1.338-3.361-1.338-.452-1.152-1.107-1.459-1.107-1.459-.905-.619.069-.605.069-.605 1.002.07 1.527 1.028 1.527 1.028.89 1.524 2.336 1.084 2.902.829.091-.645.351-1.085.635-1.334-2.214-.251-4.542-1.107-4.542-4.93 0-1.087.389-1.979 1.024-2.675-.101-.253-.446-1.268.099-2.64 0 0 .837-.269 2.742 1.021a9.582 9.582 0 0 1 2.496-.336 9.554 9.554 0 0 1 2.496.336c1.906-1.291 2.742-1.021 2.742-1.021.545 1.372.203 2.387.099 2.64.64.696 1.024 1.587 1.024 2.675 0 3.833-2.33 4.675-4.552 4.922.355.308.675.916.675 1.846 0 1.334-.012 2.41-.012 2.737 0 .267.178.577.687.479C19.146 20.115 22 16.379 22 11.974 22 6.465 17.535 2 12.026 2z"/>
@@ -2397,7 +2410,9 @@ interface UpdateVerificationInfo {
         void persistQuotaToProfile(profileId, { used: info.used, total: info.total, usedSource: 'api' });
         const autoScan = !!(prof?.options?.autoScanUsedOnConnect || opts?.autoScanUsedOnConnect);
         const hasScanBaseline = !!prof?.lastQuota && (prof.lastQuota.usedSource === 'scan' || prof.lastQuota.used > 0);
-        const scanEligibleProtocol = ['ftp', 'ftps', 'sftp', 's3', 'webdav'].includes(protocol);
+        const scanEligibleProtocol =
+          ['ftp', 'ftps', 'sftp', 's3', 'webdav'].includes(protocol) ||
+          isMegaCmdQuotaProfile(liveCp, prof);
         if (autoScan && scanEligibleProtocol && !hasScanBaseline) {
           void scanUsedStorage({
             automatic: true,
@@ -2511,11 +2526,13 @@ interface UpdateVerificationInfo {
     let manualTotal: number | undefined;
     let scanRoot = currentRemotePath || '/';
     let profileId: string | undefined;
+    let quotaProfile: ServerProfile | undefined;
     try {
       const all = await loadSavedServerProfiles();
       const prof = scanOptions?.profileHint
         || resolveLiveProfile(all, cp, activeSession, scanOptions?.connectionParams?.savedServerId);
       if (prof) {
+        quotaProfile = prof;
         profileId = prof.id;
         if (prof.initialPath?.trim()) {
           const resolved = resolveUsernameTemplate(prof.initialPath.trim(), cp.username);
@@ -2554,6 +2571,45 @@ interface UpdateVerificationInfo {
       `${t('statusBar.usedScanRunning')} ${scanRoot}`,
       'running',
     );
+    if (isMegaCmdQuotaProfile(cp, quotaProfile)) {
+      try {
+        const [used, total] = await invoke<[number, number]>('mega_df_query', {
+          profileId: profileId || '',
+        });
+        const eff = resolveEffectiveQuota(used, total, manualTotal);
+        if (version === quotaVersionRef.current) {
+          setStorageQuota({
+            used: eff.used,
+            total: eff.total,
+            free: eff.total > eff.used ? eff.total - eff.used : 0,
+          });
+        }
+        await persistQuotaToProfile(profileId, {
+          used,
+          total,
+          usedSource: 'api',
+          used_at: new Date().toISOString(),
+        });
+        const doneDetail = formatBytes(used);
+        notify.success(t('statusBar.usedScanDone'), doneDetail);
+        activityLog.updateEntry(scanLogId, {
+          status: 'success',
+          message: t('statusBar.usedScanDone'),
+          details: `${doneDetail} [mega-df]`,
+        });
+      } catch (err) {
+        notify.error(t('statusBar.usedScanFailed'), String(err));
+        activityLog.updateEntry(scanLogId, {
+          status: 'error',
+          message: t('statusBar.usedScanFailed'),
+          details: String(err),
+        });
+      } finally {
+        setUsedScanStatus(null);
+        scanInFlightRef.current = false;
+      }
+      return;
+    }
     const unlisten = await listen<{ used: number; file_count: number; scanning: boolean }>(
       'used-scan-progress',
       (event) => {
@@ -4148,6 +4204,7 @@ interface UpdateVerificationInfo {
     const protocol = effectiveParams.protocol;
     const providerParams = {
       protocol,
+      provider_id: effectiveParams.providerId || null,
       server: effectiveParams.server,
       port: effectiveParams.port,
       username: effectiveParams.username,

--- a/src/components/ConnectionScreen.tsx
+++ b/src/components/ConnectionScreen.tsx
@@ -527,6 +527,10 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
     const selectedProvider = selectedProviderId ? getProviderById(selectedProviderId) : null;
     const megaMode = getMegaConnectionMode(connectionParams.options);
     const isMegaCmdMode = megaMode === 'megacmd';
+    const activeProviderId = connectionParams.providerId || selectedProviderId || undefined;
+    const isMegaCmdStorage =
+        (protocol === 'mega' && isMegaCmdMode) ||
+        (protocol === 'webdav' && (activeProviderId === 'megacmd' || activeProviderId === 'megacmd-webdav'));
 
     // Protocol selector open state (to hide form when selector is open)
     const [isProtocolSelectorOpen, setIsProtocolSelectorOpen] = useState(false);
@@ -1927,7 +1931,7 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                     noise there. */}
                 {!providerServesQuota(
                     connectionParams.protocol,
-                    connectionParams.providerId,
+                    activeProviderId,
                     connectionParams.server,
                 ) && (
                 <div>
@@ -1959,11 +1963,14 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                     <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">
                         {t('connection.manualTotalStorageHint')}
                     </p>
-                    {/* Item 4b opt-in: auto-run the recursive used-storage
-                        scan on connect for no-quota backends. Default OFF so
-                        a huge tree (web project on FTP) is not walked on
-                        every connect unless the user asked for it. */}
-                    <div className="mt-2.5">
+                </div>
+                )}
+                {(!providerServesQuota(
+                    connectionParams.protocol,
+                    activeProviderId,
+                    connectionParams.server,
+                ) || isMegaCmdStorage) && (
+                    <div>
                         <Checkbox
                             checked={!!connectionParams.options?.autoScanUsedOnConnect}
                             onChange={(checked) => {
@@ -1979,10 +1986,11 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                             labelClassName="text-sm"
                         />
                         <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">
-                            {t('connection.autoScanUsedOnConnectHint')}
+                            {isMegaCmdStorage
+                                ? t('connection.megacmdDfHint')
+                                : t('connection.autoScanUsedOnConnectHint')}
                         </p>
                     </div>
-                </div>
                 )}
                 {/* Action Buttons. Issue #215: mode switch in edit takes
                     over the footer with Save-as-new + Convert when the

--- a/src/i18n/locales/bg.json
+++ b/src/i18n/locales/bg.json
@@ -272,7 +272,8 @@
             "profileConverted": "Профилът е преобразуван",
             "profileDuplicated": "Профилът е дублиран",
             "convertUndone": "Профилът е възстановен",
-            "undo": "Отмени"
+            "undo": "Отмени",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "Отдалечен",

--- a/src/i18n/locales/bg.json
+++ b/src/i18n/locales/bg.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "Профилът е дублиран",
             "convertUndone": "Профилът е възстановен",
             "undo": "Отмени",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd използва mega-df директно за заявка на използваното и общото хранилище. Ръчното задаване на общото не е необходимо."
         },
         "browser": {
             "remote": "Отдалечен",

--- a/src/i18n/locales/bn.json
+++ b/src/i18n/locales/bn.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "প্রোফাইল ডুপ্লিকেট করা হয়েছে",
             "convertUndone": "প্রোফাইল পুনরুদ্ধার করা হয়েছে",
             "undo": "পূর্বাবস্থা",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd সরাসরি mega-df ব্যবহার করে ব্যবহৃত এবং মোট স্টোরেজ অনুসন্ধান করে। মোটের ম্যানুয়াল ওভাররাইডের প্রয়োজন নেই।"
         },
         "browser": {
             "remote": "রিমোট",

--- a/src/i18n/locales/bn.json
+++ b/src/i18n/locales/bn.json
@@ -272,7 +272,8 @@
             "profileConverted": "প্রোফাইল রূপান্তরিত হয়েছে",
             "profileDuplicated": "প্রোফাইল ডুপ্লিকেট করা হয়েছে",
             "convertUndone": "প্রোফাইল পুনরুদ্ধার করা হয়েছে",
-            "undo": "পূর্বাবস্থা"
+            "undo": "পূর্বাবস্থা",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "রিমোট",

--- a/src/i18n/locales/ca.json
+++ b/src/i18n/locales/ca.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "Perfil duplicat",
             "convertUndone": "Perfil restaurat",
             "undo": "Desfés",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd utilitza mega-df directament per consultar l'espai utilitzat i el total. No cal la substitució manual del total."
         },
         "browser": {
             "remote": "Remot",

--- a/src/i18n/locales/ca.json
+++ b/src/i18n/locales/ca.json
@@ -272,7 +272,8 @@
             "profileConverted": "Perfil convertit",
             "profileDuplicated": "Perfil duplicat",
             "convertUndone": "Perfil restaurat",
-            "undo": "Desfés"
+            "undo": "Desfés",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "Remot",

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "Profil duplikován",
             "convertUndone": "Profil obnoven",
             "undo": "Zpět",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd používá mega-df přímo k dotazu na použité a celkové úložiště. Manuální přepsání celkové hodnoty není potřeba."
         },
         "browser": {
             "remote": "Vzdálený",

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -272,7 +272,8 @@
             "profileConverted": "Profil převeden",
             "profileDuplicated": "Profil duplikován",
             "convertUndone": "Profil obnoven",
-            "undo": "Zpět"
+            "undo": "Zpět",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "Vzdálený",

--- a/src/i18n/locales/cy.json
+++ b/src/i18n/locales/cy.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "Wedi dyblygu'r proffil",
             "convertUndone": "Wedi adfer y proffil",
             "undo": "Dadwneud",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "Mae MEGAcmd yn defnyddio mega-df yn uniongyrchol i ymholi storfa a ddefnyddir a chyfanswm. Nid oes angen y diystyriad cyfanswm â llaw."
         },
         "browser": {
             "remote": "Pell",

--- a/src/i18n/locales/cy.json
+++ b/src/i18n/locales/cy.json
@@ -272,7 +272,8 @@
             "profileConverted": "Wedi trosi'r proffil",
             "profileDuplicated": "Wedi dyblygu'r proffil",
             "convertUndone": "Wedi adfer y proffil",
-            "undo": "Dadwneud"
+            "undo": "Dadwneud",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "Pell",

--- a/src/i18n/locales/da.json
+++ b/src/i18n/locales/da.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "Profil duplikeret",
             "convertUndone": "Profil gendannet",
             "undo": "Fortryd",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd bruger mega-df direkte til at forespørge brugt og samlet lagerplads. Manuel tilsidesættelse af totalen er ikke nødvendig."
         },
         "browser": {
             "remote": "Ekstern",

--- a/src/i18n/locales/da.json
+++ b/src/i18n/locales/da.json
@@ -272,7 +272,8 @@
             "profileConverted": "Profil konverteret",
             "profileDuplicated": "Profil duplikeret",
             "convertUndone": "Profil gendannet",
-            "undo": "Fortryd"
+            "undo": "Fortryd",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "Ekstern",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "Profil dupliziert",
             "convertUndone": "Profil wiederhergestellt",
             "undo": "Rückgängig",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd verwendet mega-df direkt, um den belegten und den gesamten Speicher abzufragen. Die manuelle Gesamtüberschreibung ist nicht erforderlich."
         },
         "browser": {
             "remote": "Remote",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -272,7 +272,8 @@
             "profileConverted": "Profil umgewandelt",
             "profileDuplicated": "Profil dupliziert",
             "convertUndone": "Profil wiederhergestellt",
-            "undo": "Rückgängig"
+            "undo": "Rückgängig",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "Remote",

--- a/src/i18n/locales/el.json
+++ b/src/i18n/locales/el.json
@@ -272,7 +272,8 @@
             "profileConverted": "Το προφίλ μετατράπηκε",
             "profileDuplicated": "Το προφίλ αντιγράφηκε",
             "convertUndone": "Το προφίλ αποκαταστάθηκε",
-            "undo": "Αναίρεση"
+            "undo": "Αναίρεση",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "Απομακρυσμένο",

--- a/src/i18n/locales/el.json
+++ b/src/i18n/locales/el.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "Το προφίλ αντιγράφηκε",
             "convertUndone": "Το προφίλ αποκαταστάθηκε",
             "undo": "Αναίρεση",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "Το MEGAcmd χρησιμοποιεί απευθείας το mega-df για να ζητήσει τον χρησιμοποιούμενο και τον συνολικό αποθηκευτικό χώρο. Η χειροκίνητη αντικατάσταση του συνόλου δεν είναι απαραίτητη."
         },
         "browser": {
             "remote": "Απομακρυσμένο",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1179,6 +1179,7 @@
             "manualTotalStorageHint": "Optional. Plan/account cap for backends with no quota API (FTP, S3, WebDAV) or that report only used space (Backblaze B2). The provider's own total always takes precedence.",
             "autoScanUsedOnConnect": "Calculate used storage on connect",
             "autoScanUsedOnConnectHint": "Only for backends with no used-space API (FTP, S3, WebDAV). Off by default: a large tree (e.g. a web project) is walked recursively, which can be slow. Otherwise use the StatusBar action on demand.",
+            "megacmdDfHint": "MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed.",
             "localPathPlaceholder": "/home/user/projects",
             "logoutOnDisconnect": "Logout on disconnect",
             "logoutOnDisconnectDesc": "Terminate MEGAcmd session when closing connection",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "Perfil duplicado",
             "convertUndone": "Perfil restaurado",
             "undo": "Deshacer",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd utiliza mega-df directamente para consultar el almacenamiento usado y el total. No es necesaria la anulación manual del total."
         },
         "browser": {
             "remote": "Remoto",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -272,7 +272,8 @@
             "profileConverted": "Perfil convertido",
             "profileDuplicated": "Perfil duplicado",
             "convertUndone": "Perfil restaurado",
-            "undo": "Deshacer"
+            "undo": "Deshacer",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "Remoto",

--- a/src/i18n/locales/et.json
+++ b/src/i18n/locales/et.json
@@ -272,7 +272,8 @@
             "profileConverted": "Profiil teisendatud",
             "profileDuplicated": "Profiil dubleeritud",
             "convertUndone": "Profiil taastatud",
-            "undo": "Võta tagasi"
+            "undo": "Võta tagasi",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "Kaugserver",

--- a/src/i18n/locales/et.json
+++ b/src/i18n/locales/et.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "Profiil dubleeritud",
             "convertUndone": "Profiil taastatud",
             "undo": "Võta tagasi",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd kasutab mega-df otse, et küsida kasutatud ja kogusalvestust. Käsitsi koguarvu alistamine pole vajalik."
         },
         "browser": {
             "remote": "Kaugserver",

--- a/src/i18n/locales/eu.json
+++ b/src/i18n/locales/eu.json
@@ -272,7 +272,8 @@
             "profileConverted": "Profila bihurtuta",
             "profileDuplicated": "Profila bikoiztuta",
             "convertUndone": "Profila berreskuratuta",
-            "undo": "Desegin"
+            "undo": "Desegin",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "Urrunekoa",

--- a/src/i18n/locales/eu.json
+++ b/src/i18n/locales/eu.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "Profila bikoiztuta",
             "convertUndone": "Profila berreskuratuta",
             "undo": "Desegin",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd-ek mega-df zuzenean erabiltzen du erabilitako eta guztizko biltegiratzea kontsultatzeko. Ez da behar guztizkoaren eskuzko gainidazketa."
         },
         "browser": {
             "remote": "Urrunekoa",

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -272,7 +272,8 @@
             "profileConverted": "Profiili muunnettu",
             "profileDuplicated": "Profiili monistettu",
             "convertUndone": "Profiili palautettu",
-            "undo": "Kumoa"
+            "undo": "Kumoa",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "Etä",

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "Profiili monistettu",
             "convertUndone": "Profiili palautettu",
             "undo": "Kumoa",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd käyttää suoraan mega-df-komentoa käytetyn ja kokonaistallennustilan kyselyyn. Manuaalista kokonaismäärän ohitusta ei tarvita."
         },
         "browser": {
             "remote": "Etä",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "Profil dupliqué",
             "convertUndone": "Profil restauré",
             "undo": "Annuler",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd utilise mega-df directement pour interroger l'espace utilisé et le total. Le remplacement manuel du total n'est pas nécessaire."
         },
         "browser": {
             "remote": "Distant",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -272,7 +272,8 @@
             "profileConverted": "Profil converti",
             "profileDuplicated": "Profil dupliqué",
             "convertUndone": "Profil restauré",
-            "undo": "Annuler"
+            "undo": "Annuler",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "Distant",

--- a/src/i18n/locales/gl.json
+++ b/src/i18n/locales/gl.json
@@ -272,7 +272,8 @@
             "profileConverted": "Perfil convertido",
             "profileDuplicated": "Perfil duplicado",
             "convertUndone": "Perfil restaurado",
-            "undo": "Desfacer"
+            "undo": "Desfacer",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "Remoto",

--- a/src/i18n/locales/gl.json
+++ b/src/i18n/locales/gl.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "Perfil duplicado",
             "convertUndone": "Perfil restaurado",
             "undo": "Desfacer",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd usa mega-df directamente para consultar o almacenamento usado e o total. Non é necesaria a substitución manual do total."
         },
         "browser": {
             "remote": "Remoto",

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "प्रोफ़ाइल नकल किया गया",
             "convertUndone": "प्रोफ़ाइल पुनर्स्थापित",
             "undo": "पूर्ववत्",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd उपयोग किए गए और कुल स्टोरेज की पूछताछ के लिए सीधे mega-df का उपयोग करता है। मैन्युअल कुल ओवरराइड की आवश्यकता नहीं है।"
         },
         "browser": {
             "remote": "दूरस्थ",

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -272,7 +272,8 @@
             "profileConverted": "प्रोफ़ाइल बदल दिया गया",
             "profileDuplicated": "प्रोफ़ाइल नकल किया गया",
             "convertUndone": "प्रोफ़ाइल पुनर्स्थापित",
-            "undo": "पूर्ववत्"
+            "undo": "पूर्ववत्",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "दूरस्थ",

--- a/src/i18n/locales/hr.json
+++ b/src/i18n/locales/hr.json
@@ -272,7 +272,8 @@
             "profileConverted": "Profil pretvoren",
             "profileDuplicated": "Profil dupliciran",
             "convertUndone": "Profil vraćen",
-            "undo": "Poništi"
+            "undo": "Poništi",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "Udaljeno",

--- a/src/i18n/locales/hr.json
+++ b/src/i18n/locales/hr.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "Profil dupliciran",
             "convertUndone": "Profil vraćen",
             "undo": "Poništi",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd izravno koristi mega-df za upit o iskorištenom i ukupnom prostoru. Ručno nadjačavanje ukupnog nije potrebno."
         },
         "browser": {
             "remote": "Udaljeno",

--- a/src/i18n/locales/hu.json
+++ b/src/i18n/locales/hu.json
@@ -272,7 +272,8 @@
             "profileConverted": "Profil konvertálva",
             "profileDuplicated": "Profil megkettőzve",
             "convertUndone": "Profil visszaállítva",
-            "undo": "Visszavonás"
+            "undo": "Visszavonás",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "Távoli",

--- a/src/i18n/locales/hu.json
+++ b/src/i18n/locales/hu.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "Profil megkettőzve",
             "convertUndone": "Profil visszaállítva",
             "undo": "Visszavonás",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "A MEGAcmd közvetlenül a mega-df parancsot használja a használt és teljes tárhely lekérdezéséhez. A teljes érték manuális felülbírálására nincs szükség."
         },
         "browser": {
             "remote": "Távoli",

--- a/src/i18n/locales/hy.json
+++ b/src/i18n/locales/hy.json
@@ -272,7 +272,8 @@
             "profileConverted": "Պրոֆիլը փոխարկվել է",
             "profileDuplicated": "Պրոֆիլը կրկնօրինակվել է",
             "convertUndone": "Պրոֆիլը վերականգնվել է",
-            "undo": "Հետարկել"
+            "undo": "Հետարկել",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "Հեռավոր",

--- a/src/i18n/locales/hy.json
+++ b/src/i18n/locales/hy.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "Պրոֆիլը կրկնօրինակվել է",
             "convertUndone": "Պրոֆիլը վերականգնվել է",
             "undo": "Հետարկել",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd-ը ուղղակիորեն օգտագործում է mega-df-ը՝ օգտագործված և ընդհանուր պահեստավորման հարցումը կատարելու համար։ Ընդհանուրի ձեռքով վերագրումը անհրաժեշտ չէ։"
         },
         "browser": {
             "remote": "Հեռավոր",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -272,7 +272,8 @@
             "profileConverted": "Profil dikonversi",
             "profileDuplicated": "Profil diduplikasi",
             "convertUndone": "Profil dipulihkan",
-            "undo": "Urungkan"
+            "undo": "Urungkan",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "Jarak Jauh",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "Profil diduplikasi",
             "convertUndone": "Profil dipulihkan",
             "undo": "Urungkan",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd menggunakan mega-df langsung untuk menanyakan penyimpanan terpakai dan total. Penggantian total manual tidak diperlukan."
         },
         "browser": {
             "remote": "Jarak Jauh",

--- a/src/i18n/locales/is.json
+++ b/src/i18n/locales/is.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "Vistun afrituð",
             "convertUndone": "Vistun endurheimt",
             "undo": "Afturkalla",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd notar mega-df beint til að fyrirspyrja notaða og heildargeymslu. Ekki er þörf á handvirkri yfirfærslu á heildinni."
         },
         "browser": {
             "remote": "Fjartengdur",

--- a/src/i18n/locales/is.json
+++ b/src/i18n/locales/is.json
@@ -272,7 +272,8 @@
             "profileConverted": "Vistun umbreytt",
             "profileDuplicated": "Vistun afrituð",
             "convertUndone": "Vistun endurheimt",
-            "undo": "Afturkalla"
+            "undo": "Afturkalla",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "Fjartengdur",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -293,6 +293,7 @@
             "manualTotalStorageHint": "Facoltativo. Limite del piano o dell'account per i backend senza API di quota (FTP, S3, WebDAV) o che riportano solo lo spazio usato (Backblaze B2). Il totale fornito dal provider ha sempre la precedenza.",
             "autoScanUsedOnConnect": "Calcola lo spazio usato alla connessione",
             "autoScanUsedOnConnectHint": "Solo per i backend senza API per lo spazio usato (FTP, S3, WebDAV). Disattivato per impostazione predefinita: un albero di grandi dimensioni (es. un progetto web) viene percorso ricorsivamente, operazione che può essere lenta. In alternativa usa l'azione nella StatusBar quando serve.",
+            "megacmdDfHint": "MEGAcmd usa direttamente mega-df per leggere spazio usato e totale. L'override manuale del totale non serve.",
             "saveAsNewProfile": "Salva come nuovo profilo",
             "saveAsNewProfileTitle": "Salva il modulo corrente come nuovo profilo in questa modalità. Il profilo originale viene mantenuto.",
             "convertToMode": "Converti in {{mode}}",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "プロファイルが複製されました",
             "convertUndone": "プロファイルが復元されました",
             "undo": "元に戻す",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd は mega-df を直接使用して、使用済みおよび合計ストレージを照会します。手動による合計の上書きは不要です。"
         },
         "browser": {
             "remote": "リモート",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -272,7 +272,8 @@
             "profileConverted": "プロファイルが変換されました",
             "profileDuplicated": "プロファイルが複製されました",
             "convertUndone": "プロファイルが復元されました",
-            "undo": "元に戻す"
+            "undo": "元に戻す",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "リモート",

--- a/src/i18n/locales/ka.json
+++ b/src/i18n/locales/ka.json
@@ -272,7 +272,8 @@
             "profileConverted": "პროფილი გადაყვანილია",
             "profileDuplicated": "პროფილი დუბლირებულია",
             "convertUndone": "პროფილი აღდგენილია",
-            "undo": "გაუქმება"
+            "undo": "გაუქმება",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "დისტანციური",

--- a/src/i18n/locales/ka.json
+++ b/src/i18n/locales/ka.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "პროფილი დუბლირებულია",
             "convertUndone": "პროფილი აღდგენილია",
             "undo": "გაუქმება",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd იყენებს mega-df-ს უშუალოდ გამოყენებული და მთლიანი საცავის შესაკითხად. მთლიანის ხელით გადაჭარბება არ არის საჭირო."
         },
         "browser": {
             "remote": "დისტანციური",

--- a/src/i18n/locales/km.json
+++ b/src/i18n/locales/km.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "ប្រវត្តិរូបបានចម្លង",
             "convertUndone": "ប្រវត្តិរូបបានស្ដារ",
             "undo": "មិនធ្វើវិញ",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd ប្រើ mega-df ដោយផ្ទាល់ ដើម្បីសួរអំពីការផ្ទុកដែលបានប្រើ និងសរុប។ ការសរសេរជាន់លើសរុបដោយដៃ មិនចាំបាច់ទេ។"
         },
         "browser": {
             "remote": "ពីចម្ងាយ",

--- a/src/i18n/locales/km.json
+++ b/src/i18n/locales/km.json
@@ -272,7 +272,8 @@
             "profileConverted": "ប្រវត្តិរូបបានបំលែង",
             "profileDuplicated": "ប្រវត្តិរូបបានចម្លង",
             "convertUndone": "ប្រវត្តិរូបបានស្ដារ",
-            "undo": "មិនធ្វើវិញ"
+            "undo": "មិនធ្វើវិញ",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "ពីចម្ងាយ",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -272,7 +272,8 @@
             "profileConverted": "프로필이 변환되었습니다",
             "profileDuplicated": "프로필이 복제되었습니다",
             "convertUndone": "프로필이 복원되었습니다",
-            "undo": "실행 취소"
+            "undo": "실행 취소",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "원격",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "프로필이 복제되었습니다",
             "convertUndone": "프로필이 복원되었습니다",
             "undo": "실행 취소",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd는 mega-df를 직접 사용하여 사용된 저장 공간과 총 저장 공간을 조회합니다. 수동 총량 재정의는 필요하지 않습니다."
         },
         "browser": {
             "remote": "원격",

--- a/src/i18n/locales/lt.json
+++ b/src/i18n/locales/lt.json
@@ -272,7 +272,8 @@
             "profileConverted": "Profilis konvertuotas",
             "profileDuplicated": "Profilis dubliuotas",
             "convertUndone": "Profilis atkurtas",
-            "undo": "Anuliuoti"
+            "undo": "Anuliuoti",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "Nuotolinis",

--- a/src/i18n/locales/lt.json
+++ b/src/i18n/locales/lt.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "Profilis dubliuotas",
             "convertUndone": "Profilis atkurtas",
             "undo": "Anuliuoti",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd tiesiogiai naudoja mega-df, kad užklaustų sunaudotos ir bendros saugyklos. Rankinis bendros vertės pakeitimas nebūtinas."
         },
         "browser": {
             "remote": "Nuotolinis",

--- a/src/i18n/locales/lv.json
+++ b/src/i18n/locales/lv.json
@@ -272,7 +272,8 @@
             "profileConverted": "Profils pārvērsts",
             "profileDuplicated": "Profils dublēts",
             "convertUndone": "Profils atjaunots",
-            "undo": "Atsaukt"
+            "undo": "Atsaukt",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "Attālināts",

--- a/src/i18n/locales/lv.json
+++ b/src/i18n/locales/lv.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "Profils dublēts",
             "convertUndone": "Profils atjaunots",
             "undo": "Atsaukt",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd tieši izmanto mega-df, lai vaicātu izmantoto un kopējo krātuvi. Manuālā kopējās vērtības aizstāšana nav nepieciešama."
         },
         "browser": {
             "remote": "Attālināts",

--- a/src/i18n/locales/mk.json
+++ b/src/i18n/locales/mk.json
@@ -272,7 +272,8 @@
             "profileConverted": "Профилот е конвертиран",
             "profileDuplicated": "Профилот е дуплиран",
             "convertUndone": "Профилот е вратен",
-            "undo": "Откажи"
+            "undo": "Откажи",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "Далечински",

--- a/src/i18n/locales/mk.json
+++ b/src/i18n/locales/mk.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "Профилот е дуплиран",
             "convertUndone": "Профилот е вратен",
             "undo": "Откажи",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd директно го користи mega-df за барање на искористениот и вкупниот простор. Рачното пренапишување на вкупното не е потребно."
         },
         "browser": {
             "remote": "Далечински",

--- a/src/i18n/locales/ms.json
+++ b/src/i18n/locales/ms.json
@@ -272,7 +272,8 @@
             "profileConverted": "Profil ditukar",
             "profileDuplicated": "Profil diduplikasi",
             "convertUndone": "Profil dipulihkan",
-            "undo": "Buat asal"
+            "undo": "Buat asal",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "Jauh",

--- a/src/i18n/locales/ms.json
+++ b/src/i18n/locales/ms.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "Profil diduplikasi",
             "convertUndone": "Profil dipulihkan",
             "undo": "Buat asal",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd menggunakan mega-df secara langsung untuk menanyakan storan yang digunakan dan jumlah. Penggantian jumlah secara manual tidak diperlukan."
         },
         "browser": {
             "remote": "Jauh",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "Profiel gedupliceerd",
             "convertUndone": "Profiel hersteld",
             "undo": "Ongedaan maken",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd gebruikt mega-df rechtstreeks om gebruikte en totale opslag op te vragen. Het handmatig overschrijven van het totaal is niet nodig."
         },
         "browser": {
             "remote": "Extern",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -272,7 +272,8 @@
             "profileConverted": "Profiel geconverteerd",
             "profileDuplicated": "Profiel gedupliceerd",
             "convertUndone": "Profiel hersteld",
-            "undo": "Ongedaan maken"
+            "undo": "Ongedaan maken",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "Extern",

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -272,7 +272,8 @@
             "profileConverted": "Profil konvertert",
             "profileDuplicated": "Profil duplisert",
             "convertUndone": "Profil gjenopprettet",
-            "undo": "Angre"
+            "undo": "Angre",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "Ekstern",

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "Profil duplisert",
             "convertUndone": "Profil gjenopprettet",
             "undo": "Angre",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd bruker mega-df direkte for å spørre om brukt og total lagring. Manuell overstyring av totalen er ikke nødvendig."
         },
         "browser": {
             "remote": "Ekstern",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "Profil zduplikowany",
             "convertUndone": "Profil przywrócony",
             "undo": "Cofnij",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd używa mega-df bezpośrednio do zapytania o wykorzystaną i całkowitą przestrzeń. Ręczne zastąpienie wartości całkowitej nie jest potrzebne."
         },
         "browser": {
             "remote": "Zdalny",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -272,7 +272,8 @@
             "profileConverted": "Profil przekonwertowany",
             "profileDuplicated": "Profil zduplikowany",
             "convertUndone": "Profil przywrócony",
-            "undo": "Cofnij"
+            "undo": "Cofnij",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "Zdalny",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -272,7 +272,8 @@
             "profileConverted": "Perfil convertido",
             "profileDuplicated": "Perfil duplicado",
             "convertUndone": "Perfil restaurado",
-            "undo": "Desfazer"
+            "undo": "Desfazer",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "Remoto",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "Perfil duplicado",
             "convertUndone": "Perfil restaurado",
             "undo": "Desfazer",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "O MEGAcmd usa o mega-df diretamente para consultar o armazenamento usado e o total. A substituição manual do total não é necessária."
         },
         "browser": {
             "remote": "Remoto",

--- a/src/i18n/locales/ro.json
+++ b/src/i18n/locales/ro.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "Profil duplicat",
             "convertUndone": "Profil restaurat",
             "undo": "Anulează",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd folosește mega-df direct pentru a interoga spațiul utilizat și totalul. Suprascrierea manuală a totalului nu este necesară."
         },
         "browser": {
             "remote": "La distanță",

--- a/src/i18n/locales/ro.json
+++ b/src/i18n/locales/ro.json
@@ -272,7 +272,8 @@
             "profileConverted": "Profil convertit",
             "profileDuplicated": "Profil duplicat",
             "convertUndone": "Profil restaurat",
-            "undo": "Anulează"
+            "undo": "Anulează",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "La distanță",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -272,7 +272,8 @@
             "profileConverted": "Профиль преобразован",
             "profileDuplicated": "Профиль дублирован",
             "convertUndone": "Профиль восстановлен",
-            "undo": "Отменить"
+            "undo": "Отменить",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "Удалённый",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "Профиль дублирован",
             "convertUndone": "Профиль восстановлен",
             "undo": "Отменить",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd напрямую использует mega-df для запроса использованного и общего хранилища. Ручная замена общего значения не требуется."
         },
         "browser": {
             "remote": "Удалённый",

--- a/src/i18n/locales/sk.json
+++ b/src/i18n/locales/sk.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "Profil duplikovaný",
             "convertUndone": "Profil obnovený",
             "undo": "Späť",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd používa mega-df priamo na získanie použitého a celkového úložiska. Manuálne prepísanie celkovej hodnoty nie je potrebné."
         },
         "browser": {
             "remote": "Vzdialený",

--- a/src/i18n/locales/sk.json
+++ b/src/i18n/locales/sk.json
@@ -272,7 +272,8 @@
             "profileConverted": "Profil prevedený",
             "profileDuplicated": "Profil duplikovaný",
             "convertUndone": "Profil obnovený",
-            "undo": "Späť"
+            "undo": "Späť",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "Vzdialený",

--- a/src/i18n/locales/sl.json
+++ b/src/i18n/locales/sl.json
@@ -272,7 +272,8 @@
             "profileConverted": "Profil pretvorjen",
             "profileDuplicated": "Profil podvojen",
             "convertUndone": "Profil obnovljen",
-            "undo": "Razveljavi"
+            "undo": "Razveljavi",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "Oddaljeno",

--- a/src/i18n/locales/sl.json
+++ b/src/i18n/locales/sl.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "Profil podvojen",
             "convertUndone": "Profil obnovljen",
             "undo": "Razveljavi",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd uporablja mega-df neposredno za poizvedbo o uporabljeni in skupni shrambi. Ročno preglasitev skupne vrednosti ni potrebna."
         },
         "browser": {
             "remote": "Oddaljeno",

--- a/src/i18n/locales/sr.json
+++ b/src/i18n/locales/sr.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "Профил дуплиран",
             "convertUndone": "Профил враћен",
             "undo": "Опозови",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd директно користи mega-df за упит о искоришћеном и укупном простору. Ручно преписивање укупног није потребно."
         },
         "browser": {
             "remote": "Удаљено",

--- a/src/i18n/locales/sr.json
+++ b/src/i18n/locales/sr.json
@@ -272,7 +272,8 @@
             "profileConverted": "Профил претворен",
             "profileDuplicated": "Профил дуплиран",
             "convertUndone": "Профил враћен",
-            "undo": "Опозови"
+            "undo": "Опозови",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "Удаљено",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "Profil duplicerad",
             "convertUndone": "Profil återställd",
             "undo": "Ångra",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd använder mega-df direkt för att fråga efter använt och totalt lagringsutrymme. Manuell åsidosättning av totalen behövs inte."
         },
         "browser": {
             "remote": "Fjärr",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -272,7 +272,8 @@
             "profileConverted": "Profil konverterad",
             "profileDuplicated": "Profil duplicerad",
             "convertUndone": "Profil återställd",
-            "undo": "Ångra"
+            "undo": "Ångra",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "Fjärr",

--- a/src/i18n/locales/sw.json
+++ b/src/i18n/locales/sw.json
@@ -272,7 +272,8 @@
             "profileConverted": "Wasifu umebadilishwa",
             "profileDuplicated": "Wasifu umenakiliwa",
             "convertUndone": "Wasifu umerejeshwa",
-            "undo": "Tendua"
+            "undo": "Tendua",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "Mbali",

--- a/src/i18n/locales/sw.json
+++ b/src/i18n/locales/sw.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "Wasifu umenakiliwa",
             "convertUndone": "Wasifu umerejeshwa",
             "undo": "Tendua",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd inatumia mega-df moja kwa moja kuuliza hifadhi iliyotumika na jumla. Kubadilisha jumla kwa mkono hakuhitajiki."
         },
         "browser": {
             "remote": "Mbali",

--- a/src/i18n/locales/th.json
+++ b/src/i18n/locales/th.json
@@ -272,7 +272,8 @@
             "profileConverted": "แปลงโปรไฟล์แล้ว",
             "profileDuplicated": "ทำซ้ำโปรไฟล์แล้ว",
             "convertUndone": "กู้คืนโปรไฟล์แล้ว",
-            "undo": "เลิกทำ"
+            "undo": "เลิกทำ",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "ระยะไกล",

--- a/src/i18n/locales/th.json
+++ b/src/i18n/locales/th.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "ทำซ้ำโปรไฟล์แล้ว",
             "convertUndone": "กู้คืนโปรไฟล์แล้ว",
             "undo": "เลิกทำ",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd ใช้ mega-df โดยตรงเพื่อสอบถามพื้นที่จัดเก็บที่ใช้และทั้งหมด ไม่จำเป็นต้องแทนที่ค่ารวมด้วยตนเอง"
         },
         "browser": {
             "remote": "ระยะไกล",

--- a/src/i18n/locales/tl.json
+++ b/src/i18n/locales/tl.json
@@ -272,7 +272,8 @@
             "profileConverted": "Na-convert ang profile",
             "profileDuplicated": "Na-duplicate ang profile",
             "convertUndone": "Na-restore ang profile",
-            "undo": "I-undo"
+            "undo": "I-undo",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "Remote",

--- a/src/i18n/locales/tl.json
+++ b/src/i18n/locales/tl.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "Na-duplicate ang profile",
             "convertUndone": "Na-restore ang profile",
             "undo": "I-undo",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "Direktang ginagamit ng MEGAcmd ang mega-df upang i-query ang nagamit at kabuuang storage. Hindi kailangan ang manu-manong pag-override ng kabuuan."
         },
         "browser": {
             "remote": "Remote",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -272,7 +272,8 @@
             "profileConverted": "Profil dönüştürüldü",
             "profileDuplicated": "Profil çoğaltıldı",
             "convertUndone": "Profil geri yüklendi",
-            "undo": "Geri al"
+            "undo": "Geri al",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "Uzak",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "Profil çoğaltıldı",
             "convertUndone": "Profil geri yüklendi",
             "undo": "Geri al",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd, kullanılan ve toplam depolama alanını sorgulamak için doğrudan mega-df'i kullanır. Toplamın manuel olarak geçersiz kılınmasına gerek yoktur."
         },
         "browser": {
             "remote": "Uzak",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "Профіль дубльовано",
             "convertUndone": "Профіль відновлено",
             "undo": "Скасувати",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd безпосередньо використовує mega-df для запиту використаного та загального сховища. Ручна заміна загального значення не потрібна."
         },
         "browser": {
             "remote": "Віддалений",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -272,7 +272,8 @@
             "profileConverted": "Профіль перетворено",
             "profileDuplicated": "Профіль дубльовано",
             "convertUndone": "Профіль відновлено",
-            "undo": "Скасувати"
+            "undo": "Скасувати",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "Віддалений",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "Đã nhân bản hồ sơ",
             "convertUndone": "Đã khôi phục hồ sơ",
             "undo": "Hoàn tác",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd sử dụng trực tiếp mega-df để truy vấn dung lượng đã dùng và tổng dung lượng. Không cần ghi đè tổng dung lượng theo cách thủ công."
         },
         "browser": {
             "remote": "Từ xa",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -272,7 +272,8 @@
             "profileConverted": "Đã chuyển đổi hồ sơ",
             "profileDuplicated": "Đã nhân bản hồ sơ",
             "convertUndone": "Đã khôi phục hồ sơ",
-            "undo": "Hoàn tác"
+            "undo": "Hoàn tác",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "Từ xa",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -273,7 +273,7 @@
             "profileDuplicated": "配置已复制",
             "convertUndone": "配置已恢复",
             "undo": "撤销",
-            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
+            "megacmdDfHint": "MEGAcmd 直接使用 mega-df 查询已用和总存储空间。无需手动覆盖总量。"
         },
         "browser": {
             "remote": "远程",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -272,7 +272,8 @@
             "profileConverted": "配置已转换",
             "profileDuplicated": "配置已复制",
             "convertUndone": "配置已恢复",
-            "undo": "撤销"
+            "undo": "撤销",
+            "megacmdDfHint": "[NEEDS TRANSLATION] MEGAcmd uses mega-df directly to query used and total storage. The manual total override is not needed."
         },
         "browser": {
             "remote": "远程",

--- a/src/types.ts
+++ b/src/types.ts
@@ -182,6 +182,7 @@ export const providerServesQuota = (
   if (isNativeApiProtocol(protocol)) return true;
   if (protocol === "webdav") {
     const host = (server || "").toLowerCase();
+    if (providerId === "megacmd" || providerId === "megacmd-webdav") return true;
     if (providerId === "koofr" || host.includes("koofr")) return true;
     if (
       providerId === "opendrive-webdav" ||


### PR DESCRIPTION
## Summary

Adds a `mega-df` helper that surfaces storage quota for MEGA accounts via the official MEGAcmd daemon. The daemon is warmed up automatically on first request and cached for subsequent calls.

Translated across all 47 locales (Italian manual; 45 via batch helper).

## Reporter

@EhudKirsh

## Test plan

- [ ] Reporter confirms storage quota visible on next build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic storage quota detection for MEGAcmd profiles, enabling direct queries of actual used storage without manual estimation.

* **Documentation**
  * Added localized help text explaining MEGAcmd quota behavior across all supported languages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/axpdev-lab/aeroftp/pull/257?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->