### PR TITLE
fix(clippy): unblock Build AeroFTP CI (too_many_arguments + doc_lazy_continuation)

### DIFF
--- a/src-tauri/src/user_partitions.rs
+++ b/src-tauri/src/user_partitions.rs
@@ -1765,6 +1765,7 @@ fn relocate_secret_kind(credential_key: &str) -> &'static str {
 /// `store: None` skips vault ops only (unit-test seam: partition-only dual).
 /// Production always passes `Some(store)`. Behavior with a store for `server_*`
 /// matches the pre-F4 body byte-for-byte aside from multi-key iteration.
+#[allow(clippy::too_many_arguments)]
 fn relocate_secret_key_dual(
     conn: &Connection,
     store: Option<&CredentialStore>,
@@ -4095,9 +4096,9 @@ pub fn cli_relocate_server_profile(
 
 /// CLI bridge (MUV-3) for the credential half of a cross-user relocation: copies
 /// every per-profile secret from [`relocate_credential_key_candidates`]
-/// (`server_<id>` plus OAuth/Jottacloud when applicable) onto the new id (vault
-/// + the target user's partition under its scoped DEK) and, on a Move, drops
-/// the orphaned source secrets from both stores. Call after
+/// (`server_<id>` plus OAuth/Jottacloud when applicable) onto the new id
+/// (vault + the target user's partition under its scoped DEK) and, on a Move,
+/// drops the orphaned source secrets from both stores. Call after
 /// [`cli_relocate_server_profile`] with the same `target_passphrase` still live.
 pub fn cli_relocate_server_credential_dual(
     store: &CredentialStore,


### PR DESCRIPTION
Fixes the **Build AeroFTP** red on `main` (merge #426, `cab20ef4e`; same failure on the #426 PR build). The Linux job failed at the **Rust linting (clippy)** step with 3 errors in `src-tauri/src/user_partitions.rs`:

- `clippy::too_many_arguments` on `relocate_secret_key_dual` (9 params) -> add `#[allow(clippy::too_many_arguments)]` (house style: 107 existing allows, no threshold override).
- `clippy::doc_lazy_continuation` x2 on `cli_relocate_server_credential_dual`'s doc -> reflow so no line begins with `+ ` (markdown parsed it as a bullet list). Prose unchanged, wrapping only.

**Verification:** `cargo clippy --all-targets -- -D warnings` clean locally (`CARGO_INCREMENTAL=0`, CI parity). No behavior change (doc comment + lint allow only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting of credential relocation documentation without changing its behavior.

* **Chores**
  * Addressed a code-quality warning in the credential relocation implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->