### PR TITLE
feat(cli): --access privacy flag for put and mkdir (#252)

### DIFF
--- a/docs/CLI-GUIDE.md
+++ b/docs/CLI-GUIDE.md
@@ -388,15 +388,25 @@ aeroftp-cli put sftp://user@host ./project/ /var/www/project/ -r
 
 # Delta-aware single-file upload (Z.4.5 R1, SFTP only today)
 aeroftp-cli put sftp://user@host ./report.pdf /uploads/report.pdf --delta
+
+# Set the uploaded file's privacy on OpenDrive (private | public | hidden)
+aeroftp-cli put opendrive://user@host ./secret.pdf /docs/ --access private
 ```
 
 > **`--delta`**: same semantics as on `get` (see above). On a successful delta upload the CLI prints `bytes_on_wire / total` and the rsync speedup ratio so you can confirm the saving.
+
+> **`--access <private|public|hidden>`** (issue #252): on providers that model a three-level access scheme (OpenDrive today), sets the uploaded file's privacy. When omitted on an OpenDrive target the upload defaults to **private** (max-privacy, opt out with `--access public`), mirroring rclone's `--opendrive-access`. Applies to single-file uploads; for recursive/glob uploads set the destination folder privacy with `mkdir --access`, which cascades to children. Ignored, with a note, on providers that do not model access.
 
 ### mkdir - Create Directory
 
 ```bash
 aeroftp-cli mkdir sftp://user@host /var/www/new-folder
+
+# Create a private OpenDrive folder (privacy cascades to its children)
+aeroftp-cli mkdir opendrive://user@host /private-docs --access private
 ```
+
+> **`--access <private|public|hidden>`** (issue #252): on OpenDrive, sets the created folder's privacy, which cascades to existing children server-side. Defaults to **private** when omitted on an OpenDrive target.
 
 ### rm - Delete File or Directory
 

--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -842,6 +842,103 @@ enum RcloneFilenameEncryption {
     Off,
 }
 
+/// Issue #252: per-create privacy level for providers that expose a
+/// three-level access model (OpenDrive today). Mirrors rclone's
+/// `--opendrive-access`. Defaults to `private` (max-privacy, opt-out)
+/// when the flag is omitted on an OpenDrive target. Ignored, with a
+/// note, on providers that do not model access.
+#[derive(Copy, Clone, Debug, ValueEnum, PartialEq, Eq)]
+enum CliAccessLevel {
+    /// Not listed, not shared; reachable only by the owner.
+    Private,
+    /// Anyone with the link can access; searchable.
+    Public,
+    /// Accessible by direct link only; not searchable.
+    Hidden,
+}
+
+impl CliAccessLevel {
+    fn to_opendrive(self) -> ftp_client_gui_lib::providers::opendrive::OpenDriveAccessLevel {
+        use ftp_client_gui_lib::providers::opendrive::OpenDriveAccessLevel as L;
+        match self {
+            CliAccessLevel::Private => L::Private,
+            CliAccessLevel::Public => L::Public,
+            CliAccessLevel::Hidden => L::Hidden,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            CliAccessLevel::Private => "private",
+            CliAccessLevel::Public => "public",
+            CliAccessLevel::Hidden => "hidden",
+        }
+    }
+}
+
+/// Issue #252: apply a privacy level to a freshly created remote path on
+/// providers that model access. Today only OpenDrive does; the call is a
+/// no-op (with a one-line note when `requested` is explicit) on every
+/// other backend. When `requested` is `None` and the target is OpenDrive,
+/// defaults to `private` so CLI uploads are max-privacy by default
+/// (opt out with `--access public`). Folder access cascades to children
+/// server-side (`with_child_files=true`). Non-fatal: a failure here warns
+/// but never changes the upload exit code.
+async fn apply_remote_access(
+    provider: &mut dyn ftp_client_gui_lib::providers::StorageProvider,
+    remote_path: &str,
+    is_dir: bool,
+    requested: Option<CliAccessLevel>,
+    cli: &Cli,
+) {
+    use ftp_client_gui_lib::providers::opendrive::OpenDriveProvider;
+
+    let opendrive = provider
+        .as_any_mut()
+        .downcast_mut::<OpenDriveProvider>();
+
+    let Some(od) = opendrive else {
+        // Not an access-modelling provider. Only speak up if the user
+        // explicitly asked for an access level, so the silence is honest.
+        if requested.is_some() && !cli.quiet {
+            eprintln!(
+                "Note: --access is only supported on OpenDrive in this release; ignored for this provider"
+            );
+        }
+        return;
+    };
+
+    let level = requested.unwrap_or(CliAccessLevel::Private);
+    let result = if is_dir {
+        od.set_folder_access(remote_path, level.to_opendrive()).await
+    } else {
+        od.set_file_access(remote_path, level.to_opendrive()).await
+    };
+
+    match result {
+        Ok(()) => {
+            if !cli.quiet {
+                let how = if requested.is_some() {
+                    ""
+                } else {
+                    " by default (use --access public to opt out)"
+                };
+                eprintln!("OpenDrive: set {} access on {}{}", level.label(), remote_path, how);
+            }
+        }
+        Err(e) => {
+            if !cli.quiet {
+                eprintln!(
+                    "Warning: could not set {} access on {}: {}",
+                    level.label(),
+                    remote_path,
+                    e
+                );
+            }
+        }
+    }
+}
+
 /// KE-C1: FUSE caching policy preset. Maps directly onto the
 /// (`attr_timeout`, `dir_cache_time`, `cache_ttl`) trio at
 /// `AeroFuseFs` construction time. Granular per-knob overrides
@@ -1010,6 +1107,13 @@ enum Commands {
         /// recursive / glob uploads.
         #[arg(long)]
         delta: bool,
+        /// Issue #252: privacy level to apply to the uploaded file on
+        /// providers that model access (OpenDrive). Defaults to `private`
+        /// when omitted on an OpenDrive target. Applies to single-file
+        /// uploads; for recursive/glob uploads set the destination folder
+        /// privacy with `mkdir --access` (it cascades to children).
+        #[arg(long, value_enum)]
+        access: Option<CliAccessLevel>,
     },
     /// Create a remote directory
     Mkdir {
@@ -1022,6 +1126,12 @@ enum Commands {
         /// Create parent directories as needed; no error if existing
         #[arg(short, long)]
         parents: bool,
+        /// Issue #252: privacy level for the created folder on providers
+        /// that model access (OpenDrive). Defaults to `private` when
+        /// omitted on an OpenDrive target. Cascades to existing children
+        /// server-side.
+        #[arg(long, value_enum)]
+        access: Option<CliAccessLevel>,
     },
     /// Delete a remote file or directory
     Rm {
@@ -17815,6 +17925,7 @@ async fn cmd_put(
     recursive: bool,
     no_clobber: bool,
     delta: bool,
+    access: Option<CliAccessLevel>,
     cli: &Cli,
     format: OutputFormat,
     cancelled: Arc<AtomicBool>,
@@ -17830,6 +17941,11 @@ async fn cmd_put(
                 "Note: --delta is a no-op for recursive uploads in this release; use `aeroftp sync --delta` for recursive delta sync"
             );
         }
+        if access.is_some() && !cli.quiet {
+            eprintln!(
+                "Note: --access is not applied per-file on recursive uploads in this release; set the destination folder privacy with `aeroftp mkdir --access` (it cascades to children)"
+            );
+        }
         return cmd_put_recursive(url, local, remote, cli, format, cancelled).await;
     }
 
@@ -17838,6 +17954,11 @@ async fn cmd_put(
         if delta && !cli.quiet {
             eprintln!(
                 "Note: --delta is a no-op for glob uploads in this release; use `aeroftp sync --delta` for glob delta sync"
+            );
+        }
+        if access.is_some() && !cli.quiet {
+            eprintln!(
+                "Note: --access is not applied per-file on glob uploads in this release; set the destination folder privacy with `aeroftp mkdir --access` (it cascades to children)"
             );
         }
         return cmd_put_glob(url, local, remote, cli, format, cancelled).await;
@@ -18038,6 +18159,7 @@ async fn cmd_put(
                         }));
                     }
                 }
+                apply_remote_access(provider.as_mut(), remote_path, false, access, cli).await;
                 let _ = provider.disconnect().await;
                 return 0;
             }
@@ -18075,6 +18197,7 @@ async fn cmd_put(
     match up_result {
         Ok(()) => {
             session_transfer_add(file_size);
+            apply_remote_access(provider.as_mut(), remote_path, false, access, cli).await;
             let elapsed = start.elapsed();
             let speed = if elapsed.as_secs_f64() > 0.0 {
                 (file_size as f64 / elapsed.as_secs_f64()) as u64
@@ -18398,7 +18521,14 @@ async fn cmd_put_recursive(
     }
 }
 
-async fn cmd_mkdir(url: &str, path: &str, parents: bool, cli: &Cli, format: OutputFormat) -> i32 {
+async fn cmd_mkdir(
+    url: &str,
+    path: &str,
+    parents: bool,
+    access: Option<CliAccessLevel>,
+    cli: &Cli,
+    format: OutputFormat,
+) -> i32 {
     let (mut provider, initial_path) = match create_and_connect(url, cli, format).await {
         Ok(v) => v,
         Err(code) => return code,
@@ -18486,6 +18616,12 @@ async fn cmd_mkdir(url: &str, path: &str, parents: bool, cli: &Cli, format: Outp
                 "already_existed": leaf_already_existed,
             })),
         }
+        // Apply privacy to the leaf folder. With an explicit --access, always
+        // honour it; with the default (private), skip a folder that already
+        // existed so we never silently flip an established folder's privacy.
+        if access.is_some() || !leaf_already_existed {
+            apply_remote_access(provider.as_mut(), path, true, access, cli).await;
+        }
         let _ = provider.disconnect().await;
         0
     } else {
@@ -18504,6 +18640,8 @@ async fn cmd_mkdir(url: &str, path: &str, parents: bool, cli: &Cli, format: Outp
                         "already_existed": false,
                     })),
                 }
+                // Freshly created (Ok == created; existing dirs land in Err).
+                apply_remote_access(provider.as_mut(), path, true, access, cli).await;
                 let _ = provider.disconnect().await;
                 0
             }
@@ -34650,6 +34788,7 @@ async fn cmd_batch(file: &str, cli: &Cli, format: OutputFormat, cancelled: Arc<A
                     false,
                     false,
                     false,
+                    None,
                     cli,
                     format,
                     cancelled.clone(),
@@ -34813,7 +34952,7 @@ async fn cmd_batch(file: &str, cli: &Cli, format: OutputFormat, cancelled: Arc<A
                     eprintln!("Line {}: MKDIR requires a path", line_num + 1);
                     return 5;
                 }
-                exit_code = cmd_mkdir(&url, parts[1], false, cli, format).await;
+                exit_code = cmd_mkdir(&url, parts[1], false, None, cli, format).await;
                 if let Some(code) = check_exit(
                     exit_code,
                     line_num,
@@ -38578,6 +38717,7 @@ async fn main() {
             recursive,
             no_clobber,
             delta,
+            access,
         } => {
             let (u, l, r) = if cli.profile.is_some() && !url.contains("://") && url != "_" {
                 ("_", url.as_str(), Some(local.as_str()))
@@ -38596,6 +38736,7 @@ async fn main() {
                     *recursive,
                     *no_clobber,
                     *delta,
+                    *access,
                     &cli,
                     format,
                     cancelled.clone(),
@@ -38619,13 +38760,18 @@ async fn main() {
             }
             last_code
         }
-        Commands::Mkdir { url, path, parents } => {
+        Commands::Mkdir {
+            url,
+            path,
+            parents,
+            access,
+        } => {
             let (u, p) = if cli.profile.is_some() && !url.contains("://") && url != "_" {
                 ("_", url.as_str())
             } else {
                 (url.as_str(), path.as_str())
             };
-            cmd_mkdir(u, p, *parents, &cli, format).await
+            cmd_mkdir(u, p, *parents, *access, &cli, format).await
         }
         Commands::Rm {
             url,
@@ -40569,6 +40715,35 @@ mod tests {
     use super::*;
     use ftp_client_gui_lib::profile_loader::insert_profile_option;
     use serde_json::json;
+
+    #[test]
+    fn cli_access_level_maps_to_opendrive_levels() {
+        use ftp_client_gui_lib::providers::opendrive::OpenDriveAccessLevel as L;
+        assert_eq!(CliAccessLevel::Private.to_opendrive(), L::Private);
+        assert_eq!(CliAccessLevel::Public.to_opendrive(), L::Public);
+        assert_eq!(CliAccessLevel::Hidden.to_opendrive(), L::Hidden);
+        assert_eq!(CliAccessLevel::Private.label(), "private");
+        assert_eq!(CliAccessLevel::Public.label(), "public");
+        assert_eq!(CliAccessLevel::Hidden.label(), "hidden");
+    }
+
+    #[test]
+    fn cli_access_level_parses_lowercase_tokens() {
+        use clap::ValueEnum;
+        assert_eq!(
+            CliAccessLevel::from_str("private", true),
+            Ok(CliAccessLevel::Private)
+        );
+        assert_eq!(
+            CliAccessLevel::from_str("public", true),
+            Ok(CliAccessLevel::Public)
+        );
+        assert_eq!(
+            CliAccessLevel::from_str("hidden", true),
+            Ok(CliAccessLevel::Hidden)
+        );
+        assert!(CliAccessLevel::from_str("bogus", true).is_err());
+    }
 
     #[test]
     fn rust_log_warn_does_not_enable_debug_tracing() {


### PR DESCRIPTION
## Summary

Adds an `--access <private|public|hidden>` flag to `aeroftp-cli put` and `mkdir`, mirroring rclone's `--opendrive-access`. Resolves the enhancement raised by @EhudKirsh in #252 (the base 400-on-folders bug was already fixed in v4.0.0; this is the follow-up CLI control he asked for).

## Behaviour

- On OpenDrive (the only backend that models a three-level access scheme today) the level is applied right after a successful single-file upload or folder creation, reusing the existing `OpenDriveAccessLevel` + `file/access.json` / `folder/setaccess.json` machinery.
- Folder access cascades to children server-side (`with_child_files=true`), so `mkdir --access private` makes the whole subtree private.
- When the flag is omitted on an OpenDrive target the operation defaults to **private** (max-privacy, opt out with `--access public`), so CLI uploads are not publicly exposed by default. The default is transparent: a one-line note is printed.
- `mkdir` skips re-applying the default to a folder that already existed, so an established folder's privacy is never silently flipped.
- Non-OpenDrive providers ignore the flag with a note. Recursive/glob uploads print a note pointing at `mkdir --access` for folder-level cascade.

## Design note

The dummy-name create-then-rename approach from the thread is intentionally not implemented: OpenDrive is not public-by-default, so an immediate `setaccess` after create is the correct mitigation without the extra complexity and failure modes.

## Tests

- `cli_access_level_maps_to_opendrive_levels`, `cli_access_level_parses_lowercase_tokens` (green).
- `cargo check` and `cargo clippy --bin aeroftp-cli` clean.
- `docs/CLI-GUIDE.md` updated for both commands.

Refs #252 (left open for @EhudKirsh to verify on the next build and close).

Co-authored with @EhudKirsh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--access <private|public|hidden>` flag to `put` command for controlling file privacy on OpenDrive.
  * Added `--access <private|public|hidden>` flag to `mkdir` command for controlling folder privacy on OpenDrive (cascades to children).
  * Default privacy setting is `private` on OpenDrive when flag is omitted.

* **Documentation**
  * Updated CLI guide with examples and usage details for the new privacy access feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->