### PR TITLE
feat(cli): slice 3 switch active user from profiles -i

### DIFF
--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -9393,7 +9393,7 @@ fn interactive_profiles_loop(cli: &Cli, store: &CredentialStore, profiles: Vec<s
         }
 
         eprintln!(
-            "\nInteractive: l/t/d/f/c/r/e <N|name> [N|name ...]  ·  # <sel> <N> reorder  ·  legacy 1l/l1 still works  ·  0/q = quit"
+            "\nInteractive: l/t/d/f/c/r/e <N|name> [N|name ...]  ·  # <sel> <N> reorder  ·  u switch user  ·  legacy 1l/l1 still works  ·  0/q = quit"
         );
         eprint!("profiles> ");
         let _ = io::stderr().flush();
@@ -9431,6 +9431,7 @@ fn interactive_profiles_loop(cli: &Cli, store: &CredentialStore, profiles: Vec<s
             eprintln!("  s <selector>    save-as-new in a different mode of the same provider group (issue #215)");
             eprintln!("  v <selector>    convert profile to a different mode, REPLACES the original (issue #215)");
             eprintln!("  # <sel> <N>     move a profile to index N (renumber, clamped to count, persisted)");
+            eprintln!("  u [N|name]      switch active user (lists accounts when bare); reloads profiles");
             eprintln!("  Nl  Nt  Nd      legacy single-target compact form (e.g. '1l', 'l1')");
             eprintln!("  0/q             quit");
             eprintln!();
@@ -9520,6 +9521,124 @@ fn interactive_profiles_loop(cli: &Cli, store: &CredentialStore, profiles: Vec<s
                 Err(e) => {
                     current = snapshot;
                     eprintln!("Move failed to persist: {}. Order unchanged.", e);
+                }
+            }
+            continue;
+        }
+
+        // Switch the active local user (#270). `u` alone lists the accounts
+        // and prompts for a selection; `u <N|name>` switches directly. The
+        // numeric selector is the 1-based position in the printed list (what
+        // the user sees), not the database id. After a switch the profile
+        // table reloads to show the new user's profiles.
+        if lower == "u" || lower.starts_with("u ") {
+            let users = match user_partitions::cli_list_users(store) {
+                Ok(u) => u,
+                Err(e) => {
+                    eprintln!("Could not list users: {}", e);
+                    continue;
+                }
+            };
+            if users.len() <= 1 {
+                eprintln!("Only one user account exists; nothing to switch to.");
+                continue;
+            }
+            let inline = raw[1..].trim().to_string();
+            let selector = if inline.is_empty() {
+                eprintln!("\nUsers:");
+                for (i, u) in users.iter().enumerate() {
+                    eprintln!(
+                        "  {}  {}{}{}",
+                        i + 1,
+                        u.name,
+                        if u.has_passphrase { " \u{1f512}" } else { "" },
+                        if u.is_active { "  (active)" } else { "" },
+                    );
+                }
+                eprint!("switch to user # (0 to cancel): ");
+                let _ = io::stderr().flush();
+                let mut sel_line = String::new();
+                match io::stdin().lock().read_line(&mut sel_line) {
+                    Ok(0) => {
+                        eprintln!();
+                        return 0;
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        eprintln!("Read error: {}.", e);
+                        continue;
+                    }
+                }
+                sel_line.trim().to_string()
+            } else {
+                inline
+            };
+            if selector.is_empty() || selector == "0" {
+                continue;
+            }
+            // A bare number is the 1-based list position (matches the printed
+            // list); anything else resolves by name via resolve_cli_user.
+            let user = if let Ok(pos) = selector.parse::<usize>() {
+                if pos >= 1 && pos <= users.len() {
+                    users[pos - 1].clone()
+                } else {
+                    eprintln!("Index out of range (1..={}).", users.len());
+                    continue;
+                }
+            } else {
+                match resolve_cli_user(&users, &selector) {
+                    Ok(u) => u,
+                    Err(e) => {
+                        eprintln!("Selector '{}' skipped: {}", selector, e);
+                        continue;
+                    }
+                }
+            };
+            if user.is_active {
+                eprintln!("Already on user '{}'.", user.name);
+                continue;
+            }
+            let mut passphrase = if user.has_passphrase {
+                match read_user_passphrase(
+                    cli,
+                    &user.name,
+                    &format!("Account password for user '{}': ", user.name),
+                    true,
+                    true,
+                ) {
+                    Ok(value) => value,
+                    Err(e) => {
+                        eprintln!("{}", e);
+                        continue;
+                    }
+                }
+            } else {
+                None
+            };
+            let result = user_partitions::cli_unlock_user(store, user.id, passphrase.as_deref());
+            if let Some(value) = passphrase.as_mut() {
+                value.zeroize();
+            }
+            match result {
+                Ok(_) => {
+                    eprintln!("Switched to user '{}'.", user.name);
+                    match load_active_user_profiles(cli, store) {
+                        Ok(p) => {
+                            current = p;
+                            tombstones.clear();
+                            if current.is_empty() {
+                                eprintln!("(this user has no saved profiles)");
+                            } else {
+                                print_profiles_summary_with_tombstones(&current, &[]);
+                            }
+                        }
+                        Err(e) => {
+                            eprintln!("Switched, but could not load this user's profiles: {}", e);
+                        }
+                    }
+                }
+                Err(e) => {
+                    eprintln!("Switch failed: {}", e);
                 }
             }
             continue;


### PR DESCRIPTION
Wishlist #270 slice 3. Most of the slice-3 backlog was already shipped in v4.0.1 (verified against git, not the wishlist text): rclone import ordering (W14, alphabetical = rclone config order), plain-text Edit button in preview (W17, the text allowlist now covers tsv/csv/... and the preview Edit button is gated on `isSourceViewable`), import-file-before-password (W11), and the `# <sel> <N>` reorder in `profiles -i` (W13). The one genuinely-open, codeable item was the new user-switch request.

## Change
- `aeroftp-cli profiles -i`: new `u` action. Bare `u` lists the local accounts (lock marker for passphrase-protected, active marker) and prompts for a selection; `u <N|name>` switches directly. The numeric selector is the 1-based list position (what the user sees), not the database id. After a switch the profile table reloads for the new user, prompting for the account password first when required. Reuses the existing `users switch` path (cli_list_users / cli_unlock_user / read_user_passphrase). Help text and prompt hint updated.

No release attached: queued for a future tag.

## Validation
cargo clippy clean, 202/202 CLI bin tests pass.

Refs #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)