### PR TITLE
feat(ai): add Kilo Gateway as a native AI provider

### DIFF
--- a/src-tauri/src/ai.rs
+++ b/src-tauri/src/ai.rs
@@ -97,6 +97,7 @@ pub enum AIProviderType {
     Hyperbolic,
     Novita,
     Yi,
+    Kilo,
 }
 
 // Image attachment for vision models

--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -49508,6 +49508,7 @@ fn default_model(provider: &str) -> &'static str {
         "fireworks" => "accounts/fireworks/models/llama-v3p1-70b-instruct",
         "cerebras" => "llama-3.3-70b",
         "sambanova" => "Meta-Llama-3.1-70B-Instruct",
+        "kilo" => "kilo-auto/free",
         _ => "gpt-4o",
     }
 }
@@ -49534,6 +49535,7 @@ fn provider_type_from_name(name: &str) -> ftp_client_gui_lib::ai::AIProviderType
         "qwen" => AIProviderType::Qwen,
         "ai21" => AIProviderType::Ai21,
         "openrouter" => AIProviderType::OpenRouter,
+        "kilo" => AIProviderType::Kilo,
         _ => AIProviderType::Custom,
     }
 }
@@ -51889,6 +51891,7 @@ async fn cmd_agent(
             "deepseek" => "https://api.deepseek.com",
             "xai" => "https://api.x.ai/v1",
             "openrouter" => "https://openrouter.ai/api/v1",
+            "kilo" => "https://api.kilo.ai/api/gateway",
             "together" => "https://api.together.xyz/v1",
             "fireworks" => "https://api.fireworks.ai/inference/v1",
             "cerebras" => "https://api.cerebras.ai/v1",

--- a/src/components/AISettings/AISettingsPanel.tsx
+++ b/src/components/AISettings/AISettingsPanel.tsx
@@ -10,7 +10,7 @@ import type { PluginManifest } from '../../types/plugins';
 import { DEFAULT_MACROS } from '../DevTools/aiChatToolMacros';
 import { detectOllamaModelFamily } from '../DevTools/aiProviderProfiles';
 import { OllamaGpuMonitor } from '../DevTools/OllamaGpuMonitor';
-import { GeminiIcon, OpenAIIcon, AnthropicIcon, XAIIcon, OpenRouterIcon, OllamaIcon, KimiIcon, QwenIcon, DeepSeekIcon, MistralIcon, GroqIcon, PerplexityIcon, CohereIcon, TogetherIcon, AI21Icon, CerebrasIcon, SambaNovaIcon, FireworksIcon, NvidiaIcon, ZaiIcon, HyperbolicIcon, NovitaIcon, YiIcon } from '../DevTools/AIIcons';
+import { GeminiIcon, OpenAIIcon, AnthropicIcon, XAIIcon, OpenRouterIcon, OllamaIcon, KimiIcon, QwenIcon, DeepSeekIcon, MistralIcon, GroqIcon, PerplexityIcon, CohereIcon, TogetherIcon, AI21Icon, CerebrasIcon, SambaNovaIcon, FireworksIcon, NvidiaIcon, ZaiIcon, HyperbolicIcon, NovitaIcon, YiIcon, KiloIcon } from '../DevTools/AIIcons';
 import { AIProvider, AIModel, AISettings, AIProviderType, PROVIDER_PRESETS, DEFAULT_MODELS, generateId, getDefaultAISettings } from '../../types/ai';
 import { logger } from '../../utils/logger';
 import './AISettingsPanel.css';
@@ -75,6 +75,8 @@ const getProviderIcon = (type: AIProviderType): React.ReactNode => {
             return <NovitaIcon size={16} />;
         case 'yi':
             return <YiIcon size={16} />;
+        case 'kilo':
+            return <KiloIcon size={16} />;
         case 'custom':
             return <Server size={14} className="text-gray-400" />;
         default:

--- a/src/components/AISettings/ProviderMarketplace.tsx
+++ b/src/components/AISettings/ProviderMarketplace.tsx
@@ -15,7 +15,7 @@ import {
     OllamaIcon, KimiIcon, QwenIcon, DeepSeekIcon, MistralIcon,
     GroqIcon, PerplexityIcon, CohereIcon, TogetherIcon,
     AI21Icon, CerebrasIcon, SambaNovaIcon, FireworksIcon,
-    NvidiaIcon, ZaiIcon, HyperbolicIcon, NovitaIcon, YiIcon
+    NvidiaIcon, ZaiIcon, HyperbolicIcon, NovitaIcon, YiIcon, KiloIcon
 } from '../DevTools/AIIcons';
 
 interface ProviderMarketplaceProps {
@@ -49,6 +49,7 @@ const PROVIDER_ICON_MAP: Record<AIProviderType, React.FC<{ size?: number; classN
     hyperbolic: HyperbolicIcon,
     novita: NovitaIcon,
     yi: YiIcon,
+    kilo: KiloIcon,
     custom: OpenAIIcon,
 };
 

--- a/src/components/AISettings/providerMarketplaceData.ts
+++ b/src/components/AISettings/providerMarketplaceData.ts
@@ -248,6 +248,15 @@ export const MARKETPLACE_PROVIDERS: MarketplaceProvider[] = [
         highlight: '200+ models',
     },
     {
+        type: 'kilo',
+        name: 'Kilo (Gateway)',
+        description: 'OpenAI-compatible gateway. Free rotating models (Auto Free), plus Anthropic, OpenAI, Mistral and more.',
+        category: 'gateway',
+        features: ['streaming', 'tools', 'vision'],
+        pricingTier: 'freemium',
+        highlight: 'Free models, no credits',
+    },
+    {
         type: 'custom',
         name: 'Custom',
         description: 'Connect any OpenAI-compatible API endpoint.',

--- a/src/components/DevTools/AIChat.tsx
+++ b/src/components/DevTools/AIChat.tsx
@@ -5,7 +5,7 @@ import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react'
 import { Send, Bot, Sparkles, Mic, MicOff, ChevronDown, Trash2, MessageSquare, ImageIcon, X, ShieldAlert, AlertTriangle, FolderOpen, FileCode, Search, Archive, Terminal, Shield, RefreshCw, Brain, Eye, Key, Settings, Upload, Download, Square } from 'lucide-react';
 import { invoke } from '@tauri-apps/api/core';
 import { createTauriListener } from '../../hooks/useTauriListener';
-import { GeminiIcon, OpenAIIcon, AnthropicIcon, XAIIcon, OpenRouterIcon, OllamaIcon, KimiIcon, QwenIcon, DeepSeekIcon, MistralIcon, GroqIcon, PerplexityIcon, CohereIcon, TogetherIcon, AI21Icon, CerebrasIcon, SambaNovaIcon, FireworksIcon, NvidiaIcon, ZaiIcon, HyperbolicIcon, NovitaIcon, YiIcon } from './AIIcons';
+import { GeminiIcon, OpenAIIcon, AnthropicIcon, XAIIcon, OpenRouterIcon, OllamaIcon, KimiIcon, QwenIcon, DeepSeekIcon, MistralIcon, GroqIcon, PerplexityIcon, CohereIcon, TogetherIcon, AI21Icon, CerebrasIcon, SambaNovaIcon, FireworksIcon, NvidiaIcon, ZaiIcon, HyperbolicIcon, NovitaIcon, YiIcon, KiloIcon } from './AIIcons';
 import { AISettingsPanel } from '../AISettings';
 import { AISettings, AIProviderType } from '../../types/ai';
 import { AgentToolCall, AGENT_TOOLS, toNativeDefinitions, isSafeTool, getToolByName, getToolByNameFromAll } from '../../types/tools';
@@ -273,6 +273,7 @@ const getProviderIcon = (type: AIProviderType, size = 12): React.ReactNode => {
         case 'hyperbolic': return <HyperbolicIcon size={size} />;
         case 'novita': return <NovitaIcon size={size} />;
         case 'yi': return <YiIcon size={size} />;
+        case 'kilo': return <KiloIcon size={size} />;
         case 'custom': return <Bot size={size} className="text-gray-400" />;
         default: return <Bot size={size} />;
     }

--- a/src/components/DevTools/AIIcons.tsx
+++ b/src/components/DevTools/AIIcons.tsx
@@ -246,3 +246,11 @@ export const YiIcon: React.FC<IconProps> = ({ size = 16, className = '' }) => (
     </svg>
 );
 
+// Kilo (Kilo Gateway) - "K" monogram on a dark tile (amber #F5C518)
+export const KiloIcon: React.FC<IconProps> = ({ size = 16, className = '' }) => (
+    <svg viewBox="0 0 24 24" width={size} height={size} className={className}>
+        <rect x="2" y="2" width="20" height="20" rx="5" fill="#0B0B0B" />
+        <path d="M7.5 6h2.6v4.9L14.6 6h3.2l-5.2 6.1L18.1 18h-3.3l-3.5-5.3-1.2 1.4V18H7.5z" fill="#F5C518" />
+    </svg>
+);
+

--- a/src/components/DevTools/aiProviderProfiles.ts
+++ b/src/components/DevTools/aiProviderProfiles.ts
@@ -334,6 +334,12 @@ export const PROVIDER_PROFILES: Record<AIProviderType, ProviderPromptProfile> = 
         toolFormat: 'native',
         behaviorRules: OPENAI_BEHAVIOR_RULES,
     },
+    kilo: {
+        identity: 'You are AeroAgent, an AI file management assistant for AeroFTP powered by the Kilo Gateway. You support ' + STORAGE_PROTOCOL_COUNT + ' storage protocols with access to many open and free models behind a single endpoint.',
+        style: 'Be direct and action-oriented. Use function calls for all file operations. Keep explanations concise.',
+        toolFormat: 'native',
+        behaviorRules: OPENAI_BEHAVIOR_RULES,
+    },
     custom: {
         identity: 'You are AeroAgent, an efficient and direct AI file management assistant for AeroFTP. You support ' + STORAGE_PROTOCOL_COUNT + ' storage protocols and prioritize getting things done.',
         style: 'Be direct and action-oriented. Use function calls for all file operations: never describe what you would do, just do it. Respond with structured data when possible. Keep explanations concise.',
@@ -406,6 +412,7 @@ const PARAMETER_PRESETS: Record<AIProviderType, Record<TaskType | 'default', Par
     hyperbolic: OPENAI_PRESETS,
     novita: OPENAI_PRESETS,
     yi: OPENAI_PRESETS,
+    kilo: OPENAI_PRESETS,
     custom: OPENAI_PRESETS,
 };
 

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -3,7 +3,7 @@
 
 // AI Provider and Model Types for AeroFTP AI Agent
 
-export type AIProviderType = 'openai' | 'anthropic' | 'google' | 'xai' | 'openrouter' | 'ollama' | 'custom' | 'kimi' | 'qwen' | 'deepseek' | 'mistral' | 'groq' | 'perplexity' | 'cohere' | 'together' | 'ai21' | 'cerebras' | 'sambanova' | 'fireworks' | 'nvidia' | 'zai' | 'hyperbolic' | 'novita' | 'yi';
+export type AIProviderType = 'openai' | 'anthropic' | 'google' | 'xai' | 'openrouter' | 'ollama' | 'custom' | 'kimi' | 'qwen' | 'deepseek' | 'mistral' | 'groq' | 'perplexity' | 'cohere' | 'together' | 'ai21' | 'cerebras' | 'sambanova' | 'fireworks' | 'nvidia' | 'zai' | 'hyperbolic' | 'novita' | 'yi' | 'kilo';
 
 export interface AIProvider {
     id: string;
@@ -240,6 +240,13 @@ export const PROVIDER_PRESETS: Omit<AIProvider, 'id' | 'apiKey' | 'createdAt' | 
         isDefault: false,
     },
     {
+        name: 'Kilo (Gateway)',
+        type: 'kilo',
+        baseUrl: 'https://api.kilo.ai/api/gateway',
+        isEnabled: false,
+        isDefault: false,
+    },
+    {
         name: 'Custom',
         type: 'custom',
         baseUrl: '',
@@ -273,6 +280,7 @@ export const DEFAULT_MODELS: Record<AIProviderType, Omit<AIModel, 'id' | 'provid
     hyperbolic: [],
     novita: [],
     yi: [],
+    kilo: [],
     custom: [],
 };
 


### PR DESCRIPTION
## Summary

I added Kilo (Kilo Gateway) as a native AeroAgent provider. Kilo Gateway is an OpenAI-compatible endpoint (https://api.kilo.ai/api/gateway) that routes to many open and free models behind a single key, including the rotating "Auto Free" model (kilo-auto/free, 256K context) which needs no credits. The paid path also reaches Anthropic, OpenAI, and Mistral with a signup credit.

This gives users another genuinely free way to try AeroAgent, alongside the existing free tiers (Ollama, Cerebras, Groq, Gemini).

## Changes

Wired through the existing OpenAI-compatible dispatch path, so no new request logic was needed.

- Type and preset in `src/types/ai.ts` (plus the DEFAULT_MODELS entry).
- Marketplace entry in the Gateway category, freemium tier, in `providerMarketplaceData.ts`.
- Prompt and parameter profiles in `aiProviderProfiles.ts`.
- A `KiloIcon` and the three provider icon switches (`AISettingsPanel`, `ProviderMarketplace`, `AIChat`).
- Rust enum variant `Kilo` in `ai.rs`.
- CLI parity in `aeroftp_cli.rs`: provider name mapping, base URL, and default model (kilo-auto/free).

## Verification

Local gate green: `cargo fmt`, `tsc --noEmit`, `npm run i18n:validate` (46/46), `cargo clippy --all-features --tests` (lib and `--bin aeroftp-cli`), `cargo test --all-features` (0 failed).

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Kilo AI provider.
  * Kilo now appears as a selectable provider with its own marketplace listing and icon.
  * The app can now use Kilo’s gateway endpoint and recommended model settings.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->