### PR TITLE
fix(mega): unblock recursive delete and Windows local-path uploads (#263)

### DIFF
--- a/src-tauri/src/providers/mega.rs
+++ b/src-tauri/src/providers/mega.rs
@@ -55,6 +55,25 @@ impl MegaCmdProvider {
         super::mega_df::resolve_mega_cmd(cmd)
     }
 
+    /// Normalize a local filesystem path before passing it as an argument to
+    /// MEGAcmd's CLI. On Windows the frontend sends paths with `/` separators
+    /// (`get_local_files` normalizes for the UI); MEGAcmd internally resolves
+    /// the argument to a `\\?\`-prefixed verbatim path, and verbatim paths
+    /// reject `/` as a separator. The resulting "Unable to open local path:
+    /// \\?\C:/Users/...\file" error (issue #263) goes away as soon as the
+    /// separators are flipped to `\` before invoking `mega-put`/`mega-get`.
+    /// On POSIX the separator is already `/` natively, so this is a no-op.
+    fn normalize_local_path_for_cli(l: &str) -> String {
+        #[cfg(windows)]
+        {
+            l.replace('/', "\\")
+        }
+        #[cfg(not(windows))]
+        {
+            l.to_string()
+        }
+    }
+
     /// Classify MEGAcmd stderr into typed ProviderError (ERR-01).
     fn classify_mega_error(stderr: &str) -> ProviderError {
         let lower = stderr.to_lowercase();
@@ -602,8 +621,11 @@ impl StorageProvider for MegaCmdProvider {
         }
 
         // Download file (--resume removed: not supported by all MEGAcmd versions)
+        // Issue #263: normalize `/` → `\` on Windows so the verbatim-path
+        // resolution inside MEGAcmd does not produce `\\?\C:/...` (invalid).
+        let local_arg = Self::normalize_local_path_for_cli(l);
         match self
-            .run_mega_cmd_with_reauth("mega-get", &[&abs_remote, l])
+            .run_mega_cmd_with_reauth("mega-get", &[&abs_remote, &local_arg])
             .await
         {
             Ok(out) => {
@@ -695,7 +717,10 @@ impl StorageProvider for MegaCmdProvider {
             cb(0, 0);
         }
 
-        self.run_mega_cmd_with_reauth("mega-put", &[l, &abs_remote])
+        // Issue #263: normalize `/` → `\` on Windows so the verbatim-path
+        // resolution inside MEGAcmd does not produce `\\?\C:/...` (invalid).
+        let local_arg = Self::normalize_local_path_for_cli(l);
+        self.run_mega_cmd_with_reauth("mega-put", &[&local_arg, &abs_remote])
             .await
             .map_err(|e| ProviderError::TransferFailed(format!("Upload failed: {}", e)))?;
 
@@ -725,15 +750,19 @@ impl StorageProvider for MegaCmdProvider {
 
     async fn rmdir(&mut self, p: &str) -> Result<(), ProviderError> {
         let p = self.resolve_path(p);
-        // Soft delete: -r for recursive, moves to rubbish bin
-        self.run_mega_cmd_with_reauth("mega-rm", &["-r", &p])
+        // Issue #263: `-f` is mandatory in the one-shot wrapper path. Without
+        // it MEGAcmd's recursive `rm` prompts "Are you sure?" on stdin, the
+        // wrapper has no tty/stdin attached, and the call hangs until the
+        // 60s outer timeout in `run_mega_cmd` kills it.
+        self.run_mega_cmd_with_reauth("mega-rm", &["-r", "-f", &p])
             .await?;
         Ok(())
     }
 
     async fn rmdir_recursive(&mut self, p: &str) -> Result<(), ProviderError> {
         let p = self.resolve_path(p);
-        self.run_mega_cmd_with_reauth("mega-rm", &["-r", &p])
+        // Issue #263: see `rmdir` above for the rationale on `-f`.
+        self.run_mega_cmd_with_reauth("mega-rm", &["-r", "-f", &p])
             .await?;
         Ok(())
     }


### PR DESCRIPTION
## Summary

- **Add `-f` to `mega-rm -r` calls** so MEGAcmd never waits on a closed stdin during a recursive directory delete. Without `-f` the one-shot wrapper prompts "Are you sure?" on stdin; AeroFTP launches it without a tty, so the prompt blocks until the 60 s outer timeout in `run_mega_cmd` kills it — surfacing exactly as the "Failed to delete directory: Timeout" Ehud reports after 60 s.
- **Normalize local path `/` → `\\` on Windows** before passing it to `mega-put` / `mega-get`. The frontend forwards paths with forward slashes (`get_local_files` normalizes for display). MEGAcmd resolves the argument to a `\\?\`-prefixed verbatim path, and verbatim paths reject `/` as a separator — producing the "Unable to open local path: \\?\\C:/Users/…\\<file>" error Ehud sees when pasting into the non-WebDAV MEGAcmd panel.

## What is fixed

Closes the two non-WebDAV symptoms in #263:
- Delete folder → 60 s timeout (cross-platform; reproduced live on Linux)
- Upload via Ctrl+C/Paste → "Unable to open local path: \\?\…" (Windows-only)

## What is NOT in this PR

Issue **#264** (WebDAV MEGAcmd cannot preview images) is **intentionally out of scope**. The reqwest "error sending request for url" message Ehud quoted needs a Windows reproduction with the effective URL / HTTP status before the root cause (TLS self-signed? digest auth on binary GET? content-type mismatch?) can be confirmed. Tracked separately on the issue.

## Reproduction (local)

```bash
mega-mkdir /aeroftp-test-263
time mega-rm -r /aeroftp-test-263       # pre-fix: hangs ~70 s, SIGTERM, exit 143
time mega-rm -r -f /aeroftp-test-263    # post-fix equivalent: 0.084 s, exit 0
```

## Test plan

- [x] `cargo check --lib` — clean build, 0 warnings
- [x] `cargo test --lib providers::mega` — 31/31 ok
- [x] Live reproduction of the delete-folder timeout on Linux without the fix
- [ ] Manual verification on Windows 10 (delete + upload via Ctrl+C/Paste) — needs Claude Windows or Ehud confirmation
- [ ] Manual verification of the delete folder fix from AeroFTP GUI on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed path handling issues on Windows for MEGA cloud storage operations.
  * Resolved hanging behavior during directory removal operations, eliminating unwanted interactive confirmation prompts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/axpdev-lab/aeroftp/pull/265?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->