### PR TITLE
fix(connection): profile edit UX, duplicate ordering, and FileLu mode tabs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6043,16 +6043,35 @@ interface UpdateVerificationInfo {
       } else {
         oauthResponse = await loadRemoteFiles(protocol);
       }
-      // Navigate to initial local directory if specified
-      if (quickConnectDirs.localDir) {
-        await changeLocalDirectory(quickConnectDirs.localDir);
+      // The saved profile is the source of truth for the tab title and the local
+      // directory when this connect is linked to one (savedServerId). An edit-mode
+      // rename or local-path change must take effect on the LIVE session, not only
+      // after a later reconnect from the saved card: the form-tab handoff carries a
+      // stale global quickConnectDirs and the generic provider name, so read the
+      // fresh values off the profile here. Unsaved connect keeps the old behaviour.
+      let oauthTabName = providerName;
+      let oauthLocalDir = quickConnectDirs.localDir;
+      if (effectiveParams.savedServerId) {
+        try {
+          const linkedProfile = (await loadSavedServerProfiles()).find(
+            (p) => p.id === effectiveParams.savedServerId,
+          );
+          if (linkedProfile) {
+            if (linkedProfile.name) oauthTabName = linkedProfile.name;
+            if (linkedProfile.localInitialPath) oauthLocalDir = linkedProfile.localInitialPath;
+          }
+        } catch { /* best-effort: keep the generic name / global dir */ }
       }
-      // Create session with provider name: pass fresh files to avoid stale closure
+      // Navigate to initial local directory if specified
+      if (oauthLocalDir) {
+        await changeLocalDirectory(oauthLocalDir);
+      }
+      // Create session: profile name titles the tab, fresh files avoid stale closure
       await createSession(
-        providerName,
+        oauthTabName,
         effectiveParams,
         oauthResponse?.current_path || '/',
-        quickConnectDirs.localDir || currentLocalPath,
+        oauthLocalDir || currentLocalPath,
         overlayHint ? [] : oauthResponse?.files
       );
       // Defer the overlay auto-unlock to the post-connect effect (inline unlock

--- a/src/components/ConnectionScreen.tsx
+++ b/src/components/ConnectionScreen.tsx
@@ -1513,6 +1513,86 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
         onConnect();
     };
 
+    // Persist a name / local-path (and remote path / icon) edit to an existing
+    // OAuth or API profile WITHOUT re-running the OAuth sign-in. The shared footer
+    // Save is hidden for OAuth providers (renderRightColumn hideSaveButton), so
+    // without this the only way to save a rename was to sign in again. Mirrors the
+    // OAuth-shaped merge in the sign-in success handler (keeps host/username from
+    // the stored profile, never clobbers them from empty connectionParams) but
+    // does not connect.
+    const handleOAuthMetadataSave = async () => {
+        if (!editingProfileId) return;
+        const existingServers = await loadSavedServerProfiles();
+        const prevProfile = existingServers.find((s) => s.id === editingProfileId);
+        if (!prevProfile) return;
+        const saveName = connectionName || prevProfile.name;
+        const overlayFields = await aeroCryptOverlayFields(
+            editingProfileId,
+            prevProfile.hasStoredAeroCryptPassword,
+            prevProfile.hasStoredAeroCryptSalt,
+            prevProfile.hasStoredAeroCryptKeyfilePath,
+        );
+        const updated = existingServers.map((s) =>
+            s.id === editingProfileId
+                ? {
+                    ...s,
+                    name: saveName || s.name,
+                    initialPath: quickConnectDirs.remoteDir || s.initialPath,
+                    localInitialPath: quickConnectDirs.localDir,
+                    customIconUrl: customIconForSave !== undefined ? customIconForSave : s.customIconUrl,
+                    ...overlayFields,
+                }
+                : s,
+        );
+        await storeSavedServerProfiles(updated).catch(() => { });
+        setSavedServersUpdate(Date.now());
+        const savedServer = updated.find((s) => s.id === editingProfileId);
+        if (savedServer) {
+            logActivity(
+                'PROFILE_SAVE',
+                `Profile updated: "${savedServer.name}"`,
+                'success',
+                `dedupKey=${getStorageDedupKey(savedServer)}`,
+            );
+        }
+        // Close the IntroHub form tab after saving (the renamed profile shows in My
+        // Servers); on the main screen there is no tab, so exit edit and confirm.
+        if (onFormSaved) {
+            onFormSaved();
+        } else {
+            handleCancelEdit();
+            setGitHubAlert({
+                title: t('common.save'),
+                message: saveName,
+                type: 'info',
+            });
+        }
+    };
+
+    // Cancel the OAuth/API edit: discard form state and close the IntroHub form
+    // tab (or just exit edit mode on the main screen). Paired with the edit-mode
+    // Save so the footer is not a lone Save button.
+    const handleOAuthCancel = () => {
+        handleCancelEdit();
+        onFormSaved?.();
+    };
+
+    // Whether the OAuth/API edit form has an unsaved change to a metadata field
+    // (name, local path, remote path, icon) relative to the stored profile. Used
+    // to keep the edit-mode Save button disabled until something actually changed.
+    // An empty connection name means "keep the stored name", so it is not a change.
+    const oauthEditHasChanges = (): boolean => {
+        if (!editingProfileId) return false;
+        const ep = servers.find((s) => s.id === editingProfileId);
+        if (!ep) return false;
+        return (
+            (connectionName || ep.name) !== ep.name ||
+            (quickConnectDirs.localDir || '') !== (ep.localInitialPath || '') ||
+            (quickConnectDirs.remoteDir || '') !== (ep.initialPath || '') ||
+            (customIconForSave !== undefined && customIconForSave !== ep.customIconUrl)
+        );
+    };
+
     const handleSaveAsNew = async () => {
         if (!protocol || !editingProfileId) return;
         // Validate name is different
@@ -2548,6 +2628,14 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
         showIconPicker?: boolean;
         showCancelSaveAsNew?: boolean;
         hideSaveButton?: boolean;
+        // When set, the footer button persists metadata via this handler instead of
+        // connecting (used to save a name / local-path edit on an OAuth profile
+        // without re-running the sign-in). The button honours the `disabled` opt so
+        // callers can gate it on a dirty check.
+        saveOverride?: () => void | Promise<void>;
+        // Paired Cancel next to a `saveOverride` Save, so the footer is not a lone
+        // Save button (closes the form tab / exits edit mode).
+        cancelOverride?: () => void;
     }) => {
         const {
             disabled: btnDisabled,
@@ -2559,6 +2647,8 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
             showIconPicker: showIcon = true,
             showCancelSaveAsNew = false,
             hideSaveButton = false,
+            saveOverride,
+            cancelOverride,
         } = opts;
         const isSourceForge = selectedProviderId === 'sourceforge';
         const sfPrefix = '/home/frs/project/';
@@ -3000,7 +3090,7 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                 {hideSaveButton ? null : modeChanged && editingProfileId ? (
                     renderModeChangedFooter()
                 ) : (
-                    <div className={showCancelSaveAsNew ? 'flex gap-2' : 'pt-2'}>
+                    <div className={(showCancelSaveAsNew || cancelOverride) ? 'flex gap-2' : 'pt-2'}>
                         {showCancelSaveAsNew && editingProfileId && (
                             <button onClick={handleCancelEdit} className="px-4 py-3 bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 font-medium rounded-lg hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors" title={t('connection.cancelEditing')}>
                                 <X size={20} />
@@ -3011,10 +3101,15 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                                 <Copy size={18} />
                             </button>
                         )}
+                        {cancelOverride && (
+                            <button onClick={cancelOverride} className="px-4 py-3 bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 font-medium rounded-lg hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors flex items-center gap-2" title={t('common.cancel')}>
+                                <X size={20} /> {t('common.cancel')}
+                            </button>
+                        )}
                         <button
-                            onClick={handleConnectAndSave}
-                            disabled={loading || btnDisabled || aeroCryptConfirmMismatch}
-                            className={`${showCancelSaveAsNew ? 'flex-1' : 'w-full'} py-3 rounded-lg font-medium text-white cursor-pointer active:scale-[0.98] transition-all flex items-center justify-center gap-2 shadow-[0_1px_3px_rgba(0,0,0,0.08)] dark:shadow-[0_1px_3px_rgba(0,0,0,0.3)] disabled:opacity-50 ${loading ? 'bg-gray-400 !cursor-not-allowed' : buttonColorClass}`}
+                            onClick={saveOverride || handleConnectAndSave}
+                            disabled={saveOverride ? (loading || btnDisabled) : (loading || btnDisabled || aeroCryptConfirmMismatch)}
+                            className={`${(showCancelSaveAsNew || cancelOverride) ? 'flex-1' : 'w-full'} py-3 rounded-lg font-medium text-white cursor-pointer active:scale-[0.98] transition-all flex items-center justify-center gap-2 shadow-[0_1px_3px_rgba(0,0,0,0.08)] dark:shadow-[0_1px_3px_rgba(0,0,0,0.3)] disabled:opacity-50 ${loading ? 'bg-gray-400 !cursor-not-allowed' : buttonColorClass}`}
                         >
                             {loading ? (
                                 <><div className="w-5 h-5 border-2 border-white/30 border-t-white rounded-full animate-spin" /> {t('connection.connecting')}</>
@@ -3423,7 +3518,18 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                                 provider={protocol as 'googledrive' | 'googlephotos' | 'dropbox' | 'onedrive' | 'box' | 'pcloud' | 'zohoworkdrive' | 'yandexdisk'}
                                 initialLocalPath={quickConnectDirs.localDir}
                                 onLocalPathChange={(path) => onQuickConnectDirsChange({ ...quickConnectDirs, localDir: path })}
-                                rightColumn={renderRightColumn({ disabled: false, buttonColorClass: '', hideSaveButton: true })}
+                                rightColumn={renderRightColumn(
+                                    editingProfileId
+                                        ? {
+                                            disabled: !oauthEditHasChanges(),
+                                            buttonColorClass: 'bg-green-600 hover:bg-green-700',
+                                            hideSaveButton: false,
+                                            saveOverride: handleOAuthMetadataSave,
+                                            cancelOverride: handleOAuthCancel,
+                                            buttonText: (<><Save size={18} /> {t('common.save')}</>),
+                                        }
+                                        : { disabled: false, buttonColorClass: '', hideSaveButton: true },
+                                )}
                                 saveConnection={saveConnection}
                                 onSaveConnectionChange={setSaveConnection}
                                 connectionName={connectionName}

--- a/src/components/IntroHub/IntroHub.tsx
+++ b/src/components/IntroHub/IntroHub.tsx
@@ -451,11 +451,15 @@ export function IntroHub(props: IntroHubProps) {
                             onQuickConnectDirsChange={(dirs) => updateFormTabDirs(activeFormTab.id, dirs)}
                             onTabLabelChange={(name) => updateFormTabLabel(activeFormTab.id, name)}
                             editingProfile={activeFormTab.editingProfile}
-                            onConnect={() => {
-                                // Pass params directly to avoid stale React state (#81)
+                            onConnect={(overrideParams) => {
+                                // Pass params directly to avoid stale React state (#81).
+                                // Forward the override ConnectionScreen hands us (it carries
+                                // savedServerId for a linked OAuth connect) so connectToFtp can
+                                // title the tab and set the local dir from the saved profile
+                                // (profile = source of truth); fall back to the form-tab params.
                                 onConnectionParamsChange(activeFormTab.connectionParams);
                                 onQuickConnectDirsChange(activeFormTab.quickConnectDirs);
-                                onConnect(activeFormTab.connectionParams);
+                                onConnect(overrideParams || activeFormTab.connectionParams);
                                 handleCloseFormTab(activeFormTab.id);
                             }}
                             onSavedServerConnect={async (params, initialPath, localInitialPath) => {

--- a/src/components/IntroHub/MyServersPanel.tsx
+++ b/src/components/IntroHub/MyServersPanel.tsx
@@ -1274,7 +1274,10 @@ export function MyServersPanel({
         dup.hasStoredFilenApiKey = copiedSecrets.filen_api_key;
         dup.hasStoredAeroCryptPassword = copiedSecrets.aerocrypt_overlay_pw;
         dup.hasStoredAeroCryptSalt = copiedSecrets.aerocrypt_overlay_salt;
-        const updated = [dup, ...servers];
+        // Append the copy at the tail, consistent with add/import and the
+        // SavedServers duplicate handler. The list has no id/order sort (array
+        // position IS the order), so prepending made the copy jump to the top.
+        const updated = [...servers, dup];
         setServers(updated);
         storeSavedServerProfiles(updated).catch(() => {});
         // Log the same two entries as an edit that overlaps an existing profile,

--- a/src/components/providerModeGroups.tsx
+++ b/src/components/providerModeGroups.tsx
@@ -104,7 +104,11 @@ export const PROVIDER_MODE_GROUPS: ProviderModeGroup[] = [
         headerLabel: 'FileLu Modes',
         modes: [
             {
-                providerId: 'filelu',
+                // Preset-less like every other group's native mode (Filen, Koofr,
+                // OpenDrive, MEGA): matched by protocol so the FILELU MODES tabs also
+                // appear when entering via the Native API discover preset (which sets
+                // no providerId). Declaring providerId:'filelu' here forced the strict
+                // providerId match, which never fired on the native entry point.
                 protocol: 'filelu',
                 icon: <Key size={14} />,
                 activeColor: 'text-sky-500',


### PR DESCRIPTION
Three connection/profile UX fixes found while testing the trash-crypt fix.

## 1. Duplicate profile ordering

The My Servers duplicate action prepended the copy, so it jumped to the top of the list, while add and import both append at the tail. The saved-servers list has no id/order field (array position is the order), so this was a pure ordering inconsistency. Duplicate now appends, consistent with add, import, and the other duplicate handler.

## 2. Save OAuth/API profile edits without re-signin, and apply them live

Editing a saved OAuth or API profile could not persist a name or local-path change without re-running the "Sign in with X" flow (the shared footer Save is hidden for OAuth). The OAuth edit form now shows a Save button (with a paired Cancel that closes the form tab) wired to a metadata-only save that mirrors the OAuth-shaped merge, so host and username are preserved. Save stays disabled until a metadata field (name, local path, remote path, icon) actually differs from the stored profile.

Separately, a freshly edited name or local path was persisted but ignored by the live session (the OAuth tab title came from the generic provider name and the local dir from global quick-connect state), so the new values only applied after a reconnect from the saved card. The saved profile is now the source of truth: when the connect is linked to a savedServerId the tab title and local dir come from that profile, and the IntroHub form-tab wrapper no longer drops the savedServerId.

## 3. FileLu Native API entry shows the mode tabs

FileLu was the only native mode declaring a providerId, so it took the strict match and never matched when entered via the Native API discover preset (no providerId): the FILELU MODES tab bar did not render, while the S3 and WebDAV entries showed it. The native mode is now preset-less like every other group's native mode (Filen, Koofr, OpenDrive, MEGA), matching by protocol, which fixes every FileLu entry point.

## Verification

tsc --noEmit is clean. All three fixes verified in the running dev app (duplicate lands at the bottom, OAuth edit Save/Cancel persist name and local path without re-signin and disable until changed, FileLu Native API opens the multi-mode form).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Saved OAuth/API profiles now reopen with the correct tab name and local folder, based on the latest saved profile details.
  * Editing an existing connected profile now supports saving only updated metadata, with clear Save/Cancel controls.

* **Bug Fixes**
  * Connect actions now use the currently edited tab values to avoid stale connection details.
  * Duplicated servers now stay in list order instead of jumping to the top.
  * The FileLu native mode is now shown more reliably in the provider tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->