### PR TITLE
fix(transfers): freeze batch delete/upload/download triggers and add a cancel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -855,6 +855,16 @@ const App: React.FC = () => {
   const remoteNavInFlightRef = useRef(false);
   const localNavInFlightRef = useRef(false);
 
+  // Batch-op freeze latch: mirrors the scanning spinner so the batch
+  // delete/upload/download triggers no-op on re-entry while an op is in flight
+  // (prevents a second click firing a duplicate op before the selection clears).
+  // Kept in sync with scanningState.active so it never sticks; the spinner's
+  // Cancel raises batchCancelledRef, the loops break, and the latch auto-clears.
+  const batchOpInFlightRef = useRef(false);
+  useEffect(() => {
+    batchOpInFlightRef.current = scanningState.active;
+  }, [scanningState.active]);
+
   // Dialogs
   const [confirmDialog, setConfirmDialog] = useState<{ message: string; onConfirm: () => void; onCancel?: () => void } | null>(null);
   const [pendingUnifiedTransferPlan, setPendingUnifiedTransferPlan] = useState<{
@@ -9614,6 +9624,7 @@ interface UpdateVerificationInfo {
   // Upload files (Selected or Dialog)
   const uploadMultipleFiles = async (filesOverride?: string[]) => {
     if (!isConnected) return;
+    if (batchOpInFlightRef.current) return; // freeze: a batch op is already in flight
 
     // Reset apply-to-all for new batch
     resetOverwriteSettings();
@@ -10175,6 +10186,7 @@ interface UpdateVerificationInfo {
   // === Bulk Operations ===
   const downloadMultipleFiles = async (filesOverride?: string[]) => {
     if (!isConnected) return;
+    if (batchOpInFlightRef.current) return; // freeze: a batch op is already in flight
     const names = filesOverride || Array.from(selectedRemoteFiles);
     if (names.length === 0) return;
 
@@ -10505,6 +10517,7 @@ interface UpdateVerificationInfo {
   };
 
   const deleteMultipleRemoteFiles = (filesOverride?: string[]) => {
+    if (batchOpInFlightRef.current) return; // freeze: a batch op is already in flight
     const names = filesOverride || Array.from(selectedRemoteFiles);
     if (names.length === 0) return;
 
@@ -10679,6 +10692,7 @@ interface UpdateVerificationInfo {
   };
 
   const deleteMultipleLocalFiles = (filesOverride?: string[], localPanelId: 'local' | 'local2' = activeLocalPanelId) => {
+    if (batchOpInFlightRef.current) return; // freeze: a batch op is already in flight
     const panel = getActiveLocalState(localPanelId);
     const names = filesOverride || Array.from(panel.selection);
     if (names.length === 0) return;
@@ -13234,7 +13248,7 @@ interface UpdateVerificationInfo {
             dialog + session inbox + its own toasts. Mounted only while the flag
             is on; unmount stops the receive loop. */}
         {aeroShareEnabled && <AeroShareHub />}
-        <ScanningToast state={scanningState} t={t} />
+        <ScanningToast state={scanningState} t={t} onCancel={() => { batchCancelledRef.current = true; }} />
         <FontSizeIndicator indicator={fontSizeIndicator} />
 
         {/* Update Available Toast with inline download */}
@@ -14935,8 +14949,8 @@ interface UpdateVerificationInfo {
                   {isConnected && showRemotePanel && (
                     <button
                       onClick={() => activePanel === 'local' ? uploadMultipleFiles() : downloadMultipleFiles()}
-                      disabled={(activePanel === 'local' ? selectedLocalFiles.size : selectedRemoteFiles.size) === 0}
-                      className={`relative px-3 py-1.5 rounded-lg text-sm flex items-center gap-1.5 transition-all ${(activePanel === 'local' ? selectedLocalFiles.size : selectedRemoteFiles.size) > 0
+                      disabled={(activePanel === 'local' ? selectedLocalFiles.size : selectedRemoteFiles.size) === 0 || scanningState.active}
+                      className={`relative px-3 py-1.5 rounded-lg text-sm flex items-center gap-1.5 transition-all ${(activePanel === 'local' ? selectedLocalFiles.size : selectedRemoteFiles.size) > 0 && !scanningState.active
                         ? 'bg-green-500 hover:bg-green-600 text-white shadow-sm hover:shadow-md'
                         : 'bg-gray-200 dark:bg-gray-600 text-gray-400 dark:text-gray-500 cursor-not-allowed'
                         }`}
@@ -14963,8 +14977,8 @@ interface UpdateVerificationInfo {
                         deleteMultipleLocalFiles(Array.from(selectedLocalFiles));
                       }
                     }}
-                    disabled={(activePanel === 'remote' ? selectedRemoteFiles.size : selectedLocalFiles.size) === 0}
-                    className={`relative px-3 py-1.5 rounded-lg text-sm flex items-center gap-1.5 transition-all ${(activePanel === 'remote' ? selectedRemoteFiles.size : selectedLocalFiles.size) > 0
+                    disabled={(activePanel === 'remote' ? selectedRemoteFiles.size : selectedLocalFiles.size) === 0 || scanningState.active}
+                    className={`relative px-3 py-1.5 rounded-lg text-sm flex items-center gap-1.5 transition-all ${(activePanel === 'remote' ? selectedRemoteFiles.size : selectedLocalFiles.size) > 0 && !scanningState.active
                       ? 'bg-red-500 hover:bg-red-600 text-white shadow-sm hover:shadow-md'
                       : 'bg-gray-200 dark:bg-gray-600 text-gray-400 dark:text-gray-500 cursor-not-allowed'
                       }`}

--- a/src/components/ScanningToast.tsx
+++ b/src/components/ScanningToast.tsx
@@ -20,6 +20,9 @@ const INITIAL_STATE: ScanningState = {
 interface ScanningToastProps {
   state: ScanningState;
   t: (key: string, params?: Record<string, string | number>) => string;
+  // When provided, renders a Cancel button so an operation stalled on an
+  // external/network problem never traps the user behind the spinner.
+  onCancel?: () => void;
 }
 
 const operationIcons: Record<string, string> = {
@@ -28,7 +31,7 @@ const operationIcons: Record<string, string> = {
   upload: 'M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12',
 };
 
-export const ScanningToast: React.FC<ScanningToastProps> = React.memo(({ state, t }) => {
+export const ScanningToast: React.FC<ScanningToastProps> = React.memo(({ state, t, onCancel }) => {
   if (!state.active) return null;
 
   const iconPath = operationIcons[state.operation] || operationIcons.download;
@@ -73,6 +76,16 @@ export const ScanningToast: React.FC<ScanningToastProps> = React.memo(({ state, 
             {state.message || t('scanning.preparing')}
           </p>
         </div>
+
+        {/* Cancel: aborts the in-flight batch op so an external stall never traps the user */}
+        {onCancel && (
+          <button
+            onClick={onCancel}
+            className="flex-shrink-0 px-2.5 py-1 rounded-md text-xs font-medium border border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+          >
+            {t('common.cancel')}
+          </button>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

The batch delete, upload, and download triggers were gated only on selection size, and the selection is cleared only after the operation completes, so a second click while an operation was in flight re-fired a duplicate operation. The pre-op scanning toast is `pointer-events-none`, so it did not block the toolbar underneath either.

This generalizes the freeze+cancel principle already applied to directory navigation (#401) to the batch operations, the last uncovered surface:

- A `batchOpInFlightRef` latch mirrors `scanningState.active` and makes the four batch handlers (`uploadMultipleFiles`, `downloadMultipleFiles`, `deleteMultipleRemoteFiles`, `deleteMultipleLocalFiles`) no-op on re-entry. One latch covers the toolbar buttons, keyboard shortcuts, and context-menu entries at once.
- The Upload/Download and Delete toolbar buttons also disable and grey out while an operation is in flight, for the visual cue.
- `ScanningToast` now renders an optional Cancel button that raises `batchCancelledRef`, the signal every batch loop already checks to break early, so an external stall never traps the user behind the frozen state.

The latch is derived from `scanningState.active`, so it never sticks: when the loop breaks and the spinner clears, the freeze releases.

## Testing

- `npx tsc --noEmit`: 0 errors.

Owner-found (surfaced during the #401 discussion); no external co-author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate batch actions while scanning or other bulk activity is already in progress.
  * Improved the cancel behavior for scanning-related toasts so cancel actions now properly stop the current operation state.
  * Disabled bulk action buttons during active scanning to reduce accidental repeated triggers.
* **New Features**
  * Added an optional Cancel button to the scanning status message when supported by the active workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->