### PR TITLE
feat(opendrive): three-level Privacy chooser (#252 pt 2)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15596,6 +15596,7 @@ pub fn run() {
             provider_commands::opendrive_permanent_delete,
             provider_commands::opendrive_empty_trash,
             provider_commands::opendrive_set_path_privacy,
+            provider_commands::opendrive_set_path_access,
             provider_commands::fourshared_set_path_privacy,
             provider_commands::yandex_list_trash,
             provider_commands::yandex_restore_from_trash,

--- a/src-tauri/src/provider_commands.rs
+++ b/src-tauri/src/provider_commands.rs
@@ -5841,6 +5841,54 @@ pub async fn opendrive_set_path_privacy(
     }
 }
 
+/// Set OpenDrive three-level access for a file or folder. Accepts the
+/// AeroFTP-canonical tokens `private`, `public`, or `hidden`.
+#[tauri::command]
+pub async fn opendrive_set_path_access(
+    state: State<'_, ProviderState>,
+    path: String,
+    access_level: String,
+    is_dir: bool,
+) -> Result<(), String> {
+    let level = match access_level.to_ascii_lowercase().as_str() {
+        "private" => crate::providers::opendrive::OpenDriveAccessLevel::Private,
+        "public" => crate::providers::opendrive::OpenDriveAccessLevel::Public,
+        "hidden" => crate::providers::opendrive::OpenDriveAccessLevel::Hidden,
+        other => {
+            return Err(format!(
+                "Unknown OpenDrive access level: '{}' (expected private, public, or hidden)",
+                other
+            ));
+        }
+    };
+
+    let mut provider_guard = state.provider.lock().await;
+    let provider = provider_guard
+        .as_mut()
+        .ok_or_else(|| "Not connected to any provider".to_string())?;
+
+    if provider.provider_type() != ProviderType::OpenDrive {
+        return Err("This operation is only available for OpenDrive".to_string());
+    }
+
+    let opendrive = provider
+        .as_any_mut()
+        .downcast_mut::<crate::providers::opendrive::OpenDriveProvider>()
+        .ok_or_else(|| "Failed to access OpenDrive provider".to_string())?;
+
+    if is_dir {
+        opendrive
+            .set_folder_access(&path, level)
+            .await
+            .map_err(|e| format!("Set folder access failed for {}: {}", path, e))
+    } else {
+        opendrive
+            .set_file_access(&path, level)
+            .await
+            .map_err(|e| format!("Set file access failed for {}: {}", path, e))
+    }
+}
+
 /// Set FourShared privacy for a file or folder.
 /// is_public=false => private, is_public=true => public.
 #[tauri::command]

--- a/src-tauri/src/providers/opendrive.rs
+++ b/src-tauri/src/providers/opendrive.rs
@@ -390,6 +390,30 @@ fn access_to_permissions(access: u64) -> Option<&'static str> {
     }
 }
 
+/// Typed OpenDrive access level for `file/access.json` and
+/// `folder/setaccess.json`.
+///
+/// Same numeric mapping as [`access_to_permissions`] (0=private,
+/// 1=public, 2=hidden); kept as a dedicated enum so callers don't
+/// have to reason about the magic integers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum OpenDriveAccessLevel {
+    Private,
+    Public,
+    Hidden,
+}
+
+impl OpenDriveAccessLevel {
+    fn to_api_value(self) -> &'static str {
+        match self {
+            OpenDriveAccessLevel::Private => "0",
+            OpenDriveAccessLevel::Public => "1",
+            OpenDriveAccessLevel::Hidden => "2",
+        }
+    }
+}
+
 fn parse_timestamp_to_iso(value: Option<&serde_json::Value>) -> Option<String> {
     let raw = match value {
         Some(serde_json::Value::Number(n)) => n.as_i64(),
@@ -1162,16 +1186,29 @@ impl OpenDriveProvider {
         path: &str,
         is_public: bool,
     ) -> Result<(), ProviderError> {
+        let level = if is_public {
+            OpenDriveAccessLevel::Public
+        } else {
+            OpenDriveAccessLevel::Private
+        };
+        self.set_file_access(path, level).await
+    }
+
+    pub async fn set_file_access(
+        &mut self,
+        path: &str,
+        level: OpenDriveAccessLevel,
+    ) -> Result<(), ProviderError> {
         if !self.connected {
             return Err(ProviderError::NotConnected);
         }
 
         let resolved = self.resolve_path(path)?;
-        let file_ispublic = if is_public { "1" } else { "0" };
+        let level_value = level.to_api_value().to_string();
 
         self.with_reauth(|this| {
             let resolved = resolved.clone();
-            let file_ispublic = file_ispublic.to_string();
+            let level_value = level_value.clone();
             Box::pin(async move {
                 let file_id = this.resolve_file_id(&resolved).await?;
                 this.post_form_unit(
@@ -1179,7 +1216,7 @@ impl OpenDriveProvider {
                     &[
                         ("session_id", this.session_id.clone()),
                         ("file_id", file_id),
-                        ("file_ispublic", file_ispublic),
+                        ("file_ispublic", level_value),
                     ],
                 )
                 .await
@@ -1193,12 +1230,25 @@ impl OpenDriveProvider {
         path: &str,
         is_public: bool,
     ) -> Result<(), ProviderError> {
+        let level = if is_public {
+            OpenDriveAccessLevel::Public
+        } else {
+            OpenDriveAccessLevel::Private
+        };
+        self.set_folder_access(path, level).await
+    }
+
+    pub async fn set_folder_access(
+        &mut self,
+        path: &str,
+        level: OpenDriveAccessLevel,
+    ) -> Result<(), ProviderError> {
         if !self.connected {
             return Err(ProviderError::NotConnected);
         }
 
         let resolved = self.resolve_path(path)?;
-        let folder_is_public = if is_public { "1" } else { "0" };
+        let folder_is_public = level.to_api_value().to_string();
 
         self.with_reauth(|this| {
             let resolved = resolved.clone();
@@ -2351,6 +2401,31 @@ mod tests {
         assert_eq!(access_to_permissions(2), Some("hidden"));
         assert_eq!(access_to_permissions(3), None);
         assert_eq!(access_to_permissions(99), None);
+    }
+
+    #[test]
+    fn opendrive_access_level_round_trips_via_api_value() {
+        // The api_value strings must keep the same mapping as the
+        // listing-side Access integer, otherwise a set_*_access call
+        // would write a value the next listing pass would misread.
+        assert_eq!(OpenDriveAccessLevel::Private.to_api_value(), "0");
+        assert_eq!(OpenDriveAccessLevel::Public.to_api_value(), "1");
+        assert_eq!(OpenDriveAccessLevel::Hidden.to_api_value(), "2");
+
+        for level in [
+            OpenDriveAccessLevel::Private,
+            OpenDriveAccessLevel::Public,
+            OpenDriveAccessLevel::Hidden,
+        ] {
+            let raw: u64 = level.to_api_value().parse().unwrap();
+            let token = access_to_permissions(raw).unwrap();
+            let expected = match level {
+                OpenDriveAccessLevel::Private => "private",
+                OpenDriveAccessLevel::Public => "public",
+                OpenDriveAccessLevel::Hidden => "hidden",
+            };
+            assert_eq!(token, expected, "level={:?}", level);
+        }
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -964,6 +964,9 @@ const App: React.FC = () => {
   const [fileLuFolderSettingsDialog, setFileLuFolderSettingsDialog] = useState<{
     path: string; name: string; filedrop: boolean; isPublic: boolean;
   } | null>(null);
+  const [openDrivePrivacyDialog, setOpenDrivePrivacyDialog] = useState<{
+    path: string; name: string; isDir: boolean; current: 'public' | 'private' | 'hidden'; selected: 'public' | 'private' | 'hidden';
+  } | null>(null);
   const [fileLuRemoteUploadDialog, setFileLuRemoteUploadDialog] = useState<{
     destPath: string;
   } | null>(null);
@@ -9799,6 +9802,25 @@ interface UpdateVerificationInfo {
             },
           },
         ] : []),
+        ...(isOpenDriveContext ? [
+          {
+            label: t('contextMenu.privacyEllipsis') || 'Privacy...',
+            icon: <Shield size={14} />,
+            action: () => {
+              const current: 'public' | 'private' | 'hidden' =
+                filePrivacy === 'public' ? 'public' :
+                filePrivacy === 'hidden' ? 'hidden' :
+                'private';
+              setOpenDrivePrivacyDialog({
+                path: file.path || `${currentRemotePath === '/' ? '' : currentRemotePath}/${file.name}`,
+                name: file.name,
+                isDir: !!file.is_dir,
+                current,
+                selected: current,
+              });
+            },
+          },
+        ] : []),
         ...(count > 1 ? [{
           label: t('contextMenu.makeAllPrivate') || 'Make all private',
           icon: <OpenDriveLogo size={14} />,
@@ -12421,6 +12443,95 @@ interface UpdateVerificationInfo {
                     setFileLuFolderSettingsDialog(null);
                   }}
                   className="px-4 py-2 text-sm rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition-colors"
+                >
+                  {t('common.save')}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+        {/* OpenDrive: Privacy three-level chooser */}
+        {openDrivePrivacyDialog && (
+          <div className="fixed inset-0 z-50 flex items-start justify-center pt-[5vh] bg-black/50 backdrop-blur-sm">
+            <div className="w-full max-w-md mx-4 rounded-xl shadow-2xl bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 animate-scale-in p-6">
+              <h2 className="text-base font-semibold text-gray-900 dark:text-gray-100 mb-1 flex items-center gap-2">
+                <OpenDriveLogo size={18} />
+                {t('opendrive.privacyTitle') || 'OpenDrive Privacy'}
+              </h2>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mb-4 truncate">
+                <span className="font-medium text-gray-700 dark:text-gray-300">{openDrivePrivacyDialog.name}</span>
+              </p>
+              <div className="space-y-2 mb-5">
+                {(['private', 'public', 'hidden'] as const).map((level) => {
+                  const isSelected = openDrivePrivacyDialog.selected === level;
+                  const labelKey = level === 'private' ? 'properties.privacyPrivate'
+                    : level === 'public' ? 'properties.privacyPublic'
+                    : 'properties.privacyHidden';
+                  const descKey = level === 'private' ? 'properties.privacyPrivateDesc'
+                    : level === 'public' ? 'properties.privacyPublicDesc'
+                    : 'properties.privacyHiddenDesc';
+                  return (
+                    <button
+                      key={level}
+                      type="button"
+                      onClick={() => setOpenDrivePrivacyDialog(d => d ? { ...d, selected: level } : null)}
+                      className={`w-full text-left px-3 py-2 rounded-lg border transition-colors ${
+                        isSelected
+                          ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/30'
+                          : 'border-gray-200 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700/50'
+                      }`}
+                    >
+                      <div className="flex items-start gap-2">
+                        <span className={`mt-0.5 inline-block w-3 h-3 rounded-full border ${
+                          isSelected
+                            ? 'border-blue-500 bg-blue-500'
+                            : 'border-gray-400 dark:border-gray-500'
+                        }`} />
+                        <div className="flex-1 min-w-0">
+                          <div className="text-sm font-medium text-gray-900 dark:text-gray-100 flex items-center gap-2">
+                            {t(labelKey)}
+                            {level === openDrivePrivacyDialog.current && (
+                              <span className="text-[10px] uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                                {t('common.current') || 'current'}
+                              </span>
+                            )}
+                          </div>
+                          <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{t(descKey)}</div>
+                        </div>
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+              <div className="flex gap-3 justify-end">
+                <button
+                  onClick={() => setOpenDrivePrivacyDialog(null)}
+                  className="px-4 py-2 text-sm rounded-lg bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 transition-colors"
+                >
+                  {t('common.cancel')}
+                </button>
+                <button
+                  disabled={openDrivePrivacyDialog.selected === openDrivePrivacyDialog.current}
+                  onClick={async () => {
+                    const d = openDrivePrivacyDialog;
+                    if (!d || d.selected === d.current) return;
+                    const logId = humanLog.logRaw('activity.opendrive_set_access', 'INFO', { provider: 'OpenDrive', filename: d.name }, 'running');
+                    try {
+                      await invoke('opendrive_set_path_access', {
+                        path: d.path,
+                        accessLevel: d.selected,
+                        isDir: d.isDir,
+                      });
+                      notify.success(t('opendrive.privacyUpdated') || 'OpenDrive privacy updated');
+                      humanLog.updateEntry(logId, { status: 'success', message: `[OpenDrive] Access set to ${d.selected}` });
+                      await loadRemoteFiles(undefined, true);
+                    } catch (err) {
+                      notify.error(String(err));
+                      humanLog.updateEntry(logId, { status: 'error', message: `[OpenDrive] Set access ${d.selected} failed` });
+                    }
+                    setOpenDrivePrivacyDialog(null);
+                  }}
+                  className="px-4 py-2 text-sm rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   {t('common.save')}
                 </button>

--- a/src/i18n/locales/bg.json
+++ b/src/i18n/locales/bg.json
@@ -67,7 +67,8 @@
             "check": "Check",
             "selectAll": "Select All",
             "required": "задължително",
-            "duplicate": "Дублиране"
+            "duplicate": "Дублиране",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "Свързване със сървър",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Кошче Azure Blob",
             "lockRcloneCrypt": "Заключи наслагване Rclone Crypt",
             "unlockRcloneCrypt": "Дешифрирай като наслагване Rclone Crypt…",
-            "openAsAeroVaultOverlay": "Отвори като AeroVault Overlay"
+            "openAsAeroVaultOverlay": "Отвори като AeroVault Overlay",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "Прехвърляне...",
@@ -4601,6 +4603,10 @@
             "lastUsedYesterday": "[NEEDS TRANSLATION] Used yesterday",
             "lastUsedDaysAgo": "[NEEDS TRANSLATION] Used {days} days ago",
             "securityNote": "Акаунтът е защитен с криптиране Argon2id + AES-KW + AES-256-GCM"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/bn.json
+++ b/src/i18n/locales/bn.json
@@ -67,7 +67,8 @@
             "check": "Check",
             "selectAll": "Select All",
             "required": "প্রয়োজনীয়",
-            "duplicate": "ডুপ্লিকেট"
+            "duplicate": "ডুপ্লিকেট",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "সার্ভারে সংযোগ করুন",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Azure Blob ট্র্যাশ",
             "lockRcloneCrypt": "Rclone Crypt ওভারলে লক করুন",
             "unlockRcloneCrypt": "Rclone Crypt ওভারলে হিসাবে ডিক্রিপ্ট করুন…",
-            "openAsAeroVaultOverlay": "AeroVault Overlay হিসেবে খুলুন"
+            "openAsAeroVaultOverlay": "AeroVault Overlay হিসেবে খুলুন",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "স্থানান্তর করা হচ্ছে...",
@@ -4601,6 +4603,10 @@
             "lastUsedYesterday": "[NEEDS TRANSLATION] Used yesterday",
             "lastUsedDaysAgo": "[NEEDS TRANSLATION] Used {days} days ago",
             "securityNote": "অ্যাকাউন্ট Argon2id + AES-KW + AES-256-GCM এনক্রিপশন দ্বারা সুরক্ষিত"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/ca.json
+++ b/src/i18n/locales/ca.json
@@ -67,7 +67,8 @@
             "check": "Check",
             "selectAll": "Select All",
             "required": "obligatori",
-            "duplicate": "Duplicar"
+            "duplicate": "Duplicar",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "Connectar al Servidor",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Paperera d'Azure Blob",
             "lockRcloneCrypt": "Bloqueja la superposició Rclone Crypt",
             "unlockRcloneCrypt": "Desxifra com a superposició Rclone Crypt…",
-            "openAsAeroVaultOverlay": "Obre com a AeroVault Overlay"
+            "openAsAeroVaultOverlay": "Obre com a AeroVault Overlay",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "Transferint...",
@@ -4620,6 +4622,10 @@
             "lastUsedYesterday": "[NEEDS TRANSLATION] Used yesterday",
             "lastUsedDaysAgo": "[NEEDS TRANSLATION] Used {days} days ago",
             "securityNote": "Compte protegit amb xifratge Argon2id + AES-KW + AES-256-GCM"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -67,7 +67,8 @@
             "check": "Check",
             "selectAll": "Select All",
             "required": "povinné",
-            "duplicate": "Duplikovat"
+            "duplicate": "Duplikovat",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "Připojení k serveru",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Koš Azure Blob",
             "lockRcloneCrypt": "Zamknout překryv Rclone Crypt",
             "unlockRcloneCrypt": "Dešifrovat jako překryv Rclone Crypt…",
-            "openAsAeroVaultOverlay": "Otevřít jako AeroVault Overlay"
+            "openAsAeroVaultOverlay": "Otevřít jako AeroVault Overlay",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "Přenášení...",
@@ -4601,6 +4603,10 @@
             "lastUsedYesterday": "[NEEDS TRANSLATION] Used yesterday",
             "lastUsedDaysAgo": "[NEEDS TRANSLATION] Used {days} days ago",
             "securityNote": "Účet chráněn šifrováním Argon2id + AES-KW + AES-256-GCM"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/cy.json
+++ b/src/i18n/locales/cy.json
@@ -67,7 +67,8 @@
             "check": "Check",
             "selectAll": "Select All",
             "required": "gofynnol",
-            "duplicate": "Dyblygu"
+            "duplicate": "Dyblygu",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "Cysylltu a'r Gweinydd",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Sbwriel Azure Blob",
             "lockRcloneCrypt": "Cloi troshaen Rclone Crypt",
             "unlockRcloneCrypt": "Dadgryptio fel troshaen Rclone Crypt…",
-            "openAsAeroVaultOverlay": "Agor fel AeroVault Overlay"
+            "openAsAeroVaultOverlay": "Agor fel AeroVault Overlay",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "Yn trosglwyddo...",
@@ -4620,6 +4622,10 @@
             "lastUsedYesterday": "[NEEDS TRANSLATION] Used yesterday",
             "lastUsedDaysAgo": "[NEEDS TRANSLATION] Used {days} days ago",
             "securityNote": "Cyfrif wedi'i ddiogelu â chryptiad Argon2id + AES-KW + AES-256-GCM"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/da.json
+++ b/src/i18n/locales/da.json
@@ -67,7 +67,8 @@
             "check": "Check",
             "selectAll": "Select All",
             "required": "påkrævet",
-            "duplicate": "Dupliker"
+            "duplicate": "Dupliker",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "Forbind til server",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Azure Blob papirkurv",
             "lockRcloneCrypt": "Lås Rclone Crypt-overlay",
             "unlockRcloneCrypt": "Dekrypter som Rclone Crypt-overlay…",
-            "openAsAeroVaultOverlay": "Åbn som AeroVault Overlay"
+            "openAsAeroVaultOverlay": "Åbn som AeroVault Overlay",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "Overfører...",
@@ -4601,6 +4603,10 @@
             "lastUsedYesterday": "[NEEDS TRANSLATION] Used yesterday",
             "lastUsedDaysAgo": "[NEEDS TRANSLATION] Used {days} days ago",
             "securityNote": "Konto beskyttet med Argon2id + AES-KW + AES-256-GCM-kryptering"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -67,7 +67,8 @@
             "check": "Prüfen",
             "selectAll": "Select All",
             "required": "erforderlich",
-            "duplicate": "Duplizieren"
+            "duplicate": "Duplizieren",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "Mit Server verbinden",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Azure Blob Papierkorb",
             "lockRcloneCrypt": "Rclone-Crypt-Overlay sperren",
             "unlockRcloneCrypt": "Als Rclone-Crypt-Overlay entschlüsseln…",
-            "openAsAeroVaultOverlay": "Als AeroVault Overlay öffnen"
+            "openAsAeroVaultOverlay": "Als AeroVault Overlay öffnen",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "Übertragung...",
@@ -4601,6 +4603,10 @@
             "lastUsedYesterday": "Gestern verwendet",
             "lastUsedDaysAgo": "Vor {days} Tagen verwendet",
             "securityNote": "Konto geschützt mit Argon2id + AES-KW + AES-256-GCM-Verschlüsselung"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/el.json
+++ b/src/i18n/locales/el.json
@@ -67,7 +67,8 @@
             "check": "Check",
             "selectAll": "Select All",
             "required": "απαιτείται",
-            "duplicate": "Αντίγραφο"
+            "duplicate": "Αντίγραφο",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "Σύνδεση σε διακομιστή",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Κάδος Azure Blob",
             "lockRcloneCrypt": "Κλείδωμα επικάλυψης Rclone Crypt",
             "unlockRcloneCrypt": "Αποκρυπτογράφηση ως επικάλυψη Rclone Crypt…",
-            "openAsAeroVaultOverlay": "Άνοιγμα ως AeroVault Overlay"
+            "openAsAeroVaultOverlay": "Άνοιγμα ως AeroVault Overlay",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "Μεταφορά...",
@@ -4601,6 +4603,10 @@
             "lastUsedYesterday": "[NEEDS TRANSLATION] Used yesterday",
             "lastUsedDaysAgo": "[NEEDS TRANSLATION] Used {days} days ago",
             "securityNote": "Ο λογαριασμός προστατεύεται με κρυπτογράφηση Argon2id + AES-KW + AES-256-GCM"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1006,6 +1006,7 @@
             "copied": "Copied",
             "copy": "Copy",
             "create": "Create",
+            "current": "current",
             "cut": "Cut",
             "dark": "Dark",
             "delete": "Delete",
@@ -1369,6 +1370,7 @@
             "pathCopied": "Path copied",
             "permissions": "Permissions",
             "preview": "Preview",
+            "privacyEllipsis": "Privacy...",
             "properties": "Properties",
             "refresh": "Refresh",
             "selectAll": "Select All",
@@ -2030,6 +2032,10 @@
             "read": "Read",
             "title": "Permissions",
             "write": "Write"
+        },
+        "opendrive": {
+            "privacyTitle": "OpenDrive Privacy",
+            "privacyUpdated": "OpenDrive privacy updated"
         },
         "preview": {
             "audio": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -67,7 +67,8 @@
             "check": "Verificar",
             "selectAll": "Select All",
             "required": "obligatorio",
-            "duplicate": "Duplicar"
+            "duplicate": "Duplicar",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "Conectar al Servidor",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Papelera de Azure Blob",
             "lockRcloneCrypt": "Bloquear superposición Rclone Crypt",
             "unlockRcloneCrypt": "Descifrar como superposición Rclone Crypt…",
-            "openAsAeroVaultOverlay": "Abrir como AeroVault Overlay"
+            "openAsAeroVaultOverlay": "Abrir como AeroVault Overlay",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "Transfiriendo...",
@@ -4601,6 +4603,10 @@
             "lastUsedYesterday": "Usado ayer",
             "lastUsedDaysAgo": "Usado hace {days} días",
             "securityNote": "Cuenta protegida con cifrado Argon2id + AES-KW + AES-256-GCM"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/et.json
+++ b/src/i18n/locales/et.json
@@ -67,7 +67,8 @@
             "check": "Check",
             "selectAll": "Select All",
             "required": "nõutav",
-            "duplicate": "Dubleeri"
+            "duplicate": "Dubleeri",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "Ühenda serveriga",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Azure Blob prügikast",
             "lockRcloneCrypt": "Lukusta Rclone Crypt kate",
             "unlockRcloneCrypt": "Dekrüpteeri Rclone Crypt kattena…",
-            "openAsAeroVaultOverlay": "Ava AeroVault Overlay-na"
+            "openAsAeroVaultOverlay": "Ava AeroVault Overlay-na",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "Ülekanne...",
@@ -4601,6 +4603,10 @@
             "lastUsedYesterday": "[NEEDS TRANSLATION] Used yesterday",
             "lastUsedDaysAgo": "[NEEDS TRANSLATION] Used {days} days ago",
             "securityNote": "Konto on kaitstud Argon2id + AES-KW + AES-256-GCM krüpteeringuga"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/eu.json
+++ b/src/i18n/locales/eu.json
@@ -67,7 +67,8 @@
             "check": "Check",
             "selectAll": "Select All",
             "required": "beharrezkoa",
-            "duplicate": "Bikoiztu"
+            "duplicate": "Bikoiztu",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "Zerbitzarira Konektatu",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Azure Blob zakarrontzia",
             "lockRcloneCrypt": "Blokeatu Rclone Crypt gainjartzea",
             "unlockRcloneCrypt": "Deszifratu Rclone Crypt gainjartze gisa…",
-            "openAsAeroVaultOverlay": "Ireki AeroVault Overlay gisa"
+            "openAsAeroVaultOverlay": "Ireki AeroVault Overlay gisa",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "Transferitzen...",
@@ -4620,6 +4622,10 @@
             "lastUsedYesterday": "[NEEDS TRANSLATION] Used yesterday",
             "lastUsedDaysAgo": "[NEEDS TRANSLATION] Used {days} days ago",
             "securityNote": "Kontua Argon2id + AES-KW + AES-256-GCM enkriptaziorekin babestuta"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -67,7 +67,8 @@
             "check": "Check",
             "selectAll": "Select All",
             "required": "vaadittu",
-            "duplicate": "Kopioi"
+            "duplicate": "Kopioi",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "Yhdistä palvelimeen",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Azure Blob roskakori",
             "lockRcloneCrypt": "Lukitse Rclone Crypt -peittokerros",
             "unlockRcloneCrypt": "Pura salaus Rclone Crypt -peittokerroksena…",
-            "openAsAeroVaultOverlay": "Avaa AeroVault Overlayna"
+            "openAsAeroVaultOverlay": "Avaa AeroVault Overlayna",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "Siirretään...",
@@ -4601,6 +4603,10 @@
             "lastUsedYesterday": "[NEEDS TRANSLATION] Used yesterday",
             "lastUsedDaysAgo": "[NEEDS TRANSLATION] Used {days} days ago",
             "securityNote": "Tili suojattu Argon2id + AES-KW + AES-256-GCM -salauksella"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -67,7 +67,8 @@
             "check": "Vérifier",
             "selectAll": "Select All",
             "required": "obligatoire",
-            "duplicate": "Dupliquer"
+            "duplicate": "Dupliquer",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "Connexion au Serveur",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Corbeille Azure Blob",
             "lockRcloneCrypt": "Verrouiller la superposition Rclone Crypt",
             "unlockRcloneCrypt": "Déchiffrer comme superposition Rclone Crypt…",
-            "openAsAeroVaultOverlay": "Ouvrir en tant qu'AeroVault Overlay"
+            "openAsAeroVaultOverlay": "Ouvrir en tant qu'AeroVault Overlay",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "Transfert en cours...",
@@ -4601,6 +4603,10 @@
             "lastUsedYesterday": "Utilisé hier",
             "lastUsedDaysAgo": "Utilisé il y a {days} jours",
             "securityNote": "Compte protégé par chiffrement Argon2id + AES-KW + AES-256-GCM"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/gl.json
+++ b/src/i18n/locales/gl.json
@@ -67,7 +67,8 @@
             "check": "Check",
             "selectAll": "Select All",
             "required": "obrigatorio",
-            "duplicate": "Duplicar"
+            "duplicate": "Duplicar",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "Conectar ao Servidor",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Papeleira de Azure Blob",
             "lockRcloneCrypt": "Bloquear superposición Rclone Crypt",
             "unlockRcloneCrypt": "Descifrar como superposición Rclone Crypt…",
-            "openAsAeroVaultOverlay": "Abrir como AeroVault Overlay"
+            "openAsAeroVaultOverlay": "Abrir como AeroVault Overlay",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "Transferindo...",
@@ -4620,6 +4622,10 @@
             "lastUsedYesterday": "[NEEDS TRANSLATION] Used yesterday",
             "lastUsedDaysAgo": "[NEEDS TRANSLATION] Used {days} days ago",
             "securityNote": "Conta protexida con cifrado Argon2id + AES-KW + AES-256-GCM"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -67,7 +67,8 @@
             "check": "Check",
             "selectAll": "Select All",
             "required": "आवश्यक",
-            "duplicate": "डुप्लिकेट"
+            "duplicate": "डुप्लिकेट",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "सर्वर से कनेक्ट करें",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Azure Blob ट्रैश",
             "lockRcloneCrypt": "Rclone Crypt ओवरले लॉक करें",
             "unlockRcloneCrypt": "Rclone Crypt ओवरले के रूप में डिक्रिप्ट करें…",
-            "openAsAeroVaultOverlay": "AeroVault Overlay के रूप में खोलें"
+            "openAsAeroVaultOverlay": "AeroVault Overlay के रूप में खोलें",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "स्थानांतरित हो रहा है...",
@@ -4601,6 +4603,10 @@
             "lastUsedYesterday": "[NEEDS TRANSLATION] Used yesterday",
             "lastUsedDaysAgo": "[NEEDS TRANSLATION] Used {days} days ago",
             "securityNote": "खाता Argon2id + AES-KW + AES-256-GCM एन्क्रिप्शन से सुरक्षित"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/hr.json
+++ b/src/i18n/locales/hr.json
@@ -67,7 +67,8 @@
             "check": "Check",
             "selectAll": "Select All",
             "required": "obavezno",
-            "duplicate": "Dupliciraj"
+            "duplicate": "Dupliciraj",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "Poveži se na poslužitelj",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Azure Blob smece",
             "lockRcloneCrypt": "Zaključaj prekrivač Rclone Crypt",
             "unlockRcloneCrypt": "Dešifriraj kao prekrivač Rclone Crypt…",
-            "openAsAeroVaultOverlay": "Otvori kao AeroVault Overlay"
+            "openAsAeroVaultOverlay": "Otvori kao AeroVault Overlay",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "Prijenos...",
@@ -4601,6 +4603,10 @@
             "lastUsedYesterday": "[NEEDS TRANSLATION] Used yesterday",
             "lastUsedDaysAgo": "[NEEDS TRANSLATION] Used {days} days ago",
             "securityNote": "Račun zaštićen Argon2id + AES-KW + AES-256-GCM enkripcijom"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/hu.json
+++ b/src/i18n/locales/hu.json
@@ -67,7 +67,8 @@
             "check": "Check",
             "selectAll": "Select All",
             "required": "kötelező",
-            "duplicate": "Másolat"
+            "duplicate": "Másolat",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "Csatlakozás szerverhez",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Azure Blob lomtar",
             "lockRcloneCrypt": "Rclone Crypt fedőréteg zárolása",
             "unlockRcloneCrypt": "Visszafejtés Rclone Crypt fedőrétegként…",
-            "openAsAeroVaultOverlay": "Megnyitás AeroVault Overlay-ként"
+            "openAsAeroVaultOverlay": "Megnyitás AeroVault Overlay-ként",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "Átvitel...",
@@ -4601,6 +4603,10 @@
             "lastUsedYesterday": "[NEEDS TRANSLATION] Used yesterday",
             "lastUsedDaysAgo": "[NEEDS TRANSLATION] Used {days} days ago",
             "securityNote": "A fiókot Argon2id + AES-KW + AES-256-GCM titkosítás védi"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/hy.json
+++ b/src/i18n/locales/hy.json
@@ -67,7 +67,8 @@
             "check": "Check",
             "selectAll": "Select All",
             "required": "պարտադիր",
-            "duplicate": "Կրկնակ"
+            "duplicate": "Կրկնակ",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "Կապվել սերվերուհն",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Azure Blob Աղբաման",
             "lockRcloneCrypt": "Կողպել Rclone Crypt ծածկույթը",
             "unlockRcloneCrypt": "Վերծանել որպես Rclone Crypt ծածկույթ…",
-            "openAsAeroVaultOverlay": "Բացել որպես AeroVault Overlay"
+            "openAsAeroVaultOverlay": "Բացել որպես AeroVault Overlay",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "Փոխանցում...",
@@ -4601,6 +4603,10 @@
             "lastUsedYesterday": "[NEEDS TRANSLATION] Used yesterday",
             "lastUsedDaysAgo": "[NEEDS TRANSLATION] Used {days} days ago",
             "securityNote": "Հաշիվը պաշտպանված է Argon2id + AES-KW + AES-256-GCM կրիպտոգրաֆիայով"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -67,7 +67,8 @@
             "check": "Check",
             "selectAll": "Select All",
             "required": "wajib",
-            "duplicate": "Duplikat"
+            "duplicate": "Duplikat",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "Hubungkan ke Server",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Sampah Azure Blob",
             "lockRcloneCrypt": "Kunci overlay Rclone Crypt",
             "unlockRcloneCrypt": "Dekripsi sebagai overlay Rclone Crypt…",
-            "openAsAeroVaultOverlay": "Buka sebagai AeroVault Overlay"
+            "openAsAeroVaultOverlay": "Buka sebagai AeroVault Overlay",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "Mentransfer...",
@@ -4601,6 +4603,10 @@
             "lastUsedYesterday": "[NEEDS TRANSLATION] Used yesterday",
             "lastUsedDaysAgo": "[NEEDS TRANSLATION] Used {days} days ago",
             "securityNote": "Akun dilindungi dengan enkripsi Argon2id + AES-KW + AES-256-GCM"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/is.json
+++ b/src/i18n/locales/is.json
@@ -67,7 +67,8 @@
             "check": "Check",
             "selectAll": "Select All",
             "required": "nauðsynlegt",
-            "duplicate": "Afrita"
+            "duplicate": "Afrita",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "Tengjast þjóni",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Azure Blob rusl",
             "lockRcloneCrypt": "Læsa Rclone Crypt yfirlag",
             "unlockRcloneCrypt": "Afkóða sem Rclone Crypt yfirlag…",
-            "openAsAeroVaultOverlay": "Opna sem AeroVault Overlay"
+            "openAsAeroVaultOverlay": "Opna sem AeroVault Overlay",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "Flytur...",
@@ -4620,6 +4622,10 @@
             "lastUsedYesterday": "[NEEDS TRANSLATION] Used yesterday",
             "lastUsedDaysAgo": "[NEEDS TRANSLATION] Used {days} days ago",
             "securityNote": "Reikningur varinn með Argon2id + AES-KW + AES-256-GCM dulkóðun"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -37,6 +37,7 @@
             "browse": "Sfoglia",
             "select": "Seleziona",
             "copy": "Copia",
+            "current": "attuale",
             "paste": "Incolla",
             "cut": "Taglia",
             "rename": "Rinomina",
@@ -702,6 +703,7 @@
             "permanentDeleteSuccess": "{count} elemento/i eliminato/i definitivamente",
             "permissions": "Permessi",
             "preview": "Anteprima",
+            "privacyEllipsis": "Privacy...",
             "properties": "Proprietà",
             "refresh": "Aggiorna",
             "restoreFromTrash": "Ripristina",
@@ -3468,6 +3470,10 @@
             "public": "Pubblico",
             "octal": "Valore Numerico (Ottale)",
             "apply": "Applica"
+        },
+        "opendrive": {
+            "privacyTitle": "Privacy OpenDrive",
+            "privacyUpdated": "Privacy OpenDrive aggiornata"
         },
         "error": {
             "title": "Qualcosa è andato storto",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -67,7 +67,8 @@
             "check": "確認",
             "selectAll": "Select All",
             "required": "必須",
-            "duplicate": "複製"
+            "duplicate": "複製",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "サーバーに接続",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Azure Blob ゴミ箱",
             "lockRcloneCrypt": "Rclone Crypt オーバーレイをロック",
             "unlockRcloneCrypt": "Rclone Crypt オーバーレイとして復号…",
-            "openAsAeroVaultOverlay": "AeroVault Overlay として開く"
+            "openAsAeroVaultOverlay": "AeroVault Overlay として開く",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "転送中...",
@@ -4601,6 +4603,10 @@
             "lastUsedYesterday": "昨日使用",
             "lastUsedDaysAgo": "{days}日前に使用",
             "securityNote": "アカウントは Argon2id + AES-KW + AES-256-GCM 暗号化で保護されています"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/ka.json
+++ b/src/i18n/locales/ka.json
@@ -67,7 +67,8 @@
             "check": "Check",
             "selectAll": "Select All",
             "required": "სავალდებულო",
-            "duplicate": "დუბლირება"
+            "duplicate": "დუბლირება",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "სერვერთან დაკავშირება",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Azure Blob ნაგავი",
             "lockRcloneCrypt": "Rclone Crypt გადაფარვის დაბლოკვა",
             "unlockRcloneCrypt": "Rclone Crypt გადაფარვად გაშიფვრა…",
-            "openAsAeroVaultOverlay": "გახსნა როგორც AeroVault Overlay"
+            "openAsAeroVaultOverlay": "გახსნა როგორც AeroVault Overlay",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "გადაცემა...",
@@ -4601,6 +4603,10 @@
             "lastUsedYesterday": "[NEEDS TRANSLATION] Used yesterday",
             "lastUsedDaysAgo": "[NEEDS TRANSLATION] Used {days} days ago",
             "securityNote": "ანგარიში დაცულია Argon2id + AES-KW + AES-256-GCM დაშიფვრით"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/km.json
+++ b/src/i18n/locales/km.json
@@ -67,7 +67,8 @@
             "check": "Check",
             "selectAll": "Select All",
             "required": "ចាំបាច់",
-            "duplicate": "ចម្លងទម្រង់"
+            "duplicate": "ចម្លងទម្រង់",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "តភ្ជាប់ទៅម៉ាស៊ីនបម្រើ",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Azure Blob ធុងស្ដុបស្ដាំង",
             "lockRcloneCrypt": "ចាក់សោការត្រួតលើ Rclone Crypt",
             "unlockRcloneCrypt": "ឌិគ្រីបជាការត្រួតលើ Rclone Crypt…",
-            "openAsAeroVaultOverlay": "បើកជា AeroVault Overlay"
+            "openAsAeroVaultOverlay": "បើកជា AeroVault Overlay",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "កំពុងផ្ទេរ...",
@@ -4620,6 +4622,10 @@
             "lastUsedYesterday": "[NEEDS TRANSLATION] Used yesterday",
             "lastUsedDaysAgo": "[NEEDS TRANSLATION] Used {days} days ago",
             "securityNote": "គណនីត្រូវបានការពារដោយការអ៊ិនគ្រីប Argon2id + AES-KW + AES-256-GCM"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -67,7 +67,8 @@
             "check": "확인",
             "selectAll": "Select All",
             "required": "필수",
-            "duplicate": "복제"
+            "duplicate": "복제",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "서버에 연결",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Azure Blob 휴지통",
             "lockRcloneCrypt": "Rclone Crypt 오버레이 잠금",
             "unlockRcloneCrypt": "Rclone Crypt 오버레이로 복호화…",
-            "openAsAeroVaultOverlay": "AeroVault Overlay로 열기"
+            "openAsAeroVaultOverlay": "AeroVault Overlay로 열기",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "전송 중...",
@@ -4601,6 +4603,10 @@
             "lastUsedYesterday": "[NEEDS TRANSLATION] Used yesterday",
             "lastUsedDaysAgo": "[NEEDS TRANSLATION] Used {days} days ago",
             "securityNote": "계정은 Argon2id + AES-KW + AES-256-GCM 암호화로 보호됩니다"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/lt.json
+++ b/src/i18n/locales/lt.json
@@ -67,7 +67,8 @@
             "check": "Check",
             "selectAll": "Select All",
             "required": "privalomas",
-            "duplicate": "Dubliuoti"
+            "duplicate": "Dubliuoti",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "Prisijungti prie serverio",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Azure Blob šiukšliadėžė",
             "lockRcloneCrypt": "Užrakinti Rclone Crypt sluoksnį",
             "unlockRcloneCrypt": "Iššifruoti kaip Rclone Crypt sluoksnį…",
-            "openAsAeroVaultOverlay": "Atidaryti kaip AeroVault Overlay"
+            "openAsAeroVaultOverlay": "Atidaryti kaip AeroVault Overlay",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "Perduodama...",
@@ -4601,6 +4603,10 @@
             "lastUsedYesterday": "[NEEDS TRANSLATION] Used yesterday",
             "lastUsedDaysAgo": "[NEEDS TRANSLATION] Used {days} days ago",
             "securityNote": "Paskyra apsaugota Argon2id + AES-KW + AES-256-GCM šifravimu"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/lv.json
+++ b/src/i18n/locales/lv.json
@@ -67,7 +67,8 @@
             "check": "Check",
             "selectAll": "Select All",
             "required": "obligāts",
-            "duplicate": "Dublēt"
+            "duplicate": "Dublēt",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "Savienoties ar serveri",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Azure Blob atkritne",
             "lockRcloneCrypt": "Bloķēt Rclone Crypt pārklājumu",
             "unlockRcloneCrypt": "Atšifrēt kā Rclone Crypt pārklājumu…",
-            "openAsAeroVaultOverlay": "Atvērt kā AeroVault Overlay"
+            "openAsAeroVaultOverlay": "Atvērt kā AeroVault Overlay",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "Pārsūta...",
@@ -4601,6 +4603,10 @@
             "lastUsedYesterday": "[NEEDS TRANSLATION] Used yesterday",
             "lastUsedDaysAgo": "[NEEDS TRANSLATION] Used {days} days ago",
             "securityNote": "Konts ir aizsargāts ar Argon2id + AES-KW + AES-256-GCM šifrēšanu"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/mk.json
+++ b/src/i18n/locales/mk.json
@@ -67,7 +67,8 @@
             "check": "Check",
             "selectAll": "Select All",
             "required": "задолжително",
-            "duplicate": "Дуплирај"
+            "duplicate": "Дуплирај",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "Поврзи се на сервер",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Azure Blob корпа",
             "lockRcloneCrypt": "Заклучи преклоп Rclone Crypt",
             "unlockRcloneCrypt": "Дешифрирај како преклоп Rclone Crypt…",
-            "openAsAeroVaultOverlay": "Отвори како AeroVault Overlay"
+            "openAsAeroVaultOverlay": "Отвори како AeroVault Overlay",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "Се пренесува...",
@@ -4620,6 +4622,10 @@
             "lastUsedYesterday": "[NEEDS TRANSLATION] Used yesterday",
             "lastUsedDaysAgo": "[NEEDS TRANSLATION] Used {days} days ago",
             "securityNote": "Сметката е заштитена со Argon2id + AES-KW + AES-256-GCM криптирање"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/ms.json
+++ b/src/i18n/locales/ms.json
@@ -67,7 +67,8 @@
             "check": "Check",
             "selectAll": "Select All",
             "required": "diperlukan",
-            "duplicate": "Gandakan"
+            "duplicate": "Gandakan",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "Sambung ke Pelayan",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Tong Sampah Azure Blob",
             "lockRcloneCrypt": "Kunci tindihan Rclone Crypt",
             "unlockRcloneCrypt": "Nyahsulit sebagai tindihan Rclone Crypt…",
-            "openAsAeroVaultOverlay": "Buka sebagai AeroVault Overlay"
+            "openAsAeroVaultOverlay": "Buka sebagai AeroVault Overlay",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "Memindahkan...",
@@ -4601,6 +4603,10 @@
             "lastUsedYesterday": "[NEEDS TRANSLATION] Used yesterday",
             "lastUsedDaysAgo": "[NEEDS TRANSLATION] Used {days} days ago",
             "securityNote": "Akaun dilindungi dengan penyulitan Argon2id + AES-KW + AES-256-GCM"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -67,7 +67,8 @@
             "check": "Check",
             "selectAll": "Select All",
             "required": "vereist",
-            "duplicate": "Dupliceren"
+            "duplicate": "Dupliceren",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "Verbinden met Server",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Azure Blob prullenbak",
             "lockRcloneCrypt": "Rclone Crypt-overlay vergrendelen",
             "unlockRcloneCrypt": "Ontsleutelen als Rclone Crypt-overlay…",
-            "openAsAeroVaultOverlay": "Openen als AeroVault Overlay"
+            "openAsAeroVaultOverlay": "Openen als AeroVault Overlay",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "Overdragen...",
@@ -4601,6 +4603,10 @@
             "lastUsedYesterday": "Gisteren gebruikt",
             "lastUsedDaysAgo": "{days} dagen geleden gebruikt",
             "securityNote": "Account beschermd met Argon2id + AES-KW + AES-256-GCM-versleuteling"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -67,7 +67,8 @@
             "check": "Check",
             "selectAll": "Select All",
             "required": "påkrevd",
-            "duplicate": "Dupliser"
+            "duplicate": "Dupliser",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "Koble til server",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Azure Blob papirkurv",
             "lockRcloneCrypt": "Lås Rclone Crypt-overlegg",
             "unlockRcloneCrypt": "Dekrypter som Rclone Crypt-overlegg…",
-            "openAsAeroVaultOverlay": "Åpne som AeroVault Overlay"
+            "openAsAeroVaultOverlay": "Åpne som AeroVault Overlay",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "Overfører...",
@@ -4620,6 +4622,10 @@
             "lastUsedYesterday": "[NEEDS TRANSLATION] Used yesterday",
             "lastUsedDaysAgo": "[NEEDS TRANSLATION] Used {days} days ago",
             "securityNote": "Konto beskyttet med Argon2id + AES-KW + AES-256-GCM-kryptering"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -67,7 +67,8 @@
             "check": "Check",
             "selectAll": "Select All",
             "required": "wymagane",
-            "duplicate": "Duplikuj"
+            "duplicate": "Duplikuj",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "Połącz z serwerem",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Azure Blob Kosz",
             "lockRcloneCrypt": "Zablokuj nakładkę Rclone Crypt",
             "unlockRcloneCrypt": "Odszyfruj jako nakładkę Rclone Crypt…",
-            "openAsAeroVaultOverlay": "Otwórz jako AeroVault Overlay"
+            "openAsAeroVaultOverlay": "Otwórz jako AeroVault Overlay",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "Przesyłanie...",
@@ -4601,6 +4603,10 @@
             "lastUsedYesterday": "[NEEDS TRANSLATION] Used yesterday",
             "lastUsedDaysAgo": "[NEEDS TRANSLATION] Used {days} days ago",
             "securityNote": "Konto chronione szyfrowaniem Argon2id + AES-KW + AES-256-GCM"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -67,7 +67,8 @@
             "check": "Verificar",
             "selectAll": "Select All",
             "required": "obrigatório",
-            "duplicate": "Duplicar"
+            "duplicate": "Duplicar",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "Conectar ao Servidor",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Lixeira Azure Blob",
             "lockRcloneCrypt": "Bloquear sobreposição Rclone Crypt",
             "unlockRcloneCrypt": "Descriptografar como sobreposição Rclone Crypt…",
-            "openAsAeroVaultOverlay": "Abrir como AeroVault Overlay"
+            "openAsAeroVaultOverlay": "Abrir como AeroVault Overlay",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "Transferindo...",
@@ -4601,6 +4603,10 @@
             "lastUsedYesterday": "Usada ontem",
             "lastUsedDaysAgo": "Usada há {days} dias",
             "securityNote": "Conta protegida com criptografia Argon2id + AES-KW + AES-256-GCM"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/ro.json
+++ b/src/i18n/locales/ro.json
@@ -67,7 +67,8 @@
             "check": "Check",
             "selectAll": "Select All",
             "required": "obligatoriu",
-            "duplicate": "Duplică"
+            "duplicate": "Duplică",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "Conectare la server",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Azure Blob Coș de gunoi",
             "lockRcloneCrypt": "Blochează suprapunerea Rclone Crypt",
             "unlockRcloneCrypt": "Decriptează ca suprapunere Rclone Crypt…",
-            "openAsAeroVaultOverlay": "Deschide ca AeroVault Overlay"
+            "openAsAeroVaultOverlay": "Deschide ca AeroVault Overlay",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "Se transferă...",
@@ -4601,6 +4603,10 @@
             "lastUsedYesterday": "[NEEDS TRANSLATION] Used yesterday",
             "lastUsedDaysAgo": "[NEEDS TRANSLATION] Used {days} days ago",
             "securityNote": "Cont protejat cu criptare Argon2id + AES-KW + AES-256-GCM"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -67,7 +67,8 @@
             "check": "Проверить",
             "selectAll": "Select All",
             "required": "обязательно",
-            "duplicate": "Дублировать"
+            "duplicate": "Дублировать",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "Подключение к серверу",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Azure Blob Корзина",
             "lockRcloneCrypt": "Заблокировать наложение Rclone Crypt",
             "unlockRcloneCrypt": "Расшифровать как наложение Rclone Crypt…",
-            "openAsAeroVaultOverlay": "Открыть как AeroVault Overlay"
+            "openAsAeroVaultOverlay": "Открыть как AeroVault Overlay",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "Передача...",
@@ -4601,6 +4603,10 @@
             "lastUsedYesterday": "[NEEDS TRANSLATION] Used yesterday",
             "lastUsedDaysAgo": "[NEEDS TRANSLATION] Used {days} days ago",
             "securityNote": "Аккаунт защищён шифрованием Argon2id + AES-KW + AES-256-GCM"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/sk.json
+++ b/src/i18n/locales/sk.json
@@ -67,7 +67,8 @@
             "check": "Check",
             "selectAll": "Select All",
             "required": "povinné",
-            "duplicate": "Duplikovať"
+            "duplicate": "Duplikovať",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "Pripojenie k serveru",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Azure Blob Kôš",
             "lockRcloneCrypt": "Zamknúť prekrytie Rclone Crypt",
             "unlockRcloneCrypt": "Dešifrovať ako prekrytie Rclone Crypt…",
-            "openAsAeroVaultOverlay": "Otvoriť ako AeroVault Overlay"
+            "openAsAeroVaultOverlay": "Otvoriť ako AeroVault Overlay",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "Prenáša sa...",
@@ -4601,6 +4603,10 @@
             "lastUsedYesterday": "[NEEDS TRANSLATION] Used yesterday",
             "lastUsedDaysAgo": "[NEEDS TRANSLATION] Used {days} days ago",
             "securityNote": "Účet chránený šifrovaním Argon2id + AES-KW + AES-256-GCM"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/sl.json
+++ b/src/i18n/locales/sl.json
@@ -67,7 +67,8 @@
             "check": "Check",
             "selectAll": "Select All",
             "required": "obvezno",
-            "duplicate": "Podvoji"
+            "duplicate": "Podvoji",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "Poveži se s strežnikom",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Azure Blob Koš",
             "lockRcloneCrypt": "Zakleni prekrivanje Rclone Crypt",
             "unlockRcloneCrypt": "Dešifriraj kot prekrivanje Rclone Crypt…",
-            "openAsAeroVaultOverlay": "Odpri kot AeroVault Overlay"
+            "openAsAeroVaultOverlay": "Odpri kot AeroVault Overlay",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "Prenašanje...",
@@ -4601,6 +4603,10 @@
             "lastUsedYesterday": "[NEEDS TRANSLATION] Used yesterday",
             "lastUsedDaysAgo": "[NEEDS TRANSLATION] Used {days} days ago",
             "securityNote": "Račun je zaščiten s šifriranjem Argon2id + AES-KW + AES-256-GCM"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/sr.json
+++ b/src/i18n/locales/sr.json
@@ -67,7 +67,8 @@
             "check": "Check",
             "selectAll": "Select All",
             "required": "обавезно",
-            "duplicate": "Дуплирај"
+            "duplicate": "Дуплирај",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "Повежи се на сервер",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Azure Blob Корпа",
             "lockRcloneCrypt": "Закључај прекривач Rclone Crypt",
             "unlockRcloneCrypt": "Дешифруј као прекривач Rclone Crypt…",
-            "openAsAeroVaultOverlay": "Отвори као AeroVault Overlay"
+            "openAsAeroVaultOverlay": "Отвори као AeroVault Overlay",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "Пренос...",
@@ -4601,6 +4603,10 @@
             "lastUsedYesterday": "[NEEDS TRANSLATION] Used yesterday",
             "lastUsedDaysAgo": "[NEEDS TRANSLATION] Used {days} days ago",
             "securityNote": "Налог заштићен Argon2id + AES-KW + AES-256-GCM шифровањем"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -67,7 +67,8 @@
             "check": "Check",
             "selectAll": "Select All",
             "required": "obligatorisk",
-            "duplicate": "Duplicera"
+            "duplicate": "Duplicera",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "Anslut till server",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Azure Blob Papperskorgen",
             "lockRcloneCrypt": "Lås Rclone Crypt-överlägg",
             "unlockRcloneCrypt": "Dekryptera som Rclone Crypt-överlägg…",
-            "openAsAeroVaultOverlay": "Öppna som AeroVault Overlay"
+            "openAsAeroVaultOverlay": "Öppna som AeroVault Overlay",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "Överför...",
@@ -4601,6 +4603,10 @@
             "lastUsedYesterday": "[NEEDS TRANSLATION] Used yesterday",
             "lastUsedDaysAgo": "[NEEDS TRANSLATION] Used {days} days ago",
             "securityNote": "Konto skyddat med Argon2id + AES-KW + AES-256-GCM-kryptering"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/sw.json
+++ b/src/i18n/locales/sw.json
@@ -67,7 +67,8 @@
             "check": "Check",
             "selectAll": "Select All",
             "required": "inahitajika",
-            "duplicate": "Nakili"
+            "duplicate": "Nakili",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "Unganisha na Seva",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Azure Blob Tupio",
             "lockRcloneCrypt": "Funga uwekeleaji wa Rclone Crypt",
             "unlockRcloneCrypt": "Simbua kama uwekeleaji wa Rclone Crypt…",
-            "openAsAeroVaultOverlay": "Fungua kama AeroVault Overlay"
+            "openAsAeroVaultOverlay": "Fungua kama AeroVault Overlay",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "Inahamisha...",
@@ -4601,6 +4603,10 @@
             "lastUsedYesterday": "[NEEDS TRANSLATION] Used yesterday",
             "lastUsedDaysAgo": "[NEEDS TRANSLATION] Used {days} days ago",
             "securityNote": "Akaunti imelindwa kwa usimbaji wa Argon2id + AES-KW + AES-256-GCM"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/th.json
+++ b/src/i18n/locales/th.json
@@ -67,7 +67,8 @@
             "check": "Check",
             "selectAll": "Select All",
             "required": "จำเป็น",
-            "duplicate": "ทำซ้ำ"
+            "duplicate": "ทำซ้ำ",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "เชื่อมต่อเซิร์ฟเวอร์",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Azure Blob ถังขยะ",
             "lockRcloneCrypt": "ล็อกการซ้อนทับ Rclone Crypt",
             "unlockRcloneCrypt": "ถอดรหัสเป็นการซ้อนทับ Rclone Crypt…",
-            "openAsAeroVaultOverlay": "เปิดเป็น AeroVault Overlay"
+            "openAsAeroVaultOverlay": "เปิดเป็น AeroVault Overlay",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "กำลังถ่ายโอน...",
@@ -4601,6 +4603,10 @@
             "lastUsedYesterday": "[NEEDS TRANSLATION] Used yesterday",
             "lastUsedDaysAgo": "[NEEDS TRANSLATION] Used {days} days ago",
             "securityNote": "บัญชีได้รับการป้องกันด้วยการเข้ารหัส Argon2id + AES-KW + AES-256-GCM"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/tl.json
+++ b/src/i18n/locales/tl.json
@@ -67,7 +67,8 @@
             "check": "Check",
             "selectAll": "Select All",
             "required": "kinakailangan",
-            "duplicate": "Doblehin"
+            "duplicate": "Doblehin",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "Kumonekta sa Server",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Azure Blob Basurahan",
             "lockRcloneCrypt": "I-lock ang Rclone Crypt overlay",
             "unlockRcloneCrypt": "I-decrypt bilang Rclone Crypt overlay…",
-            "openAsAeroVaultOverlay": "Buksan bilang AeroVault Overlay"
+            "openAsAeroVaultOverlay": "Buksan bilang AeroVault Overlay",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "Naglilipat...",
@@ -4620,6 +4622,10 @@
             "lastUsedYesterday": "[NEEDS TRANSLATION] Used yesterday",
             "lastUsedDaysAgo": "[NEEDS TRANSLATION] Used {days} days ago",
             "securityNote": "Account protektado ng pag-encrypt na Argon2id + AES-KW + AES-256-GCM"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -67,7 +67,8 @@
             "check": "Check",
             "selectAll": "Select All",
             "required": "gerekli",
-            "duplicate": "Çoğalt"
+            "duplicate": "Çoğalt",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "Sunucuya Bağlan",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Azure Blob Çöp Kutusu",
             "lockRcloneCrypt": "Rclone Crypt katmanını kilitle",
             "unlockRcloneCrypt": "Rclone Crypt katmanı olarak çöz…",
-            "openAsAeroVaultOverlay": "AeroVault Overlay olarak aç"
+            "openAsAeroVaultOverlay": "AeroVault Overlay olarak aç",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "Aktarılıyor...",
@@ -4601,6 +4603,10 @@
             "lastUsedYesterday": "[NEEDS TRANSLATION] Used yesterday",
             "lastUsedDaysAgo": "[NEEDS TRANSLATION] Used {days} days ago",
             "securityNote": "Hesap Argon2id + AES-KW + AES-256-GCM şifrelemesi ile korunuyor"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -67,7 +67,8 @@
             "check": "Check",
             "selectAll": "Select All",
             "required": "обов'язково",
-            "duplicate": "Дублювати"
+            "duplicate": "Дублювати",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "Підключення до сервера",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Azure Blob Кошик",
             "lockRcloneCrypt": "Заблокувати накладання Rclone Crypt",
             "unlockRcloneCrypt": "Розшифрувати як накладання Rclone Crypt…",
-            "openAsAeroVaultOverlay": "Відкрити як AeroVault Overlay"
+            "openAsAeroVaultOverlay": "Відкрити як AeroVault Overlay",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "Передача...",
@@ -4601,6 +4603,10 @@
             "lastUsedYesterday": "[NEEDS TRANSLATION] Used yesterday",
             "lastUsedDaysAgo": "[NEEDS TRANSLATION] Used {days} days ago",
             "securityNote": "Обліковий запис захищений шифруванням Argon2id + AES-KW + AES-256-GCM"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -67,7 +67,8 @@
             "check": "Check",
             "selectAll": "Select All",
             "required": "bắt buộc",
-            "duplicate": "Nhân bản"
+            "duplicate": "Nhân bản",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "Kết nối đến máy chủ",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Azure Blob Thùng rác",
             "lockRcloneCrypt": "Khóa lớp phủ Rclone Crypt",
             "unlockRcloneCrypt": "Giải mã làm lớp phủ Rclone Crypt…",
-            "openAsAeroVaultOverlay": "Mở dưới dạng AeroVault Overlay"
+            "openAsAeroVaultOverlay": "Mở dưới dạng AeroVault Overlay",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "Đang truyền...",
@@ -4601,6 +4603,10 @@
             "lastUsedYesterday": "[NEEDS TRANSLATION] Used yesterday",
             "lastUsedDaysAgo": "[NEEDS TRANSLATION] Used {days} days ago",
             "securityNote": "Tài khoản được bảo vệ bằng mã hóa Argon2id + AES-KW + AES-256-GCM"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -67,7 +67,8 @@
             "check": "检查",
             "selectAll": "Select All",
             "required": "必填",
-            "duplicate": "复制"
+            "duplicate": "复制",
+            "current": "[NEEDS TRANSLATION] current"
         },
         "connection": {
             "title": "连接到服务器",
@@ -422,7 +423,8 @@
             "azureTrashTitle": "Azure Blob 回收站",
             "lockRcloneCrypt": "锁定 Rclone Crypt 覆盖层",
             "unlockRcloneCrypt": "解密为 Rclone Crypt 覆盖层…",
-            "openAsAeroVaultOverlay": "作为 AeroVault Overlay 打开"
+            "openAsAeroVaultOverlay": "作为 AeroVault Overlay 打开",
+            "privacyEllipsis": "[NEEDS TRANSLATION] Privacy..."
         },
         "transfer": {
             "transferring": "传输中...",
@@ -4601,6 +4603,10 @@
             "lastUsedYesterday": "昨天使用",
             "lastUsedDaysAgo": "{days} 天前使用",
             "securityNote": "账户受 Argon2id + AES-KW + AES-256-GCM 加密保护"
+        },
+        "opendrive": {
+            "privacyTitle": "[NEEDS TRANSLATION] OpenDrive Privacy",
+            "privacyUpdated": "[NEEDS TRANSLATION] OpenDrive privacy updated"
         }
     }
 }


### PR DESCRIPTION
## Summary

Refs #252 point 2. Third and final piece of the OpenDrive privacy slice for v4.0.0, on top of:

- PR #259 (already merged): backend `with_child_files=true` on `folder/setaccess.json`, fixing the HTTP 400 on Set as Private for folders.
- PR #280 (already merged): GUI surface of the privacy state, conditional context-menu rendering instead of disabled items.
- PR #281 (already merged): per-provider privacy semantics documented in `docs/PROTOCOL-FEATURES.md`.

OpenDrive documents three visibility levels (`0=private`, `1=public`, `2=hidden`) for both files and folders via the official API samples (`test_set_folder_access.php`, `test_set_file_access.php`). The existing `Set as Private` / `Set as Public` toggle only exposes the binary public-vs-private flip, leaving `hidden` unreachable. This PR adds a richer three-option chooser on top, without removing the existing toggles.

## Changes

### Backend (`opendrive.rs`)

- New `OpenDriveAccessLevel` enum (Private / Public / Hidden) with `to_api_value()` matching the documented integers.
- New `set_file_access(path, level)` and `set_folder_access(path, level)` methods drive the same `file/access.json` and `folder/setaccess.json` endpoints with the typed level.
- The existing `set_file_privacy` / `set_folder_privacy` become thin wrappers over the new methods, so the binary toggle keeps its wire shape and existing callers do not change.
- Unit test cross-checks that `to_api_value()` round-trips through `access_to_permissions` so a set call always produces a listing the frontend reads back the same way.

Note on multi-axis flags: OpenDrive accepts the richer per-axis flags (`folder_public_upl`, `folder_public_display`, `folder_public_dnl`) only on `folder/create.json`, never on `folder/setaccess.json`. Modifying them after creation is therefore not exposed; PR #281 documents this explicitly.

### Tauri (`provider_commands.rs`, `lib.rs`)

- New `opendrive_set_path_access(path, access_level, is_dir)` command alongside the existing `opendrive_set_path_privacy`. Validates the `access_level` string against the three canonical tokens and rejects unknowns with a clear error.

### Frontend (`App.tsx`)

- New `openDrivePrivacyDialog` state plus dialog component: three-option radio list with per-level description, `current` badge on the active level, Save disabled until the user changes the selection.
- New `Privacy...` entry in the OpenDrive context menu next to the existing `Set as Private` / `Set as Public` toggles. Opens the dialog pre-selected on the current state.

### i18n

- 4 new keys: `common.current`, `contextMenu.privacyEllipsis`, `opendrive.privacyTitle`, `opendrive.privacyUpdated`. Italian translated manually; the other 45 locales receive `[NEEDS TRANSLATION]` placeholders via `npm run i18n:sync`. `i18n:validate` PASSED with the expected placeholder warnings.

## Compatibility

- Existing binary toggle in the context menu is unchanged.
- Listing payloads from OpenDrive remain unchanged: `access_to_permissions` already maps the three documented integers introduced in PR #280.
- Pre-v4.0.0 wire shape for `opendrive_set_path_privacy` retained.

## Gate (verified locally)

- `cargo test --lib` opendrive suite passes.
- `cargo clippy --all-targets -- -D warnings` clean.
- `npx tsc --noEmit` clean.

## Reporter

@EhudKirsh (#252)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added privacy management dialog for OpenDrive files and folders with three access levels: private, public, and hidden.
  * Updated context menu to provide privacy option for OpenDrive items.
  * Privacy changes now display confirmation message to users.

* **Localization**
  * Added translation keys across all supported language files for the new privacy interface and dialog strings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/axpdev-lab/aeroftp/pull/282?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->