### PR TITLE
feat(places): Windows hotplug PLACES volumes + parent-up drive root fix

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -259,6 +259,13 @@ windows = { version = "0.58", features = [
     # console Ctrl+C / Ctrl+Break broadcasts (self-updater, parent shell)
     # instead of dying. See install_mcp_signal_guard in aeroftp_cli.rs.
     "Win32_System_Console",
+    # WM_DEVICECHANGE mount watcher (PLACES volumes hotplug):
+    # hidden top-level window + GetMessage loop on a dedicated thread.
+    # Win32_Graphics_Gdi is required by windows 0.58 for WNDCLASSEXW
+    # (hbrBackground: HBRUSH) and RegisterClassExW.
+    "Win32_UI_WindowsAndMessaging",
+    "Win32_System_LibraryLoader",
+    "Win32_Graphics_Gdi",
 ] }
 # Windows Registry access for auto-update install-format detection.
 # Walks HKLM/HKCU `Software\Microsoft\Windows\CurrentVersion\Uninstall`

--- a/src-tauri/src/filesystem.rs
+++ b/src-tauri/src/filesystem.rs
@@ -22,7 +22,7 @@ use serde::Serialize;
 use std::path::{Component, Path, PathBuf};
 #[cfg(target_os = "linux")]
 use std::sync::{LazyLock, Mutex};
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 use tauri::Emitter;
 #[cfg(target_os = "linux")]
 use tracing::{error, info, warn};
@@ -2012,12 +2012,13 @@ pub fn volumes_changed() -> bool {
 
 // ─── Mount watcher (event-driven, replaces 5s setInterval) ──────────────────
 
-/// Start a background thread that watches `/proc/mounts` (via `poll()`) and
-/// the GVFS directory (via `inotify`) for mount table changes. Emits a
-/// `volumes-changed` Tauri event when either source changes, so the frontend
-/// can react immediately instead of polling every 5 seconds.
+/// Start a background thread that watches for mount/volume table changes and
+/// emits a `volumes-changed` Tauri event so the frontend can react immediately
+/// instead of waiting on the 30s poll fallback.
 ///
-/// On non-Linux platforms this is a no-op: frontend falls back to polling.
+/// - Linux: `poll()` on `/proc/mounts` + `inotify` on GVFS
+/// - Windows: hidden message window handling `WM_DEVICECHANGE` (volume arrival/removal)
+/// - Other platforms: no-op (frontend poll + focus refetch remain the safety net)
 #[cfg(target_os = "linux")]
 pub fn start_mount_watcher(app_handle: tauri::AppHandle) {
     use std::io::{Read, Seek, SeekFrom};
@@ -2134,7 +2135,226 @@ pub fn start_mount_watcher(app_handle: tauri::AppHandle) {
         .ok();
 }
 
-#[cfg(not(target_os = "linux"))]
+// ─── Windows mount watcher (WM_DEVICECHANGE) ────────────────────────────────
+
+/// Win32 dbt.h constants (avoid Win32_Devices_* feature thrash for three values).
+#[cfg(target_os = "windows")]
+const DBT_DEVICEARRIVAL: usize = 0x8000;
+#[cfg(target_os = "windows")]
+const DBT_DEVICEREMOVECOMPLETE: usize = 0x8004;
+#[cfg(target_os = "windows")]
+const DBT_DEVTYP_VOLUME: u32 = 0x0000_0002;
+/// ERROR_CLASS_ALREADY_EXISTS (winerror.h) -- class still usable for CreateWindow.
+#[cfg(target_os = "windows")]
+const ERROR_CLASS_ALREADY_EXISTS: u32 = 1410;
+
+/// Minimal DEV_BROADCAST_HDR for filtering volume device-change events.
+#[cfg(target_os = "windows")]
+#[repr(C)]
+struct DevBroadcastHdr {
+    dbch_size: u32,
+    dbch_devicetype: u32,
+    dbch_reserved: u32,
+}
+
+/// AppHandle for the Windows mount-watcher WndProc -> emit path.
+/// Set once when the watcher thread starts; never cleared (process lifetime).
+#[cfg(target_os = "windows")]
+static WIN_MOUNT_WATCHER_APP: std::sync::OnceLock<tauri::AppHandle> = std::sync::OnceLock::new();
+
+/// Coalesce rapid WM_DEVICECHANGE bursts into a single delayed emit (mirrors Linux 300ms).
+#[cfg(target_os = "windows")]
+static WIN_MOUNT_DEBOUNCE: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Schedule a debounced `volumes-changed` emit from the Windows device-change path.
+#[cfg(target_os = "windows")]
+fn schedule_windows_volumes_changed() {
+    use std::sync::atomic::Ordering;
+
+    // If a debounce is already pending, drop this event; the pending emit will
+    // re-list after the settle window and pick up the final drive mask.
+    if WIN_MOUNT_DEBOUNCE.swap(true, Ordering::SeqCst) {
+        return;
+    }
+    std::thread::Builder::new()
+        .name("mount-watcher-debounce".to_string())
+        .spawn(|| {
+            std::thread::sleep(std::time::Duration::from_millis(300));
+            WIN_MOUNT_DEBOUNCE.store(false, Ordering::SeqCst);
+            if let Some(app) = WIN_MOUNT_WATCHER_APP.get() {
+                let _ = app.emit("volumes-changed", ());
+            }
+        })
+        .ok();
+}
+
+/// WndProc for the hidden mount-watcher window. Emits on volume arrival/removal.
+#[cfg(target_os = "windows")]
+unsafe extern "system" fn mount_watcher_wndproc(
+    hwnd: windows::Win32::Foundation::HWND,
+    msg: u32,
+    wparam: windows::Win32::Foundation::WPARAM,
+    lparam: windows::Win32::Foundation::LPARAM,
+) -> windows::Win32::Foundation::LRESULT {
+    use windows::Win32::Foundation::LRESULT;
+    use windows::Win32::UI::WindowsAndMessaging::{DefWindowProcW, WM_DEVICECHANGE};
+
+    if msg == WM_DEVICECHANGE {
+        let event = wparam.0;
+        if event == DBT_DEVICEARRIVAL || event == DBT_DEVICEREMOVECOMPLETE {
+            // Prefer volume-only events; if the header is missing, emit anyway
+            // (list_mounted_volumes is cheap and the 300ms debounce coalesces noise).
+            let is_volume = if lparam.0 == 0 {
+                true
+            } else {
+                // SAFETY: lParam is a DEV_BROADCAST_HDR* for arrival/removecomplete
+                // when non-null (MSDN WM_DEVICECHANGE).
+                let hdr = &*(lparam.0 as *const DevBroadcastHdr);
+                hdr.dbch_devicetype == DBT_DEVTYP_VOLUME
+            };
+            if is_volume {
+                schedule_windows_volumes_changed();
+            }
+        }
+        // TRUE acknowledges the notification; irrelevant for arrival/remove but harmless.
+        return LRESULT(1);
+    }
+    DefWindowProcW(hwnd, msg, wparam, lparam)
+}
+
+/// Start a background thread with a hidden top-level window that receives
+/// `WM_DEVICECHANGE` broadcasts for volume arrival/removal and emits
+/// `volumes-changed` (debounced 300ms). Message-only windows do NOT receive
+/// system device-change broadcasts, so this uses a zero-size tool window.
+///
+/// Frontend 30s poll + focus refetch remain as safety nets.
+#[cfg(target_os = "windows")]
+pub fn start_mount_watcher(app_handle: tauri::AppHandle) {
+    use windows::core::{w, PCWSTR};
+    use windows::Win32::Foundation::{GetLastError, HINSTANCE, HWND};
+    use windows::Win32::System::LibraryLoader::GetModuleHandleW;
+    use windows::Win32::UI::WindowsAndMessaging::{
+        CreateWindowExW, DispatchMessageW, GetMessageW, RegisterClassExW, TranslateMessage,
+        CS_HREDRAW, CS_VREDRAW, HMENU, MSG, WNDCLASSEXW, WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW,
+        WS_POPUP,
+    };
+
+    if WIN_MOUNT_WATCHER_APP.set(app_handle).is_err() {
+        // Already running (e.g. setup called twice); keep the first handle.
+        warn!("mount-watcher: Windows watcher already started");
+        return;
+    }
+
+    std::thread::Builder::new()
+        .name("mount-watcher".to_string())
+        .spawn(move || {
+            let hinstance: HINSTANCE = match unsafe { GetModuleHandleW(None) } {
+                Ok(h) => h.into(),
+                Err(e) => {
+                    warn!(
+                        "mount-watcher: GetModuleHandleW failed: {}; frontend poll remains",
+                        e
+                    );
+                    return;
+                }
+            };
+
+            let class_name = w!("AeroFTPMountWatcher");
+            let wc = WNDCLASSEXW {
+                cbSize: std::mem::size_of::<WNDCLASSEXW>() as u32,
+                style: CS_HREDRAW | CS_VREDRAW,
+                lpfnWndProc: Some(mount_watcher_wndproc),
+                cbClsExtra: 0,
+                cbWndExtra: 0,
+                hInstance: hinstance,
+                hIcon: Default::default(),
+                hCursor: Default::default(),
+                hbrBackground: Default::default(),
+                lpszMenuName: PCWSTR::null(),
+                lpszClassName: class_name,
+                hIconSm: Default::default(),
+            };
+
+            // SAFETY: wc points at valid WNDCLASSEXW for the duration of the call.
+            let atom = unsafe { RegisterClassExW(&wc) };
+            if atom == 0 {
+                let err = unsafe { GetLastError() };
+                // Class may already exist after a hot-reload; CreateWindow can still use it.
+                if err.0 != ERROR_CLASS_ALREADY_EXISTS {
+                    warn!(
+                        "mount-watcher: RegisterClassExW failed (win32 {}); frontend poll remains",
+                        err.0
+                    );
+                    return;
+                }
+            }
+
+            // Hidden top-level tool window: receives WM_DEVICECHANGE broadcasts.
+            // Zero size, no activate, not on the taskbar. Do not ShowWindow.
+            // SAFETY: class registered (or already existed); null parent = top-level.
+            let hwnd = match unsafe {
+                CreateWindowExW(
+                    WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE,
+                    class_name,
+                    w!(""),
+                    WS_POPUP,
+                    0,
+                    0,
+                    0,
+                    0,
+                    HWND::default(),
+                    HMENU::default(),
+                    hinstance,
+                    None,
+                )
+            } {
+                Ok(h) if !h.is_invalid() => h,
+                Ok(_) => {
+                    warn!(
+                        "mount-watcher: CreateWindowExW returned null HWND; frontend poll remains"
+                    );
+                    return;
+                }
+                Err(e) => {
+                    warn!(
+                        "mount-watcher: CreateWindowExW failed: {}; frontend poll remains",
+                        e
+                    );
+                    return;
+                }
+            };
+
+            // Keep the HWND alive for the message loop (system owns the window object).
+            let _hwnd = hwnd;
+            info!("mount-watcher: Windows WM_DEVICECHANGE watcher started");
+
+            let mut msg = MSG::default();
+            loop {
+                // SAFETY: msg is a valid writable MSG; filter range 0..0 = all messages.
+                let ret = unsafe { GetMessageW(&mut msg, None, 0, 0) };
+                if ret.0 == 0 {
+                    // WM_QUIT
+                    break;
+                }
+                if ret.0 == -1 {
+                    warn!("mount-watcher: GetMessageW error; exiting watcher thread");
+                    break;
+                }
+                unsafe {
+                    let _ = TranslateMessage(&msg);
+                    DispatchMessageW(&msg);
+                }
+            }
+
+            info!("mount-watcher thread exited");
+        })
+        .ok();
+}
+
+/// macOS and other non-Linux/non-Windows targets: no real-time watcher yet.
+/// Frontend 30s poll + focus refetch remain the path.
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
 pub fn start_mount_watcher(_app_handle: tauri::AppHandle) {
-    // No-op: macOS/Windows rely on frontend polling fallback
+    // No-op: rely on frontend polling fallback
 }

--- a/src-tauri/src/filesystem.rs
+++ b/src-tauri/src/filesystem.rs
@@ -2003,8 +2003,31 @@ pub fn volumes_changed() -> bool {
     }
 }
 
-/// Non-Linux platforms always report changed (fall back to regular polling).
-#[cfg(not(target_os = "linux"))]
+/// Cached logical drive bitmask from the last `volumes_changed` call on Windows.
+/// Bit N set means drive letter `'A' + N` is present (`GetLogicalDrives`).
+#[cfg(target_os = "windows")]
+static LAST_DRIVE_MASK: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+
+/// Returns true if the set of logical drive letters changed since the last call.
+///
+/// Compares the `GetLogicalDrives` bitmask (cheap kernel query) so the 30s frontend
+/// poll only triggers a full volume refresh when a drive was inserted or removed.
+/// Label renames without a mask change are rare and are still covered by the
+/// real-time `WM_DEVICECHANGE` watcher emit and the focus-refetch safety net.
+/// First call with a non-zero mask reports changed (same pattern as Linux hash at 0).
+#[cfg(target_os = "windows")]
+#[tauri::command]
+pub fn volumes_changed() -> bool {
+    use std::sync::atomic::Ordering;
+    use windows::Win32::Storage::FileSystem::GetLogicalDrives;
+
+    let mask = unsafe { GetLogicalDrives() };
+    let last = LAST_DRIVE_MASK.swap(mask, Ordering::SeqCst);
+    last != mask
+}
+
+/// Non-Linux, non-Windows platforms always report changed (poll full refresh).
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
 #[tauri::command]
 pub fn volumes_changed() -> bool {
     true

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -423,7 +423,8 @@ import { DecryptingText } from './components/DecryptingText';
 import type { TrashItem, FolderSizeResult, LocalTab } from './types/aerofile';
 
 // Utilities
-import { formatBytes, formatSpeed, formatETA, formatDate } from './utils';
+import { formatBytes, formatSpeed, formatETA, formatDate, isWindowsDriveRoot, parentLocalPath } from './utils';
+
 import { useArchiveMeta } from './hooks/useArchiveMeta';
 import { formatArchiveCipher } from './utils/archiveCipher';
 import { useIconTheme, getDefaultIconTheme } from './hooks/useIconTheme';
@@ -2613,9 +2614,13 @@ interface UpdateVerificationInfo {
       } else {
         const panel = getActiveLocalState();
         if (!panel.currentPath) return;
-        if (panel.currentPath !== '/') panel.changeDir(panel.currentPath.split(/[\\/]/).slice(0, -1).join('/') || '/');
+        // Windows drive roots (`D:/`) and bare `D:` must not go up; parent of
+        // `D:/boot` must be `D:/` (absolute), not bare `D:` (Rust rejects it).
+        if (panel.currentPath === '/' || isWindowsDriveRoot(panel.currentPath)) return;
+        panel.changeDir(parentLocalPath(panel.currentPath));
       }
     },
+
 
     // Tab: switch active panel. In AeroFile dual-panel mode, cycle between the
     // two local panels (left → right → left). Otherwise toggle remote↔local.

--- a/src/components/LocalFilePanel.tsx
+++ b/src/components/LocalFilePanel.tsx
@@ -27,7 +27,8 @@ import { LargeIconsGrid } from './LargeIconsGrid';
 import { ImageThumbnail } from './ImageThumbnail';
 import { getPreviewCategory, isPreviewable as isMediaPreviewable } from './Preview';
 import { isPreviewable } from './DevTools';
-import { formatBytes, formatDate } from '../utils';
+import { formatBytes, formatDate, isWindowsDriveRoot, parentLocalPath } from '../utils';
+
 import { LocalFile } from '../types';
 import type { ServerProfile } from '../types';
 import type { TrashItem, FileTag, PanelEndpoint } from '../types/aerofile';
@@ -370,10 +371,10 @@ export const LocalFilePanel: React.FC<LocalFilePanelProps> = ({
     return <BridgeConfigBadge source={source} title={`${source.label} - ${t('contextMenu.importToAeroFTP')}`} />;
   };
 
-  // Navigate to parent directory
+  // Navigate to parent directory (normalize bare Windows drive letters to X:/
+  // so Rust Path::is_absolute accepts them; see BUG-parent-up-windows-drive).
   const navigateUp = () => {
-    const parent = currentPath.split(/[\\/]/).slice(0, -1).join('/') || '/';
-    onNavigate(parent);
+    onNavigate(parentLocalPath(currentPath));
   };
 
   // Handle file double-click
@@ -502,7 +503,7 @@ export const LocalFilePanel: React.FC<LocalFilePanelProps> = ({
     }
   };
 
-  const isAtRoot = currentPath === '/' || !!(
+  const isAtRoot = currentPath === '/' || isWindowsDriveRoot(currentPath) || !!(
     isSyncNavigation && syncBasePaths && (
       (currentPath.endsWith('/') && currentPath.length > 1 ? currentPath.slice(0, -1) : currentPath) ===
       (syncBasePaths.local.endsWith('/') && syncBasePaths.local.length > 1 ? syncBasePaths.local.slice(0, -1) : syncBasePaths.local)
@@ -969,8 +970,8 @@ export const LocalFilePanel: React.FC<LocalFilePanelProps> = ({
               {/* Go Up Row */}
               <tr
                 role="row"
-                className={`${currentPath !== '/' ? 'hover:bg-gray-50 dark:hover:bg-gray-700/50 cursor-pointer' : 'opacity-50 cursor-not-allowed'}`}
-                onClick={() => currentPath !== '/' && navigateUp()}
+                className={`${!isAtRoot ? 'hover:bg-gray-50 dark:hover:bg-gray-700/50 cursor-pointer' : 'opacity-50 cursor-not-allowed'}`}
+                onClick={() => !isAtRoot && navigateUp()}
               >
                 <td className="px-4 py-2 flex items-center gap-2 text-gray-500">
                   {iconProvider.getFolderUpIcon(16).icon}
@@ -1045,9 +1046,9 @@ export const LocalFilePanel: React.FC<LocalFilePanelProps> = ({
           /* ===================== GRID VIEW ===================== */
           <div className="file-grid" role="grid" aria-label={t('browser.name')}>
             <div
-              className={`file-grid-item file-grid-go-up ${currentPath === '/' ? 'opacity-50 cursor-not-allowed' : ''}`}
+              className={`file-grid-item file-grid-go-up ${isAtRoot ? 'opacity-50 cursor-not-allowed' : ''}`}
               role="row"
-              onClick={() => currentPath !== '/' && navigateUp()}
+              onClick={() => !isAtRoot && navigateUp()}
             >
               <div className="file-grid-icon">
                 {iconProvider.getFolderUpIcon(32).icon}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,3 +8,4 @@
 export { formatBytes, formatSize, formatSpeed, formatETA, formatDate, formatDateCompact, parseHumanSize } from './formatters';
 export { getFileIcon, getFileIconColor } from './fileIcons';
 export { logger } from './logger';
+export { isWindowsDriveRoot, parentLocalPath } from './parentLocalPath';

--- a/src/utils/parentLocalPath.test.ts
+++ b/src/utils/parentLocalPath.test.ts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+import { describe, expect, it } from 'vitest';
+import { isWindowsDriveRoot, parentLocalPath } from './parentLocalPath';
+
+describe('isWindowsDriveRoot', () => {
+  it('matches bare and slash-terminated drive roots', () => {
+    expect(isWindowsDriveRoot('D:')).toBe(true);
+    expect(isWindowsDriveRoot('D:/')).toBe(true);
+    expect(isWindowsDriveRoot('D:\\')).toBe(true);
+    expect(isWindowsDriveRoot('c:')).toBe(true);
+    expect(isWindowsDriveRoot('C:/Users')).toBe(false);
+    expect(isWindowsDriveRoot('/')).toBe(false);
+    expect(isWindowsDriveRoot('/home')).toBe(false);
+  });
+});
+
+describe('parentLocalPath', () => {
+  it('returns absolute drive root from first-level folder (Windows bug fix)', () => {
+    expect(parentLocalPath('D:/boot')).toBe('D:/');
+    expect(parentLocalPath('D:\\boot')).toBe('D:/');
+    expect(parentLocalPath('C:/Users')).toBe('C:/');
+    expect(parentLocalPath('C:\\Windows')).toBe('C:/');
+  });
+
+  it('walks multi-segment paths', () => {
+    expect(parentLocalPath('D:/boot/grub')).toBe('D:/boot');
+    expect(parentLocalPath('C:/Users/axpne/Documents')).toBe('C:/Users/axpne');
+  });
+
+  it('stays at Windows drive root', () => {
+    expect(parentLocalPath('D:')).toBe('D:/');
+    expect(parentLocalPath('D:/')).toBe('D:/');
+    expect(parentLocalPath('D:\\')).toBe('D:/');
+  });
+
+  it('handles Unix paths', () => {
+    expect(parentLocalPath('/')).toBe('/');
+    expect(parentLocalPath('/home')).toBe('/');
+    expect(parentLocalPath('/home/user')).toBe('/home');
+    expect(parentLocalPath('/home/user/docs')).toBe('/home/user');
+  });
+
+  it('handles empty', () => {
+    expect(parentLocalPath('')).toBe('/');
+  });
+});

--- a/src/utils/parentLocalPath.ts
+++ b/src/utils/parentLocalPath.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+/**
+ * Local-path parent navigation helpers (AeroFile / local panels).
+ *
+ * On Windows, Rust `Path::is_absolute()` treats bare `D:` as drive-relative
+ * (false) but `D:/` and `D:\` as absolute (true). Parent computation that
+ * joins path segments can produce `D:` from `D:/boot`, which then fails
+ * `get_local_files` with "Path must be absolute". Always normalize bare
+ * drive letters to `X:/` before navigating.
+ */
+
+/** True for Windows drive roots: `C:`, `C:/`, `C:\`, `D:\\`, etc. */
+export function isWindowsDriveRoot(path: string): boolean {
+  return /^[A-Za-z]:[\\/]?$/.test(path);
+}
+
+/**
+ * Parent of a local filesystem path for panel "go up" navigation.
+ * Linux/macOS roots stay `/`. Windows drive roots stay absolute (`D:/`).
+ */
+export function parentLocalPath(currentPath: string): string {
+  if (!currentPath) return '/';
+  const normalized = currentPath.replace(/\\/g, '/').replace(/\/+$/, '');
+  if (!normalized || normalized === '/') return '/';
+  // Already at Windows drive root after strip of trailing slashes
+  if (/^[A-Za-z]:$/.test(normalized)) return `${normalized}/`;
+  const idx = normalized.lastIndexOf('/');
+  if (idx <= 0) return '/';
+  let parent = normalized.slice(0, idx);
+  if (/^[A-Za-z]:$/.test(parent)) parent = `${parent}/`;
+  return parent || '/';
+}


### PR DESCRIPTION
## Summary
- **Windows PLACES hotplug**: real-time `WM_DEVICECHANGE` watcher emits `volumes-changed` (debounced 300ms); `volumes_changed` uses `GetLogicalDrives` mask instead of always-true. Linux path unchanged; macOS still poll/focus fallback.
- **Parent-up bug (found during live test)**: navigating up from `D:/boot` produced bare `D:`, rejected by Rust `Path::is_absolute`. Normalize to `D:/` via `parentLocalPath`; Windows drive roots treated as root in go-up UI.

## Live verification (Grok W2, Win11, USB UBUNTU 24_0 D:)
- Startup: `mount-watcher: Windows WM_DEVICECHANGE watcher started`
- Insert latency ~0.6s OS→app; eject ~1s; re-insert ~0.5s
- Owner: immediate recognition in PLACES, no focus cycle / no 30s poll wait
- Evidence: `docs/dev/drafts/TRACKER-422-DRAFT-windows-hotplug.md`, peer report 422

## Commits
- `8b88b6ea3` WM_DEVICECHANGE watcher
- `8ecfdedba` volumes_changed mask
- `6343a3e19` parent-up bare drive letter

## Refs
- Tracker #422 Requested #1
- Related #351 (@EhudKirsh)

## Test plan
- [x] Linux: cargo fmt, check --lib, clippy -D warnings (watcher + mask batons)
- [x] FE: vitest parentLocalPath (6), tsc --noEmit
- [x] Live Win11 USB hotplug PASS (W2)
- [ ] Live retest parent-up after merge (optional W2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows support for detecting connected drive changes and automatically refreshing mounted volumes.
  * Improved navigation to parent folders on Windows, including correct handling of drive roots such as `C:/`.

* **Bug Fixes**
  * Fixed navigation from Windows drive paths to prevent invalid or non-absolute parent locations.
  * Preserved correct parent-directory behavior for Unix paths.

* **Tests**
  * Added coverage for Windows drive roots, nested paths, Unix paths, and empty locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->