### PR TITLE
ci(portable): ship aeroftp-cli.exe + aeroftp-dispatch.exe in the Windows portable ZIP (#340)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -330,6 +330,8 @@ jobs:
       # Create portable ZIP for Windows (no installer needed).
       # Includes:
       #   - AeroFTP.exe          (the app)
+      #   - aeroftp-cli.exe      (headless CLI: providers, transfers, vault)
+      #   - aeroftp-dispatch.exe (CLI subcommand dispatcher / shim)
       #   - portable.marker      (detection key for the in-place auto-updater;
       #                          presence triggers portable-mode behaviour:
       #                          data dir next to .exe, in-place .exe swap on
@@ -346,6 +348,19 @@ jobs:
             exit 1
           }
 
+          # The CLI binaries are produced by the same `tauri build` (cargo builds
+          # every [[bin]] in the crate). Ship them inside the portable ZIP so the
+          # headless CLI is available without the installer (issue #340). Hard-fail
+          # if absent so a packaging regression can never silently drop them again.
+          $cliExe      = "src-tauri/target/release/aeroftp-cli.exe"
+          $dispatchExe = "src-tauri/target/release/aeroftp-dispatch.exe"
+          foreach ($bin in @($cliExe, $dispatchExe)) {
+            if (-not (Test-Path $bin)) {
+              Write-Host "::error::CLI binary not found at $bin"
+              exit 1
+            }
+          }
+
           $version = (Get-Content src-tauri/tauri.conf.json | ConvertFrom-Json).version
           $zipName = "AeroFTP-${version}-portable-windows-x64.zip"
           $stage = "src-tauri/target/release/bundle/portable-stage"
@@ -356,6 +371,8 @@ jobs:
           New-Item -ItemType Directory -Path $stage | Out-Null
 
           Copy-Item $exe                                              "$stage\AeroFTP.exe"
+          Copy-Item $cliExe                                           "$stage\aeroftp-cli.exe"
+          Copy-Item $dispatchExe                                      "$stage\aeroftp-dispatch.exe"
           Copy-Item "src-tauri/installer/portable/portable.marker"    "$stage\portable.marker"
           Copy-Item "src-tauri/installer/portable/README.txt"         "$stage\README.txt"
           Copy-Item "LICENSE"                                         "$stage\LICENSE.txt"

--- a/docs/CLI-GUIDE.md
+++ b/docs/CLI-GUIDE.md
@@ -48,6 +48,22 @@ aeroftp-cli --version
 aeroftp-cli --help
 ```
 
+### Windows portable ZIP
+
+The Windows portable build (`AeroFTP-<version>-portable-windows-x64.zip`, no
+installer) ships `aeroftp-cli.exe` next to `AeroFTP.exe` (since v4.0.8). It is
+not on `PATH` automatically: either call it by its full path, `cd` into the
+extracted folder, or add that folder to your `PATH`.
+
+```powershell
+# From inside the extracted portable folder
+.\aeroftp-cli.exe --version
+.\aeroftp-cli.exe --help
+```
+
+The portable CLI shares the portable `data\` folder, so the servers and vault
+you set up in the GUI are visible to the CLI and vice versa.
+
 ### Building from Source
 
 ```bash

--- a/src-tauri/installer/portable/README.txt
+++ b/src-tauri/installer/portable/README.txt
@@ -14,6 +14,21 @@ QUICK START
    folder to another machine and pick up where you left off.
 
 
+COMMAND-LINE TOOLS
+------------------
+
+This folder also ships the headless command-line tools, next to AeroFTP.exe:
+
+  - aeroftp-cli.exe       Scriptable client for every provider (FTP/SFTP/cloud),
+                          transfers, and AeroVault. Run "aeroftp-cli.exe --help".
+  - aeroftp-dispatch.exe  Subcommand dispatcher used by the CLI; you normally
+                          do not call it directly.
+
+They share the same portable "data\" folder as the app, so servers and the
+vault you set up in the GUI are visible to the CLI and vice versa. To use them
+from any prompt, add this folder to your PATH (optional).
+
+
 REQUIREMENTS
 ------------
 


### PR DESCRIPTION
## What

The Windows portable ZIP shipped only `AeroFTP.exe`, so the headless CLI was unavailable to portable users (issue #340, portable-only; installers were never affected).

`npm run tauri build` already produces the CLI binaries (cargo builds every `[[bin]]` in the crate), so this is a packaging-only fix:

- Stage `aeroftp-cli.exe` and `aeroftp-dispatch.exe` into the portable layout next to `AeroFTP.exe`.
- Hard-fail `Test-Path` guard mirroring `AeroFTP.exe`, so a packaging regression can never silently drop them again.
- Document the portable CLI in `README.txt` (portable) and in `docs/CLI-GUIDE.md` (Windows portable ZIP subsection).

## Validation

Promised fix for v4.0.8. The Windows leg of this CI run packages the portable ZIP and now fails fast if either CLI binary is missing.

Refs #340.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Command-line tools now included and distributed with the Windows portable build, sharing configuration with the GUI application.

* **Documentation**
  * Updated CLI guide with installation and usage instructions for command-line tools in portable builds.
  * Added command-line tools reference section to portable README, detailing available tools and shared data folder functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->