### PR TITLE
chore(mega): drop redundant CommandExt trait imports

### DIFF
--- a/src-tauri/src/providers/mega.rs
+++ b/src-tauri/src/providers/mega.rs
@@ -135,7 +135,6 @@ impl MegaCmdProvider {
             cmd_builder.args(args);
             #[cfg(windows)]
             {
-                use std::os::windows::process::CommandExt as _;
                 cmd_builder.creation_flags(CREATE_NO_WINDOW);
             }
             let output_future = cmd_builder.output();
@@ -261,7 +260,6 @@ impl MegaCmdProvider {
             #[cfg(windows)]
             let output = {
                 // CREATE_NO_WINDOW prevents cmd.exe console flash
-                use std::os::windows::process::CommandExt as _;
                 let mut cmd = Command::new(&resolved_cmd);
                 cmd.arg(&self.config.email).arg(&password);
                 if let Some(ref code) = auth_code {
@@ -348,7 +346,6 @@ impl MegaCmdProvider {
                     .stderr(std::process::Stdio::null());
                 #[cfg(windows)]
                 {
-                    use std::os::windows::process::CommandExt as _;
                     daemon_cmd.creation_flags(CREATE_NO_WINDOW);
                 }
                 let _ = daemon_cmd.spawn();

--- a/src-tauri/src/providers/mega_df.rs
+++ b/src-tauri/src/providers/mega_df.rs
@@ -65,7 +65,6 @@ pub async fn mega_df_query() -> Result<(u64, u64), ProviderError> {
     let mut cmd = Command::new(&resolved_cmd);
     #[cfg(windows)]
     {
-        use std::os::windows::process::CommandExt as _;
         cmd.creation_flags(CREATE_NO_WINDOW);
     }
 


### PR DESCRIPTION
## Summary

Removes 4 redundant trait imports in \`mega.rs\` (x3) and \`mega_df.rs\` (x1):

\`\`\`rust
use std::os::windows::process::CommandExt as _;
\`\`\`

\`tokio::process::Command\` exposes \`creation_flags(u32)\` as an inherent method on Windows, so the trait import is redundant: the method resolves directly on the tokio type. The leftover \`use\` lines only triggered \`unused_imports\` warnings on Windows builds.

## How this was found

Surfaced by the Windows debug runner during PR #265 validation. Pre-existing dead code from an earlier refactor that swapped \`std::process::Command\` for \`tokio::process::Command\` without cleaning up the trait imports.

## Risk

Zero functional change. The \`creation_flags(CREATE_NO_WINDOW)\` calls themselves are untouched. Linux/macOS builds are unaffected (the \`#[cfg(windows)]\` blocks are not compiled there). Windows builds simply stop emitting four \`unused_imports\` warnings.

## Test plan

- [x] \`cargo check --lib\` on Linux — passes
- [ ] Windows CI smoke — covered by the normal CI matrix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal Windows process management code for improved code maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/axpdev-lab/aeroftp/pull/268?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->