### PR TITLE
fix(cli): bump aeroftp-cli stack reserve to 8 MB on Windows

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -77,6 +77,14 @@ fn main() {
 
     println!("cargo:rerun-if-changed=Cargo.lock");
 
+    // Windows main thread default stack is 1 MB. The aeroftp-cli `Cli` enum
+    // produced by clap derive has ~80 subcommand variants and is constructed
+    // on the stack during `Cli::parse_from`, blowing the limit before main
+    // can even print --help. Bump the reserve to 8 MB (matches POSIX default)
+    // for this bin only; other bins are unaffected.
+    #[cfg(target_os = "windows")]
+    println!("cargo:rustc-link-arg-bin=aeroftp-cli=/STACK:8388608");
+
     // Detect Rust compiler version at build time: "rustc 1.84.0 (...)" → "1.84.0"
     if let Ok(output) = std::process::Command::new("rustc")
         .arg("--version")


### PR DESCRIPTION
## Summary

`aeroftp-cli.exe` panics with stack overflow on every Windows invocation, even `--version` / `--help`:

```
thread 'main' (NNNNN) has overflowed its stack
```

Root cause: the Windows main-thread default stack reserve is 1 MB. `aeroftp-cli`'s top-level `Cli` enum is produced by clap's `Subcommand` derive over ~80 variants (plus ~20 nested subcommand groups), and the resulting struct is constructed on the stack inside `Cli::parse_from`. The allocation overflows the limit before `main` can even print `--help`. POSIX targets (default 8 MB thread stack) are unaffected.

## Fix

One `cargo:rustc-link-arg-bin=aeroftp-cli=/STACK:8388608` directive in `src-tauri/build.rs`, gated on `target_os = "windows"`. Bumps the reserve to 8 MB (matches POSIX default) for this bin only; other binaries and the library are unaffected.

## How this was found

Diagnosed during the Windows validation pass for PR #265 (issue #263 fix). The Windows runner could not exercise any `aeroftp-cli` test path at all until this was in place. The diagnostic + patch were authored by the Windows-side debug runner (Claude Opus 4.7) and ack'd via the cross-dev transport.

## Why this is propaedeutic

Any future Windows-side test of `aeroftp-cli` (manual smoke, CI, validation of provider fixes that include the CLI path) is blocked until this lands. Merging this unblocks the MCP extension validation path too, since the MCP subcommand is registered through the same `Cli` enum.

## Test plan

- [x] `cargo check --lib` on Linux — passes (no-op on POSIX)
- [x] `cargo build --bin aeroftp-cli` on Windows + `aeroftp-cli --version` — fixed (Windows runner verified)
- [ ] Windows CI smoke (deferred to merge — first Windows CI run after merge is the production check)
- [ ] Confirm other bins (`aeroftp`, MCP subprocess) still build and run on Windows — verified by Windows runner via `aeroftp-cli ls --profile "MEGA cmd"` and full mega test pass

## Risk

Negligible. `/STACK:` is the standard MSVC mechanism; 8 MB is the POSIX default already in use everywhere else. The directive is `target_os = "windows"`-gated so nothing changes on Linux/macOS. If a future Windows env reports stack-related symptoms on other bins, the same pattern can be applied per-bin without affecting this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stack size allocation in Windows builds to enhance runtime stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/axpdev-lab/aeroftp/pull/267?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->