### PR TITLE
fix(transfer): DAG engine audit fixes (patch sets 1-2 + Nextcloud threshold)

### DIFF
--- a/src-tauri/src/provider_commands.rs
+++ b/src-tauri/src/provider_commands.rs
@@ -1075,13 +1075,50 @@ async fn run_dag_download_leaf(
             "Download routed to Legacy engine: {} ({})",
             filename, decision.reason
         );
-        let mut guard = provider.lock().await;
-        let result = match guard.as_mut() {
-            Some(p) => p.download(&remote_path, &local_path, progress_cb).await,
-            None => Err(ProviderError::NotConnected),
+        let result = {
+            let mut guard = provider.lock().await;
+            match guard.as_mut() {
+                Some(p) => p.download(&remote_path, &local_path, progress_cb).await,
+                None => Err(ProviderError::NotConnected),
+            }
         };
         return match result {
-            Ok(()) => Ok(format!("Downloaded: {}", filename)),
+            Ok(()) => {
+                // Parity with the DAG `PreserveMetadata` node: restore the
+                // remote mtime and emit the GUI completion event. Without this
+                // the Legacy download route silently dropped the remote mtime
+                // (breaking overwrite-if-newer sync) and never finished the
+                // progress bar (audit W1.2, the prerequisite for any future
+                // download->Legacy routing carve-out).
+                crate::preserve_remote_mtime(&local_path, modified.as_deref());
+                let actual_size = tokio::fs::metadata(&local_path)
+                    .await
+                    .map(|m| m.len())
+                    .unwrap_or(file_size);
+                let _ = app.emit(
+                    "transfer_event",
+                    crate::TransferEvent {
+                        event_type: "complete".to_string(),
+                        transfer_id: transfer_id.clone(),
+                        filename: filename.clone(),
+                        direction: "download".to_string(),
+                        message: Some(format!(
+                            "({} in 0s)",
+                            if actual_size > 1_048_576 {
+                                format!("{:.1} MB", actual_size as f64 / 1_048_576.0)
+                            } else {
+                                format!("{:.1} KB", actual_size as f64 / 1024.0)
+                            }
+                        )),
+                        progress: None,
+                        path: None,
+                        delta_stats: None,
+                        fallback_reason: delta_fallback_reason,
+                    },
+                );
+                info!("Download completed: {}", filename);
+                Ok(format!("Downloaded: {}", filename))
+            }
             Err(e) => {
                 let _ = app.emit(
                     "transfer_event",

--- a/src-tauri/src/providers/azure.rs
+++ b/src-tauri/src/providers/azure.rs
@@ -46,6 +46,12 @@ const BLOCK_SIZE: usize = 4 * 1024 * 1024;
 /// graph has enough fan-out without creating excessive Azure Put Block calls.
 const DAG_MULTIPART_BLOCK_SIZE: u64 = 8 * 1024 * 1024;
 const DAG_MULTIPART_MAX_PARALLEL: u8 = 4;
+/// Size at or above which the shaped graph fans out into parallel Put Block
+/// uploads. Below it a single-shot upload is faster: the 2026-05-29 lab
+/// benchmark measured the parallel fan-out losing 17% at 100 MiB but winning
+/// 69% at 256 MiB, so the crossover is kept conservatively at 200 MiB (audit
+/// Patch Set 2). Distinct from the legacy `BLOCK_UPLOAD_THRESHOLD`.
+const DAG_MULTIPART_THRESHOLD: u64 = 200 * 1024 * 1024;
 
 /// AZ-016: Maximum time to wait for async copy completion (5 minutes)
 const COPY_POLL_TIMEOUT_SECS: u64 = 300;
@@ -1182,7 +1188,7 @@ impl StorageProvider for AzureProvider {
     fn transfer_optimization_hints(&self) -> super::TransferOptimizationHints {
         super::TransferOptimizationHints {
             supports_multipart: true,
-            multipart_threshold: DAG_MULTIPART_BLOCK_SIZE,
+            multipart_threshold: DAG_MULTIPART_THRESHOLD,
             multipart_part_size: DAG_MULTIPART_BLOCK_SIZE,
             multipart_max_parallel: DAG_MULTIPART_MAX_PARALLEL,
             supports_range_download: true,
@@ -2415,7 +2421,9 @@ Time:2026-01-01</Message>
         let hints = p.transfer_optimization_hints();
 
         assert!(hints.supports_multipart);
-        assert_eq!(hints.multipart_threshold, DAG_MULTIPART_BLOCK_SIZE);
+        // Fan-out only kicks in at the DAG threshold (200 MiB); below it Azure
+        // stays single-shot (audit Patch Set 2).
+        assert_eq!(hints.multipart_threshold, DAG_MULTIPART_THRESHOLD);
         assert_eq!(hints.multipart_part_size, DAG_MULTIPART_BLOCK_SIZE);
         assert_eq!(hints.multipart_max_parallel, DAG_MULTIPART_MAX_PARALLEL);
         assert!(hints.supports_range_download);

--- a/src-tauri/src/providers/b2.rs
+++ b/src-tauri/src/providers/b2.rs
@@ -2601,6 +2601,23 @@ impl StorageProvider for B2Provider {
             ..Default::default()
         }
     }
+
+    // B2 large-file parts are independent `b2_upload_part` calls keyed by the
+    // shared `fileId`, so they can run on independent cloned workers. This
+    // mirrors the S3/Azure clone contract and matches how the single-file
+    // multipart runner already cloned B2 (previously via a hardcoded downcast,
+    // now via the trait, audit CHUNK-01).
+    fn transfer_executor_kind(&self) -> super::ProviderTransferExecutorKind {
+        super::ProviderTransferExecutorKind::HttpClonePool
+    }
+
+    fn transfer_executor_max_sessions(&self) -> u16 {
+        LARGE_FILE_MAX_PARALLEL as u16
+    }
+
+    fn clone_for_transfer(&self) -> Result<Box<dyn StorageProvider>, ProviderError> {
+        Ok(Box::new(self.clone()))
+    }
 }
 
 // ─── Helpers ───

--- a/src-tauri/src/providers/webdav.rs
+++ b/src-tauri/src/providers/webdav.rs
@@ -2049,6 +2049,18 @@ fn parse_oc_checksums(raw: &str) -> HashMap<String, String> {
 /// to disk.
 const NEXTCLOUD_DAG_CHUNK_SIZE: u64 = 10 * 1024 * 1024;
 
+/// Size at or above which a Nextcloud upload fans out into chunked v2 parts.
+///
+/// Below it a single `PUT` is used. The 2026-05-29 lab benchmark measured the
+/// chunked path (MKCOL + N `PUT` + `MOVE`) losing to a single `PUT` on a
+/// low-RTT LAN even with 4-way parallel chunks (-36% at 100 MiB), because the
+/// extra round-trips dominate when bandwidth is not the bottleneck. The
+/// threshold keeps medium uploads on the faster single `PUT` while still
+/// chunking large uploads, where a single multi-hundred-MiB `PUT` is fragile
+/// over WAN (one failure restarts the whole transfer) and resumable chunks pay
+/// off (audit Patch Set 2). 256 MiB is the agreed crossover.
+const NEXTCLOUD_DAG_THRESHOLD: u64 = 256 * 1024 * 1024;
+
 /// Cap on parallel `upload_part` nodes for Nextcloud, aligned with S3 / Azure.
 ///
 /// Most self-hosted Nextcloud deployments sit behind nginx / Apache with
@@ -3826,7 +3838,7 @@ impl StorageProvider for WebDavProvider {
             if self.is_nextcloud_for_dav() {
                 (
                     true,
-                    NEXTCLOUD_DAG_CHUNK_SIZE,
+                    NEXTCLOUD_DAG_THRESHOLD,
                     NEXTCLOUD_DAG_CHUNK_SIZE,
                     NEXTCLOUD_DAG_MAX_PARALLEL,
                 )
@@ -4518,7 +4530,9 @@ mod tests {
         let hints = p.transfer_optimization_hints();
         assert!(hints.supports_multipart);
         assert_eq!(hints.multipart_part_size, NEXTCLOUD_DAG_CHUNK_SIZE);
-        assert_eq!(hints.multipart_threshold, NEXTCLOUD_DAG_CHUNK_SIZE);
+        // Chunked v2 only engages at/above the threshold; medium uploads stay
+        // on a single PUT (faster on LAN), audit Patch Set 2.
+        assert_eq!(hints.multipart_threshold, NEXTCLOUD_DAG_THRESHOLD);
         assert_eq!(hints.multipart_max_parallel, NEXTCLOUD_DAG_MAX_PARALLEL);
     }
 

--- a/src-tauri/src/providers/webdav.rs
+++ b/src-tauri/src/providers/webdav.rs
@@ -46,6 +46,7 @@ pub struct NextcloudTrashEntry {
 // ============ HTTP Digest Authentication (RFC 2617) ============
 
 /// State for HTTP Digest authentication
+#[derive(Clone)]
 struct DigestState {
     realm: String,
     nonce: String,
@@ -215,6 +216,7 @@ fn path_violates_root(path: &str, boundary: Option<&str>) -> bool {
 }
 
 /// WebDAV Storage Provider
+#[derive(Clone)]
 pub struct WebDavProvider {
     config: WebDavConfig,
     client: Client,
@@ -3839,6 +3841,29 @@ impl StorageProvider for WebDavProvider {
             supports_range_download: true,
             supports_resume_download: true,
             ..Default::default()
+        }
+    }
+
+    /// Mint an independent worker for concurrent Nextcloud chunked-upload parts.
+    ///
+    /// Nextcloud chunked v2 uploads each chunk as an independent `PUT` to a
+    /// distinct `/uploads/<user>/<uuid>/<n>` path under one shared session
+    /// folder, finalised by a single `MOVE`. Those PUTs carry no ordering
+    /// constraint, so a cloned worker (independent reqwest client, same
+    /// credentials and session uuid carried in the handle) can upload parts in
+    /// parallel safely. This is what turns the serial-chunk upload regression
+    /// into a fan-out win (audit CHUNK-01 follow-up). Vanilla WebDAV has no
+    /// chunked multipart, so it stays un-cloneable and single-stream. NOTE:
+    /// this intentionally does NOT override `transfer_executor_kind()`, so the
+    /// batch/folder executor selection is unchanged; only the single-file
+    /// multipart part path consults `clone_for_transfer()`.
+    fn clone_for_transfer(&self) -> Result<Box<dyn StorageProvider>, ProviderError> {
+        if self.is_nextcloud_for_dav() {
+            Ok(Box::new(self.clone()))
+        } else {
+            Err(ProviderError::NotSupported(
+                "clone_for_transfer (vanilla WebDAV has no parallel multipart)".to_string(),
+            ))
         }
     }
 

--- a/src-tauri/src/transfer_dag/adaptive.rs
+++ b/src-tauri/src/transfer_dag/adaptive.rs
@@ -155,11 +155,24 @@ impl Drop for DynamicPermit {
     fn drop(&mut self) {
         // Return the permit first (its own Drop calls add_permits(1)).
         drop(self.permit.take());
-        // If a shrink is still owed, reclaim one freed slot now.
+        // If a shrink is still owed, reclaim one freed slot now. Use a CAS so a
+        // concurrent grow-path pay-down cannot drive the deficit below zero,
+        // which on AtomicUsize wraps to usize::MAX and would permanently pin
+        // concurrency at the floor for the rest of the run (audit AIMD-02).
         if self.deficit.load(Ordering::SeqCst) > 0 {
             if let Ok(p) = self.sem.try_acquire() {
                 p.forget();
-                self.deficit.fetch_sub(1, Ordering::SeqCst);
+                let consumed = self
+                    .deficit
+                    .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |cur| {
+                        (cur > 0).then(|| cur - 1)
+                    })
+                    .is_ok();
+                if !consumed {
+                    // The deficit was cleared concurrently: hand the slot back
+                    // instead of dropping it, so live concurrency stays intact.
+                    self.sem.add_permits(1);
+                }
             }
         }
     }
@@ -212,13 +225,18 @@ impl DynamicSemaphore {
         let mut live = self.live.lock().expect("dynamic semaphore mutex poisoned");
         if target > *live {
             let mut need = target - *live;
-            // Pay down any owed shrink before adding real permits.
-            let owed = self.deficit.load(Ordering::SeqCst);
-            let pay = need.min(owed);
-            if pay > 0 {
-                self.deficit.fetch_sub(pay, Ordering::SeqCst);
-                need -= pay;
-            }
+            // Pay down any owed shrink before adding real permits. A CAS loop so
+            // a concurrent `DynamicPermit::drop` reclaiming a slot between our
+            // read and write cannot underflow the deficit (audit AIMD-02).
+            let mut paid = 0usize;
+            let _ = self
+                .deficit
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |cur| {
+                    let pay = need.min(cur);
+                    paid = pay;
+                    Some(cur - pay)
+                });
+            need -= paid;
             if need > 0 {
                 self.sem.add_permits(need);
             }
@@ -912,6 +930,39 @@ mod tests {
         drop(a);
         assert_eq!(ds2.pending_shrink(), 0);
         assert_eq!(ds2.available(), 1);
+    }
+
+    #[tokio::test]
+    async fn deficit_paydown_then_release_never_wraps_and_loses_no_permits() {
+        // AIMD-02 invariant: when the grow path pays down the whole owed
+        // shrink and the in-flight permits are then released, the deficit must
+        // settle at exactly 0 (never wrap below zero, which on AtomicUsize is
+        // usize::MAX and would pin concurrency at the floor for the rest of the
+        // run) and no permit may be lost.
+        let ds = DynamicSemaphore::new(4, 4);
+        let p1 = ds.acquire().await.unwrap();
+        let p2 = ds.acquire().await.unwrap();
+        let p3 = ds.acquire().await.unwrap();
+        let p4 = ds.acquire().await.unwrap();
+        assert_eq!(ds.available(), 0);
+
+        // Shrink to 1 with everything checked out: 0 reclaimable now, owe 3.
+        ds.set_live(1);
+        assert_eq!(ds.pending_shrink(), 3);
+
+        // Grow back to the ceiling: the pay-down clears all 3 owed slots via a
+        // saturating CAS and never underflows.
+        ds.set_live(4);
+        assert_eq!(ds.pending_shrink(), 0);
+
+        // Releasing the in-flight permits now that nothing is owed must return
+        // them to the pool, not absorb them, and must keep the deficit at 0.
+        drop(p1);
+        drop(p2);
+        drop(p3);
+        drop(p4);
+        assert_eq!(ds.pending_shrink(), 0, "deficit must not wrap below zero");
+        assert_eq!(ds.available(), 4, "all permits restored, none lost");
     }
 
     #[tokio::test]

--- a/src-tauri/src/transfer_dag/builder.rs
+++ b/src-tauri/src/transfer_dag/builder.rs
@@ -348,7 +348,18 @@ impl TransferGraphProfile {
         } else {
             1
         };
-        let preferred_chunk_size = if multipart_eligible { chunk_hint } else { 0 };
+        // `upload_parts` is clamped to `MAX_MULTIPART_PARTS`. When the file is
+        // larger than `MAX_MULTIPART_PARTS * chunk_hint` the clamp would leave
+        // `parts * chunk_hint < file_size`, and the runner (which reads exactly
+        // `part_size` bytes per part) would silently drop the tail. Grow the
+        // effective chunk so the parts always cover the whole file. This only
+        // changes anything in the clamped case: when unclamped,
+        // `div_ceil(file_size, upload_parts) <= chunk_hint`.
+        let preferred_chunk_size = if multipart_eligible {
+            chunk_hint.max(file_size.div_ceil(upload_parts as u64))
+        } else {
+            0
+        };
 
         Self {
             upload_parts,
@@ -1782,6 +1793,55 @@ mod tests {
         assert_eq!(nodes[built.verify].depends_on, built.transfer);
         // discover + acquire + 5 parts + verify + preserve + commit + emit.
         assert_eq!(nodes.len(), 11);
+    }
+
+    #[test]
+    fn shaped_upload_grows_chunk_when_parts_clamp_to_cover_the_tail() {
+        // A file larger than MAX_MULTIPART_PARTS * chunk_hint would otherwise
+        // clamp upload_parts and leave the tail unscheduled (the runner reads
+        // exactly preferred_chunk_size bytes per part). The shaping must grow
+        // the effective chunk so the parts always cover the whole file.
+        const MIB: u64 = 1024 * 1024;
+        let chunk = MIB;
+        let file_size = 20_000 * MIB; // > MAX_MULTIPART_PARTS (10_000) * 1 MiB
+        let built = TransferDagBuilder::shaped_file(
+            TransferDirection::Upload,
+            &caps_multipart(chunk),
+            file_size,
+        );
+
+        // Parts are clamped to the hard cap, but the chunk grew to compensate.
+        assert_eq!(built.profile.upload_parts, MAX_MULTIPART_PARTS);
+        assert!(
+            built.profile.preferred_chunk_size > chunk,
+            "chunk must grow past the hint when clamped"
+        );
+        // The invariant that prevents tail loss: parts * chunk >= file_size.
+        let covered =
+            built.profile.upload_parts as u64 * built.profile.preferred_chunk_size;
+        assert!(
+            covered >= file_size,
+            "parts ({}) * chunk ({}) = {} must cover file_size {}",
+            built.profile.upload_parts,
+            built.profile.preferred_chunk_size,
+            covered,
+            file_size
+        );
+    }
+
+    #[test]
+    fn shaped_upload_keeps_provider_chunk_when_not_clamped() {
+        // The clamp-compensation must be a no-op in the common case: when the
+        // part count fits under the cap, the provider's advertised chunk size
+        // is honoured verbatim (alignment contracts depend on it).
+        let chunk = 8 * 1024 * 1024;
+        let built = TransferDagBuilder::shaped_file(
+            TransferDirection::Upload,
+            &caps_multipart(chunk),
+            80 * 1024 * 1024, // 10 parts, well under the cap
+        );
+        assert_eq!(built.profile.upload_parts, 10);
+        assert_eq!(built.profile.preferred_chunk_size, chunk);
     }
 
     #[test]

--- a/src-tauri/src/transfer_dag/builder.rs
+++ b/src-tauri/src/transfer_dag/builder.rs
@@ -322,25 +322,33 @@ impl TransferGraphProfile {
             .filter(|size| *size > 0)
             .unwrap_or(DEFAULT_MULTIPART_CHUNK_SIZE);
 
-        let upload_parts =
-            if direction == TransferDirection::Upload && caps.multipart_upload.is_available() {
-                let parts = file_size.div_ceil(chunk_hint).max(1);
-                (parts as usize).clamp(1, MAX_MULTIPART_PARTS)
-            } else {
-                1
-            };
-        let max_chunk_slots =
-            if direction == TransferDirection::Upload && caps.multipart_upload.is_available() {
-                caps.max_chunk_slots.unwrap_or(1).max(1)
-            } else {
-                1
-            };
-        let preferred_chunk_size =
-            if direction == TransferDirection::Upload && caps.multipart_upload.is_available() {
-                chunk_hint
-            } else {
-                0
-            };
+        // Honour the provider's multipart_threshold: below it, an upload stays a
+        // single PUT exactly like the legacy `upload()` path. `0` means unset, in
+        // which case we fall back to the chunk size (any file larger than one
+        // part fans out, the pre-fix behaviour). This keeps the DAG's
+        // single-vs-multipart decision aligned with the rest of the codebase and
+        // removes the orchestration cost on medium uploads (audit DISP-01/CORR-02).
+        let multipart_threshold = if caps.multipart_threshold == 0 {
+            chunk_hint
+        } else {
+            caps.multipart_threshold
+        };
+        let multipart_eligible = direction == TransferDirection::Upload
+            && caps.multipart_upload.is_available()
+            && file_size >= multipart_threshold;
+
+        let upload_parts = if multipart_eligible {
+            let parts = file_size.div_ceil(chunk_hint).max(1);
+            (parts as usize).clamp(1, MAX_MULTIPART_PARTS)
+        } else {
+            1
+        };
+        let max_chunk_slots = if multipart_eligible {
+            caps.max_chunk_slots.unwrap_or(1).max(1)
+        } else {
+            1
+        };
+        let preferred_chunk_size = if multipart_eligible { chunk_hint } else { 0 };
 
         Self {
             upload_parts,
@@ -1454,6 +1462,7 @@ mod tests {
         let caps = TransferCapabilities {
             multipart_upload: Capability::Supported,
             preferred_chunk_size: Some(8 * 1024 * 1024),
+            multipart_threshold: 0, // unset: fan out at chunk size
             ..TransferCapabilities::default()
         };
         let items = vec![
@@ -1539,6 +1548,7 @@ mod tests {
         let caps = TransferCapabilities {
             multipart_upload: Capability::Supported,
             preferred_chunk_size: Some(8 * 1024 * 1024),
+            multipart_threshold: 0, // unset: fan out at chunk size
             ..TransferCapabilities::default()
         };
         let items = vec![
@@ -1708,6 +1718,7 @@ mod tests {
             multipart_upload: Capability::Supported,
             preferred_chunk_size: Some(chunk_size),
             max_chunk_slots: Some(4),
+            multipart_threshold: 0, // unset: fan out at chunk size
             ..TransferCapabilities::default()
         }
     }
@@ -1788,6 +1799,71 @@ mod tests {
             built.dag.nodes()[built.transfer[0]].kind,
             TransferNodeKind::UploadFile
         );
+    }
+
+    #[test]
+    fn shaped_upload_below_multipart_threshold_stays_single_put() {
+        // A multipart-capable provider that declares a 200 MiB threshold must
+        // keep a 100 MiB upload as a single UploadFile node, exactly like the
+        // legacy upload() single-PUT decision. Before the fix the DAG fanned
+        // out any file larger than one chunk regardless of threshold (audit
+        // DISP-01 / CORR-02).
+        let caps = TransferCapabilities {
+            multipart_upload: Capability::Supported,
+            preferred_chunk_size: Some(16 * 1024 * 1024),
+            max_chunk_slots: Some(4),
+            multipart_threshold: 200 * 1024 * 1024,
+            ..TransferCapabilities::default()
+        };
+        let built = TransferDagBuilder::shaped_file(
+            TransferDirection::Upload,
+            &caps,
+            100 * 1024 * 1024,
+        );
+        assert_eq!(built.profile.upload_parts, 1, "below threshold => single PUT");
+        assert_eq!(built.transfer.len(), 1);
+        assert_eq!(
+            built.dag.nodes()[built.transfer[0]].kind,
+            TransferNodeKind::UploadFile
+        );
+    }
+
+    #[test]
+    fn shaped_upload_at_or_above_multipart_threshold_fans_out() {
+        let caps = TransferCapabilities {
+            multipart_upload: Capability::Supported,
+            preferred_chunk_size: Some(16 * 1024 * 1024),
+            max_chunk_slots: Some(4),
+            multipart_threshold: 200 * 1024 * 1024,
+            ..TransferCapabilities::default()
+        };
+        // 256 MiB >= 200 MiB threshold: fans out into ceil(256/16) = 16 parts.
+        let built = TransferDagBuilder::shaped_file(
+            TransferDirection::Upload,
+            &caps,
+            256 * 1024 * 1024,
+        );
+        assert_eq!(built.profile.upload_parts, 16);
+        assert_eq!(built.transfer.len(), 16);
+    }
+
+    #[test]
+    fn shaped_upload_threshold_zero_falls_back_to_chunk_size() {
+        // multipart_threshold == 0 means "unset": preserve the historical
+        // "fan out any file larger than one part" behaviour.
+        let caps = TransferCapabilities {
+            multipart_upload: Capability::Supported,
+            preferred_chunk_size: Some(8 * 1024 * 1024),
+            max_chunk_slots: Some(4),
+            multipart_threshold: 0,
+            ..TransferCapabilities::default()
+        };
+        let built = TransferDagBuilder::shaped_file(
+            TransferDirection::Upload,
+            &caps,
+            24 * 1024 * 1024,
+        );
+        assert_eq!(built.profile.upload_parts, 3);
     }
 
     #[test]

--- a/src-tauri/src/transfer_dag/capabilities.rs
+++ b/src-tauri/src/transfer_dag/capabilities.rs
@@ -51,6 +51,14 @@ pub struct TransferCapabilities {
     pub max_chunk_slots: Option<u16>,
     pub max_checker_slots: Option<u16>,
     pub preferred_chunk_size: Option<u64>,
+    /// Minimum file size (bytes) at or above which an upload should fan out
+    /// into multipart parts. Mirrors the per-provider `multipart_threshold`
+    /// hint that the legacy `upload()` path honours. `0` means "unset": the
+    /// shaping profile falls back to the chunk size, preserving the historical
+    /// "fan out any file larger than one part" behaviour for providers that
+    /// declare multipart without a threshold. Defaults to `u64::MAX` so a
+    /// capability built without hints never accidentally fans out a small file.
+    pub multipart_threshold: u64,
 }
 
 impl Default for TransferCapabilities {
@@ -74,6 +82,7 @@ impl Default for TransferCapabilities {
             max_chunk_slots: Some(1),
             max_checker_slots: Some(1),
             preferred_chunk_size: None,
+            multipart_threshold: u64::MAX,
         }
     }
 }
@@ -93,6 +102,11 @@ impl TransferCapabilities {
             preferred_chunk_size: (hints.multipart_part_size > 0)
                 .then_some(hints.multipart_part_size),
             max_chunk_slots: Some(hints.multipart_max_parallel.max(1) as u16),
+            // 0 = unset: the profile falls back to the chunk size (preserving
+            // pre-fix behaviour). A provider that advertises multipart with a
+            // very high threshold can opt out of fan-out without lying about
+            // `supports_multipart` (the filen-s3 CreateMultipartUpload hazard).
+            multipart_threshold: hints.multipart_threshold,
             ..Self::default()
         };
 

--- a/src-tauri/src/transfer_dag_single_file.rs
+++ b/src-tauri/src/transfer_dag_single_file.rs
@@ -79,7 +79,7 @@ use tokio::io::{AsyncReadExt, AsyncSeekExt};
 use tokio::sync::Mutex;
 
 use crate::providers::{
-    B2Provider, MultipartHandle, ProviderError, S3Provider, StorageProvider, UploadedPart,
+    MultipartHandle, ProviderError, ProviderTransferExecutorKind, StorageProvider, UploadedPart,
 };
 use crate::transfer_dag::executor::{execute_dag, DagNodeRunner, NodeFuture, NodeOutcome};
 use crate::transfer_dag::graph::{TransferNode, TransferNodeKind};
@@ -379,29 +379,42 @@ pub async fn execute_single_file_dag(
                     TransferNodeKind::CommitTemp => {
                         // For multipart uploads, finalize the session by
                         // submitting the accumulated parts in part-number
-                        // order. The handle is taken (the session is no
-                        // longer valid after `complete_multipart_upload`,
-                        // success or failure), so the failure-path abort
-                        // below knows to skip when commit already consumed
-                        // it. For the single-transfer-core shape this is a
-                        // no-op.
+                        // order. The handle is CLONED for the complete call
+                        // and the slot is cleared only on success; on a
+                        // commit-time failure the handle stays in place so the
+                        // post-execute abort guard reliably aborts the
+                        // orphaned session instead of leaking the upload id
+                        // (audit ERR-01). For the single-transfer-core shape
+                        // this is a no-op.
                         if let Some(ctx) = multipart_ctx.as_ref() {
                             let handle = {
-                                let mut handle_guard = ctx.handle.lock().await;
-                                handle_guard.take()
+                                let handle_guard = ctx.handle.lock().await;
+                                handle_guard.as_ref().cloned()
                             };
                             if let Some(handle) = handle {
                                 let mut parts = std::mem::take(&mut *ctx.parts.lock().await);
                                 parts.sort_by_key(|p| p.part_number);
-                                let mut guard = provider.lock().await;
-                                let Some(p) = guard.as_mut() else {
-                                    return record_failure(
-                                        &first_error,
-                                        ProviderError::NotConnected,
-                                    );
+                                // Scope the provider guard so it is released
+                                // before we touch the handle mutex, keeping the
+                                // lock order (handle then provider) consistent
+                                // with the lazy-begin path.
+                                let result = {
+                                    let mut guard = provider.lock().await;
+                                    let Some(p) = guard.as_mut() else {
+                                        return record_failure(
+                                            &first_error,
+                                            ProviderError::NotConnected,
+                                        );
+                                    };
+                                    p.complete_multipart_upload(handle, parts).await
                                 };
-                                match p.complete_multipart_upload(handle, parts).await {
-                                    Ok(()) => NodeOutcome::Completed,
+                                match result {
+                                    Ok(()) => {
+                                        // Session finalized: clear the handle so
+                                        // the abort guard becomes a no-op.
+                                        ctx.handle.lock().await.take();
+                                        NodeOutcome::Completed
+                                    }
                                     Err(e) => record_failure(&first_error, e),
                                 }
                             } else {
@@ -449,8 +462,9 @@ pub async fn execute_single_file_dag(
 
     // On failure, best-effort abort an in-flight multipart session so the
     // provider does not accumulate orphan upload IDs. Idempotent because the
-    // commit branch already `take()`s the handle on success, so this only
-    // runs when the failure happened before commit ran.
+    // commit branch clears the handle ONLY on success, so this runs for both a
+    // failure before commit AND a commit-time failure (audit ERR-01); a
+    // successful commit leaves no handle and this is a no-op.
     if outcome.is_err() {
         if let Some(ctx) = multipart_ctx.as_ref() {
             let leftover_handle = {
@@ -520,14 +534,23 @@ fn single_file_budget(built: &ShapedFileDag) -> TransferBudget {
     budget
 }
 
-fn clone_multipart_worker(provider: &mut dyn StorageProvider) -> Option<Box<dyn StorageProvider>> {
-    if let Some(s3) = provider.as_any_mut().downcast_mut::<S3Provider>() {
-        return Some(Box::new(s3.clone()));
+/// Mint an independent worker for a concurrent part upload, or `None` when the
+/// provider must serialise its parts on the shared session mutex.
+///
+/// Routed through the `transfer_executor_kind()` + `clone_for_transfer()` trait
+/// contract rather than a hardcoded `S3`/`B2` downcast, so every provider that
+/// advertises `HttpClonePool` (S3, B2, Azure, and any future clone-backed
+/// backend) actually fans its parts out in parallel instead of paying the
+/// per-part request cost while serialising on one mutex (audit CHUNK-01).
+/// Providers that report `LockedSingle` keep the mutex fallback at the call
+/// site, so this is a pure widening: no provider that was parallel before
+/// becomes serial.
+fn clone_multipart_worker(provider: &dyn StorageProvider) -> Option<Box<dyn StorageProvider>> {
+    if provider.transfer_executor_kind() == ProviderTransferExecutorKind::HttpClonePool {
+        provider.clone_for_transfer().ok()
+    } else {
+        None
     }
-    if let Some(b2) = provider.as_any_mut().downcast_mut::<B2Provider>() {
-        return Some(Box::new(b2.clone()));
-    }
-    None
 }
 
 #[cfg(test)]
@@ -554,6 +577,7 @@ mod tests {
         let caps = TransferCapabilities {
             multipart_upload: Capability::Supported,
             preferred_chunk_size: Some(8 * 1024 * 1024),
+            multipart_threshold: 0, // unset: fan out at chunk size
             ..TransferCapabilities::default()
         };
         let file_size: u64 = 24 * 1024 * 1024;
@@ -593,6 +617,7 @@ mod tests {
             multipart_upload: Capability::Supported,
             preferred_chunk_size: Some(8 * 1024 * 1024),
             max_chunk_slots: Some(4),
+            multipart_threshold: 0, // unset: fan out at chunk size
             ..TransferCapabilities::default()
         };
         let built =
@@ -610,6 +635,7 @@ mod tests {
             multipart_upload: Capability::Supported,
             preferred_chunk_size: Some(8 * 1024 * 1024),
             max_chunk_slots: Some(4),
+            multipart_threshold: 0, // unset: fan out at chunk size
             ..TransferCapabilities::default()
         };
         let built =

--- a/src-tauri/src/transfer_dag_single_file.rs
+++ b/src-tauri/src/transfer_dag_single_file.rs
@@ -78,9 +78,7 @@ use std::sync::{Arc, Mutex as StdMutex};
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
 use tokio::sync::Mutex;
 
-use crate::providers::{
-    MultipartHandle, ProviderError, ProviderTransferExecutorKind, StorageProvider, UploadedPart,
-};
+use crate::providers::{MultipartHandle, ProviderError, StorageProvider, UploadedPart};
 use crate::transfer_dag::executor::{execute_dag, DagNodeRunner, NodeFuture, NodeOutcome};
 use crate::transfer_dag::graph::{TransferNode, TransferNodeKind};
 use crate::transfer_dag::{
@@ -537,20 +535,20 @@ fn single_file_budget(built: &ShapedFileDag) -> TransferBudget {
 /// Mint an independent worker for a concurrent part upload, or `None` when the
 /// provider must serialise its parts on the shared session mutex.
 ///
-/// Routed through the `transfer_executor_kind()` + `clone_for_transfer()` trait
-/// contract rather than a hardcoded `S3`/`B2` downcast, so every provider that
-/// advertises `HttpClonePool` (S3, B2, Azure, and any future clone-backed
-/// backend) actually fans its parts out in parallel instead of paying the
-/// per-part request cost while serialising on one mutex (audit CHUNK-01).
-/// Providers that report `LockedSingle` keep the mutex fallback at the call
-/// site, so this is a pure widening: no provider that was parallel before
-/// becomes serial.
+/// Gated on `clone_for_transfer()` (the actual capability the parallel part
+/// path needs: an independent HTTP/session worker) rather than a hardcoded
+/// `S3`/`B2` downcast or the `transfer_executor_kind()` flag. Gating on the
+/// clone itself lets a provider parallelise its multipart chunks WITHOUT also
+/// opting into clone-pool BATCH execution (which `transfer_executor_kind`
+/// drives), so the blast radius stays exactly the per-part path. S3, B2, Azure
+/// and Nextcloud WebDAV produce an independent worker here; providers that
+/// cannot clone (the trait default) return `None` and keep the session-mutex
+/// fallback at the call site (audit CHUNK-01). Ordering-sensitive providers
+/// (Drive/OneDrive) stay correct regardless: the builder serialises their part
+/// nodes when `max_chunk_slots <= 1`, so even a cloned worker runs them one at
+/// a time in part-number order.
 fn clone_multipart_worker(provider: &dyn StorageProvider) -> Option<Box<dyn StorageProvider>> {
-    if provider.transfer_executor_kind() == ProviderTransferExecutorKind::HttpClonePool {
-        provider.clone_for_transfer().ok()
-    } else {
-        None
-    }
+    provider.clone_for_transfer().ok()
 }
 
 #[cfg(test)]

--- a/src-tauri/src/transfer_router/hints.rs
+++ b/src-tauri/src/transfer_router/hints.rs
@@ -139,9 +139,7 @@ fn webdav_variant(server_url: Option<&str>, preset_id: Option<&str>) -> Provider
 pub fn recommend(ctx: RouteContext) -> Decision {
     match ctx.provider {
         ProviderHint::WebDavVanilla => recommend_webdav_vanilla(ctx),
-        ProviderHint::WebDavNextcloud => default_dag(
-            "WebDAV Nextcloud: all sizes WIN on Phase A (download 100M +6.0%, 1G +16.8%)",
-        ),
+        ProviderHint::WebDavNextcloud => recommend_webdav_nextcloud(ctx),
         ProviderHint::WebDavGateway => {
             default_dag("WebDAV gateway (Koofr): WIN +132% upload 1G, +161% download 100M")
         }
@@ -161,18 +159,36 @@ pub fn recommend(ctx: RouteContext) -> Decision {
 }
 
 fn recommend_webdav_vanilla(ctx: RouteContext) -> Decision {
-    // Revalidation 2026-05-25 (T-DEBT-RTR-04): forced DAG vs forced Legacy
-    // on the same v4 binary showed no structural WebDAV-vanilla regression.
-    // `strace -c -e trace=network` was byte-shape identical (51 network
-    // syscalls in both paths); the earlier mod_dav decay is treated as lab
-    // load / paired-run noise, not a router-worthy engine distinction.
-    let reason = match ctx.operation {
+    // Downloads never fan out in the DAG (multipart is upload-only), so the
+    // shaped graph can only add wrapper cost on the download direction. The
+    // 2026-05-29 lab re-benchmark measured WebDAV download regressing under the
+    // DAG, so route downloads to the provider-direct Legacy path (the internal
+    // range/concurrent-download logic lives inside `download()` and is
+    // preserved either way). Uploads have no multipart on vanilla WebDAV so the
+    // DAG is also pure overhead, but uploads were within gate on Phase A; keep
+    // them on the default DAG for now and revisit if a re-benchmark regresses.
+    match ctx.operation {
         Operation::Download => {
-            "WebDAV vanilla download: revalidated DAG/Legacy parity; DAG default"
+            default_legacy("WebDAV vanilla download: DAG adds wrapper cost, no fan-out (audit PS2)")
         }
-        Operation::Upload => "WebDAV vanilla upload: Phase A within gate; DAG default",
-    };
-    default_dag(reason)
+        Operation::Upload => default_dag("WebDAV vanilla upload: Phase A within gate; DAG default"),
+    }
+}
+
+fn recommend_webdav_nextcloud(ctx: RouteContext) -> Decision {
+    // Upload stays on the DAG: Nextcloud chunked v2 now fans out into parallel
+    // `UploadPart` nodes (clone_for_transfer is wired for Nextcloud), which is
+    // the path that pays off on large uploads. Download routes to Legacy: it
+    // never fans out, so the DAG only adds the node-graph wrapper, which the
+    // 2026-05-29 lab re-benchmark showed regressing (audit PS2).
+    match ctx.operation {
+        Operation::Download => {
+            default_legacy("WebDAV Nextcloud download: DAG adds wrapper cost, no fan-out (audit PS2)")
+        }
+        Operation::Upload => {
+            default_dag("WebDAV Nextcloud upload: parallel chunked v2 fan-out via shaped graph")
+        }
+    }
 }
 
 fn recommend_s3(_ctx: RouteContext) -> Decision {
@@ -199,6 +215,13 @@ fn default_dag(reason: &'static str) -> Decision {
     }
 }
 
+fn default_legacy(reason: &'static str) -> Decision {
+    Decision {
+        engine: Engine::Legacy,
+        reason,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::Router;
@@ -211,35 +234,13 @@ mod tests {
     // ── WebDAV vanilla: revalidated DAG default ───────────────────────
 
     #[test]
-    fn webdav_vanilla_download_medium_stays_on_dag() {
-        let d = Router::new().pick(ctx(
-            ProviderHint::WebDavVanilla,
-            Operation::Download,
-            100 * 1024 * 1024,
-        ));
-        assert_eq!(d.engine, Engine::Dag);
-        assert!(d.reason.contains("revalidated"));
-    }
-
-    #[test]
-    fn webdav_vanilla_download_1g_stays_on_dag() {
-        let d = Router::new().pick(ctx(
-            ProviderHint::WebDavVanilla,
-            Operation::Download,
-            1 << 30,
-        ));
-        assert_eq!(d.engine, Engine::Dag);
-    }
-
-    #[test]
-    fn webdav_vanilla_download_small_stays_on_dag() {
-        // Small files: latency-bound, DAG default.
-        let d = Router::new().pick(ctx(
-            ProviderHint::WebDavVanilla,
-            Operation::Download,
-            1024 * 1024,
-        ));
-        assert_eq!(d.engine, Engine::Dag);
+    fn webdav_vanilla_download_routes_to_legacy() {
+        // Downloads never fan out, so the DAG only adds wrapper cost; the
+        // 2026-05-29 re-benchmark routed WebDAV download to Legacy (audit PS2).
+        for size in [1024 * 1024, 100 * 1024 * 1024, 1 << 30] {
+            let d = Router::new().pick(ctx(ProviderHint::WebDavVanilla, Operation::Download, size));
+            assert_eq!(d.engine, Engine::Legacy, "size {size} should be Legacy");
+        }
     }
 
     #[test]
@@ -265,15 +266,21 @@ mod tests {
     // ── WebDAV Nextcloud / gateway: always DAG ────────────────────────
 
     #[test]
-    fn webdav_nextcloud_download_medium_stays_on_dag() {
-        // The case ieri sera looked broken but the overnight matrix
-        // proved was an artefact: +6.0% on the clean re-run.
-        let d = Router::new().pick(ctx(
+    fn webdav_nextcloud_download_routes_to_legacy_upload_stays_dag() {
+        // Download has no fan-out so it goes Legacy (audit PS2); upload keeps
+        // the DAG because Nextcloud chunked v2 now fans out in parallel.
+        let down = Router::new().pick(ctx(
             ProviderHint::WebDavNextcloud,
             Operation::Download,
             100 * 1024 * 1024,
         ));
-        assert_eq!(d.engine, Engine::Dag);
+        assert_eq!(down.engine, Engine::Legacy);
+        let up = Router::new().pick(ctx(
+            ProviderHint::WebDavNextcloud,
+            Operation::Upload,
+            100 * 1024 * 1024,
+        ));
+        assert_eq!(up.engine, Engine::Dag);
     }
 
     #[test]

--- a/src-tauri/src/transfer_router/hints.rs
+++ b/src-tauri/src/transfer_router/hints.rs
@@ -12,9 +12,10 @@
 //! - latency (list/stat) +-10% = ok
 //!
 //! The size thresholds use binary units (1 MiB = 1 << 20 bytes) because
-//! every Phase A report uses those units. The cutoffs (`SMALL_CUTOFF`,
-//! `MEDIUM_CUTOFF`) align with the benchmark sizes (1M / 100M / 1G) so
-//! a future report can be diffed against this table directly.
+//! every Phase A report uses those units. The single-vs-multipart fan-out
+//! decision is NOT made here: it lives in `transfer_dag::builder` and is gated
+//! on the provider's `multipart_threshold` capability. The router only selects
+//! the engine; it does not size parts.
 
 use super::{Decision, Engine, Operation, ProviderHint, RouteContext};
 use crate::providers::types::ProviderType;
@@ -135,9 +136,6 @@ fn webdav_variant(server_url: Option<&str>, preset_id: Option<&str>) -> Provider
     ProviderHint::WebDavVanilla
 }
 
-/// Large-file threshold used by providers with multipart fan-out decisions.
-const MEDIUM_CUTOFF: u64 = 250 * 1024 * 1024; // 250 MiB
-
 pub fn recommend(ctx: RouteContext) -> Decision {
     match ctx.provider {
         ProviderHint::WebDavVanilla => recommend_webdav_vanilla(ctx),
@@ -177,16 +175,14 @@ fn recommend_webdav_vanilla(ctx: RouteContext) -> Decision {
     default_dag(reason)
 }
 
-fn recommend_s3(ctx: RouteContext) -> Decision {
-    // Phase A finding (round 1 2026-05-24): S3 multipart upload WIN big
-    // after the chunk-parallel fix (`b8217fe1`), upload 1G +38.6%,
-    // download 1G +40.7%. Small files are no-op for multipart.
-    match (ctx.operation, ctx.size_bytes) {
-        (Operation::Upload, sz) if sz >= MEDIUM_CUTOFF => {
-            default_dag("S3 upload >=250M: Phase A WIN +38.6% (multipart fan-out parallel)")
-        }
-        _ => default_dag("S3: Phase A gate green"),
-    }
+fn recommend_s3(_ctx: RouteContext) -> Decision {
+    // Phase A finding (round 1 2026-05-24): S3 multipart upload WIN big after
+    // the chunk-parallel fix (`b8217fe1`), upload 1G +38.6%. The single-vs-
+    // multipart decision is size-gated in the builder via multipart_threshold
+    // (audit DISP-01); the router only selects the engine, so there is no
+    // size branch here (the previous MEDIUM_CUTOFF arm was dead: both arms
+    // returned DAG, audit DISP-04).
+    default_dag("S3: multipart fan-out for large uploads, single PUT below threshold (builder-gated)")
 }
 
 fn recommend_b2(_ctx: RouteContext) -> Decision {


### PR DESCRIPTION
## Summary

Fixes from the 2026-05-29 deep audit of the v4 DAG transfer engine
(`docs/dev/roadmap/AUDIT-ZONE/2026-05-29_DAG-ENGINE-DEEP-AUDIT/`). The audit ran a
swarm of specialist agents with adversarial verification on every finding: 42 of 49
findings confirmed against code, 0 critical. The engine is structurally sound (byte-identical
contract holds, typed hard-error/security path preserved, no eager connect-time probing); the
issues were routing economics plus three isolated defects. This branch lands the high/medium,
code-confirmed, CLI-observable fixes and validates them with a live legacy-vs-DAG benchmark.

## What changed

Patch set 1 (`a1d5bbf7`):
- DISP-01/CORR-02: plumb `multipart_threshold` into `TransferCapabilities` and gate upload
  fan-out on it, so a medium upload below the provider threshold stays a single PUT.
- CHUNK-01: route multipart part workers through `clone_for_transfer()` instead of a hardcoded
  S3/B2 downcast, so every clone-capable provider runs parts in parallel. B2 gains the trait impl.
- AIMD-02: fix the `DynamicSemaphore` deficit race (saturating `fetch_update` CAS) so concurrency
  can no longer collapse to the floor via a `usize::MAX` underflow.
- ERR-01: stop leaking the multipart upload session on a commit-time failure.
- W1.2: the Legacy download route now restores remote mtime and emits the completion event.
- DISP-04: remove the dead `MEDIUM_CUTOFF` router branch.

Patch set 2 (`bd5396fa`):
- CHUNK-01 follow-up: gate `clone_multipart_worker` on `clone_for_transfer()` (not
  `transfer_executor_kind`), and add `clone_for_transfer()` to `WebDavProvider` for Nextcloud so
  chunked-v2 parts run in parallel. `Clone` derived on `WebDavProvider` + `DigestState`.
- Azure: raise the DAG `multipart_threshold` to 200 MiB so a 100 MiB upload stays single-shot
  while large uploads keep fanning out.
- Router: route WebDAV (vanilla + Nextcloud) downloads to Legacy (downloads never fan out, so the
  DAG only adds wrapper cost). Nextcloud uploads stay on the DAG.

Nextcloud threshold (`83b55b4a`):
- Set Nextcloud chunked-v2 `multipart_threshold` to 256 MiB: chunking lost to a single PUT on a
  low-RTT LAN even parallelised, so medium uploads stay single PUT and only large uploads chunk
  (where resumable chunks pay off over WAN).

## Live benchmark validation (lab, legacy vs DAG, best-of-3)

| Provider | Op | Size | Result |
|----------|----|------|--------|
| Azure | up | 256M | +80% (CHUNK-01 parallel parts) |
| Azure | up | 100M | parity (was -17%, threshold fix) |
| MinIO S3 | up/down | 100M | parity |
| SFTP (NAS) | up/down | 100M | parity (feared -12% not reproduced) |
| Nextcloud | download | any | routed to Legacy (carve-out) |
| Nextcloud | up | 100M | single PUT after threshold (was -36%/-49%) |

Full data: `docs/dev/roadmap/AUDIT-ZONE/2026-05-29_DAG-ENGINE-DEEP-AUDIT/benchmarks/`.

## Tests

`cargo test --lib` green (2056 passed, 0 failed), clippy clean. New unit tests: multipart
threshold gate, AIMD deficit invariant, WebDAV download routing, Nextcloud/Azure threshold values.

## Deferred (tracked in the audit execution plan)

- DAG-native batch/sync multipart (provider-internal multipart already covers it).
- Download->Legacy carve-out for SFTP/FTP/OAuth (benchmark showed parity; not needed).
- OAuth provider live benchmark (re-auth pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Intelligent multipart thresholds to control when uploads fan out.
  * Provider cloning support to enable parallel upload workers for B2 and Nextcloud WebDAV.

* **Bug Fixes**
  * Preserved file modification times after legacy downloads.
  * Fixed semaphore concurrency to prevent permit loss during scaling.
  * Improved lock ordering and multipart commit/abort reliability.
  * WebDAV download routing now favors the legacy engine for stability.

* **Improvements**
  * Clearer routing and multipart sizing semantics for uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->