### PR TITLE
AeroCrypt overlay Remote Path (#369) + profile export/import completeness (v4.1.4)

### DIFF
--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -2635,6 +2635,34 @@ enum Commands {
         /// Mutually exclusive with --credential-json and --password-stdin.
         #[arg(long, value_name = "PATH")]
         credential_json_file: Option<String>,
+        /// HTTP base URL used to build share links for this profile (the GUI's
+        /// "Public URL base", e.g. `https://www.example.com/`). Top-level
+        /// profile field; without it share links must be re-entered after an
+        /// import.
+        #[arg(long, value_name = "URL")]
+        public_url_base: Option<String>,
+        /// User-chosen custom icon for the My Servers card, as a data URL
+        /// (`data:image/png;base64,...`). Top-level profile field mirroring the
+        /// GUI Edit modal icon picker.
+        #[arg(long, value_name = "DATA_URL")]
+        custom_icon_url: Option<String>,
+        /// Auto-detected project favicon, as a data URL. Top-level profile field
+        /// (normally set by the GUI on connect); exposed here for CLI-driven
+        /// test fixtures.
+        #[arg(long, value_name = "DATA_URL")]
+        favicon_url: Option<String>,
+        /// Suppress the classic-fallback (delta-eligibility) modal for this
+        /// saved server, matching the GUI checkbox. Top-level profile
+        /// preference.
+        #[arg(long)]
+        skip_delta_eligibility_prompt: bool,
+        /// Filen CLI API key (issue #230). Stored in the vault under
+        /// `filen_api_key_<id>` (NOT on the saved profile) and flags
+        /// `hasStoredFilenApiKey`, exactly like the GUI Edit modal, so the
+        /// profile connects via the key and skips the /v3/login + TOTP window.
+        /// Only valid for `--protocol filen`. Inline value is visible in `ps`.
+        #[arg(long, value_name = "KEY")]
+        filen_api_key: Option<String>,
     },
     /// Duplicate a saved server profile inside the vault
     ///
@@ -19725,6 +19753,11 @@ fn cmd_profile_add(
     password_stdin: bool,
     credential_json: Option<&str>,
     credential_json_file: Option<&str>,
+    public_url_base: Option<&str>,
+    custom_icon_url: Option<&str>,
+    favicon_url: Option<&str>,
+    skip_delta_eligibility_prompt: bool,
+    filen_api_key: Option<&str>,
 ) -> i32 {
     let trimmed_name = name.trim();
     if trimmed_name.is_empty() {
@@ -19791,6 +19824,18 @@ fn cmd_profile_add(
         );
         return 5;
     }
+    // Issue #230: the Filen CLI API key is a Filen-only credential. Reject it on
+    // any other protocol so a mistyped profile does not silently carry a dead
+    // vault entry.
+    let filen_api_key = filen_api_key.map(|k| k.trim()).filter(|k| !k.is_empty());
+    if filen_api_key.is_some() && proto_lower != "filen" {
+        print_error(
+            format,
+            "--filen-api-key is only valid for --protocol filen",
+            5,
+        );
+        return 5;
+    }
     let manual_total_bytes = match manual_total {
         Some(s) => match parse_manual_total_size(s) {
             Ok(b) if b > 0 => Some(b),
@@ -19848,6 +19893,11 @@ fn cmd_profile_add(
         color,
         provider_id,
         manual_total_bytes,
+        public_url_base,
+        custom_icon_url,
+        favicon_url,
+        skip_delta_eligibility_prompt,
+        filen_api_key.is_some(),
     ) {
         Ok(id) => id,
         Err(e) => {
@@ -19883,6 +19933,28 @@ fn cmd_profile_add(
         }
     }
 
+    // Issue #230: seed the Filen CLI API key into its own vault slot
+    // (`filen_api_key_<id>`), exactly where the GUI Edit modal writes it and
+    // where `collect_provider_secrets_for_server` reads it for the profile
+    // export. Same hard-error contract as the main credential.
+    let seeded_filen_api_key = filen_api_key.is_some();
+    if let Some(key) = filen_api_key {
+        let vault_key = format!("filen_api_key_{}", new_id);
+        if let Err(e) = ftp_client_gui_lib::user_partitions::store_active_credential_dual(
+            &store, &vault_key, key,
+        ) {
+            print_error(
+                format,
+                &format!(
+                    "Profile '{}' created (id={}) but Filen API key write failed: {}",
+                    trimmed_name, new_id, e
+                ),
+                5,
+            );
+            return 5;
+        }
+    }
+
     match format {
         OutputFormat::Json => {
             let out = serde_json::json!({
@@ -19891,6 +19963,7 @@ fn cmd_profile_add(
                 "protocol": proto_lower,
                 "port": resolved_port,
                 "credential_seeded": seeded_credential,
+                "filen_api_key_seeded": seeded_filen_api_key,
             });
             println!("{}", serde_json::to_string_pretty(&out).unwrap_or_default());
         }
@@ -19934,6 +20007,11 @@ fn persist_new_profile_entry(
     color: Option<&str>,
     provider_id: Option<&str>,
     manual_total_bytes: Option<u64>,
+    public_url_base: Option<&str>,
+    custom_icon_url: Option<&str>,
+    favicon_url: Option<&str>,
+    skip_delta_eligibility_prompt: bool,
+    has_filen_api_key: bool,
 ) -> Result<String, String> {
     let mut profiles: Vec<serde_json::Value> = match load_active_user_profiles(cli, store) {
         Ok(p) => p,
@@ -19967,13 +20045,19 @@ fn persist_new_profile_entry(
         "protocol".into(),
         serde_json::Value::String(protocol.to_string()),
     );
-    if let Some(h) = host {
-        entry.insert("host".into(), serde_json::Value::String(h.to_string()));
-    }
+    // Always write `host` and `username` (empty string when not provided).
+    // The GUI stores them unconditionally and `ServerProfileExport` requires
+    // both as non-optional strings, so omitting them made a cloud profile
+    // (no host/user) fail `profile-export` with "missing field `host`".
+    entry.insert(
+        "host".into(),
+        serde_json::Value::String(host.unwrap_or("").to_string()),
+    );
     entry.insert("port".into(), serde_json::json!(port));
-    if let Some(u) = username {
-        entry.insert("username".into(), serde_json::Value::String(u.to_string()));
-    }
+    entry.insert(
+        "username".into(),
+        serde_json::Value::String(username.unwrap_or("").to_string()),
+    );
     entry.insert(
         "initialPath".into(),
         serde_json::Value::String(initial_path.to_string()),
@@ -19997,6 +20081,36 @@ fn persist_new_profile_entry(
         let mut options = serde_json::Map::new();
         options.insert("manualTotalBytes".into(), serde_json::json!(mtb));
         entry.insert("options".into(), serde_json::Value::Object(options));
+    }
+    // Top-level ServerProfile fields (outside `options`) that the GUI Edit modal
+    // sets; carried here so a CLI-created profile is a faithful fixture and its
+    // `.aeroftp` export/import round-trips them (v4.1.4 export audit GAP 2/3/4).
+    if let Some(u) = public_url_base {
+        entry.insert(
+            "publicUrlBase".into(),
+            serde_json::Value::String(u.to_string()),
+        );
+    }
+    if let Some(u) = custom_icon_url {
+        entry.insert(
+            "customIconUrl".into(),
+            serde_json::Value::String(u.to_string()),
+        );
+    }
+    if let Some(u) = favicon_url {
+        entry.insert(
+            "faviconUrl".into(),
+            serde_json::Value::String(u.to_string()),
+        );
+    }
+    if skip_delta_eligibility_prompt {
+        entry.insert("skipDeltaEligibilityPrompt".into(), serde_json::json!(true));
+    }
+    // Issue #230: mirror the GUI flag so the My Servers card and the export know
+    // a Filen CLI API key lives in the vault under `filen_api_key_<id>` (the key
+    // itself is written separately by the caller, never onto the profile).
+    if has_filen_api_key {
+        entry.insert("hasStoredFilenApiKey".into(), serde_json::json!(true));
     }
 
     profiles.insert(0, serde_json::Value::Object(entry));
@@ -20254,6 +20368,11 @@ fn interactive_new_profile(
         None,
         provider_id.as_deref(),
         None,
+        None,
+        None,
+        None,
+        false,
+        false,
     )?;
     eprintln!(
         "{}",
@@ -59499,6 +59618,11 @@ async fn main() {
             manual_total,
             credential_json,
             credential_json_file,
+            public_url_base,
+            custom_icon_url,
+            favicon_url,
+            skip_delta_eligibility_prompt,
+            filen_api_key,
         } => cmd_profile_add(
             &cli,
             format,
@@ -59515,6 +59639,11 @@ async fn main() {
             cli.password_stdin,
             credential_json.as_deref(),
             credential_json_file.as_deref(),
+            public_url_base.as_deref(),
+            custom_icon_url.as_deref(),
+            favicon_url.as_deref(),
+            *skip_delta_eligibility_prompt,
+            filen_api_key.as_deref(),
         ),
         Commands::ProfileDuplicate {
             selector,

--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -4489,7 +4489,32 @@ enum CryptCommands {
         /// omitting it prints the kit and requires an explicit YES acknowledgement before init succeeds.
         #[arg(long)]
         emergency_kit: Option<String>,
+        /// Do NOT bind the overlay to the saved profile. By default, `crypt init
+        /// --profile X` binds X so the whole app (CLI ls/get/sync, MCP, GUI)
+        /// transparently decrypts it on connect; --no-bind keeps X plain and
+        /// leaves the overlay reachable only via the standalone `crypt` commands.
+        #[arg(long)]
+        no_bind: bool,
     },
+    /// Bind an existing crypt overlay to a saved profile so the whole app
+    /// (CLI ls/get/sync, MCP, GUI) transparently decrypts it on connect.
+    Bind {
+        /// Remote encrypted directory the overlay covers (the scope). Defaults
+        /// to the profile's initial path.
+        #[arg(default_value = "/")]
+        path: String,
+        /// Overlay password to store for transparent unlock (or set
+        /// AEROFTP_CRYPT_PASSWORD). Omit for a keyfile-only vault.
+        #[arg(long, env = "AEROFTP_CRYPT_PASSWORD", hide_env_values = true)]
+        password: Option<String>,
+        /// Keyfile path to store for transparent unlock (keyfile vaults only).
+        #[arg(long)]
+        keyfile: Option<String>,
+    },
+    /// Remove the crypt-overlay binding from a saved profile (the overlay
+    /// itself and its remote data are untouched; standalone `crypt` commands
+    /// keep working).
+    Unbind,
     /// Convert a headed vault to local-metadata headerless mode
     ToHeaderless {
         /// Server URL (omit when using --profile)
@@ -24231,17 +24256,33 @@ async fn create_and_connect(
     cli: &Cli,
     format: OutputFormat,
 ) -> Result<(Box<dyn StorageProvider>, String), i32> {
-    create_and_connect_with(url, cli, cli.profile.as_deref(), format).await
+    create_and_connect_with(url, cli, cli.profile.as_deref(), format, true).await
+}
+
+/// Connect WITHOUT applying a bound profile's transparent crypt overlay. The
+/// standalone `crypt` subcommands (init/ls/put/get + the migrations) are the
+/// crypt layer themselves, so wrapping them in the bound overlay would
+/// double-encrypt (F4). They always drive the raw provider and manage the
+/// encryption explicitly with the password/keyfile passed on the command line.
+async fn create_and_connect_raw(
+    url: &str,
+    cli: &Cli,
+    format: OutputFormat,
+) -> Result<(Box<dyn StorageProvider>, String), i32> {
+    create_and_connect_with(url, cli, cli.profile.as_deref(), format, false).await
 }
 
 /// Like `create_and_connect` but with an explicit profile-name override instead
 /// of relying on the global `--profile`. Used by multi-profile benchmark
 /// compare, which connects each profile by name while `--profile` stays unset.
+/// `apply_overlay` wraps a bound profile in its transparent crypt overlay; the
+/// standalone `crypt` commands pass `false` so they see the raw ciphertext.
 async fn create_and_connect_with(
     url: &str,
     cli: &Cli,
     profile_override: Option<&str>,
     format: OutputFormat,
+    apply_overlay: bool,
 ) -> Result<(Box<dyn StorageProvider>, String), i32> {
     // Check if the selected profile points to an OAuth provider - handle separately
     // Uses the same strict matching as profile_to_provider_config (exact → ID → disambiguated substring)
@@ -24329,9 +24370,15 @@ async fn create_and_connect_with(
                                 apply_google_drive_runtime_knobs(&mut p, cli);
                                 // Crypt-overlay chokepoint: an OAuth backend can
                                 // carry a crypt binding too (overlay is
-                                // protocol-agnostic). Wrap before returning.
-                                let p = cli_apply_crypt_overlay(p, cli, profile_override, format)
-                                    .await?;
+                                // protocol-agnostic). Wrap before returning
+                                // unless the caller wants the raw provider (the
+                                // standalone `crypt` commands, F4).
+                                let p = if apply_overlay {
+                                    cli_apply_crypt_overlay(p, cli, profile_override, format)
+                                        .await?
+                                } else {
+                                    p
+                                };
                                 return Ok((p, path));
                             } else {
                                 return result;
@@ -24481,7 +24528,13 @@ async fn create_and_connect_with(
     // applied to the inner provider before wrapping; the decorator advertises
     // the byte-inexact surfaces (resume/multipart/range/checksum) as disabled so
     // callers fall back to whole-file paths. Fail-closed on a bound profile.
-    let provider = cli_apply_crypt_overlay(provider, cli, profile_override, format).await?;
+    // Skipped (raw provider) for the standalone `crypt` commands, which are the
+    // crypt layer themselves and would otherwise double-encrypt (F4).
+    let provider = if apply_overlay {
+        cli_apply_crypt_overlay(provider, cli, profile_override, format).await?
+    } else {
+        provider
+    };
 
     Ok((provider, path))
 }
@@ -38388,7 +38441,7 @@ async fn cmd_benchmark(
     // the global --profile (which stays unset across the whole compare run).
     let profile_for_connect = compare_label.or(cli.profile.as_deref());
     let (mut provider, initial_path) =
-        match create_and_connect_with("_", cli, profile_for_connect, format).await {
+        match create_and_connect_with("_", cli, profile_for_connect, format, true).await {
             Ok(v) => v,
             Err(code) => return code,
         };
@@ -46353,7 +46406,7 @@ async fn cmd_crypt_to_headerless(
         Ok(target) => target,
         Err(code) => return code,
     };
-    let (mut provider, initial_path) = match create_and_connect(url, cli, format).await {
+    let (mut provider, initial_path) = match create_and_connect_raw(url, cli, format).await {
         Ok(provider) => provider,
         Err(code) => return code,
     };
@@ -46509,7 +46562,7 @@ async fn cmd_crypt_to_headed(
         Ok(target) => target,
         Err(code) => return code,
     };
-    let (mut provider, initial_path) = match create_and_connect(url, cli, format).await {
+    let (mut provider, initial_path) = match create_and_connect_raw(url, cli, format).await {
         Ok(provider) => provider,
         Err(code) => return code,
     };
@@ -46713,6 +46766,246 @@ fn handle_emergency_kit_emission(
     }
 }
 
+/// Validate an overlay scope against the profile Remote Path (#369): the scope
+/// must EQUAL the Remote Path or be a strict DESCENDANT of it. A blank scope is
+/// valid (it means "same as the Remote Path"). When the Remote Path is the root
+/// (`/`), any folder is a descendant. Rejects ancestors (scope `/` under a
+/// subfolder Remote Path), siblings, the `/database` vs `/data` prefix trap, and
+/// unrelated paths. Mirrors the GUI's `isValidOverlayScope` in overlayScope.ts.
+fn is_valid_overlay_scope(scope: &str, remote_path: &str) -> bool {
+    if scope.trim().is_empty() {
+        return true;
+    }
+    let r = normalize_remote_path(remote_path);
+    if r == "/" {
+        return true; // remote path is the root: any folder is a descendant
+    }
+    let s = normalize_remote_path(scope);
+    if s == "/" {
+        return false; // scope is "/" but the remote path is a subfolder: ancestor
+    }
+    s == r || s.starts_with(&format!("{}/", r))
+}
+
+/// Read a saved profile's `initialPath` (the GUI's remote landing path), used
+/// as the default overlay scope for `crypt bind` when no path is given.
+fn profile_initial_path(cli: &Cli, store: &CredentialStore, profile_id: &str) -> Option<String> {
+    let profiles = load_active_user_profiles(cli, store).ok()?;
+    profiles
+        .iter()
+        .find(|p| p.get("id").and_then(|v| v.as_str()) == Some(profile_id))
+        .and_then(|p| p.get("initialPath").and_then(|v| v.as_str()))
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+}
+
+/// Bind a native AeroCrypt overlay to a saved profile so the whole app (the CLI
+/// transparent chokepoint `cli_apply_crypt_overlay`, the MCP pool resolver, the
+/// GUI file panel, sync) auto-decrypts it on connect. Writes the profile's
+/// `aeroCryptOverlay` JSON and stores the per-profile overlay password (+ keyfile
+/// path when supplied). Idempotent: re-binding overwrites the previous binding.
+fn bind_crypt_overlay_to_profile(
+    cli: &Cli,
+    store: &CredentialStore,
+    uid: Option<i64>,
+    profile_id: &str,
+    remote_scope: &str,
+    password: &str,
+    keyfile_path: Option<&str>,
+) -> Result<(), String> {
+    let binding = serde_json::json!({
+        "enabled": true,
+        "kind": "aerocrypt",
+        "remoteScope": remote_scope,
+        "filenameEncryption": "standard",
+        "directoryNameEncryption": true,
+    });
+    update_profile_field_in_vault(cli, store, profile_id, "aeroCryptOverlay", binding)?;
+    if !password.is_empty() {
+        dual_store_server_cred(
+            store,
+            uid,
+            &format!("aerocrypt_overlay_pw_{}", profile_id),
+            password,
+        );
+    }
+    if let Some(path) = keyfile_path.filter(|p| !p.is_empty()) {
+        dual_store_server_cred(
+            store,
+            uid,
+            &format!("aerocrypt_overlay_keyfile_path_{}", profile_id),
+            path,
+        );
+    }
+    Ok(())
+}
+
+/// Best-effort bind after a successful `crypt init --profile` (non-fatal: the
+/// overlay was already created, so a binding hiccup must not fail the whole
+/// init). Prints a one-line confirmation on success, a warning on failure.
+#[allow(clippy::too_many_arguments)]
+fn bind_after_init(
+    cli: &Cli,
+    format: OutputFormat,
+    store: &CredentialStore,
+    uid: Option<i64>,
+    profile_id: &str,
+    remote_scope: &str,
+    password: &str,
+    keyfile_path: Option<&str>,
+) {
+    match bind_crypt_overlay_to_profile(
+        cli,
+        store,
+        uid,
+        profile_id,
+        remote_scope,
+        password,
+        keyfile_path,
+    ) {
+        Ok(()) => {
+            if !cli.quiet && !matches!(format, OutputFormat::Json) {
+                println!(
+                    "Bound overlay to profile (transparent decrypt on connect; use --raw to bypass, 'crypt unbind' to remove)"
+                );
+            }
+        }
+        Err(e) => {
+            eprintln!("Warning: overlay created but profile binding failed: {e}");
+        }
+    }
+}
+
+/// `crypt bind`: attach an existing overlay to a saved profile.
+async fn cmd_crypt_bind(
+    path: &str,
+    password: &str,
+    keyfile_path: Option<&str>,
+    cli: &Cli,
+    format: OutputFormat,
+) -> i32 {
+    let profile_query = match cli.profile.as_deref() {
+        Some(p) => p,
+        None => {
+            print_error(
+                format,
+                "crypt bind requires a saved profile: pass --profile <name-or-index>.",
+                5,
+            );
+            return 5;
+        }
+    };
+    let store = match open_vault(cli) {
+        Ok(s) => s,
+        Err(e) => {
+            print_error(format, &e, 5);
+            return 5;
+        }
+    };
+    let profile_id = match resolve_profile_id_for_query(cli, &store, profile_query, format) {
+        Ok(id) => id,
+        Err(code) => return code,
+    };
+    let uid = scoped_credential_user_id(cli, &store);
+    let remote_path =
+        profile_initial_path(cli, &store, &profile_id).unwrap_or_else(|| "/".to_string());
+    // Resolve the scope: an explicit non-root path wins, else the profile's
+    // Remote Path, else "/".
+    let scope = if path != "/" && !path.is_empty() {
+        path.to_string()
+    } else {
+        remote_path.clone()
+    };
+    // #369: the overlay scope must equal the profile Remote Path or be a strict
+    // descendant of it. Pinning the anchor above the vault (an ancestor) or to a
+    // sibling produces the empty-listing misconfiguration; reject it up front.
+    if !is_valid_overlay_scope(&scope, &remote_path) {
+        print_error(
+            format,
+            &format!(
+                "Overlay scope {:?} must be the profile Remote Path {:?} or a folder inside it.",
+                scope, remote_path
+            ),
+            5,
+        );
+        return 5;
+    }
+    let scope = normalize_remote_path(&scope);
+    if let Err(e) = bind_crypt_overlay_to_profile(
+        cli,
+        &store,
+        uid,
+        &profile_id,
+        scope.trim_end_matches('/'),
+        password,
+        keyfile_path,
+    ) {
+        print_error(format, &format!("Failed to bind overlay: {}", e), 5);
+        return 5;
+    }
+    if matches!(format, OutputFormat::Json) {
+        print_json(&serde_json::json!({
+            "status": "ok",
+            "bound": true,
+            "profile": profile_query,
+            "remoteScope": scope,
+        }));
+    } else if !cli.quiet {
+        println!(
+            "Bound crypt overlay to profile '{}' at {} (transparent decrypt on connect; use --raw to bypass).",
+            profile_query, scope
+        );
+    }
+    0
+}
+
+/// `crypt unbind`: remove the overlay binding from a saved profile. The remote
+/// data and the keystore config are left intact so standalone `crypt` commands
+/// and a later re-bind keep working.
+async fn cmd_crypt_unbind(cli: &Cli, format: OutputFormat) -> i32 {
+    let profile_query = match cli.profile.as_deref() {
+        Some(p) => p,
+        None => {
+            print_error(
+                format,
+                "crypt unbind requires a saved profile: pass --profile <name-or-index>.",
+                5,
+            );
+            return 5;
+        }
+    };
+    let store = match open_vault(cli) {
+        Ok(s) => s,
+        Err(e) => {
+            print_error(format, &e, 5);
+            return 5;
+        }
+    };
+    let profile_id = match resolve_profile_id_for_query(cli, &store, profile_query, format) {
+        Ok(id) => id,
+        Err(code) => return code,
+    };
+    if let Err(e) = update_profile_field_in_vault(
+        cli,
+        &store,
+        &profile_id,
+        "aeroCryptOverlay",
+        serde_json::Value::Null,
+    ) {
+        print_error(format, &format!("Failed to unbind overlay: {}", e), 5);
+        return 5;
+    }
+    if matches!(format, OutputFormat::Json) {
+        print_json(&serde_json::json!({"status": "ok", "bound": false, "profile": profile_query}));
+    } else if !cli.quiet {
+        println!(
+            "Removed crypt-overlay binding from profile '{}' (remote data and keystore config untouched).",
+            profile_query
+        );
+    }
+    0
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn cmd_crypt_init(
     url: &str,
@@ -46722,6 +47015,8 @@ async fn cmd_crypt_init(
     with_header: bool,
     force: bool,
     emergency_kit: Option<&str>,
+    no_bind: bool,
+    keyfile_path: Option<&str>,
     cli: &Cli,
     format: OutputFormat,
 ) -> i32 {
@@ -46768,13 +47063,28 @@ async fn cmd_crypt_init(
         }
     };
 
-    let (mut provider, initial_path) = match create_and_connect(url, cli, format).await {
+    let (mut provider, initial_path) = match create_and_connect_raw(url, cli, format).await {
         Ok(v) => v,
         Err(code) => return code,
     };
 
     let base_path = normalize_remote_path(&resolve_cli_remote_path(&initial_path, path));
     let config_path = format!("{}/.aeroftp-crypt.json", base_path.trim_end_matches('/'));
+
+    // Ensure the remote scope directory exists so `crypt init /a/b/c` prepares
+    // the vault immediately: the headed marker upload writes into it, and the
+    // first headerless `crypt put` expects it to be there. Best-effort, one
+    // component at a time (mkdir on an existing dir is ignored); a genuine
+    // failure still surfaces at the marker upload (headed) or first put.
+    {
+        let scope = base_path.trim_end_matches('/');
+        let mut acc = String::new();
+        for part in scope.split('/').filter(|s| !s.is_empty()) {
+            acc.push('/');
+            acc.push_str(part);
+            let _ = provider.mkdir(&acc).await;
+        }
+    }
 
     if !with_header {
         let (store, uid, profile_id) = headerless_target.expect("resolved above");
@@ -46854,12 +47164,28 @@ async fn cmd_crypt_init(
                     return 5;
                 }
 
+                // Bind the profile by default so the whole app decrypts it
+                // transparently on connect (--no-bind opts out). Non-fatal.
+                if !no_bind {
+                    bind_after_init(
+                        cli,
+                        format,
+                        &store,
+                        uid,
+                        &profile_id,
+                        base_path.trim_end_matches('/'),
+                        password,
+                        keyfile_path,
+                    );
+                }
+
                 if matches!(format, OutputFormat::Json) {
                     print_json(&serde_json::json!({
                         "status": "ok",
                         "path": base_path,
                         "headerless": true,
                         "config_key": config_key,
+                        "bound": !no_bind,
                     }));
                 } else if !cli.quiet {
                     println!("Crypt overlay initialized at {}", base_path);
@@ -46968,8 +47294,43 @@ async fn cmd_crypt_init(
                 return 5;
             }
 
+            // Bind the profile by default so the whole app decrypts it
+            // transparently on connect (--no-bind opts out; URL mode has no
+            // profile to bind). Non-fatal: the headed marker already exists.
+            let mut bound = false;
+            if !no_bind {
+                if let Some(profile_q) = cli.profile.as_deref() {
+                    match open_vault(cli) {
+                        Ok(store) => {
+                            match resolve_profile_id_for_query(cli, &store, profile_q, format) {
+                                Ok(pid) => {
+                                    let uid = scoped_credential_user_id(cli, &store);
+                                    bind_after_init(
+                                        cli,
+                                        format,
+                                        &store,
+                                        uid,
+                                        &pid,
+                                        base_path.trim_end_matches('/'),
+                                        password,
+                                        keyfile_path,
+                                    );
+                                    bound = true;
+                                }
+                                Err(_) => { /* error already printed; leave unbound */ }
+                            }
+                        }
+                        Err(e) => {
+                            eprintln!("Warning: cannot open vault to bind profile: {e}");
+                        }
+                    }
+                }
+            }
+
             if matches!(format, OutputFormat::Json) {
-                print_json(&serde_json::json!({"status": "ok", "path": config_path}));
+                print_json(
+                    &serde_json::json!({"status": "ok", "path": config_path, "bound": bound}),
+                );
             } else if !cli.quiet {
                 println!("Crypt overlay initialized at {}", base_path);
                 println!("Config: {}", config_path);
@@ -47019,7 +47380,7 @@ async fn cmd_crypt_ls(
     format: OutputFormat,
 ) -> i32 {
     use ftp_client_gui_lib::aerocrypt::{names, overlay};
-    let (mut provider, initial_path) = match create_and_connect(url, cli, format).await {
+    let (mut provider, initial_path) = match create_and_connect_raw(url, cli, format).await {
         Ok(v) => v,
         Err(code) => return code,
     };
@@ -47216,7 +47577,7 @@ async fn cmd_crypt_put(
     format: OutputFormat,
 ) -> i32 {
     use ftp_client_gui_lib::aerocrypt::{names, overlay};
-    let (mut provider, initial_path) = match create_and_connect(url, cli, format).await {
+    let (mut provider, initial_path) = match create_and_connect_raw(url, cli, format).await {
         Ok(v) => v,
         Err(code) => return code,
     };
@@ -47556,7 +47917,7 @@ async fn cmd_crypt_get(
     format: OutputFormat,
 ) -> i32 {
     use ftp_client_gui_lib::aerocrypt::{names, overlay};
-    let (mut provider, initial_path) = match create_and_connect(url, cli, format).await {
+    let (mut provider, initial_path) = match create_and_connect_raw(url, cli, format).await {
         Ok(v) => v,
         Err(code) => return code,
     };
@@ -47786,14 +48147,39 @@ async fn cmd_crypt_get(
         }
     };
 
+    // The decrypted original basename, used when the destination is omitted or
+    // is a directory (so `crypt get secret.txt <dir>/` lands as `<dir>/secret.txt`).
+    let enc_basename = remote_file.rsplit('/').next().unwrap_or("decrypted");
+    let decrypted_basename = names::decrypt_filename(&master_key, enc_basename)
+        .unwrap_or_else(|| "decrypted".to_string());
+
     // Write to local file
     let dest = if local_dest.is_empty() || local_dest == "." {
-        // Use decrypted original filename
-        let enc_basename = remote_file.rsplit('/').next().unwrap_or("decrypted");
-        names::decrypt_filename(&master_key, enc_basename)
-            .unwrap_or_else(|| "decrypted".to_string())
+        decrypted_basename.clone()
     } else {
-        local_dest.to_string()
+        // scp/cp semantics: an existing directory, or a path with a trailing
+        // separator, means "write the decrypted file inside this directory"
+        // rather than treating the directory path itself as the file name.
+        let dest_path = std::path::Path::new(local_dest);
+        let treat_as_dir = dest_path.is_dir()
+            || local_dest.ends_with('/')
+            || local_dest.ends_with(std::path::MAIN_SEPARATOR);
+        if treat_as_dir {
+            if let Err(e) = std::fs::create_dir_all(dest_path) {
+                print_error(
+                    format,
+                    &format!("Cannot create directory '{}': {}", local_dest, e),
+                    4,
+                );
+                return 4;
+            }
+            dest_path
+                .join(&decrypted_basename)
+                .to_string_lossy()
+                .into_owned()
+        } else {
+            local_dest.to_string()
+        }
     };
 
     if let Err(e) = std::fs::write(&dest, &plaintext) {
@@ -59376,6 +59762,7 @@ async fn main() {
                     with_header,
                     force,
                     emergency_kit,
+                    no_bind,
                 } => {
                     if let Err(msg) = ensure_headerless_init_profile_selector(
                         cli.profile.as_deref(),
@@ -59400,6 +59787,8 @@ async fn main() {
                                         path,
                                         "/",
                                     );
+                                    let keyfile_path =
+                                        keyfile_gen.as_deref().or(keyfile.as_deref());
                                     cmd_crypt_init(
                                         &u,
                                         &dir,
@@ -59408,6 +59797,8 @@ async fn main() {
                                         *with_header,
                                         *force,
                                         emergency_kit.as_deref(),
+                                        *no_bind,
+                                        keyfile_path,
                                         &cli,
                                         format,
                                     )
@@ -59417,6 +59808,15 @@ async fn main() {
                         }
                     }
                 }
+                CryptCommands::Bind {
+                    path,
+                    password,
+                    keyfile,
+                } => {
+                    let pw = resolve_crypt_password(password).unwrap_or_default();
+                    cmd_crypt_bind(path, &pw, keyfile.as_deref(), &cli, format).await
+                }
+                CryptCommands::Unbind => cmd_crypt_unbind(&cli, format).await,
                 CryptCommands::ToHeaderless {
                     url,
                     path,
@@ -63996,6 +64396,33 @@ mod tests {
             "aeroCryptOverlay": { "enabled": true, "kind": "aerocrypt", "remoteScope": "/enc" }
         });
         assert!(profile_has_crypt_overlay(&enabled));
+    }
+
+    #[test]
+    fn overlay_scope_must_equal_or_descend_remote_path() {
+        // Blank scope = "same as Remote Path" = always valid.
+        assert!(is_valid_overlay_scope("", "/data"));
+        assert!(is_valid_overlay_scope("   ", "/data"));
+        // Remote Path is the root: any folder is a descendant.
+        assert!(is_valid_overlay_scope("/anything/here", "/"));
+        assert!(is_valid_overlay_scope("/anything/here", ""));
+        // Exact match and strict descendant are valid.
+        assert!(is_valid_overlay_scope("/data", "/data"));
+        assert!(is_valid_overlay_scope("/data/vault", "/data"));
+        assert!(is_valid_overlay_scope("/data/a/b/c", "/data"));
+        // Trailing-slash and duplicate-slash normalization.
+        assert!(is_valid_overlay_scope("/data/vault/", "/data"));
+        assert!(is_valid_overlay_scope("//data//vault", "/data"));
+        // Ancestor is rejected: scope "/" under a subfolder Remote Path pins the
+        // anchor above the vault (the empty-listing misconfiguration).
+        assert!(!is_valid_overlay_scope("/", "/data"));
+        assert!(!is_valid_overlay_scope("/data", "/data/vault"));
+        // Sibling and unrelated are rejected.
+        assert!(!is_valid_overlay_scope("/other", "/data"));
+        assert!(!is_valid_overlay_scope("/data2", "/data"));
+        // The /database vs /data prefix trap must be rejected.
+        assert!(!is_valid_overlay_scope("/database", "/data"));
+        assert!(!is_valid_overlay_scope("/data-backup/x", "/data"));
     }
 
     #[test]

--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -20548,13 +20548,23 @@ fn cmd_profile_duplicate(
         return 5;
     }
 
-    // Best-effort credential clone. Missing credentials are valid for many
-    // protocols (OAuth, GitHub PAT-only flows) so we don't fail when the
-    // source key isn't present. MUV-3: same scoped user, dual-write.
+    // Best-effort clone of EVERY vault secret scoped to the source profile so a
+    // duplicate is a complete working copy, not just the password (crypt overlay,
+    // Filen key, OAuth/Jotta token, per-mode snapshots, OneDrive hints). Same
+    // single source of truth (`per_profile_vault_keys`) the GUI copy command and
+    // delete/export use. Missing keys are valid for many protocols, so a missing
+    // source key is skipped, never an error. MUV-3: same scoped user, dual-write.
     if !source_id.is_empty() {
         let scoped_uid = scoped_credential_user_id(cli, &store);
-        if let Some(cred) = read_server_cred(&store, scoped_uid, &format!("server_{}", source_id)) {
-            dual_store_server_cred(&store, scoped_uid, &format!("server_{}", new_id), &cred);
+        let protocol = source.get("protocol").and_then(|v| v.as_str());
+        let source_suffix = format!("_{}", source_id);
+        for source_key in ftp_client_gui_lib::per_profile_vault_keys(&source_id, protocol) {
+            if let Some(base) = source_key.strip_suffix(&source_suffix) {
+                if let Some(value) = read_server_cred(&store, scoped_uid, &source_key) {
+                    let target_key = format!("{}_{}", base, new_id);
+                    dual_store_server_cred(&store, scoped_uid, &target_key, &value);
+                }
+            }
         }
     }
 
@@ -21323,6 +21333,13 @@ fn delete_profile_in_vault(
     let mut profiles: Vec<serde_json::Value> = load_active_user_profiles(cli, store)
         .map_err(|e| format!("Failed to read profiles: {}", e))?;
     let before = profiles.len();
+    // Capture the protocol before removing the entry, so the OAuth-token key can
+    // be derived for the orphan cleanup below.
+    let protocol = profiles
+        .iter()
+        .find(|p| p.get("id").and_then(|v| v.as_str()) == Some(profile_id))
+        .and_then(|p| p.get("protocol").and_then(|v| v.as_str()))
+        .map(|s| s.to_string());
     profiles.retain(|p| p.get("id").and_then(|v| v.as_str()) != Some(profile_id));
     if profiles.len() == before {
         return Err(format!("Profile id '{}' not found in vault", profile_id));
@@ -21330,13 +21347,16 @@ fn delete_profile_in_vault(
     save_active_user_profiles(cli, store, &profiles)
         .map_err(|e| format!("Failed to write profiles: {}", e))?;
 
-    // Orphan credential cleanup (matches MyServersPanel.tsx confirmDelete).
-    // MUV-3: dual-delete from vault + the scoped user's partition.
-    dual_delete_server_cred(
-        store,
-        scoped_credential_user_id(cli, store),
-        &format!("server_{}", profile_id),
-    );
+    // Orphan credential cleanup: remove EVERY vault secret scoped to this profile
+    // so a delete leaves nothing behind. Same single source of truth
+    // (`per_profile_vault_keys`) the GUI `purge_profile_secrets` command and the
+    // export-collect path use, so the CLI and GUI can never diverge. MUV-3:
+    // dual-delete from the vault + the scoped user's partition; best-effort per
+    // key (a key absent for this profile kind is a no-op).
+    let scoped_uid = scoped_credential_user_id(cli, store);
+    for key in ftp_client_gui_lib::per_profile_vault_keys(profile_id, protocol.as_deref()) {
+        dual_delete_server_cred(store, scoped_uid, &key);
+    }
 
     // Drop the id from the favourites set if present. Best-effort: a missing
     // or malformed entry leaves the favourites list untouched.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15495,6 +15495,66 @@ async fn delete_credential(account: String) -> Result<(), String> {
         .map_err(|e| format!("Failed to delete credential: {}", e))
 }
 
+/// Remove EVERY vault secret scoped to a saved profile id, so deleting a profile
+/// leaves nothing behind (the user action is complete, no residue). Enumerates
+/// the keys from [`per_profile_vault_keys`] (the single source of truth shared
+/// with export and duplicate). Best-effort per key: a key absent for this
+/// profile kind is a no-op, never an error. Returns the keys that were actually
+/// present and removed. `protocol` lets the OAuth-token key be derived.
+#[tauri::command]
+async fn purge_profile_secrets(
+    profile_id: String,
+    protocol: Option<String>,
+) -> Result<Vec<String>, String> {
+    let store = credential_store::CredentialStore::from_cache()
+        .ok_or_else(|| "STORE_NOT_READY".to_string())?;
+    let mut removed = Vec::new();
+    for key in per_profile_vault_keys(&profile_id, protocol.as_deref()) {
+        // Only report keys that existed; delete is idempotent and a missing key
+        // is expected for most profile kinds.
+        let existed = store.get(&key).map(|v| !v.is_empty()).unwrap_or(false);
+        if user_partitions::delete_active_credential_dual(&store, &key).is_ok() && existed {
+            removed.push(key);
+        }
+    }
+    Ok(removed)
+}
+
+/// Copy EVERY vault secret scoped to `source_id` onto `target_id`, so
+/// duplicating a profile carries all of its credentials (the copy is complete,
+/// not just the password). Same [`per_profile_vault_keys`] source of truth as
+/// delete/export. Returns a map `base_prefix -> bool` of which secrets were
+/// copied, so the caller can set the duplicate's `hasStored*` flags. Best-effort
+/// per key.
+#[tauri::command]
+async fn copy_profile_secrets(
+    source_id: String,
+    target_id: String,
+    protocol: Option<String>,
+) -> Result<std::collections::HashMap<String, bool>, String> {
+    let store = credential_store::CredentialStore::from_cache()
+        .ok_or_else(|| "STORE_NOT_READY".to_string())?;
+    let mut copied = std::collections::HashMap::new();
+    let source_suffix = format!("_{}", source_id);
+    for source_key in per_profile_vault_keys(&source_id, protocol.as_deref()) {
+        // Derive the base prefix (everything before the trailing `_<source_id>`)
+        // and rebuild the target key for the same base under the new id.
+        let base = match source_key.strip_suffix(&source_suffix) {
+            Some(b) => b,
+            None => continue,
+        };
+        let target_key = format!("{}_{}", base, target_id);
+        if let Ok(Some(value)) = user_partitions::resolve_active_credential(&store, &source_key) {
+            let ok =
+                user_partitions::store_active_credential_dual(&store, &target_key, &value).is_ok();
+            copied.insert(base.to_string(), ok);
+        } else {
+            copied.entry(base.to_string()).or_insert(false);
+        }
+    }
+    Ok(copied)
+}
+
 #[tauri::command]
 async fn unlock_credential_store(
     password: String,
@@ -15689,6 +15749,43 @@ pub(crate) fn oauth_vault_slug_for_protocol(protocol: &str) -> Option<&'static s
     }
 }
 
+/// THE single source of truth for every vault key scoped to one saved profile
+/// id. Export-collect, delete/purge and duplicate all derive their key set from
+/// here so the three operations can never drift: what a profile can store, what
+/// its `.aeroftp` export carries, and what its delete removes are the same list.
+/// When a user deletes a profile NOTHING must remain; when a user copies one
+/// EVERYTHING must come along; when a user exports one EVERYTHING must travel.
+///
+/// Included: the main credential, the #215 per-mode snapshots, the OAuth token
+/// (protocol-derived slug) and Jottacloud refresh, all four AeroCrypt overlay
+/// secrets, the Filen CLI API key, and the OneDrive drive id/type captured at
+/// connect. NON-per-profile keys are deliberately excluded: `oauth_<slug>_client_id`
+/// / `_client_secret` are app-global (shared by every profile of a provider, so a
+/// single delete must not remove them), and `ai_apikey_*` / `peer_*` are not
+/// server-profile scoped. The non-slug keys are always emitted even for the wrong
+/// provider: a delete of a non-existent key is a harmless no-op, and always
+/// listing them means a profile that switched provider mode leaves no residue.
+pub fn per_profile_vault_keys(profile_id: &str, protocol: Option<&str>) -> Vec<String> {
+    let mut keys = vec![
+        format!("server_{}", profile_id),
+        format!("server_modes_{}", profile_id),
+        format!("jottacloud_refresh_{}", profile_id),
+        format!("aerocrypt_overlay_pw_{}", profile_id),
+        format!("aerocrypt_overlay_salt_{}", profile_id),
+        format!("aerocrypt_overlay_keyfile_path_{}", profile_id),
+        format!("aerocrypt_overlay_config_{}", profile_id),
+        format!("filen_api_key_{}", profile_id),
+        format!("onedrive_drive_id_{}", profile_id),
+        format!("onedrive_drive_type_{}", profile_id),
+    ];
+    // The per-profile OAuth token lives under `oauth_<slug>_<id>`; the slug is
+    // provider-specific, so it is only added when the protocol maps to one.
+    if let Some(slug) = protocol.and_then(oauth_vault_slug_for_protocol) {
+        keys.push(format!("oauth_{}_{}", slug, profile_id));
+    }
+    keys
+}
+
 /// Read the per-profile OAuth or Jotta token blob for a server profile, with
 /// a one-shot fallback to the legacy singleton key. The export bundle copies
 /// the value verbatim so the destination device can write it back without
@@ -15800,6 +15897,22 @@ fn collect_provider_secrets_for_server(
         out.filen_api_key = Some(api_key.to_string());
     }
 
+    // OneDrive drive id/type captured at connect (`onedrive_drive_id_<id>` /
+    // `onedrive_drive_type_<id>`). Vault-only like the Filen key, so the export
+    // dropped them; carried so a re-import is a complete snapshot.
+    if let Ok(Some(v)) = user_partitions::resolve_active_credential(
+        store,
+        &format!("onedrive_drive_id_{}", server.id),
+    ) {
+        out.onedrive_drive_id = Some(v.to_string());
+    }
+    if let Ok(Some(v)) = user_partitions::resolve_active_credential(
+        store,
+        &format!("onedrive_drive_type_{}", server.id),
+    ) {
+        out.onedrive_drive_type = Some(v.to_string());
+    }
+
     out
 }
 
@@ -15857,6 +15970,8 @@ pub async fn export_server_profiles_core(
                         || secrets.oauth_client_id.is_some()
                         || secrets.oauth_client_secret.is_some()
                         || secrets.filen_api_key.is_some()
+                        || secrets.onedrive_drive_id.is_some()
+                        || secrets.onedrive_drive_type.is_some()
                     {
                         provider_secrets.insert(server.id.clone(), secrets);
                     }
@@ -16105,6 +16220,20 @@ pub async fn import_server_profiles_core_filtered(
                             restored_filen_api_key.insert(profile_id.clone());
                         }
                         Err(e) => cred_errors.push(format!("{} filen api key: {}", profile_id, e)),
+                    }
+                }
+                // OneDrive drive id/type: vault-only reconnect hints, restored
+                // under the same keys the connect path reads/writes.
+                if let Some(ref v) = secrets.onedrive_drive_id {
+                    let key = format!("onedrive_drive_id_{}", profile_id);
+                    if let Err(e) = user_partitions::store_active_credential_dual(&store, &key, v) {
+                        cred_errors.push(format!("{} onedrive drive_id: {}", profile_id, e));
+                    }
+                }
+                if let Some(ref v) = secrets.onedrive_drive_type {
+                    let key = format!("onedrive_drive_type_{}", profile_id);
+                    if let Err(e) = user_partitions::store_active_credential_dual(&store, &key, v) {
+                        cred_errors.push(format!("{} onedrive drive_type: {}", profile_id, e));
                     }
                 }
             }
@@ -16605,6 +16734,52 @@ async fn mount_open_quick(id: String) -> Result<(), String> {
 pub fn install_crypto_provider() -> bool {
     let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
     rustls::crypto::CryptoProvider::get_default().is_some()
+}
+
+#[cfg(test)]
+mod per_profile_vault_keys_tests {
+    //! Pins the COMPLETE per-profile vault key set so delete/copy/export can
+    //! never silently drop a key again (the Filen-key class of debt). If a new
+    //! per-profile secret is added, this test forces updating the single source
+    //! of truth `per_profile_vault_keys` in the same change.
+    use super::per_profile_vault_keys;
+
+    #[test]
+    fn non_oauth_profile_lists_every_persistent_key() {
+        let keys = per_profile_vault_keys("srv_1_abc", Some("sftp"));
+        let expected = [
+            "server_srv_1_abc",
+            "server_modes_srv_1_abc",
+            "jottacloud_refresh_srv_1_abc",
+            "aerocrypt_overlay_pw_srv_1_abc",
+            "aerocrypt_overlay_salt_srv_1_abc",
+            "aerocrypt_overlay_keyfile_path_srv_1_abc",
+            "aerocrypt_overlay_config_srv_1_abc",
+            "filen_api_key_srv_1_abc",
+            "onedrive_drive_id_srv_1_abc",
+            "onedrive_drive_type_srv_1_abc",
+        ];
+        assert_eq!(keys, expected, "the complete non-oauth key set must match");
+        // No app-global key ever leaks into the per-profile delete/copy set.
+        assert!(!keys
+            .iter()
+            .any(|k| k.contains("client_id") || k.contains("client_secret")));
+    }
+
+    #[test]
+    fn oauth_profile_adds_the_slugged_token_key() {
+        let keys = per_profile_vault_keys("srv_1_abc", Some("googledrive"));
+        assert!(
+            keys.contains(&"oauth_google_srv_1_abc".to_string()),
+            "an OAuth profile must include its `oauth_<slug>_<id>` token key"
+        );
+        // The non-oauth base set is still fully present.
+        assert!(keys.contains(&"server_srv_1_abc".to_string()));
+        assert!(keys.contains(&"filen_api_key_srv_1_abc".to_string()));
+        // No slug -> no oauth key (the token key must not be fabricated).
+        let none = per_profile_vault_keys("srv_1_abc", None);
+        assert!(!none.iter().any(|k| k.starts_with("oauth_")));
+    }
 }
 
 #[cfg(test)]
@@ -17863,6 +18038,8 @@ pub fn run() {
             store_credential,
             get_credential,
             delete_credential,
+            purge_profile_secrets,
+            copy_profile_secrets,
             unlock_credential_store,
             lock_credential_store,
             enable_master_password,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15790,6 +15790,16 @@ fn collect_provider_secrets_for_server(
         out.mode_credentials = Some(modes.to_string());
     }
 
+    // Issue #230: bundle the per-profile Filen CLI API key (`filen_api_key_<id>`).
+    // It is a long-lived secret kept only in the vault (never on the saved
+    // profile's `options`), so without this the `.aeroftp` export dropped it and a
+    // re-imported Filen profile fell back to password + TOTP.
+    if let Ok(Some(api_key)) =
+        user_partitions::resolve_active_credential(store, &format!("filen_api_key_{}", server.id))
+    {
+        out.filen_api_key = Some(api_key.to_string());
+    }
+
     out
 }
 
@@ -15846,6 +15856,7 @@ pub async fn export_server_profiles_core(
                         || secrets.mode_credentials.is_some()
                         || secrets.oauth_client_id.is_some()
                         || secrets.oauth_client_secret.is_some()
+                        || secrets.filen_api_key.is_some()
                     {
                         provider_secrets.insert(server.id.clone(), secrets);
                     }
@@ -15918,6 +15929,10 @@ pub async fn import_server_profiles_core_filtered(
     let mut restored_aerocrypt_keyfile_path: std::collections::HashSet<String> =
         std::collections::HashSet::new();
     let mut restored_aerocrypt_config: std::collections::HashSet<String> =
+        std::collections::HashSet::new();
+    // Issue #230: track which profiles had their Filen CLI API key restored so
+    // the `hasStoredFilenApiKey` flag returned to the UI reflects reality.
+    let mut restored_filen_api_key: std::collections::HashSet<String> =
         std::collections::HashSet::new();
     match credential_store::CredentialStore::from_cache() {
         Some(store) => {
@@ -16080,6 +16095,18 @@ pub async fn import_server_profiles_core_filtered(
                         cred_errors.push(format!("{} mode creds: {}", profile_id, e));
                     }
                 }
+                // Issue #230: restore the Filen CLI API key under the same
+                // `filen_api_key_<id>` vault key the connect path reads, so an
+                // imported Filen profile skips the /v3/login + TOTP window again.
+                if let Some(ref api_key) = secrets.filen_api_key {
+                    let key = format!("filen_api_key_{}", profile_id);
+                    match user_partitions::store_active_credential_dual(&store, &key, api_key) {
+                        Ok(()) => {
+                            restored_filen_api_key.insert(profile_id.clone());
+                        }
+                        Err(e) => cred_errors.push(format!("{} filen api key: {}", profile_id, e)),
+                    }
+                }
             }
         }
         None => {
@@ -16125,7 +16152,19 @@ pub async fn import_server_profiles_core_filtered(
                 "lastConnected": s.last_connected,
                 "options": s.options,
                 "providerId": s.provider_id,
+                // Top-level ServerProfile fields that live OUTSIDE `options` and
+                // so must be re-emitted explicitly or the import drops them:
+                // the share-link base (GAP 2), the custom/detected icons (GAP 3)
+                // and the silenced classic-fallback modal preference (GAP 4).
+                "publicUrlBase": s.public_url_base,
+                "customIconUrl": s.custom_icon_url,
+                "faviconUrl": s.favicon_url,
+                "skipDeltaEligibilityPrompt": s.skip_delta_eligibility_prompt,
                 "hasStoredCredential": s.credential.is_some(),
+                // Issue #230: reflect whether the Filen CLI API key was actually
+                // restored so the profile reconnects via the key (skipping the
+                // TOTP window) instead of falling back to password + 2FA.
+                "hasStoredFilenApiKey": restored_filen_api_key.contains(&s.id),
                 // CWP-20B: re-import a Crypt profile AS a Crypt profile (both
                 // kinds). The flags reflect what was actually restored, not the
                 // source state, so the UI prompts for the overlay password only

--- a/src-tauri/src/profile_export.rs
+++ b/src-tauri/src/profile_export.rs
@@ -129,6 +129,14 @@ pub struct ProviderSecrets {
     /// profiles or when credentials are excluded from the export.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub filen_api_key: Option<String>,
+    /// OneDrive Graph drive id captured at connect (`onedrive_drive_id_<id>`).
+    /// Like the Filen key it lives only in the vault, not on the profile, so the
+    /// export dropped it; carried here so a re-import is a complete snapshot.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub onedrive_drive_id: Option<String>,
+    /// OneDrive Graph drive type captured at connect (`onedrive_drive_type_<id>`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub onedrive_drive_type: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Default)]
@@ -215,6 +223,8 @@ pub fn export_profiles(
             || s.aerocrypt_overlay_config.is_some()
             || s.mode_credentials.is_some()
             || s.filen_api_key.is_some()
+            || s.onedrive_drive_id.is_some()
+            || s.onedrive_drive_type.is_some()
     });
     let metadata = ExportMetadata {
         export_date: chrono::Utc::now().to_rfc3339(),
@@ -572,6 +582,8 @@ mod tests {
             "filen-profile".to_string(),
             ProviderSecrets {
                 filen_api_key: Some("filen-cli-api-key-secret".to_string()),
+                onedrive_drive_id: Some("b!driveid123".to_string()),
+                onedrive_drive_type: Some("business".to_string()),
                 ..Default::default()
             },
         );
@@ -608,6 +620,20 @@ mod tests {
                 .and_then(|s| s.filen_api_key.clone()),
             Some("filen-cli-api-key-secret".to_string()),
             "Filen CLI API key must survive as a provider secret"
+        );
+        assert_eq!(
+            restored_secrets
+                .get("filen-profile")
+                .and_then(|s| s.onedrive_drive_id.clone()),
+            Some("b!driveid123".to_string()),
+            "OneDrive drive id must survive"
+        );
+        assert_eq!(
+            restored_secrets
+                .get("filen-profile")
+                .and_then(|s| s.onedrive_drive_type.clone()),
+            Some("business".to_string()),
+            "OneDrive drive type must survive"
         );
 
         let _ = std::fs::remove_file(&tmp);

--- a/src-tauri/src/profile_export.rs
+++ b/src-tauri/src/profile_export.rs
@@ -121,6 +121,14 @@ pub struct ProviderSecrets {
     /// rclone remote (`oauth_<provider>_client_secret` vault singleton).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub oauth_client_secret: Option<String>,
+    /// Issue #230: the per-profile Filen CLI API key (`filen_api_key_<id>` vault
+    /// entry). This long-lived secret is NEVER persisted on the saved profile
+    /// (`options.filen_api_key` is transient, stripped to the vault on save), so
+    /// the `.aeroftp` profile export dropped it before this field: a re-imported
+    /// Filen profile silently fell back to password + TOTP. Absent for non-Filen
+    /// profiles or when credentials are excluded from the export.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub filen_api_key: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Default)]
@@ -142,6 +150,20 @@ pub struct ServerProfileExport {
     pub has_stored_credential: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub public_url_base: Option<String>,
+    /// User-chosen custom icon (base64 data URL). Top-level `ServerProfile`
+    /// field (NOT inside `options`), so it needs an explicit slot here or the
+    /// export drops it. Cosmetic; `#[serde(default)]` keeps older files loading.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub custom_icon_url: Option<String>,
+    /// Auto-detected project favicon (base64 data URL). Same top-level story as
+    /// `custom_icon_url`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub favicon_url: Option<String>,
+    /// Suppress the classic-fallback (delta-eligibility) modal for this saved
+    /// server. Top-level `ServerProfile` preference; without this slot the user
+    /// is re-prompted after an import for a modal they had silenced.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skip_delta_eligibility_prompt: Option<bool>,
     /// CWP-20B round-trip: the crypt-overlay binding (`AeroCryptOverlayBinding`:
     /// kind + remoteScope + filename/dir settings). Without this an exported
     /// Crypt profile silently re-imported as plaintext (the binding lived only in
@@ -192,6 +214,7 @@ pub fn export_profiles(
             || s.aerocrypt_overlay_keyfile_path.is_some()
             || s.aerocrypt_overlay_config.is_some()
             || s.mode_credentials.is_some()
+            || s.filen_api_key.is_some()
     });
     let metadata = ExportMetadata {
         export_date: chrono::Utc::now().to_rfc3339(),
@@ -310,6 +333,9 @@ mod tests {
             credential: None,
             has_stored_credential: None,
             public_url_base: None,
+            custom_icon_url: None,
+            favicon_url: None,
+            skip_delta_eligibility_prompt: None,
             aero_crypt_overlay: None,
             has_stored_aero_crypt_password: None,
             has_stored_aero_crypt_salt: None,
@@ -515,6 +541,73 @@ mod tests {
                 .get("crypt-rclone")
                 .and_then(|s| s.aerocrypt_overlay_salt.clone()),
             Some("rclone-pw2-salt".to_string()),
+        );
+
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    /// v4.1.4 export audit: four persistent fields that live at the TOP LEVEL of
+    /// `ServerProfile` (outside the opaque `options` blob) were silently dropped
+    /// by the `.aeroftp` profile export because `ServerProfileExport` had no slot
+    /// for them: `publicUrlBase` (share links), `customIconUrl`/`faviconUrl`
+    /// (icons), `skipDeltaEligibilityPrompt` (silenced classic-fallback modal),
+    /// plus the per-profile Filen CLI API key secret (`filen_api_key_<id>`, kept
+    /// only in the vault). All must survive export -> import.
+    #[test]
+    fn round_trip_preserves_top_level_profile_fields_and_filen_api_key() {
+        let tmp = std::env::temp_dir().join(format!(
+            "aeroftp_export_toplevel_{}_{}.aeroftp",
+            std::process::id(),
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0)
+        ));
+
+        let mut server = sample_server("filen-profile", "filen");
+        server.public_url_base = Some("https://share.example.com/".to_string());
+        server.custom_icon_url = Some("data:image/png;base64,CUSTOMICON".to_string());
+        server.favicon_url = Some("data:image/png;base64,FAVICON".to_string());
+        server.skip_delta_eligibility_prompt = Some(true);
+
+        let mut secrets = HashMap::new();
+        secrets.insert(
+            "filen-profile".to_string(),
+            ProviderSecrets {
+                filen_api_key: Some("filen-cli-api-key-secret".to_string()),
+                ..Default::default()
+            },
+        );
+
+        export_profiles(vec![server], secrets, "pw-12345678", &tmp).expect("export should succeed");
+
+        let (servers, restored_secrets, _meta) =
+            import_profiles(&tmp, "pw-12345678").expect("import should succeed");
+
+        let out = servers.iter().find(|s| s.id == "filen-profile").unwrap();
+        assert_eq!(
+            out.public_url_base.as_deref(),
+            Some("https://share.example.com/"),
+            "publicUrlBase must survive (share links)"
+        );
+        assert_eq!(
+            out.custom_icon_url.as_deref(),
+            Some("data:image/png;base64,CUSTOMICON"),
+            "customIconUrl must survive"
+        );
+        assert_eq!(
+            out.favicon_url.as_deref(),
+            Some("data:image/png;base64,FAVICON"),
+            "faviconUrl must survive"
+        );
+        assert_eq!(
+            out.skip_delta_eligibility_prompt,
+            Some(true),
+            "skipDeltaEligibilityPrompt must survive"
+        );
+        assert_eq!(
+            restored_secrets
+                .get("filen-profile")
+                .and_then(|s| s.filen_api_key.clone()),
+            Some("filen-cli-api-key-secret".to_string()),
+            "Filen CLI API key must survive as a provider secret"
         );
 
         let _ = std::fs::remove_file(&tmp);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -130,6 +130,18 @@ interface ImportedServerProfile {
   aeroCryptOverlay?: ServerProfile['aeroCryptOverlay'];
   hasStoredAeroCryptPassword?: boolean;
   hasStoredAeroCryptSalt?: boolean;
+  hasStoredAeroCryptKeyfilePath?: boolean;
+  // Issue #230: true when the Filen CLI API key was restored into the vault on
+  // import (skips the TOTP window on reconnect).
+  hasStoredFilenApiKey?: boolean;
+  // Top-level ServerProfile fields carried outside `options` (GAP 2/3/4 of the
+  // v4.1.4 export audit): share-link base, custom/detected icons, the silenced
+  // classic-fallback modal preference, and the #215 per-mode credential opt-in.
+  publicUrlBase?: string;
+  customIconUrl?: string;
+  faviconUrl?: string;
+  skipDeltaEligibilityPrompt?: boolean;
+  persistModeCredentials?: boolean;
 }
 
 interface ServerProfilesImportResult {
@@ -12520,6 +12532,17 @@ interface UpdateVerificationInfo {
         aeroCryptOverlay: s.aeroCryptOverlay,
         hasStoredAeroCryptPassword: s.hasStoredAeroCryptPassword || false,
         hasStoredAeroCryptSalt: s.hasStoredAeroCryptSalt || false,
+        hasStoredAeroCryptKeyfilePath: s.hasStoredAeroCryptKeyfilePath || false,
+        hasStoredFilenApiKey: s.hasStoredFilenApiKey || false,
+        // v4.1.4 export audit: carry the top-level ServerProfile fields that live
+        // outside `options` (share-link base, custom/detected icons, the silenced
+        // classic-fallback modal, and the #215 per-mode credential opt-in) so an
+        // imported profile is not silently degraded on this merge.
+        publicUrlBase: s.publicUrlBase,
+        customIconUrl: s.customIconUrl,
+        faviconUrl: s.faviconUrl,
+        skipDeltaEligibilityPrompt: s.skipDeltaEligibilityPrompt,
+        persistModeCredentials: s.persistModeCredentials,
       }));
 
     if (newServers.length > 0) {

--- a/src/components/ConnectionScreen.tsx
+++ b/src/components/ConnectionScreen.tsx
@@ -29,7 +29,7 @@ import { findActiveMode, findActiveModeGroup, modeGroupProviderIds, resolveModeH
 import { loadModeCredentials, storeModeCredentials, deleteModeCredentials, type ModeCredentialMap } from '../utils/modeCredentialStore';
 import { openUrl } from '../utils/openUrl';
 import { safePickerStartDir } from '../utils/safePickerDir';
-import { normalizeRemotePath, isValidOverlayScope } from '../utils/overlayScope';
+import { isValidOverlayScope, resolveOverlayScope } from '../utils/overlayScope';
 import { OAuthConnect } from './OAuthConnect';
 import { ProviderSelector } from './ProviderSelector';
 import { AlertDialog } from './Dialogs';
@@ -642,8 +642,10 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
     const [aeroCryptDirNameEnc, setAeroCryptDirNameEnc] = useState(true);
     // P3 follow-up (#369): optional user-pinned remote anchor for the overlay.
     // Empty means "use the profile Remote Path" (preserves today's behavior and
-    // all existing profiles). When non-empty it must be the Remote Path or a
-    // strict descendant (validated live). Persisted into aeroCryptOverlay.remoteScope.
+    // all existing profiles). A non-empty value is interpreted RELATIVE to the
+    // Remote Path (#369): a bare subfolder name is nested under it, so the prefix
+    // is never re-typed and the anchor can never escape the Remote Path. Resolved
+    // via resolveOverlayScope() and persisted into aeroCryptOverlay.remoteScope.
     const [overlaysRemotePath, setOverlaysRemotePath] = useState('');
     const [overlaysRemotePathError, setOverlaysRemotePathError] = useState<string | null>(null);
 
@@ -651,7 +653,10 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
     // (user edits Remote Path after typing a scope, or on hydration).
     useEffect(() => {
         if (!overlaysRemotePath && !overlaysRemotePathError) return;
-        const valid = isValidOverlayScope(overlaysRemotePath, quickConnectDirs.remoteDir);
+        // Validate the RESOLVED scope: a bare subfolder name is nested under the
+        // Remote Path (#369 relative UX), so it is always in scope and the error
+        // never fires for normal input; the guard only survives as a safety net.
+        const valid = isValidOverlayScope(resolveOverlayScope(overlaysRemotePath, quickConnectDirs.remoteDir), quickConnectDirs.remoteDir);
         setOverlaysRemotePathError(valid ? null : t('aerocryptProfile.overlaysRemotePathInvalid'));
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [overlaysRemotePath, quickConnectDirs.remoteDir, t]);
@@ -1040,7 +1045,7 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                 // so it persists identically to how the backend reads it. A blank
                 // or "/" scope collapses to '' and falls back to the Remote Path,
                 // preserving today's behavior and every existing profile (#369).
-                remoteScope: (normalizeRemotePath(overlaysRemotePath) || quickConnectDirs.remoteDir || ''),
+                remoteScope: resolveOverlayScope(overlaysRemotePath, quickConnectDirs.remoteDir),
                 localScope: quickConnectDirs.localDir || '',
                 filenameEncryption: isRclone ? aeroCryptFilenameEnc : 'standard',
                 ...(isRclone ? { directoryNameEncryption: aeroCryptDirNameEnc } : {}),
@@ -2853,7 +2858,7 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                                 onChange={(e) => {
                                     const v = e.target.value;
                                     setOverlaysRemotePath(v);
-                                    const valid = isValidOverlayScope(v, quickConnectDirs.remoteDir);
+                                    const valid = isValidOverlayScope(resolveOverlayScope(v, quickConnectDirs.remoteDir), quickConnectDirs.remoteDir);
                                     setOverlaysRemotePathError(valid ? null : t('aerocryptProfile.overlaysRemotePathInvalid'));
                                 }}
                                 className="w-full px-4 py-2.5 bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-sm disabled:opacity-60 disabled:cursor-not-allowed"

--- a/src/components/ConnectionScreen.tsx
+++ b/src/components/ConnectionScreen.tsx
@@ -2849,18 +2849,25 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                             <input
                                 type="text"
                                 value={overlaysRemotePath}
+                                disabled={overlayFieldsLocked}
                                 onChange={(e) => {
                                     const v = e.target.value;
                                     setOverlaysRemotePath(v);
                                     const valid = isValidOverlayScope(v, quickConnectDirs.remoteDir);
                                     setOverlaysRemotePathError(valid ? null : t('aerocryptProfile.overlaysRemotePathInvalid'));
                                 }}
-                                className="w-full px-4 py-2.5 bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-sm"
+                                className="w-full px-4 py-2.5 bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-sm disabled:opacity-60 disabled:cursor-not-allowed"
                                 placeholder={quickConnectDirs.remoteDir || '/'}
                             />
                             <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">
                                 {t('aerocryptProfile.overlaysRemotePathHint')}
                             </p>
+                            {/* #369 F5: the scope is the encryption anchor, immutable once the
+                                overlay is bound (like the Remote Path and the other crypt fields);
+                                editing it on an existing vault would orphan the encrypted data. */}
+                            {overlayFieldsLocked && (
+                                <p className="mt-1 text-xs text-amber-600 dark:text-amber-400">{t('aerocryptProfile.remotePathLockedNote')}</p>
+                            )}
                             {overlaysRemotePathError && (
                                 <p className="mt-1 text-xs text-red-600 dark:text-red-400">{overlaysRemotePathError}</p>
                             )}

--- a/src/components/ConnectionScreen.tsx
+++ b/src/components/ConnectionScreen.tsx
@@ -29,6 +29,7 @@ import { findActiveMode, findActiveModeGroup, modeGroupProviderIds, resolveModeH
 import { loadModeCredentials, storeModeCredentials, deleteModeCredentials, type ModeCredentialMap } from '../utils/modeCredentialStore';
 import { openUrl } from '../utils/openUrl';
 import { safePickerStartDir } from '../utils/safePickerDir';
+import { normalizeRemotePath, isValidOverlayScope } from '../utils/overlayScope';
 import { OAuthConnect } from './OAuthConnect';
 import { ProviderSelector } from './ProviderSelector';
 import { AlertDialog } from './Dialogs';
@@ -639,6 +640,21 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
     const [keyfileError, setKeyfileError] = useState<string | null>(null);
     const [aeroCryptFilenameEnc, setAeroCryptFilenameEnc] = useState<'standard' | 'obfuscate' | 'off'>('standard');
     const [aeroCryptDirNameEnc, setAeroCryptDirNameEnc] = useState(true);
+    // P3 follow-up (#369): optional user-pinned remote anchor for the overlay.
+    // Empty means "use the profile Remote Path" (preserves today's behavior and
+    // all existing profiles). When non-empty it must be the Remote Path or a
+    // strict descendant (validated live). Persisted into aeroCryptOverlay.remoteScope.
+    const [overlaysRemotePath, setOverlaysRemotePath] = useState('');
+    const [overlaysRemotePathError, setOverlaysRemotePathError] = useState<string | null>(null);
+
+    // Re-validate overlays remote path whenever the baseline remoteDir changes
+    // (user edits Remote Path after typing a scope, or on hydration).
+    useEffect(() => {
+        if (!overlaysRemotePath && !overlaysRemotePathError) return;
+        const valid = isValidOverlayScope(overlaysRemotePath, quickConnectDirs.remoteDir);
+        setOverlaysRemotePathError(valid ? null : t('aerocryptProfile.overlaysRemotePathInvalid'));
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [overlaysRemotePath, quickConnectDirs.remoteDir, t]);
 
     // Issue #215: MEGAcmd WebDAV endpoint auto-fetch state. Running
     // `mega-webdav /` (same idempotent call that warms the bridge for the
@@ -1020,7 +1036,11 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                 enabled: true,
                 kind: aeroCryptKind,
                 withHeader: aeroCryptWithHeader,
-                remoteScope: quickConnectDirs.remoteDir || '',
+                // Normalize the pinned anchor (strip trailing/duplicate slashes)
+                // so it persists identically to how the backend reads it. A blank
+                // or "/" scope collapses to '' and falls back to the Remote Path,
+                // preserving today's behavior and every existing profile (#369).
+                remoteScope: (normalizeRemotePath(overlaysRemotePath) || quickConnectDirs.remoteDir || ''),
                 localScope: quickConnectDirs.localDir || '',
                 filenameEncryption: isRclone ? aeroCryptFilenameEnc : 'standard',
                 ...(isRclone ? { directoryNameEncryption: aeroCryptDirNameEnc } : {}),
@@ -1142,6 +1162,11 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
         // encrypted blobs forever). The save button is already disabled on
         // mismatch (aeroCryptConfirmMismatch); this is defense-in-depth.
         if (aeroCryptConfirmMismatch) return;
+
+        // #369: block save if the overlays remote path is invalid. The field
+        // already shows the translated error and the button is disabled while
+        // invalid; this is defense-in-depth (same pattern as the password confirm).
+        if (overlaysRemotePathError) return;
 
         // #128: saving a Quick Connect profile (typically to add the Filen API
         // key so a 2FA login is no longer needed) must cancel any pending
@@ -1720,6 +1745,8 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
         setOriginalEditMode(null);
         setConnectionName('');
         setSaveConnection(false);
+        setOverlaysRemotePath('');
+        setOverlaysRemotePathError(null);
         onConnectionParamsChange({ server: '', username: '', password: '' });
         onQuickConnectDirsChange({ remoteDir: '', localDir: '' });
         onFormSaved?.();
@@ -1872,6 +1899,8 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
         setOriginalEditMode(null);
         setConnectionName('');
         setSaveConnection(false);
+        setOverlaysRemotePath('');
+        setOverlaysRemotePathError(null);
         onConnectionParamsChange({ server: '', username: '', password: '' });
         onQuickConnectDirsChange({ remoteDir: '', localDir: '' });
         onFormSaved?.();
@@ -1992,6 +2021,15 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
         setAeroCryptFilenameEnc(overlayBinding?.filenameEncryption || 'standard');
         setAeroCryptDirNameEnc(overlayBinding?.directoryNameEncryption ?? true);
         setAeroCryptWithHeader(!!overlayBinding?.withHeader);
+        // P3 follow-up (#369): hydrate the pinned overlaysRemotePath, but only if
+        // it differs from the profile's Remote Path; otherwise keep '' which means
+        // "same as Remote Path" (so an unchanged profile round-trips unchanged).
+        {
+            const savedScope = overlayBinding?.enabled ? (overlayBinding.remoteScope || '') : '';
+            const profileRemote = profile.initialPath || '';
+            setOverlaysRemotePath(savedScope && savedScope !== profileRemote ? savedScope : '');
+            setOverlaysRemotePathError(null);
+        }
         // Tier 1 keyfile PATH: a pointer, not a secret, so unlike the password
         // it IS hydrated for display and stays re-pointable (hydrated async
         // below, race-guarded like the other vault reads).
@@ -2104,6 +2142,8 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
         setAeroCryptKeyfilePath('');
         setKeyfileJustGenerated(false);
         setKeyfileError(null);
+        setOverlaysRemotePath('');
+        setOverlaysRemotePathError(null);
         modeCredentialSnapshotsRef.current = {};
         // Reset params
         onConnectionParamsChange({ ...connectionParams, server: '', username: '', password: '', options: {} });
@@ -2799,6 +2839,32 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                         </button>
                         {overlaysExpanded && (
                         <div className="p-3 border-t border-gray-200 dark:border-gray-700">
+                        {/* #369: Overlays Remote Path field (one for all overlays).
+                            Placed outside the emerald box per design. Empty value means
+                            "same as Remote Path" (no schema change; re-uses remoteScope). */}
+                        <div className="mb-3">
+                            <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+                                {t('aerocryptProfile.overlaysRemotePath')}
+                            </label>
+                            <input
+                                type="text"
+                                value={overlaysRemotePath}
+                                onChange={(e) => {
+                                    const v = e.target.value;
+                                    setOverlaysRemotePath(v);
+                                    const valid = isValidOverlayScope(v, quickConnectDirs.remoteDir);
+                                    setOverlaysRemotePathError(valid ? null : t('aerocryptProfile.overlaysRemotePathInvalid'));
+                                }}
+                                className="w-full px-4 py-2.5 bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-sm"
+                                placeholder={quickConnectDirs.remoteDir || '/'}
+                            />
+                            <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">
+                                {t('aerocryptProfile.overlaysRemotePathHint')}
+                            </p>
+                            {overlaysRemotePathError && (
+                                <p className="mt-1 text-xs text-red-600 dark:text-red-400">{overlaysRemotePathError}</p>
+                            )}
+                        </div>
                         <div className="rounded-lg border border-emerald-300/60 dark:border-emerald-700/50 bg-emerald-50/50 dark:bg-emerald-900/20 p-3 space-y-2">
                         <Checkbox
                             checked={aeroCryptEnabled}
@@ -3136,7 +3202,7 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                         )}
                         <button
                             onClick={saveOverride || handleConnectAndSave}
-                            disabled={saveOverride ? (loading || btnDisabled) : (loading || btnDisabled || aeroCryptConfirmMismatch)}
+                            disabled={saveOverride ? (loading || btnDisabled) : (loading || btnDisabled || aeroCryptConfirmMismatch || !!overlaysRemotePathError)}
                             className={`${(showCancelSaveAsNew || cancelOverride) ? 'flex-1' : 'w-full'} py-3 rounded-lg font-medium text-white cursor-pointer active:scale-[0.98] transition-all flex items-center justify-center gap-2 shadow-[0_1px_3px_rgba(0,0,0,0.08)] dark:shadow-[0_1px_3px_rgba(0,0,0,0.3)] disabled:opacity-50 ${loading ? 'bg-gray-400 !cursor-not-allowed' : buttonColorClass}`}
                         >
                             {loading ? (

--- a/src/components/IntroHub/MyServersPanel.tsx
+++ b/src/components/IntroHub/MyServersPanel.tsx
@@ -1269,7 +1269,7 @@ export function MyServersPanel({
             hasStoredAeroCryptPassword: false,
             hasStoredAeroCryptSalt: false,
         };
-        const copiedSecrets = await copyProfileVaultSecrets(server.id, newId);
+        const copiedSecrets = await copyProfileVaultSecrets(server.id, newId, server.protocol);
         dup.hasStoredCredential = copiedSecrets.server;
         dup.hasStoredFilenApiKey = copiedSecrets.filen_api_key;
         dup.hasStoredAeroCryptPassword = copiedSecrets.aerocrypt_overlay_pw;
@@ -1376,7 +1376,7 @@ export function MyServersPanel({
         const updated = servers.filter(s => s.id !== deleteTarget.id);
         setServers(updated);
         storeSavedServerProfiles(updated).catch(() => {});
-        deleteProfileVaultSecrets(deleteTarget.id).catch(() => {});
+        deleteProfileVaultSecrets(deleteTarget.id, deleteTarget.protocol).catch(() => {});
         // Drop the deleted profile from any group it belonged to (#320).
         pruneServerFromGroups(deleteTarget.id).catch(() => {});
         setGroups(prev => prev.map(g => (

--- a/src/components/SavedServers.tsx
+++ b/src/components/SavedServers.tsx
@@ -293,7 +293,7 @@ export const SavedServers: React.FC<SavedServersProps> = ({
         const updated = servers.filter(s => s.id !== deleteTarget.id);
         setServers(updated);
         saveServers(updated);
-        deleteProfileVaultSecrets(deleteTarget.id).catch(() => {});
+        deleteProfileVaultSecrets(deleteTarget.id, deleteTarget.protocol).catch(() => {});
         setDeleteTarget(null);
     };
 
@@ -324,7 +324,7 @@ export const SavedServers: React.FC<SavedServersProps> = ({
         // profile synced from another machine (per-machine keyring). The helper
         // copies every profile-scoped secret key and reports which ones actually
         // existed so the duplicate's flags match the new vault state.
-        const copiedSecrets = await copyProfileVaultSecrets(server.id, newId);
+        const copiedSecrets = await copyProfileVaultSecrets(server.id, newId, server.protocol);
         const credentialCopied = copiedSecrets.server;
         cloned.hasStoredCredential = copiedSecrets.server;
         // server_modes_<id> is copied by the helper; persistModeCredentials is a

--- a/src/i18n/locales/bg.json
+++ b/src/i18n/locales/bg.json
@@ -5042,7 +5042,10 @@
             "keyfileRepointHint": "Този път само сочи къде се намира ключовият файл; промяната му не сменя ключа на трезора. Грешен или липсващ ключов файл отказва отключването.",
             "keyfileStorageHint": "Съхранявайте го на локален диск или USB устройство, отделно от отдалеченото хранилище, което шифровате, и пазете резервно копие.",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "Отдалечен път на слоя",
+            "overlaysRemotePathHint": "Отдалечена папка, към която е закачен слоят. Оставете празно, за да се използва Отдалеченият път. Трябва да е самият Отдалечен път или папка в него.",
+            "overlaysRemotePathInvalid": "Трябва да е Отдалеченият път или негова подпапка"
         },
         "modalGuard": {
             "busyTitle": "Операция в ход",

--- a/src/i18n/locales/bg.json
+++ b/src/i18n/locales/bg.json
@@ -5044,7 +5044,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "Отдалечен път на слоя",
-            "overlaysRemotePathHint": "Отдалечена папка, към която е закачен слоят. Оставете празно, за да се използва Отдалеченият път. Трябва да е самият Отдалечен път или папка в него.",
+            "overlaysRemotePathHint": "Подпапка на Remote Path, където е закотнат оверлеят. Оставете празно, за да използвате Remote Path, или въведете само име на подпапка (тя се създава под Remote Path).",
             "overlaysRemotePathInvalid": "Трябва да е Отдалеченият път или негова подпапка"
         },
         "modalGuard": {

--- a/src/i18n/locales/bn.json
+++ b/src/i18n/locales/bn.json
@@ -5044,7 +5044,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "ওভারলে রিমোট পাথ",
-            "overlaysRemotePathHint": "যে দূরবর্তী ফোল্ডারে ওভারলে নোঙর করা হয়। রিমোট পাথ ব্যবহার করতে খালি রাখুন। এটি অবশ্যই রিমোট পাথ নিজেই বা তার ভিতরের একটি ফোল্ডার হতে হবে।",
+            "overlaysRemotePathHint": "Remote Path-এর একটি সাবফোল্ডার যেখানে ওভারলে নোঙর করা হয়। Remote Path ব্যবহার করতে খালি রাখুন, অথবা শুধু একটি সাবফোল্ডারের নাম লিখুন (এটি Remote Path-এর অধীনে তৈরি হয়)।",
             "overlaysRemotePathInvalid": "অবশ্যই রিমোট পাথ বা তার একটি সাবফোল্ডার হতে হবে"
         },
         "modalGuard": {

--- a/src/i18n/locales/bn.json
+++ b/src/i18n/locales/bn.json
@@ -5042,7 +5042,10 @@
             "keyfileRepointHint": "এই পাথ শুধু কী-ফাইলটি কোথায় আছে তা নির্দেশ করে; এটি বদলালে ভল্টের কী বদলায় না। ভুল বা অনুপস্থিত কী-ফাইল হলে আনলক প্রত্যাখ্যাত হয়।",
             "keyfileStorageHint": "এটি স্থানীয় ডিস্ক বা USB ড্রাইভে সংরক্ষণ করুন, আপনি যে রিমোট এনক্রিপ্ট করছেন তা থেকে আলাদা রাখুন এবং একটি ব্যাকআপ কপি রাখুন।",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "ওভারলে রিমোট পাথ",
+            "overlaysRemotePathHint": "যে দূরবর্তী ফোল্ডারে ওভারলে নোঙর করা হয়। রিমোট পাথ ব্যবহার করতে খালি রাখুন। এটি অবশ্যই রিমোট পাথ নিজেই বা তার ভিতরের একটি ফোল্ডার হতে হবে।",
+            "overlaysRemotePathInvalid": "অবশ্যই রিমোট পাথ বা তার একটি সাবফোল্ডার হতে হবে"
         },
         "modalGuard": {
             "busyTitle": "অপারেশন চলছে",

--- a/src/i18n/locales/ca.json
+++ b/src/i18n/locales/ca.json
@@ -5063,7 +5063,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "Ruta remota de la superposició",
-            "overlaysRemotePathHint": "Carpeta remota on s'ancora la superposició. Deixeu-ho buit per utilitzar la Ruta remota. Ha de ser la Ruta remota mateixa o una carpeta dins seu.",
+            "overlaysRemotePathHint": "Subcarpeta del Remote Path on s'ancora la superposició. Deixeu-ho buit per fer servir el Remote Path, o escriviu només un nom de subcarpeta (es crea sota el Remote Path).",
             "overlaysRemotePathInvalid": "Ha de ser la Ruta remota o una subcarpeta d'aquesta"
         },
         "modalGuard": {

--- a/src/i18n/locales/ca.json
+++ b/src/i18n/locales/ca.json
@@ -5061,7 +5061,10 @@
             "keyfileRepointHint": "Aquest camí només indica on és el fitxer de clau; canviar-lo no torna a xifrar la caixa forta. Un fitxer de clau erroni o absent bloqueja el desbloqueig.",
             "keyfileStorageHint": "Deseu-lo en un disc local o una unitat USB, separat del remot que esteu xifrant, i conserveu-ne una còpia de seguretat.",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "Ruta remota de la superposició",
+            "overlaysRemotePathHint": "Carpeta remota on s'ancora la superposició. Deixeu-ho buit per utilitzar la Ruta remota. Ha de ser la Ruta remota mateixa o una carpeta dins seu.",
+            "overlaysRemotePathInvalid": "Ha de ser la Ruta remota o una subcarpeta d'aquesta"
         },
         "modalGuard": {
             "busyTitle": "Operació en curs",

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -5042,7 +5042,10 @@
             "keyfileRepointHint": "Tato cesta pouze ukazuje, kde soubor klíče leží; její změna trezor nepřeklíčuje. Špatný nebo chybějící soubor klíče odemčení odmítne.",
             "keyfileStorageHint": "Uložte jej na místní disk nebo USB disk, odděleně od vzdáleného úložiště, které šifrujete, a uchovejte si záložní kopii.",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "Vzdálená cesta překryvu",
+            "overlaysRemotePathHint": "Vzdálená složka, ke které je překryv ukotven. Ponechte prázdné pro použití Vzdálené cesty. Musí to být samotná Vzdálená cesta nebo složka uvnitř ní.",
+            "overlaysRemotePathInvalid": "Musí to být Vzdálená cesta nebo její podsložka"
         },
         "modalGuard": {
             "busyTitle": "Probíhá operace",

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -5044,7 +5044,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "Vzdálená cesta překryvu",
-            "overlaysRemotePathHint": "Vzdálená složka, ke které je překryv ukotven. Ponechte prázdné pro použití Vzdálené cesty. Musí to být samotná Vzdálená cesta nebo složka uvnitř ní.",
+            "overlaysRemotePathHint": "Podsložka Remote Path, kde je vrstva ukotvena. Ponechte prázdné pro použití Remote Path, nebo zadejte jen název podsložky (vytvoří se pod Remote Path).",
             "overlaysRemotePathInvalid": "Musí to být Vzdálená cesta nebo její podsložka"
         },
         "modalGuard": {

--- a/src/i18n/locales/cy.json
+++ b/src/i18n/locales/cy.json
@@ -5061,7 +5061,10 @@
             "keyfileRepointHint": "Dim ond dangos lle mae'r ffeil allwedd y mae'r llwybr hwn; nid yw ei newid yn ail-allweddu'r gladdgell. Bydd ffeil allwedd anghywir neu goll yn gwrthod datgloi.",
             "keyfileStorageHint": "Cadwch ef ar ddisg lleol neu yriant USB, ar wahân i'r pell rydych chi'n ei amgryptio, a chadwch gopi wrth gefn.",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "Llwybr Pell yr Troshaen",
+            "overlaysRemotePathHint": "Ffolder bell lle mae'r troshaen wedi'i angori. Gadewch yn wag i ddefnyddio'r Llwybr Pell. Rhaid iddo fod y Llwybr Pell ei hun neu ffolder o'i fewn.",
+            "overlaysRemotePathInvalid": "Rhaid iddo fod y Llwybr Pell neu is-ffolder ohono"
         },
         "modalGuard": {
             "busyTitle": "Gweithrediad ar y gweill",

--- a/src/i18n/locales/cy.json
+++ b/src/i18n/locales/cy.json
@@ -5063,7 +5063,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "Llwybr Pell yr Troshaen",
-            "overlaysRemotePathHint": "Ffolder bell lle mae'r troshaen wedi'i angori. Gadewch yn wag i ddefnyddio'r Llwybr Pell. Rhaid iddo fod y Llwybr Pell ei hun neu ffolder o'i fewn.",
+            "overlaysRemotePathHint": "Is-ffolder o'r Remote Path lle mae'r troshaen wedi'i angori. Gadewch yn wag i ddefnyddio'r Remote Path, neu teipiwch enw is-ffolder yn unig (caiff ei greu o dan y Remote Path).",
             "overlaysRemotePathInvalid": "Rhaid iddo fod y Llwybr Pell neu is-ffolder ohono"
         },
         "modalGuard": {

--- a/src/i18n/locales/da.json
+++ b/src/i18n/locales/da.json
@@ -5042,7 +5042,10 @@
             "keyfileRepointHint": "Denne sti peger kun på, hvor nøglefilen ligger; at ændre den omnøgler ikke boksen. En forkert eller manglende nøglefil afviser oplåsningen.",
             "keyfileStorageHint": "Gem den på en lokal disk eller et USB-drev, adskilt fra det fjernlager, du krypterer, og opbevar en sikkerhedskopi.",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "Fjernsti for overlay",
+            "overlaysRemotePathHint": "Fjernmappe hvor overlayet er forankret. Lad stå tomt for at bruge Fjernstien. Det skal være selve Fjernstien eller en mappe i den.",
+            "overlaysRemotePathInvalid": "Skal være Fjernstien eller en undermappe af den"
         },
         "modalGuard": {
             "busyTitle": "Handling i gang",

--- a/src/i18n/locales/da.json
+++ b/src/i18n/locales/da.json
@@ -5044,7 +5044,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "Fjernsti for overlay",
-            "overlaysRemotePathHint": "Fjernmappe hvor overlayet er forankret. Lad stå tomt for at bruge Fjernstien. Det skal være selve Fjernstien eller en mappe i den.",
+            "overlaysRemotePathHint": "Undermappe af Remote Path, hvor overlayet er forankret. Lad feltet stå tomt for at bruge Remote Path, eller skriv blot et undermappenavn (det oprettes under Remote Path).",
             "overlaysRemotePathInvalid": "Skal være Fjernstien eller en undermappe af den"
         },
         "modalGuard": {

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -5042,7 +5042,10 @@
             "keyfileRepointHint": "Dieser Pfad zeigt nur, wo die Schlüsseldatei liegt; ihn zu ändern verschlüsselt den Tresor nicht neu. Eine falsche oder fehlende Schlüsseldatei verweigert das Entsperren.",
             "keyfileStorageHint": "Speichern Sie sie auf einer lokalen Festplatte oder einem USB-Stick, getrennt von dem Remote, das Sie verschlüsseln, und bewahren Sie eine Sicherungskopie auf.",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "Remote-Pfad des Overlays",
+            "overlaysRemotePathHint": "Remote-Ordner, an dem das Overlay verankert ist. Leer lassen, um den Remote-Pfad zu verwenden. Muss der Remote-Pfad selbst oder ein Ordner darin sein.",
+            "overlaysRemotePathInvalid": "Muss der Remote-Pfad oder ein Unterordner davon sein"
         },
         "modalGuard": {
             "busyTitle": "Vorgang läuft",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -5044,7 +5044,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "Remote-Pfad des Overlays",
-            "overlaysRemotePathHint": "Remote-Ordner, an dem das Overlay verankert ist. Leer lassen, um den Remote-Pfad zu verwenden. Muss der Remote-Pfad selbst oder ein Ordner darin sein.",
+            "overlaysRemotePathHint": "Unterordner des Remote Path, in dem das Overlay verankert wird. Leer lassen, um den Remote Path zu verwenden, oder nur einen Unterordnernamen eingeben (er wird unter dem Remote Path erstellt).",
             "overlaysRemotePathInvalid": "Muss der Remote-Pfad oder ein Unterordner davon sein"
         },
         "modalGuard": {

--- a/src/i18n/locales/el.json
+++ b/src/i18n/locales/el.json
@@ -5044,7 +5044,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "Απομακρυσμένη διαδρομή επικάλυψης",
-            "overlaysRemotePathHint": "Απομακρυσμένος φάκελος όπου αγκυρώνεται η επικάλυψη. Αφήστε το κενό για χρήση της Απομακρυσμένης διαδρομής. Πρέπει να είναι η ίδια η Απομακρυσμένη διαδρομή ή ένας φάκελος μέσα της.",
+            "overlaysRemotePathHint": "Υποφάκελος του Remote Path όπου αγκυρώνεται η επικάλυψη. Αφήστε το κενό για να χρησιμοποιήσετε το Remote Path ή πληκτρολογήστε μόνο ένα όνομα υποφακέλου (δημιουργείται κάτω από το Remote Path).",
             "overlaysRemotePathInvalid": "Πρέπει να είναι η Απομακρυσμένη διαδρομή ή ένας υποφάκελός της"
         },
         "modalGuard": {

--- a/src/i18n/locales/el.json
+++ b/src/i18n/locales/el.json
@@ -5042,7 +5042,10 @@
             "keyfileRepointHint": "Αυτή η διαδρομή δείχνει μόνο πού βρίσκεται το αρχείο κλειδιού; η αλλαγή της δεν αλλάζει το κλειδί της κρύπτης. Λάθος ή απόν αρχείο κλειδιού απορρίπτει το ξεκλείδωμα.",
             "keyfileStorageHint": "Αποθηκεύστε το σε τοπικό δίσκο ή μονάδα USB, ξεχωριστά από τον απομακρυσμένο διακομιστή που κρυπτογραφείτε, και κρατήστε ένα αντίγραφο ασφαλείας.",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "Απομακρυσμένη διαδρομή επικάλυψης",
+            "overlaysRemotePathHint": "Απομακρυσμένος φάκελος όπου αγκυρώνεται η επικάλυψη. Αφήστε το κενό για χρήση της Απομακρυσμένης διαδρομής. Πρέπει να είναι η ίδια η Απομακρυσμένη διαδρομή ή ένας φάκελος μέσα της.",
+            "overlaysRemotePathInvalid": "Πρέπει να είναι η Απομακρυσμένη διαδρομή ή ένας υποφάκελός της"
         },
         "modalGuard": {
             "busyTitle": "Λειτουργία σε εξέλιξη",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -5036,7 +5036,7 @@
             "overlaysSection": "Wrappers / Overlays",
             "overlaysActiveBadge": "On",
             "overlaysRemotePath": "Overlays Remote Path",
-            "overlaysRemotePathHint": "Remote folder where the overlay is anchored. Leave empty to use the Remote Path. Must be the Remote Path itself or a folder inside it.",
+            "overlaysRemotePathHint": "Subfolder of the Remote Path where the overlay is anchored. Leave empty to use the Remote Path, or type just a subfolder name (it is created under the Remote Path).",
             "overlaysRemotePathInvalid": "Must be the Remote Path or a subfolder of it",
             "enable": "Crypt (Encryption)",
             "hint": "Encrypt this connection transparently: the dual-panel shows clear names, uploads encrypt, downloads decrypt.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -5035,6 +5035,9 @@
         "aerocryptProfile": {
             "overlaysSection": "Wrappers / Overlays",
             "overlaysActiveBadge": "On",
+            "overlaysRemotePath": "Overlays Remote Path",
+            "overlaysRemotePathHint": "Remote folder where the overlay is anchored. Leave empty to use the Remote Path. Must be the Remote Path itself or a folder inside it.",
+            "overlaysRemotePathInvalid": "Must be the Remote Path or a subfolder of it",
             "enable": "Crypt (Encryption)",
             "hint": "Encrypt this connection transparently: the dual-panel shows clear names, uploads encrypt, downloads decrypt.",
             "hintNative": "Native AeroCrypt format: readable only from AeroFTP with this password.",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -5042,7 +5042,10 @@
             "keyfileRepointHint": "Esta ruta solo indica dónde está el archivo de clave; cambiarla no vuelve a cifrar la bóveda. Un archivo de clave erróneo o ausente rechaza el desbloqueo.",
             "keyfileStorageHint": "Guárdalo en un disco local o una unidad USB, separado del remoto que estás cifrando, y conserva una copia de seguridad.",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "Ruta remota de la superposición",
+            "overlaysRemotePathHint": "Carpeta remota donde se ancla la superposición. Déjelo vacío para usar la Ruta remota. Debe ser la Ruta remota en sí o una carpeta dentro de ella.",
+            "overlaysRemotePathInvalid": "Debe ser la Ruta remota o una subcarpeta de ella"
         },
         "modalGuard": {
             "busyTitle": "Operación en curso",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -5044,7 +5044,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "Ruta remota de la superposición",
-            "overlaysRemotePathHint": "Carpeta remota donde se ancla la superposición. Déjelo vacío para usar la Ruta remota. Debe ser la Ruta remota en sí o una carpeta dentro de ella.",
+            "overlaysRemotePathHint": "Subcarpeta del Remote Path donde se ancla la superposición. Déjalo vacío para usar el Remote Path, o escribe solo un nombre de subcarpeta (se crea bajo el Remote Path).",
             "overlaysRemotePathInvalid": "Debe ser la Ruta remota o una subcarpeta de ella"
         },
         "modalGuard": {

--- a/src/i18n/locales/et.json
+++ b/src/i18n/locales/et.json
@@ -5044,7 +5044,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "Ülekatte kaugtee",
-            "overlaysRemotePathHint": "Kaugkaust, kuhu ülekate on ankurdatud. Kaugtee kasutamiseks jätke tühjaks. Peab olema Kaugtee ise või selle sees olev kaust.",
+            "overlaysRemotePathHint": "Remote Path'i alamkaust, kuhu ülekate ankurdatakse. Jäta tühjaks, et kasutada Remote Path'i, või sisesta ainult alamkausta nimi (see luuakse Remote Path'i alla).",
             "overlaysRemotePathInvalid": "Peab olema Kaugtee või selle alamkaust"
         },
         "modalGuard": {

--- a/src/i18n/locales/et.json
+++ b/src/i18n/locales/et.json
@@ -5042,7 +5042,10 @@
             "keyfileRepointHint": "See tee näitab vaid, kus võtmefail asub; selle muutmine hoidlat ümber ei võtmesta. Vale või puuduv võtmefail keelab avamise.",
             "keyfileStorageHint": "Salvestage see kohalikule kettale või USB-mälupulgale, eraldi kaugserverist, mida krüpteerite, ja hoidke alles varukoopia.",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "Ülekatte kaugtee",
+            "overlaysRemotePathHint": "Kaugkaust, kuhu ülekate on ankurdatud. Kaugtee kasutamiseks jätke tühjaks. Peab olema Kaugtee ise või selle sees olev kaust.",
+            "overlaysRemotePathInvalid": "Peab olema Kaugtee või selle alamkaust"
         },
         "modalGuard": {
             "busyTitle": "Toiming käib",

--- a/src/i18n/locales/eu.json
+++ b/src/i18n/locales/eu.json
@@ -5063,7 +5063,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "Gainjarriaren urruneko bidea",
-            "overlaysRemotePathHint": "Gainjarria ainguratuta dagoen urruneko karpeta. Utzi hutsik Urruneko bidea erabiltzeko. Urruneko bidea bera edo bertako karpeta bat izan behar da.",
+            "overlaysRemotePathHint": "Gainjartzea ainguratzen den Remote Path-eko azpikarpeta. Utzi hutsik Remote Path erabiltzeko, edo idatzi azpikarpeta baten izena soilik (Remote Path-en azpian sortzen da).",
             "overlaysRemotePathInvalid": "Urruneko bidea edo horren azpikarpeta bat izan behar da"
         },
         "modalGuard": {

--- a/src/i18n/locales/eu.json
+++ b/src/i18n/locales/eu.json
@@ -5061,7 +5061,10 @@
             "keyfileRepointHint": "Bide honek gako-fitxategia non dagoen baino ez du adierazten; aldatzeak ez du kutxa berriro zifratzen. Gako-fitxategi oker edo faltak desblokeoa ukatzen du.",
             "keyfileStorageHint": "Gorde ezazu tokiko disko batean edo USB unitate batean, enkriptatzen ari zaren urrunekotik bereizita, eta gorde segurtasun-kopia bat.",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "Gainjarriaren urruneko bidea",
+            "overlaysRemotePathHint": "Gainjarria ainguratuta dagoen urruneko karpeta. Utzi hutsik Urruneko bidea erabiltzeko. Urruneko bidea bera edo bertako karpeta bat izan behar da.",
+            "overlaysRemotePathInvalid": "Urruneko bidea edo horren azpikarpeta bat izan behar da"
         },
         "modalGuard": {
             "busyTitle": "Eragiketa abian",

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -5042,7 +5042,10 @@
             "keyfileRepointHint": "Tämä polku vain osoittaa, missä avaintiedosto sijaitsee; sen muuttaminen ei vaihda holvin avainta. Väärä tai puuttuva avaintiedosto estää avauksen.",
             "keyfileStorageHint": "Tallenna se paikalliselle levylle tai USB-asemalle, erilleen etäpalvelimesta, jota salaat, ja säilytä varmuuskopio.",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "Peittokerroksen etäpolku",
+            "overlaysRemotePathHint": "Etäkansio, johon peittokerros on ankkuroitu. Jätä tyhjäksi käyttääksesi Etäpolkua. Sen on oltava Etäpolku itse tai sen sisällä oleva kansio.",
+            "overlaysRemotePathInvalid": "Sen on oltava Etäpolku tai sen alikansio"
         },
         "modalGuard": {
             "busyTitle": "Toiminto käynnissä",

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -5044,7 +5044,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "Peittokerroksen etäpolku",
-            "overlaysRemotePathHint": "Etäkansio, johon peittokerros on ankkuroitu. Jätä tyhjäksi käyttääksesi Etäpolkua. Sen on oltava Etäpolku itse tai sen sisällä oleva kansio.",
+            "overlaysRemotePathHint": "Remote Pathin alikansio, johon peite ankkuroidaan. Jätä tyhjäksi käyttääksesi Remote Pathia, tai kirjoita vain alikansion nimi (se luodaan Remote Pathin alle).",
             "overlaysRemotePathInvalid": "Sen on oltava Etäpolku tai sen alikansio"
         },
         "modalGuard": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -5042,7 +5042,10 @@
             "keyfileRepointHint": "Ce chemin indique seulement où se trouve le fichier de clé ; le modifier ne rechiffre pas le coffre. Un fichier de clé erroné ou absent refuse le déverrouillage.",
             "keyfileStorageHint": "Conservez-le sur un disque local ou une clé USB, séparé du serveur distant que vous chiffrez, et gardez une copie de sauvegarde.",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "Chemin distant de la superposition",
+            "overlaysRemotePathHint": "Dossier distant où la superposition est ancrée. Laissez vide pour utiliser le Chemin distant. Doit être le Chemin distant lui-même ou un dossier qu'il contient.",
+            "overlaysRemotePathInvalid": "Doit être le Chemin distant ou un de ses sous-dossiers"
         },
         "modalGuard": {
             "busyTitle": "Opération en cours",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -5044,7 +5044,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "Chemin distant de la superposition",
-            "overlaysRemotePathHint": "Dossier distant où la superposition est ancrée. Laissez vide pour utiliser le Chemin distant. Doit être le Chemin distant lui-même ou un dossier qu'il contient.",
+            "overlaysRemotePathHint": "Sous-dossier du Remote Path où la superposition est ancrée. Laissez vide pour utiliser le Remote Path, ou saisissez uniquement un nom de sous-dossier (il est créé sous le Remote Path).",
             "overlaysRemotePathInvalid": "Doit être le Chemin distant ou un de ses sous-dossiers"
         },
         "modalGuard": {

--- a/src/i18n/locales/gl.json
+++ b/src/i18n/locales/gl.json
@@ -5063,7 +5063,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "Ruta remota da superposición",
-            "overlaysRemotePathHint": "Cartafol remoto onde se ancora a superposición. Déixeo baleiro para usar a Ruta remota. Debe ser a propia Ruta remota ou un cartafol dentro dela.",
+            "overlaysRemotePathHint": "Subcartafol do Remote Path onde se ancora a superposición. Déixao baleiro para usar o Remote Path, ou escribe só un nome de subcartafol (créase baixo o Remote Path).",
             "overlaysRemotePathInvalid": "Debe ser a Ruta remota ou un subcartafol dela"
         },
         "modalGuard": {

--- a/src/i18n/locales/gl.json
+++ b/src/i18n/locales/gl.json
@@ -5061,7 +5061,10 @@
             "keyfileRepointHint": "Esta ruta só indica onde está o ficheiro de clave; cambiala non volve cifrar a caixa forte. Un ficheiro de clave errado ou ausente rexeita o desbloqueo.",
             "keyfileStorageHint": "Gárdao nun disco local ou nunha unidade USB, separado do remoto que estás cifrando, e conserva unha copia de seguranza.",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "Ruta remota da superposición",
+            "overlaysRemotePathHint": "Cartafol remoto onde se ancora a superposición. Déixeo baleiro para usar a Ruta remota. Debe ser a propia Ruta remota ou un cartafol dentro dela.",
+            "overlaysRemotePathInvalid": "Debe ser a Ruta remota ou un subcartafol dela"
         },
         "modalGuard": {
             "busyTitle": "Operación en curso",

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -5042,7 +5042,10 @@
             "keyfileRepointHint": "यह पथ केवल बताता है कि की-फ़ाइल कहाँ है; इसे बदलने से वॉल्ट की कुंजी नहीं बदलती। गलत या अनुपलब्ध की-फ़ाइल पर अनलॉक अस्वीकृत होता है।",
             "keyfileStorageHint": "इसे स्थानीय डिस्क या USB ड्राइव पर सहेजें, जिस रिमोट को आप एन्क्रिप्ट कर रहे हैं उससे अलग रखें, और एक बैकअप प्रति रखें।",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "ओवरले रिमोट पथ",
+            "overlaysRemotePathHint": "वह दूरस्थ फ़ोल्डर जहाँ ओवरले लंगर डाला गया है। रिमोट पथ का उपयोग करने के लिए खाली छोड़ें। यह रिमोट पथ स्वयं या उसके भीतर का कोई फ़ोल्डर होना चाहिए।",
+            "overlaysRemotePathInvalid": "यह रिमोट पथ या उसका उपफ़ोल्डर होना चाहिए"
         },
         "modalGuard": {
             "busyTitle": "ऑपरेशन जारी है",

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -5044,7 +5044,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "ओवरले रिमोट पथ",
-            "overlaysRemotePathHint": "वह दूरस्थ फ़ोल्डर जहाँ ओवरले लंगर डाला गया है। रिमोट पथ का उपयोग करने के लिए खाली छोड़ें। यह रिमोट पथ स्वयं या उसके भीतर का कोई फ़ोल्डर होना चाहिए।",
+            "overlaysRemotePathHint": "Remote Path का सबफ़ोल्डर जहाँ ओवरले एंकर किया जाता है। Remote Path का उपयोग करने के लिए इसे खाली छोड़ें, या केवल एक सबफ़ोल्डर नाम टाइप करें (यह Remote Path के अंतर्गत बनाया जाता है)।",
             "overlaysRemotePathInvalid": "यह रिमोट पथ या उसका उपफ़ोल्डर होना चाहिए"
         },
         "modalGuard": {

--- a/src/i18n/locales/hr.json
+++ b/src/i18n/locales/hr.json
@@ -5042,7 +5042,10 @@
             "keyfileRepointHint": "Ova putanja samo pokazuje gdje se datoteka ključa nalazi; njezina promjena ne mijenja ključ trezora. Pogrešna ili nedostajuća datoteka ključa odbija otključavanje.",
             "keyfileStorageHint": "Spremite ga na lokalni disk ili USB pogon, odvojeno od udaljenog poslužitelja koji šifrirate, i čuvajte sigurnosnu kopiju.",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "Udaljena putanja sloja",
+            "overlaysRemotePathHint": "Udaljena mapa u kojoj je sloj usidren. Ostavite prazno za korištenje Udaljene putanje. Mora biti sama Udaljena putanja ili mapa unutar nje.",
+            "overlaysRemotePathInvalid": "Mora biti Udaljena putanja ili njezina podmapa"
         },
         "modalGuard": {
             "busyTitle": "Operacija u tijeku",

--- a/src/i18n/locales/hr.json
+++ b/src/i18n/locales/hr.json
@@ -5044,7 +5044,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "Udaljena putanja sloja",
-            "overlaysRemotePathHint": "Udaljena mapa u kojoj je sloj usidren. Ostavite prazno za korištenje Udaljene putanje. Mora biti sama Udaljena putanja ili mapa unutar nje.",
+            "overlaysRemotePathHint": "Podmapa Remote Patha u kojoj je sloj usidren. Ostavite prazno za korištenje Remote Patha ili upišite samo naziv podmape (stvara se unutar Remote Patha).",
             "overlaysRemotePathInvalid": "Mora biti Udaljena putanja ili njezina podmapa"
         },
         "modalGuard": {

--- a/src/i18n/locales/hu.json
+++ b/src/i18n/locales/hu.json
@@ -5042,7 +5042,10 @@
             "keyfileRepointHint": "Ez az útvonal csak azt mutatja, hol van a kulcsfájl; módosítása nem kulcsolja újra a széfet. Hibás vagy hiányzó kulcsfájl esetén a feloldás megtagadva.",
             "keyfileStorageHint": "Mentse el helyi lemezre vagy USB-meghajtóra, a titkosított távoli tárhelytől elkülönítve, és őrizzen meg egy biztonsági másolatot.",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "Az átfedés távoli útvonala",
+            "overlaysRemotePathHint": "Távoli mappa, amelyhez az átfedés rögzítve van. Hagyja üresen a Távoli útvonal használatához. A Távoli útvonalnak magának vagy egy benne lévő mappának kell lennie.",
+            "overlaysRemotePathInvalid": "A Távoli útvonalnak vagy annak almappájának kell lennie"
         },
         "modalGuard": {
             "busyTitle": "Művelet folyamatban",

--- a/src/i18n/locales/hu.json
+++ b/src/i18n/locales/hu.json
@@ -5044,7 +5044,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "Az átfedés távoli útvonala",
-            "overlaysRemotePathHint": "Távoli mappa, amelyhez az átfedés rögzítve van. Hagyja üresen a Távoli útvonal használatához. A Távoli útvonalnak magának vagy egy benne lévő mappának kell lennie.",
+            "overlaysRemotePathHint": "A Remote Path azon almappája, ahol az átfedés rögzül. Hagyja üresen a Remote Path használatához, vagy írjon be csak egy almappanevet (a Remote Path alatt jön létre).",
             "overlaysRemotePathInvalid": "A Távoli útvonalnak vagy annak almappájának kell lennie"
         },
         "modalGuard": {

--- a/src/i18n/locales/hy.json
+++ b/src/i18n/locales/hy.json
@@ -5042,7 +5042,10 @@
             "keyfileRepointHint": "Այս ուղին միայն ցույց է տալիս, թե որտեղ է բանալի ֆայլը. այն փոխելը պահոցի բանալին չի փոխում: Սխալ կամ բացակայող բանալի ֆայլը մերժում է ապակողպումը:",
             "keyfileStorageHint": "Պահեք այն տեղական սկավառակի կամ USB կրիչի վրա՝ առանձին այն հեռավոր սերվերից, որը գաղտնագրում եք, և պահեք պահուստային պատճեն։",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "Վերադրման հեռավոր ուղի",
+            "overlaysRemotePathHint": "Հեռավոր թղթապանակ, որտեղ ամրացված է վերադրումը։ Թողեք դատարկ՝ Հեռավոր ուղին օգտագործելու համար։ Պետք է լինի հենց Հեռավոր ուղին կամ դրա ներսում գտնվող թղթապանակ։",
+            "overlaysRemotePathInvalid": "Պետք է լինի Հեռավոր ուղին կամ դրա ենթաթղթապանակը"
         },
         "modalGuard": {
             "busyTitle": "Գործողությունն ընթացքի մեջ է",

--- a/src/i18n/locales/hy.json
+++ b/src/i18n/locales/hy.json
@@ -5044,7 +5044,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "Վերադրման հեռավոր ուղի",
-            "overlaysRemotePathHint": "Հեռավոր թղթապանակ, որտեղ ամրացված է վերադրումը։ Թողեք դատարկ՝ Հեռավոր ուղին օգտագործելու համար։ Պետք է լինի հենց Հեռավոր ուղին կամ դրա ներսում գտնվող թղթապանակ։",
+            "overlaysRemotePathHint": "Remote Path-ի ենթապանակը, որտեղ ամրագրվում է վերադրումը։ Թողեք դատարկ՝ Remote Path-ն օգտագործելու համար, կամ մուտքագրեք միայն ենթապանակի անուն (այն ստեղծվում է Remote Path-ի ներքո)։",
             "overlaysRemotePathInvalid": "Պետք է լինի Հեռավոր ուղին կամ դրա ենթաթղթապանակը"
         },
         "modalGuard": {

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -5042,7 +5042,10 @@
             "keyfileRepointHint": "Jalur ini hanya menunjuk lokasi berkas kunci; mengubahnya tidak mengganti kunci brankas. Berkas kunci yang salah atau hilang menolak pembukaan.",
             "keyfileStorageHint": "Simpan di disk lokal atau drive USB, terpisah dari remote yang Anda enkripsi, dan simpan salinan cadangan.",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "Jalur Jarak Jauh Overlay",
+            "overlaysRemotePathHint": "Folder jarak jauh tempat overlay ditambatkan. Biarkan kosong untuk menggunakan Jalur Jarak Jauh. Harus berupa Jalur Jarak Jauh itu sendiri atau folder di dalamnya.",
+            "overlaysRemotePathInvalid": "Harus berupa Jalur Jarak Jauh atau subfolder darinya"
         },
         "modalGuard": {
             "busyTitle": "Operasi berlangsung",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -5044,7 +5044,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "Jalur Jarak Jauh Overlay",
-            "overlaysRemotePathHint": "Folder jarak jauh tempat overlay ditambatkan. Biarkan kosong untuk menggunakan Jalur Jarak Jauh. Harus berupa Jalur Jarak Jauh itu sendiri atau folder di dalamnya.",
+            "overlaysRemotePathHint": "Subfolder dari Remote Path tempat overlay ditambatkan. Biarkan kosong untuk menggunakan Remote Path, atau ketik hanya nama subfolder (dibuat di dalam Remote Path).",
             "overlaysRemotePathInvalid": "Harus berupa Jalur Jarak Jauh atau subfolder darinya"
         },
         "modalGuard": {

--- a/src/i18n/locales/is.json
+++ b/src/i18n/locales/is.json
@@ -5063,7 +5063,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "Fjarslóð yfirlags",
-            "overlaysRemotePathHint": "Fjarmappa þar sem yfirlagið er fest. Skildu eftir autt til að nota Fjarslóðina. Verður að vera Fjarslóðin sjálf eða mappa innan hennar.",
+            "overlaysRemotePathHint": "Undirmappa Remote Path þar sem yfirlagið er fest. Skildu eftir autt til að nota Remote Path, eða skrifaðu aðeins undirmöppuheiti (það er búið til undir Remote Path).",
             "overlaysRemotePathInvalid": "Verður að vera Fjarslóðin eða undirmappa hennar"
         },
         "modalGuard": {

--- a/src/i18n/locales/is.json
+++ b/src/i18n/locales/is.json
@@ -5061,7 +5061,10 @@
             "keyfileRepointHint": "Þessi slóð bendir aðeins á hvar lykilskráin liggur; að breyta henni endurlyklar ekki hirsluna. Röng eða vantandi lykilskrá hafnar aflæsingu.",
             "keyfileStorageHint": "Vistaðu það á staðbundnum diski eða USB-drifi, aðskilið frá fjartengingunni sem þú ert að dulkóða, og geymdu öryggisafrit.",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "Fjarslóð yfirlags",
+            "overlaysRemotePathHint": "Fjarmappa þar sem yfirlagið er fest. Skildu eftir autt til að nota Fjarslóðina. Verður að vera Fjarslóðin sjálf eða mappa innan hennar.",
+            "overlaysRemotePathInvalid": "Verður að vera Fjarslóðin eða undirmappa hennar"
         },
         "modalGuard": {
             "busyTitle": "Aðgerð í gangi",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -5052,7 +5052,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "Percorso remoto dell'overlay",
-            "overlaysRemotePathHint": "Cartella remota a cui è ancorato l'overlay. Lascia vuoto per usare il Percorso remoto. Deve essere il Percorso remoto stesso o una cartella al suo interno.",
+            "overlaysRemotePathHint": "Sottocartella del Remote Path in cui l'overlay è ancorato. Lascia vuoto per usare il Remote Path, oppure digita solo il nome di una sottocartella (viene creata sotto il Remote Path).",
             "overlaysRemotePathInvalid": "Deve essere il Percorso remoto o una sua sottocartella"
         },
         "modalGuard": {

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -5050,7 +5050,10 @@
             "keyfileGeneratedBackup": "File chiave generato. Fai subito un backup: perderlo rende la cassaforte inapribile per sempre.",
             "keyfileRepointHint": "Questo percorso indica solo dove si trova il file chiave; cambiarlo non ricifra la cassaforte. Un file chiave errato o assente rifiuta lo sblocco.",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "Percorso remoto dell'overlay",
+            "overlaysRemotePathHint": "Cartella remota a cui è ancorato l'overlay. Lascia vuoto per usare il Percorso remoto. Deve essere il Percorso remoto stesso o una cartella al suo interno.",
+            "overlaysRemotePathInvalid": "Deve essere il Percorso remoto o una sua sottocartella"
         },
         "modalGuard": {
             "busyTitle": "Operazione in corso",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -5044,7 +5044,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "オーバーレイのリモートパス",
-            "overlaysRemotePathHint": "オーバーレイを固定するリモートフォルダー。空欄にするとリモートパスを使用します。リモートパス自体か、その中のフォルダーである必要があります。",
+            "overlaysRemotePathHint": "オーバーレイをアンカーする Remote Path のサブフォルダーです。Remote Path をそのまま使うには空のままにするか、サブフォルダー名だけを入力してください（Remote Path の下に作成されます）。",
             "overlaysRemotePathInvalid": "リモートパス自体か、そのサブフォルダーである必要があります"
         },
         "modalGuard": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -5042,7 +5042,10 @@
             "keyfileRepointHint": "このパスはキーファイルの場所を指すだけで、変更してもボールトの鍵は変わりません。誤った、または見つからないキーファイルではロック解除は拒否されます。",
             "keyfileStorageHint": "暗号化するリモートとは別に、ローカルディスクまたは USB ドライブに保存し、バックアップコピーを保管してください。",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "オーバーレイのリモートパス",
+            "overlaysRemotePathHint": "オーバーレイを固定するリモートフォルダー。空欄にするとリモートパスを使用します。リモートパス自体か、その中のフォルダーである必要があります。",
+            "overlaysRemotePathInvalid": "リモートパス自体か、そのサブフォルダーである必要があります"
         },
         "modalGuard": {
             "busyTitle": "操作の実行中",

--- a/src/i18n/locales/ka.json
+++ b/src/i18n/locales/ka.json
@@ -5042,7 +5042,10 @@
             "keyfileRepointHint": "ეს გზა მხოლოდ მიუთითებს, სად დევს გასაღების ფაილი; მისი შეცვლა საცავის გასაღებს არ ცვლის. არასწორი ან დაკარგული გასაღების ფაილი განბლოკვას უარყოფს.",
             "keyfileStorageHint": "შეინახეთ ის ლოკალურ დისკზე ან USB მოწყობილობაზე, იმ დაშიფრული დისტანციური სერვერისგან ცალკე, და შეინახეთ სარეზერვო ასლი.",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "გადაფარვის დისტანციური გზა",
+            "overlaysRemotePathHint": "დისტანციური საქაღალდე, სადაც გადაფარვა არის მიმაგრებული. დატოვეთ ცარიელი დისტანციური გზის გამოსაყენებლად. უნდა იყოს თავად დისტანციური გზა ან მის შიგნით არსებული საქაღალდე.",
+            "overlaysRemotePathInvalid": "უნდა იყოს დისტანციური გზა ან მისი ქვესაქაღალდე"
         },
         "modalGuard": {
             "busyTitle": "მიმდინარეობს ოპერაცია",

--- a/src/i18n/locales/ka.json
+++ b/src/i18n/locales/ka.json
@@ -5044,7 +5044,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "გადაფარვის დისტანციური გზა",
-            "overlaysRemotePathHint": "დისტანციური საქაღალდე, სადაც გადაფარვა არის მიმაგრებული. დატოვეთ ცარიელი დისტანციური გზის გამოსაყენებლად. უნდა იყოს თავად დისტანციური გზა ან მის შიგნით არსებული საქაღალდე.",
+            "overlaysRemotePathHint": "Remote Path-ის ქვესაქაღალდე, სადაც ოვერლეი მიმაგრებულია. დატოვეთ ცარიელი Remote Path-ის გამოსაყენებლად, ან აკრიფეთ მხოლოდ ქვესაქაღალდის სახელი (ის იქმნება Remote Path-ის ქვეშ).",
             "overlaysRemotePathInvalid": "უნდა იყოს დისტანციური გზა ან მისი ქვესაქაღალდე"
         },
         "modalGuard": {

--- a/src/i18n/locales/km.json
+++ b/src/i18n/locales/km.json
@@ -5063,7 +5063,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "ផ្លូវពីចម្ងាយនៃការត្រួតលើ",
-            "overlaysRemotePathHint": "ថតពីចម្ងាយដែលការត្រួតលើត្រូវបានចងភ្ជាប់។ ទុកឱ្យទទេដើម្បីប្រើផ្លូវពីចម្ងាយ។ ត្រូវតែជាផ្លូវពីចម្ងាយខ្លួនឯង ឬថតនៅខាងក្នុងវា។",
+            "overlaysRemotePathHint": "ថតរងនៃ Remote Path ដែលការត្រួតលើត្រូវបានចងភ្ជាប់។ ទុកឲ្យទទេដើម្បីប្រើ Remote Path ឬវាយបញ្ចូលតែឈ្មោះថតរង (វាត្រូវបានបង្កើតនៅក្រោម Remote Path)។",
             "overlaysRemotePathInvalid": "ត្រូវតែជាផ្លូវពីចម្ងាយ ឬថតរងរបស់វា"
         },
         "modalGuard": {

--- a/src/i18n/locales/km.json
+++ b/src/i18n/locales/km.json
@@ -5061,7 +5061,10 @@
             "keyfileRepointHint": "ផ្លូវនេះគ្រាន់តែចង្អុលទៅកន្លែងឯកសារកូនសោស្ថិតនៅ។ ការផ្លាស់ប្ដូរវាមិនផ្លាស់ប្ដូរកូនសោឃ្លាំងទេ។ ឯកសារកូនសោខុសឬបាត់ នឹងបដិសេធការដោះសោ។",
             "keyfileStorageHint": "រក្សាទុកវានៅលើថាសមូលដ្ឋាន ឬ USB ដ្រាយ ដោយឡែកពីម៉ាស៊ីនពីចម្ងាយដែលអ្នកកំពុងអ៊ិនគ្រីប ហើយរក្សាទុកច្បាប់ចម្លងបម្រុងទុក។",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "ផ្លូវពីចម្ងាយនៃការត្រួតលើ",
+            "overlaysRemotePathHint": "ថតពីចម្ងាយដែលការត្រួតលើត្រូវបានចងភ្ជាប់។ ទុកឱ្យទទេដើម្បីប្រើផ្លូវពីចម្ងាយ។ ត្រូវតែជាផ្លូវពីចម្ងាយខ្លួនឯង ឬថតនៅខាងក្នុងវា។",
+            "overlaysRemotePathInvalid": "ត្រូវតែជាផ្លូវពីចម្ងាយ ឬថតរងរបស់វា"
         },
         "modalGuard": {
             "busyTitle": "ប្រតិបត្តិការកំពុងដំណើរការ",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -5042,7 +5042,10 @@
             "keyfileRepointHint": "이 경로는 키파일의 위치만 가리키며, 변경해도 볼트의 키는 바뀌지 않습니다. 잘못되었거나 없는 키파일은 잠금 해제가 거부됩니다.",
             "keyfileStorageHint": "암호화하는 원격 저장소와 분리하여 로컬 디스크나 USB 드라이브에 저장하고 백업 사본을 보관하세요.",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "오버레이 원격 경로",
+            "overlaysRemotePathHint": "오버레이가 고정되는 원격 폴더입니다. 원격 경로를 사용하려면 비워 두세요. 원격 경로 자체이거나 그 안의 폴더여야 합니다.",
+            "overlaysRemotePathInvalid": "원격 경로이거나 그 하위 폴더여야 합니다"
         },
         "modalGuard": {
             "busyTitle": "작업 진행 중",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -5044,7 +5044,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "오버레이 원격 경로",
-            "overlaysRemotePathHint": "오버레이가 고정되는 원격 폴더입니다. 원격 경로를 사용하려면 비워 두세요. 원격 경로 자체이거나 그 안의 폴더여야 합니다.",
+            "overlaysRemotePathHint": "오버레이가 고정되는 Remote Path의 하위 폴더입니다. Remote Path를 사용하려면 비워 두거나, 하위 폴더 이름만 입력하세요(Remote Path 아래에 생성됩니다).",
             "overlaysRemotePathInvalid": "원격 경로이거나 그 하위 폴더여야 합니다"
         },
         "modalGuard": {

--- a/src/i18n/locales/lt.json
+++ b/src/i18n/locales/lt.json
@@ -5044,7 +5044,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "Perdangos nuotolinis kelias",
-            "overlaysRemotePathHint": "Nuotolinis aplankas, prie kurio pritvirtinta perdanga. Palikite tuščią, kad būtų naudojamas Nuotolinis kelias. Tai turi būti pats Nuotolinis kelias arba jame esantis aplankas.",
+            "overlaysRemotePathHint": "Remote Path poaplankis, kuriame pritvirtinamas perdangos sluoksnis. Palikite tuščią, kad būtų naudojamas Remote Path, arba įveskite tik poaplankio pavadinimą (jis sukuriamas po Remote Path).",
             "overlaysRemotePathInvalid": "Tai turi būti Nuotolinis kelias arba jo poaplankis"
         },
         "modalGuard": {

--- a/src/i18n/locales/lt.json
+++ b/src/i18n/locales/lt.json
@@ -5042,7 +5042,10 @@
             "keyfileRepointHint": "Šis kelias tik nurodo, kur yra rakto failas; jo keitimas saugyklos rakto nekeičia. Neteisingas ar trūkstamas rakto failas atrakinimą atmeta.",
             "keyfileStorageHint": "Išsaugokite jį vietiniame diske arba USB atmintinėje, atskirai nuo šifruojamo nuotolinio serverio, ir laikykite atsarginę kopiją.",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "Perdangos nuotolinis kelias",
+            "overlaysRemotePathHint": "Nuotolinis aplankas, prie kurio pritvirtinta perdanga. Palikite tuščią, kad būtų naudojamas Nuotolinis kelias. Tai turi būti pats Nuotolinis kelias arba jame esantis aplankas.",
+            "overlaysRemotePathInvalid": "Tai turi būti Nuotolinis kelias arba jo poaplankis"
         },
         "modalGuard": {
             "busyTitle": "Vykdoma operacija",

--- a/src/i18n/locales/lv.json
+++ b/src/i18n/locales/lv.json
@@ -5044,7 +5044,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "Pārklājuma attālais ceļš",
-            "overlaysRemotePathHint": "Attālā mape, kurā ir noenkurots pārklājums. Atstājiet tukšu, lai izmantotu Attālo ceļu. Tam jābūt pašam Attālajam ceļam vai mapei tajā.",
+            "overlaysRemotePathHint": "Remote Path apakšmape, kurā pārklājums ir noenkurots. Atstājiet tukšu, lai izmantotu Remote Path, vai ievadiet tikai apakšmapes nosaukumu (tā tiek izveidota zem Remote Path).",
             "overlaysRemotePathInvalid": "Tam jābūt Attālajam ceļam vai tā apakšmapei"
         },
         "modalGuard": {

--- a/src/i18n/locales/lv.json
+++ b/src/i18n/locales/lv.json
@@ -5042,7 +5042,10 @@
             "keyfileRepointHint": "Šis ceļš tikai norāda, kur atrodas atslēgas fails; tā maiņa nepāršifrē seifu. Nepareizs vai trūkstošs atslēgas fails noraida atslēgšanu.",
             "keyfileStorageHint": "Saglabājiet to lokālajā diskā vai USB diskā, atsevišķi no attālā servera, ko šifrējat, un saglabājiet dublējumkopiju.",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "Pārklājuma attālais ceļš",
+            "overlaysRemotePathHint": "Attālā mape, kurā ir noenkurots pārklājums. Atstājiet tukšu, lai izmantotu Attālo ceļu. Tam jābūt pašam Attālajam ceļam vai mapei tajā.",
+            "overlaysRemotePathInvalid": "Tam jābūt Attālajam ceļam vai tā apakšmapei"
         },
         "modalGuard": {
             "busyTitle": "Notiek darbība",

--- a/src/i18n/locales/mk.json
+++ b/src/i18n/locales/mk.json
@@ -5061,7 +5061,10 @@
             "keyfileRepointHint": "Оваа патека само покажува каде се наоѓа клучната датотека; нејзината промена не го менува клучот на трезорот. Погрешна или отсутна клучна датотека го одбива отклучувањето.",
             "keyfileStorageHint": "Зачувајте го на локален диск или USB уред, одвоено од далечниот сервер што го шифрирате, и чувајте резервна копија.",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "Оддалечена патека на прекривката",
+            "overlaysRemotePathHint": "Оддалечена папка каде што е закотвена прекривката. Оставете празно за да се користи Оддалечената патека. Мора да биде самата Оддалечена патека или папка во неа.",
+            "overlaysRemotePathInvalid": "Мора да биде Оддалечената патека или нејзина потпапка"
         },
         "modalGuard": {
             "busyTitle": "Операција во тек",

--- a/src/i18n/locales/mk.json
+++ b/src/i18n/locales/mk.json
@@ -5063,7 +5063,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "Оддалечена патека на прекривката",
-            "overlaysRemotePathHint": "Оддалечена папка каде што е закотвена прекривката. Оставете празно за да се користи Оддалечената патека. Мора да биде самата Оддалечена патека или папка во неа.",
+            "overlaysRemotePathHint": "Потпапка на Remote Path каде што е закотвен слојот. Оставете празно за да го користите Remote Path, или внесете само име на потпапка (се создава под Remote Path).",
             "overlaysRemotePathInvalid": "Мора да биде Оддалечената патека или нејзина потпапка"
         },
         "modalGuard": {

--- a/src/i18n/locales/ms.json
+++ b/src/i18n/locales/ms.json
@@ -5044,7 +5044,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "Laluan Jauh Tindanan",
-            "overlaysRemotePathHint": "Folder jauh tempat tindanan disauhkan. Biarkan kosong untuk menggunakan Laluan Jauh. Mestilah Laluan Jauh itu sendiri atau folder di dalamnya.",
+            "overlaysRemotePathHint": "Subfolder Remote Path tempat tindihan disauh. Biarkan kosong untuk menggunakan Remote Path, atau taip hanya nama subfolder (ia dicipta di bawah Remote Path).",
             "overlaysRemotePathInvalid": "Mestilah Laluan Jauh atau subfolder daripadanya"
         },
         "modalGuard": {

--- a/src/i18n/locales/ms.json
+++ b/src/i18n/locales/ms.json
@@ -5042,7 +5042,10 @@
             "keyfileRepointHint": "Laluan ini hanya menunjuk lokasi fail kunci; mengubahnya tidak menukar kunci bilik kebal. Fail kunci yang salah atau tiada akan menolak buka kunci.",
             "keyfileStorageHint": "Simpan pada cakera setempat atau pemacu USB, berasingan daripada peranti jauh yang anda sulitkan, dan simpan salinan sandaran.",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "Laluan Jauh Tindanan",
+            "overlaysRemotePathHint": "Folder jauh tempat tindanan disauhkan. Biarkan kosong untuk menggunakan Laluan Jauh. Mestilah Laluan Jauh itu sendiri atau folder di dalamnya.",
+            "overlaysRemotePathInvalid": "Mestilah Laluan Jauh atau subfolder daripadanya"
         },
         "modalGuard": {
             "busyTitle": "Operasi sedang berjalan",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -5042,7 +5042,10 @@
             "keyfileRepointHint": "Dit pad wijst alleen aan waar het sleutelbestand staat; het wijzigen versleutelt de kluis niet opnieuw. Een verkeerd of ontbrekend sleutelbestand weigert het ontgrendelen.",
             "keyfileStorageHint": "Bewaar het op een lokale schijf of USB-stick, gescheiden van de externe locatie die u versleutelt, en bewaar een back-up.",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "Extern pad van overlay",
+            "overlaysRemotePathHint": "Externe map waaraan de overlay is verankerd. Laat leeg om het Externe pad te gebruiken. Moet het Externe pad zelf zijn of een map daarin.",
+            "overlaysRemotePathInvalid": "Moet het Externe pad of een submap ervan zijn"
         },
         "modalGuard": {
             "busyTitle": "Bewerking bezig",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -5044,7 +5044,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "Extern pad van overlay",
-            "overlaysRemotePathHint": "Externe map waaraan de overlay is verankerd. Laat leeg om het Externe pad te gebruiken. Moet het Externe pad zelf zijn of een map daarin.",
+            "overlaysRemotePathHint": "Submap van het Remote Path waar de overlay is verankerd. Laat leeg om het Remote Path te gebruiken, of typ alleen een submapnaam (deze wordt onder het Remote Path aangemaakt).",
             "overlaysRemotePathInvalid": "Moet het Externe pad of een submap ervan zijn"
         },
         "modalGuard": {

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -5063,7 +5063,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "Ekstern sti for overlegg",
-            "overlaysRemotePathHint": "Ekstern mappe der overlegget er forankret. La stå tomt for å bruke Ekstern sti. Må være Ekstern sti selv eller en mappe inne i den.",
+            "overlaysRemotePathHint": "Undermappe av Remote Path der overlegget er forankret. La feltet stå tomt for å bruke Remote Path, eller skriv bare et undermappenavn (det opprettes under Remote Path).",
             "overlaysRemotePathInvalid": "Må være Ekstern sti eller en undermappe av den"
         },
         "modalGuard": {

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -5061,7 +5061,10 @@
             "keyfileRepointHint": "Denne stien peker bare på hvor nøkkelfilen ligger; å endre den bytter ikke hvelvets nøkkel. En feil eller manglende nøkkelfil avviser opplåsingen.",
             "keyfileStorageHint": "Lagre den på en lokal disk eller USB-enhet, atskilt fra fjernlageret du krypterer, og oppbevar en sikkerhetskopi.",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "Ekstern sti for overlegg",
+            "overlaysRemotePathHint": "Ekstern mappe der overlegget er forankret. La stå tomt for å bruke Ekstern sti. Må være Ekstern sti selv eller en mappe inne i den.",
+            "overlaysRemotePathInvalid": "Må være Ekstern sti eller en undermappe av den"
         },
         "modalGuard": {
             "busyTitle": "Operasjon pågår",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -5044,7 +5044,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "Ścieżka zdalna nakładki",
-            "overlaysRemotePathHint": "Folder zdalny, do którego zakotwiczona jest nakładka. Pozostaw puste, aby użyć Ścieżki zdalnej. Musi to być sama Ścieżka zdalna lub folder w jej obrębie.",
+            "overlaysRemotePathHint": "Podfolder Remote Path, w którym zakotwiczona jest nakładka. Pozostaw puste, aby użyć Remote Path, lub wpisz tylko nazwę podfolderu (zostanie utworzony w Remote Path).",
             "overlaysRemotePathInvalid": "Musi to być Ścieżka zdalna lub jej podfolder"
         },
         "modalGuard": {

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -5042,7 +5042,10 @@
             "keyfileRepointHint": "Ta ścieżka wskazuje tylko, gdzie leży plik klucza; jej zmiana nie zmienia klucza sejfu. Błędny lub brakujący plik klucza odmawia odblokowania.",
             "keyfileStorageHint": "Przechowuj go na dysku lokalnym lub napędzie USB, oddzielnie od zdalnego serwera, który szyfrujesz, i zachowaj kopię zapasową.",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "Ścieżka zdalna nakładki",
+            "overlaysRemotePathHint": "Folder zdalny, do którego zakotwiczona jest nakładka. Pozostaw puste, aby użyć Ścieżki zdalnej. Musi to być sama Ścieżka zdalna lub folder w jej obrębie.",
+            "overlaysRemotePathInvalid": "Musi to być Ścieżka zdalna lub jej podfolder"
         },
         "modalGuard": {
             "busyTitle": "Operacja w toku",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -5044,7 +5044,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "Caminho remoto da sobreposição",
-            "overlaysRemotePathHint": "Pasta remota onde a sobreposição está ancorada. Deixe vazio para usar o Caminho remoto. Deve ser o próprio Caminho remoto ou uma pasta dentro dele.",
+            "overlaysRemotePathHint": "Subpasta do Remote Path onde a sobreposição fica ancorada. Deixe vazio para usar o Remote Path, ou digite apenas um nome de subpasta (é criada dentro do Remote Path).",
             "overlaysRemotePathInvalid": "Deve ser o Caminho remoto ou uma subpasta dele"
         },
         "modalGuard": {

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -5042,7 +5042,10 @@
             "keyfileRepointHint": "Este caminho apenas indica onde está o ficheiro de chave; alterá-lo não recifra o cofre. Um ficheiro de chave errado ou ausente recusa o desbloqueio.",
             "keyfileStorageHint": "Guarde-o em um disco local ou em uma unidade USB, separado do remoto que você está criptografando, e mantenha uma cópia de backup.",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "Caminho remoto da sobreposição",
+            "overlaysRemotePathHint": "Pasta remota onde a sobreposição está ancorada. Deixe vazio para usar o Caminho remoto. Deve ser o próprio Caminho remoto ou uma pasta dentro dele.",
+            "overlaysRemotePathInvalid": "Deve ser o Caminho remoto ou uma subpasta dele"
         },
         "modalGuard": {
             "busyTitle": "Operação em curso",

--- a/src/i18n/locales/ro.json
+++ b/src/i18n/locales/ro.json
@@ -5044,7 +5044,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "Cale la distanță a suprapunerii",
-            "overlaysRemotePathHint": "Folder la distanță unde este ancorată suprapunerea. Lăsați gol pentru a folosi Calea la distanță. Trebuie să fie chiar Calea la distanță sau un folder din interiorul ei.",
+            "overlaysRemotePathHint": "Subfolder al Remote Path unde este ancorată suprapunerea. Lăsați gol pentru a folosi Remote Path sau introduceți doar un nume de subfolder (se creează sub Remote Path).",
             "overlaysRemotePathInvalid": "Trebuie să fie Calea la distanță sau un subfolder al acesteia"
         },
         "modalGuard": {

--- a/src/i18n/locales/ro.json
+++ b/src/i18n/locales/ro.json
@@ -5042,7 +5042,10 @@
             "keyfileRepointHint": "Această cale doar indică unde se află fișierul de cheie; schimbarea ei nu recriptează seiful. Un fișier de cheie greșit sau lipsă refuză deblocarea.",
             "keyfileStorageHint": "Salvați-l pe un disc local sau pe o unitate USB, separat de serverul la distanță pe care îl criptați, și păstrați o copie de rezervă.",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "Cale la distanță a suprapunerii",
+            "overlaysRemotePathHint": "Folder la distanță unde este ancorată suprapunerea. Lăsați gol pentru a folosi Calea la distanță. Trebuie să fie chiar Calea la distanță sau un folder din interiorul ei.",
+            "overlaysRemotePathInvalid": "Trebuie să fie Calea la distanță sau un subfolder al acesteia"
         },
         "modalGuard": {
             "busyTitle": "Operațiune în curs",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -5042,7 +5042,10 @@
             "keyfileRepointHint": "Этот путь лишь указывает, где лежит файл-ключ; его изменение не меняет ключ хранилища. Неверный или отсутствующий файл-ключ отклоняет разблокировку.",
             "keyfileStorageHint": "Храните его на локальном диске или USB-накопителе, отдельно от удалённого хранилища, которое вы шифруете, и сохраните резервную копию.",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "Удалённый путь наложения",
+            "overlaysRemotePathHint": "Удалённая папка, к которой привязано наложение. Оставьте пустым, чтобы использовать Удалённый путь. Должен быть самим Удалённым путём или папкой внутри него.",
+            "overlaysRemotePathInvalid": "Должен быть Удалённым путём или его подпапкой"
         },
         "modalGuard": {
             "busyTitle": "Выполняется операция",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -5044,7 +5044,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "Удалённый путь наложения",
-            "overlaysRemotePathHint": "Удалённая папка, к которой привязано наложение. Оставьте пустым, чтобы использовать Удалённый путь. Должен быть самим Удалённым путём или папкой внутри него.",
+            "overlaysRemotePathHint": "Подпапка Remote Path, в которой закреплён оверлей. Оставьте пустым, чтобы использовать Remote Path, или введите только имя подпапки (она создаётся внутри Remote Path).",
             "overlaysRemotePathInvalid": "Должен быть Удалённым путём или его подпапкой"
         },
         "modalGuard": {

--- a/src/i18n/locales/sk.json
+++ b/src/i18n/locales/sk.json
@@ -5044,7 +5044,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "Vzdialená cesta prekrytia",
-            "overlaysRemotePathHint": "Vzdialený priečinok, ku ktorému je prekrytie ukotvené. Ponechajte prázdne na použitie Vzdialenej cesty. Musí to byť samotná Vzdialená cesta alebo priečinok v nej.",
+            "overlaysRemotePathHint": "Podpriečinok Remote Path, kde je vrstva ukotvená. Ponechajte prázdne na použitie Remote Path alebo zadajte len názov podpriečinka (vytvorí sa v Remote Path).",
             "overlaysRemotePathInvalid": "Musí to byť Vzdialená cesta alebo jej podpriečinok"
         },
         "modalGuard": {

--- a/src/i18n/locales/sk.json
+++ b/src/i18n/locales/sk.json
@@ -5042,7 +5042,10 @@
             "keyfileRepointHint": "Táto cesta iba ukazuje, kde súbor kľúča leží; jej zmena trezor neprekľúčuje. Nesprávny alebo chýbajúci súbor kľúča odomknutie odmietne.",
             "keyfileStorageHint": "Uložte ho na lokálny disk alebo USB kľúč, oddelene od vzdialeného úložiska, ktoré šifrujete, a uchovajte si záložnú kópiu.",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "Vzdialená cesta prekrytia",
+            "overlaysRemotePathHint": "Vzdialený priečinok, ku ktorému je prekrytie ukotvené. Ponechajte prázdne na použitie Vzdialenej cesty. Musí to byť samotná Vzdialená cesta alebo priečinok v nej.",
+            "overlaysRemotePathInvalid": "Musí to byť Vzdialená cesta alebo jej podpriečinok"
         },
         "modalGuard": {
             "busyTitle": "Prebieha operácia",

--- a/src/i18n/locales/sl.json
+++ b/src/i18n/locales/sl.json
@@ -5044,7 +5044,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "Oddaljena pot prekrivne plasti",
-            "overlaysRemotePathHint": "Oddaljena mapa, na katero je zasidrana prekrivna plast. Pustite prazno za uporabo Oddaljene poti. Biti mora sama Oddaljena pot ali mapa v njej.",
+            "overlaysRemotePathHint": "Podmapa poti Remote Path, kjer je prekrivni sloj zasidran. Pustite prazno za uporabo Remote Path ali vnesite le ime podmape (ustvari se pod Remote Path).",
             "overlaysRemotePathInvalid": "Biti mora Oddaljena pot ali njena podmapa"
         },
         "modalGuard": {

--- a/src/i18n/locales/sl.json
+++ b/src/i18n/locales/sl.json
@@ -5042,7 +5042,10 @@
             "keyfileRepointHint": "Ta pot samo kaže, kje leži datoteka ključa; njena sprememba ne prešifrira trezorja. Napačna ali manjkajoča datoteka ključa odklepanje zavrne.",
             "keyfileStorageHint": "Shranite ga na lokalni disk ali USB ključ, ločeno od oddaljenega strežnika, ki ga šifrirate, in hranite varnostno kopijo.",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "Oddaljena pot prekrivne plasti",
+            "overlaysRemotePathHint": "Oddaljena mapa, na katero je zasidrana prekrivna plast. Pustite prazno za uporabo Oddaljene poti. Biti mora sama Oddaljena pot ali mapa v njej.",
+            "overlaysRemotePathInvalid": "Biti mora Oddaljena pot ali njena podmapa"
         },
         "modalGuard": {
             "busyTitle": "Operacija poteka",

--- a/src/i18n/locales/sr.json
+++ b/src/i18n/locales/sr.json
@@ -5044,7 +5044,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "Удаљена путања преклопа",
-            "overlaysRemotePathHint": "Удаљена фасцикла у којој је преклоп усидрен. Оставите празно да бисте користили Удаљену путању. Мора бити сама Удаљена путања или фасцикла унутар ње.",
+            "overlaysRemotePathHint": "Потфасцикла Remote Path-а у којој је преклоп усидрен. Оставите празно да користите Remote Path или унесите само име потфасцикле (креира се унутар Remote Path-а).",
             "overlaysRemotePathInvalid": "Мора бити Удаљена путања или њена подфасцикла"
         },
         "modalGuard": {

--- a/src/i18n/locales/sr.json
+++ b/src/i18n/locales/sr.json
@@ -5042,7 +5042,10 @@
             "keyfileRepointHint": "Ова путања само показује где се датотека кључа налази; њена промена не мења кључ трезора. Погрешна или недостајућа датотека кључа одбија откључавање.",
             "keyfileStorageHint": "Сачувајте га на локалном диску или USB уређају, одвојено од удаљеног сервера који шифрујете, и чувајте резервну копију.",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "Удаљена путања преклопа",
+            "overlaysRemotePathHint": "Удаљена фасцикла у којој је преклоп усидрен. Оставите празно да бисте користили Удаљену путању. Мора бити сама Удаљена путања или фасцикла унутар ње.",
+            "overlaysRemotePathInvalid": "Мора бити Удаљена путања или њена подфасцикла"
         },
         "modalGuard": {
             "busyTitle": "Операција у току",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -5042,7 +5042,10 @@
             "keyfileRepointHint": "Denna sökväg pekar bara på var nyckelfilen ligger; att ändra den byter inte valvets nyckel. En fel eller saknad nyckelfil nekar upplåsningen.",
             "keyfileStorageHint": "Spara den på en lokal disk eller ett USB-minne, åtskild från fjärrservern du krypterar, och behåll en säkerhetskopia.",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "Fjärrsökväg för överlägg",
+            "overlaysRemotePathHint": "Fjärrmapp där överlägget är förankrat. Lämna tomt för att använda Fjärrsökvägen. Måste vara Fjärrsökvägen själv eller en mapp i den.",
+            "overlaysRemotePathInvalid": "Måste vara Fjärrsökvägen eller en undermapp till den"
         },
         "modalGuard": {
             "busyTitle": "Åtgärd pågår",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -5044,7 +5044,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "Fjärrsökväg för överlägg",
-            "overlaysRemotePathHint": "Fjärrmapp där överlägget är förankrat. Lämna tomt för att använda Fjärrsökvägen. Måste vara Fjärrsökvägen själv eller en mapp i den.",
+            "overlaysRemotePathHint": "Undermapp till Remote Path där överlägget är förankrat. Lämna tomt för att använda Remote Path, eller skriv bara ett undermappsnamn (det skapas under Remote Path).",
             "overlaysRemotePathInvalid": "Måste vara Fjärrsökvägen eller en undermapp till den"
         },
         "modalGuard": {

--- a/src/i18n/locales/sw.json
+++ b/src/i18n/locales/sw.json
@@ -5044,7 +5044,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "Njia ya Mbali ya Uwekeleaji",
-            "overlaysRemotePathHint": "Folda ya mbali ambapo uwekeleaji umenaswa. Acha wazi ili kutumia Njia ya Mbali. Lazima iwe Njia ya Mbali yenyewe au folda iliyo ndani yake.",
+            "overlaysRemotePathHint": "Kijifolda cha Remote Path ambapo tabaka limetiwa nanga. Acha wazi ili kutumia Remote Path, au andika jina la kijifolda tu (kinaundwa chini ya Remote Path).",
             "overlaysRemotePathInvalid": "Lazima iwe Njia ya Mbali au folda ndogo yake"
         },
         "modalGuard": {

--- a/src/i18n/locales/sw.json
+++ b/src/i18n/locales/sw.json
@@ -5042,7 +5042,10 @@
             "keyfileRepointHint": "Njia hii inaonyesha tu mahali faili ya ufunguo ilipo; kuibadilisha hakubadilishi ufunguo wa kasha. Faili ya ufunguo isiyo sahihi au isiyopo hukataa kufungua.",
             "keyfileStorageHint": "Ihifadhi kwenye diski ya ndani au kiendeshi cha USB, tofauti na seva ya mbali unayosimba, na uweke nakala rudufu.",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "Njia ya Mbali ya Uwekeleaji",
+            "overlaysRemotePathHint": "Folda ya mbali ambapo uwekeleaji umenaswa. Acha wazi ili kutumia Njia ya Mbali. Lazima iwe Njia ya Mbali yenyewe au folda iliyo ndani yake.",
+            "overlaysRemotePathInvalid": "Lazima iwe Njia ya Mbali au folda ndogo yake"
         },
         "modalGuard": {
             "busyTitle": "Operesheni inaendelea",

--- a/src/i18n/locales/th.json
+++ b/src/i18n/locales/th.json
@@ -5042,7 +5042,10 @@
             "keyfileRepointHint": "พาธนี้เพียงชี้ตำแหน่งของไฟล์กุญแจ การเปลี่ยนพาธไม่ได้เปลี่ยนกุญแจของตู้นิรภัย ไฟล์กุญแจที่ผิดหรือหายไปจะถูกปฏิเสธการปลดล็อก",
             "keyfileStorageHint": "จัดเก็บไว้ในดิสก์ภายในเครื่องหรือไดรฟ์ USB แยกจากรีโมทที่คุณกำลังเข้ารหัส และเก็บสำเนาสำรองไว้",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "เส้นทางระยะไกลของโอเวอร์เลย์",
+            "overlaysRemotePathHint": "โฟลเดอร์ระยะไกลที่ยึดโอเวอร์เลย์ไว้ เว้นว่างไว้เพื่อใช้เส้นทางระยะไกล ต้องเป็นเส้นทางระยะไกลนั้นเองหรือโฟลเดอร์ภายในนั้น",
+            "overlaysRemotePathInvalid": "ต้องเป็นเส้นทางระยะไกลหรือโฟลเดอร์ย่อยของมัน"
         },
         "modalGuard": {
             "busyTitle": "กำลังดำเนินการ",

--- a/src/i18n/locales/th.json
+++ b/src/i18n/locales/th.json
@@ -5044,7 +5044,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "เส้นทางระยะไกลของโอเวอร์เลย์",
-            "overlaysRemotePathHint": "โฟลเดอร์ระยะไกลที่ยึดโอเวอร์เลย์ไว้ เว้นว่างไว้เพื่อใช้เส้นทางระยะไกล ต้องเป็นเส้นทางระยะไกลนั้นเองหรือโฟลเดอร์ภายในนั้น",
+            "overlaysRemotePathHint": "โฟลเดอร์ย่อยของ Remote Path ที่ใช้ยึดโอเวอร์เลย์ ปล่อยว่างไว้เพื่อใช้ Remote Path หรือพิมพ์เพียงชื่อโฟลเดอร์ย่อย (ระบบจะสร้างไว้ภายใต้ Remote Path)",
             "overlaysRemotePathInvalid": "ต้องเป็นเส้นทางระยะไกลหรือโฟลเดอร์ย่อยของมัน"
         },
         "modalGuard": {

--- a/src/i18n/locales/tl.json
+++ b/src/i18n/locales/tl.json
@@ -5061,7 +5061,10 @@
             "keyfileRepointHint": "Ang path na ito ay tumutukoy lang kung nasaan ang keyfile; ang pagpalit nito ay hindi nagpapalit ng susi ng vault. Ang mali o nawawalang keyfile ay tatanggihan sa pag-unlock.",
             "keyfileStorageHint": "Itago ito sa lokal na disk o USB drive, hiwalay sa remote na ini-encrypt mo, at mag-ingat ng backup na kopya.",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "Remote Path ng Overlay",
+            "overlaysRemotePathHint": "Remote na folder kung saan naka-angkla ang overlay. Iwanang blangko upang gamitin ang Remote Path. Dapat itong ang mismong Remote Path o isang folder sa loob nito.",
+            "overlaysRemotePathInvalid": "Dapat itong ang Remote Path o isang subfolder nito"
         },
         "modalGuard": {
             "busyTitle": "May isinasagawang operasyon",

--- a/src/i18n/locales/tl.json
+++ b/src/i18n/locales/tl.json
@@ -5063,7 +5063,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "Remote Path ng Overlay",
-            "overlaysRemotePathHint": "Remote na folder kung saan naka-angkla ang overlay. Iwanang blangko upang gamitin ang Remote Path. Dapat itong ang mismong Remote Path o isang folder sa loob nito.",
+            "overlaysRemotePathHint": "Subfolder ng Remote Path kung saan naka-angkla ang overlay. Iwanang blangko para gamitin ang Remote Path, o mag-type lang ng pangalan ng subfolder (gagawin ito sa ilalim ng Remote Path).",
             "overlaysRemotePathInvalid": "Dapat itong ang Remote Path o isang subfolder nito"
         },
         "modalGuard": {

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -5042,7 +5042,10 @@
             "keyfileRepointHint": "Bu yol yalnızca anahtar dosyasının nerede olduğunu gösterir; değiştirmek kasanın anahtarını değiştirmez. Yanlış veya eksik anahtar dosyası kilit açmayı reddeder.",
             "keyfileStorageHint": "Şifrelediğiniz uzak sunucudan ayrı olarak yerel diskte veya USB sürücüde saklayın ve bir yedek kopyasını tutun.",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "Yer Paylaşımı Uzak Yolu",
+            "overlaysRemotePathHint": "Yer paylaşımının sabitlendiği uzak klasör. Uzak Yolu kullanmak için boş bırakın. Uzak Yolun kendisi veya içindeki bir klasör olmalıdır.",
+            "overlaysRemotePathInvalid": "Uzak Yol veya onun bir alt klasörü olmalıdır"
         },
         "modalGuard": {
             "busyTitle": "İşlem sürüyor",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -5044,7 +5044,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "Yer Paylaşımı Uzak Yolu",
-            "overlaysRemotePathHint": "Yer paylaşımının sabitlendiği uzak klasör. Uzak Yolu kullanmak için boş bırakın. Uzak Yolun kendisi veya içindeki bir klasör olmalıdır.",
+            "overlaysRemotePathHint": "Yer paylaşımının sabitlendiği Remote Path alt klasörü. Remote Path'i kullanmak için boş bırakın veya yalnızca bir alt klasör adı yazın (Remote Path altında oluşturulur).",
             "overlaysRemotePathInvalid": "Uzak Yol veya onun bir alt klasörü olmalıdır"
         },
         "modalGuard": {

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -5042,7 +5042,10 @@
             "keyfileRepointHint": "Цей шлях лише вказує, де лежить файл-ключ; його зміна не змінює ключ сховища. Неправильний або відсутній файл-ключ відхиляє розблокування.",
             "keyfileStorageHint": "Зберігайте його на локальному диску або USB-накопичувачі, окремо від віддаленого сховища, яке ви шифруєте, і зберігайте резервну копію.",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "Віддалений шлях накладання",
+            "overlaysRemotePathHint": "Віддалена папка, до якої прив'язане накладання. Залиште порожнім, щоб використати Віддалений шлях. Має бути самим Віддаленим шляхом або папкою всередині нього.",
+            "overlaysRemotePathInvalid": "Має бути Віддаленим шляхом або його підпапкою"
         },
         "modalGuard": {
             "busyTitle": "Виконується операція",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -5044,7 +5044,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "Віддалений шлях накладання",
-            "overlaysRemotePathHint": "Віддалена папка, до якої прив'язане накладання. Залиште порожнім, щоб використати Віддалений шлях. Має бути самим Віддаленим шляхом або папкою всередині нього.",
+            "overlaysRemotePathHint": "Підпапка Remote Path, у якій закріплено оверлей. Залиште порожнім, щоб використати Remote Path, або введіть лише назву підпапки (вона створюється в межах Remote Path).",
             "overlaysRemotePathInvalid": "Має бути Віддаленим шляхом або його підпапкою"
         },
         "modalGuard": {

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -5044,7 +5044,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "Đường dẫn từ xa của lớp phủ",
-            "overlaysRemotePathHint": "Thư mục từ xa nơi lớp phủ được neo. Để trống để dùng Đường dẫn từ xa. Phải là chính Đường dẫn từ xa hoặc một thư mục bên trong nó.",
+            "overlaysRemotePathHint": "Thư mục con của Remote Path nơi lớp phủ được neo. Để trống để dùng Remote Path, hoặc chỉ nhập tên thư mục con (nó được tạo bên trong Remote Path).",
             "overlaysRemotePathInvalid": "Phải là Đường dẫn từ xa hoặc thư mục con của nó"
         },
         "modalGuard": {

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -5042,7 +5042,10 @@
             "keyfileRepointHint": "Đường dẫn này chỉ trỏ tới nơi tệp khóa nằm; thay đổi nó không đổi khóa của két. Tệp khóa sai hoặc thiếu sẽ bị từ chối mở khóa.",
             "keyfileStorageHint": "Lưu nó trên ổ đĩa cục bộ hoặc ổ USB, tách biệt với máy chủ từ xa mà bạn đang mã hóa, và giữ một bản sao lưu.",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "Đường dẫn từ xa của lớp phủ",
+            "overlaysRemotePathHint": "Thư mục từ xa nơi lớp phủ được neo. Để trống để dùng Đường dẫn từ xa. Phải là chính Đường dẫn từ xa hoặc một thư mục bên trong nó.",
+            "overlaysRemotePathInvalid": "Phải là Đường dẫn từ xa hoặc thư mục con của nó"
         },
         "modalGuard": {
             "busyTitle": "Đang thực hiện thao tác",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -5042,7 +5042,10 @@
             "keyfileRepointHint": "此路径只指向密钥文件所在位置; 更改它不会更换保险库的密钥。错误或缺失的密钥文件将被拒绝解锁。",
             "keyfileStorageHint": "请将其保存在本地磁盘或 U 盘上，与您正在加密的远程存储分开，并保留一份备份。",
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
-            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore."
+            "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
+            "overlaysRemotePath": "叠加层远程路径",
+            "overlaysRemotePathHint": "叠加层锚定的远程文件夹。留空则使用远程路径。必须是远程路径本身或其中的文件夹。",
+            "overlaysRemotePathInvalid": "必须是远程路径或其子文件夹"
         },
         "modalGuard": {
             "busyTitle": "操作进行中",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -5044,7 +5044,7 @@
             "headerToggle": "Write header to remote (.aeroftp-crypt.json)",
             "headerToggleHint": "Default is headerless (tamper-evident, zero remote footprint). Enable to store the configuration on the remote instead of your local keystore.",
             "overlaysRemotePath": "叠加层远程路径",
-            "overlaysRemotePathHint": "叠加层锚定的远程文件夹。留空则使用远程路径。必须是远程路径本身或其中的文件夹。",
+            "overlaysRemotePathHint": "叠加层锚定所在的 Remote Path 子文件夹。留空以使用 Remote Path，或仅输入一个子文件夹名称（将在 Remote Path 下创建）。",
             "overlaysRemotePathInvalid": "必须是远程路径或其子文件夹"
         },
         "modalGuard": {

--- a/src/utils/overlayScope.test.ts
+++ b/src/utils/overlayScope.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeRemotePath, isValidOverlayScope } from './overlayScope';
+
+describe('normalizeRemotePath', () => {
+    it('normalizes root variants to empty', () => {
+        expect(normalizeRemotePath('')).toBe('');
+        expect(normalizeRemotePath('/')).toBe('');
+        expect(normalizeRemotePath('  /  ')).toBe('');
+    });
+
+    it('strips trailing slash and collapses duplicates', () => {
+        expect(normalizeRemotePath('/data/')).toBe('/data');
+        expect(normalizeRemotePath('/data//vault/')).toBe('/data/vault');
+        expect(normalizeRemotePath('data/vault')).toBe('/data/vault');
+    });
+});
+
+describe('isValidOverlayScope', () => {
+    it('accepts a blank field always (means same as Remote Path)', () => {
+        expect(isValidOverlayScope('', '/data')).toBe(true);
+        expect(isValidOverlayScope('   ', '/data')).toBe(true);
+        expect(isValidOverlayScope('', '')).toBe(true);
+    });
+
+    it('treats "/" as the remote root, not a blank field', () => {
+        // "/" is the root: valid only when the Remote Path is also the root.
+        expect(isValidOverlayScope('/', '/')).toBe(true);
+        expect(isValidOverlayScope('/', '')).toBe(true);
+        // "/" against a subfolder Remote Path is an ancestor: rejected. This is
+        // exactly the #386 misconfiguration the field must prevent (anchoring the
+        // overlay at the whole remote makes the root listing decrypt-or-drop).
+        expect(isValidOverlayScope('/', '/data')).toBe(false);
+    });
+
+    it('accepts exact match', () => {
+        expect(isValidOverlayScope('/data', '/data')).toBe(true);
+        expect(isValidOverlayScope('/vault', '/vault')).toBe(true);
+    });
+
+    it('accepts strict descendant', () => {
+        expect(isValidOverlayScope('/data/vault', '/data')).toBe(true);
+        expect(isValidOverlayScope('/data/vault/sub', '/data')).toBe(true);
+    });
+
+    it('accepts any descendant when remote is root', () => {
+        expect(isValidOverlayScope('/vault', '/')).toBe(true);
+        expect(isValidOverlayScope('/a/b', '')).toBe(true);
+    });
+
+    it('rejects ancestor', () => {
+        expect(isValidOverlayScope('/', '/data')).toBe(false);
+        expect(isValidOverlayScope('/data', '/data/vault')).toBe(false);
+    });
+
+    it('rejects sibling', () => {
+        expect(isValidOverlayScope('/other', '/data')).toBe(false);
+    });
+
+    it('rejects prefix trap (/database vs /data)', () => {
+        expect(isValidOverlayScope('/database', '/data')).toBe(false);
+        expect(isValidOverlayScope('/data2', '/data')).toBe(false);
+    });
+
+    it('rejects unrelated', () => {
+        expect(isValidOverlayScope('/foo/bar', '/baz')).toBe(false);
+    });
+});

--- a/src/utils/overlayScope.test.ts
+++ b/src/utils/overlayScope.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { normalizeRemotePath, isValidOverlayScope } from './overlayScope';
+import { normalizeRemotePath, isValidOverlayScope, resolveOverlayScope } from './overlayScope';
 
 describe('normalizeRemotePath', () => {
     it('normalizes root variants to empty', () => {
@@ -63,5 +63,48 @@ describe('isValidOverlayScope', () => {
 
     it('rejects unrelated', () => {
         expect(isValidOverlayScope('/foo/bar', '/baz')).toBe(false);
+    });
+});
+
+describe('resolveOverlayScope (#369 relative UX)', () => {
+    it('blank or "/" resolves to the Remote Path itself', () => {
+        expect(resolveOverlayScope('', '/data')).toBe('/data');
+        expect(resolveOverlayScope('   ', '/data')).toBe('/data');
+        expect(resolveOverlayScope('/', '/data')).toBe('/data');
+        expect(resolveOverlayScope('/', '/data/')).toBe('/data');
+    });
+
+    it('nests a bare subfolder name under the Remote Path (no prefix re-typing)', () => {
+        expect(resolveOverlayScope('folder-try', '/data')).toBe('/data/folder-try');
+        expect(resolveOverlayScope('sub/deep', '/data')).toBe('/data/sub/deep');
+        expect(resolveOverlayScope('vault', '/data/')).toBe('/data/vault');
+    });
+
+    it('nests instead of erroring when the input looks like a sibling absolute path', () => {
+        // The old field rejected "/folder-try"; now it is treated as a subfolder.
+        expect(resolveOverlayScope('/folder-try', '/data')).toBe('/data/folder-try');
+        expect(resolveOverlayScope('/other', '/data')).toBe('/data/other');
+    });
+
+    it('keeps an already-absolute in-scope path verbatim', () => {
+        expect(resolveOverlayScope('/data', '/data')).toBe('/data');
+        expect(resolveOverlayScope('/data/vault', '/data')).toBe('/data/vault');
+        expect(resolveOverlayScope('/data/vault/sub', '/data')).toBe('/data/vault/sub');
+    });
+
+    it('treats input as absolute when the Remote Path is the root', () => {
+        expect(resolveOverlayScope('vault', '/')).toBe('/vault');
+        expect(resolveOverlayScope('/a/b', '')).toBe('/a/b');
+        expect(resolveOverlayScope('', '/')).toBe('');
+    });
+
+    it('always yields an in-scope result (never fails validation)', () => {
+        const remotes = ['/data', '/data/vault', '/', ''];
+        const inputs = ['', '/', 'sub', 'a/b/c', '/other', '/data', '/data/x', '  spaced  '];
+        for (const r of remotes) {
+            for (const i of inputs) {
+                expect(isValidOverlayScope(resolveOverlayScope(i, r), r)).toBe(true);
+            }
+        }
     });
 });

--- a/src/utils/overlayScope.ts
+++ b/src/utils/overlayScope.ts
@@ -1,0 +1,21 @@
+// Normalize an absolute remote path: trim, collapse duplicate slashes, strip the
+// trailing slash; '' or '/' both mean the remote root.
+export const normalizeRemotePath = (p: string): string => {
+    const s = (p || '').trim().replace(/\/+/g, '/');
+    if (s === '' || s === '/') return '';
+    return (s.startsWith('/') ? s : '/' + s).replace(/\/$/, '');
+};
+
+// The overlays scope must equal the profile Remote Path or be a strict descendant.
+// Ancestors, siblings and unrelated paths are invalid. A blank field = valid (it
+// means "same as Remote Path"). "/" is a real value (the remote root): when the
+// Remote Path is a subfolder, "/" is an ancestor and must be rejected (pinning the
+// anchor above the vault is the misconfiguration that produces the empty-listing).
+export const isValidOverlayScope = (scope: string, remotePath: string): boolean => {
+    if ((scope || '').trim() === '') return true;
+    const r = normalizeRemotePath(remotePath);
+    if (r === '') return true;            // remote path is root: any folder is a descendant
+    const s = normalizeRemotePath(scope);
+    if (s === '') return false;           // scope is "/" but remote is a subfolder: ancestor
+    return s === r || s.startsWith(r + '/');
+};

--- a/src/utils/overlayScope.ts
+++ b/src/utils/overlayScope.ts
@@ -19,3 +19,22 @@ export const isValidOverlayScope = (scope: string, remotePath: string): boolean 
     if (s === '') return false;           // scope is "/" but remote is a subfolder: ancestor
     return s === r || s.startsWith(r + '/');
 };
+
+// Resolve the operator's overlays-scope input into the absolute path we persist,
+// interpreting it RELATIVE to the Remote Path so the prefix is never re-typed
+// (#369 UX). Blank or "/" means "the Remote Path itself". A value already equal
+// to or under the Remote Path is kept verbatim (an operator may still paste the
+// full absolute path). Anything else is treated as a subfolder name and nested
+// under the Remote Path, so the anchor can never escape the Remote Path by
+// construction and isValidOverlayScope(resolveOverlayScope(x, r), r) is always
+// true. The returned value is normalized (the exact form the backend reads).
+export const resolveOverlayScope = (input: string, remotePath: string): string => {
+    const r = normalizeRemotePath(remotePath);
+    const raw = (input || '').trim();
+    if (raw === '' || raw === '/') return r;           // same as the Remote Path
+    if (r === '') return normalizeRemotePath(raw);     // remote is root: any folder is absolute
+    const s = normalizeRemotePath(raw);
+    if (s === r || s.startsWith(r + '/')) return s;    // already absolute and in scope
+    const rel = raw.replace(/^\/+/, '');               // strip leading slashes -> subfolder name
+    return normalizeRemotePath(r + '/' + rel);         // nest under the Remote Path
+};

--- a/src/utils/profileVaultSecrets.ts
+++ b/src/utils/profileVaultSecrets.ts
@@ -3,16 +3,27 @@
 
 import { invoke } from '@tauri-apps/api/core';
 
+// Base prefixes of the per-profile vault keys, kept for reference and for the
+// copy-result flag lookups below. The AUTHORITATIVE enumeration now lives in the
+// Rust `per_profile_vault_keys` (single source of truth shared by delete,
+// duplicate and export), reached through the `purge_profile_secrets` /
+// `copy_profile_secrets` commands so the GUI and CLI can never drift. Do not
+// delete/copy by iterating this list on the frontend: call the commands.
 export const PROFILE_VAULT_SECRET_PREFIXES = [
   'server',
   'server_modes',
-  'filen_api_key',
+  'jottacloud_refresh',
   'aerocrypt_overlay_pw',
   'aerocrypt_overlay_salt',
+  'aerocrypt_overlay_keyfile_path',
+  'aerocrypt_overlay_config',
+  'filen_api_key',
+  'onedrive_drive_id',
+  'onedrive_drive_type',
+  // OAuth token key is `oauth_<slug>_<id>`; the backend derives the slug.
 ] as const;
 
-export type ProfileVaultSecretPrefix = typeof PROFILE_VAULT_SECRET_PREFIXES[number];
-export type ProfileVaultSecretCopyResult = Record<ProfileVaultSecretPrefix, boolean>;
+export type ProfileVaultSecretCopyResult = Record<string, boolean>;
 
 export const getCredentialWithRetry = async (account: string, maxRetries = 3): Promise<string> => {
   for (let attempt = 0; attempt < maxRetries; attempt++) {
@@ -30,38 +41,45 @@ export const getCredentialWithRetry = async (account: string, maxRetries = 3): P
   throw new Error('Failed to get credential after retries');
 };
 
+/**
+ * Copy EVERY vault secret scoped to `sourceProfileId` onto `targetProfileId` so
+ * a duplicated profile is a complete working copy (crypt overlay, Filen key,
+ * OAuth/Jotta token, per-mode snapshots, OneDrive hints), not just the password.
+ * Delegates to the Rust `copy_profile_secrets` single source of truth. Returns a
+ * map `base_prefix -> bool` of what was copied so the caller can set the
+ * duplicate's `hasStored*` flags. `protocol` lets the backend derive the OAuth
+ * token key.
+ */
 export const copyProfileVaultSecrets = async (
   sourceProfileId: string,
   targetProfileId: string,
+  protocol?: string,
 ): Promise<ProfileVaultSecretCopyResult> => {
-  const result = Object.fromEntries(
-    PROFILE_VAULT_SECRET_PREFIXES.map(prefix => [prefix, false]),
-  ) as ProfileVaultSecretCopyResult;
-
-  for (const prefix of PROFILE_VAULT_SECRET_PREFIXES) {
-    try {
-      const value = await getCredentialWithRetry(`${prefix}_${sourceProfileId}`);
-      if (value) {
-        await invoke('store_credential', {
-          account: `${prefix}_${targetProfileId}`,
-          password: value,
-        });
-        result[prefix] = true;
-      }
-    } catch {
-      // Missing source keys are expected for many profile kinds.
-    }
+  try {
+    return await invoke<ProfileVaultSecretCopyResult>('copy_profile_secrets', {
+      sourceId: sourceProfileId,
+      targetId: targetProfileId,
+      protocol: protocol ?? null,
+    });
+  } catch {
+    // Best-effort: a copy failure leaves the duplicate credential-free, exactly
+    // as before this helper existed.
+    return {};
   }
-
-  return result;
 };
 
-export const deleteProfileVaultSecrets = async (profileId: string): Promise<void> => {
-  await Promise.all(PROFILE_VAULT_SECRET_PREFIXES.map(async (prefix) => {
-    try {
-      await invoke('delete_credential', { account: `${prefix}_${profileId}` });
-    } catch {
-      // Best-effort cleanup: missing keys are expected for many profile kinds.
-    }
-  }));
+/**
+ * Remove EVERY vault secret scoped to a profile id so deleting a profile leaves
+ * nothing behind. Delegates to the Rust `purge_profile_secrets` single source of
+ * truth. `protocol` lets the backend derive the OAuth token key.
+ */
+export const deleteProfileVaultSecrets = async (
+  profileId: string,
+  protocol?: string,
+): Promise<void> => {
+  try {
+    await invoke('purge_profile_secrets', { profileId, protocol: protocol ?? null });
+  } catch {
+    // Best-effort cleanup: a purge failure must not block the profile removal.
+  }
 };


### PR DESCRIPTION
Bundles the v4.1.4 crypt-overlay + profile-integrity work on one branch.

## #369 Overlays Remote Path (prior commits)
- CLI overlay binding (F1-F4) + Overlays Remote Path field + scope validation
- Lock both paths once the overlay is bound (F5)
- Overlays Remote Path made relative to the connection Remote Path (owner-chosen UX)

## Profile export/import completeness (this work)
- Round-trip the 4 top-level profile fields the `.aeroftp` export silently dropped: `publicUrlBase`, `customIconUrl`, `faviconUrl`, `skipDeltaEligibilityPrompt`; plus the vault-only Filen CLI API key (#230) and OneDrive drive id/type.
- Fix the GUI import merge second drop point (`mergeImportedServerProfiles`), also restoring `persistModeCredentials` (#215) and `hasStoredAeroCryptKeyfilePath`.
- One source of truth `per_profile_vault_keys(id, protocol)` shared by export-collect, delete and duplicate so a user action is complete: delete leaves nothing, duplicate copies everything, export carries everything. Two new commands `purge_profile_secrets` / `copy_profile_secrets` back both GUI and CLI.
- CLI parity: `profile-add` gains `--public-url-base`, `--custom-icon-url`, `--favicon-url`, `--skip-delta-eligibility-prompt`, `--filen-api-key`; fixed `profile-add` omitting `host`/`username` (broke `profile-export` for cloud profiles).

## Verification
Full local gate green: fmt, clippy (bin + all-features --tests -D warnings), cargo test (lib 2594 / cli 449), typecheck, vitest 424, i18n 0, build. Live-verified with the release CLI against the real vault: export->delete->re-export round-trip carries all fields; duplicate copies the Filen key; delete leaves all 10 per-profile vault keys absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for preserving additional profile settings and provider credentials during export, import, duplication, and deletion.
  * Added Filen API key management and OneDrive configuration preservation.
  * Added AeroCrypt overlay remote-path configuration with validation.
  * Added `crypt` binding controls, including an option to initialize without binding.
* **Bug Fixes**
  * Improved profile secret cleanup and copying across protocols.
  * Prevented duplicate encryption during connection workflows.
* **Documentation**
  * Added localized guidance and validation messages for overlay remote paths across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->