### PR TITLE
fix(opendrive): pass with_child_files boolean to folder/setaccess (#252)

### DIFF
--- a/src-tauri/src/providers/opendrive.rs
+++ b/src-tauri/src/providers/opendrive.rs
@@ -1134,6 +1134,7 @@ impl OpenDriveProvider {
                         ("session_id", this.session_id.clone()),
                         ("folder_id", folder_id),
                         ("folder_is_public", folder_is_public),
+                        ("with_child_files", "true".to_string()),
                     ],
                 )
                 .await


### PR DESCRIPTION
## Summary

Setting an OpenDrive folder private/public via the API returned HTTP 400 with `Invalid value specified for "with_child_files". Expecting boolean value`. The `folder/setaccess.json` endpoint requires `with_child_files` alongside `session_id`, `folder_id` and `folder_is_public`; the matching `file/access.json` endpoint does not, which is why `setAsPrivate` / `setAsPublic` worked on files but failed on folders.

Pass `with_child_files=true` so the requested privacy is applied recursively to the files inside the folder, matching the intuitive "set folder private then its contents are private too" semantics.

## Reporter

@EhudKirsh

## Test plan

- [ ] Reporter confirms set-as-private / set-as-public on OpenDrive folders on next build