### PR TITLE
fix(catalog): category-aware tier filter (hybrid providers reachable per category)

### DIFF
--- a/src/components/IntroHub/CatalogTable.tsx
+++ b/src/components/IntroHub/CatalogTable.tsx
@@ -30,7 +30,7 @@ import {
     paidProtocols,
     companyRegions,
     companyLaunchProtocol,
-    companyTier,
+    companyTierInCategory,
 } from '../providerCatalog';
 
 type CatalogColId = 'company' | 'region' | 'freeGb' | 'free' | 'paid' | 'health';
@@ -145,9 +145,9 @@ export function CatalogTable({ companies, category, onSelectProvider, getHealth,
     const filtered = useMemo(() => {
         const q = query.trim().toLowerCase();
         let rows = q ? companies.filter(c => searchText(c).includes(q)) : companies.slice();
-        if (tierFilter === 'free') rows = rows.filter(c => companyTier(c) === 'free');
-        else if (tierFilter === 'freecard') rows = rows.filter(c => companyTier(c) === 'free-card');
-        else if (tierFilter === 'paid') rows = rows.filter(c => companyTier(c) === 'paid');
+        if (tierFilter === 'free') rows = rows.filter(c => companyTierInCategory(c, category) === 'free');
+        else if (tierFilter === 'freecard') rows = rows.filter(c => companyTierInCategory(c, category) === 'free-card');
+        else if (tierFilter === 'paid') rows = rows.filter(c => companyTierInCategory(c, category) === 'paid');
         const dir = effectiveSort.dir === 'asc' ? 1 : -1;
         rows.sort((a, b) => {
             switch (effectiveSort.colId) {
@@ -165,7 +165,7 @@ export function CatalogTable({ companies, category, onSelectProvider, getHealth,
             }
         });
         return rows;
-    }, [companies, query, tierFilter, effectiveSort.colId, effectiveSort.dir]);
+    }, [companies, category, query, tierFilter, effectiveSort.colId, effectiveSort.dir]);
 
     const totalGb = useMemo(() => totalFreeStorageGb(filtered), [filtered]);
 

--- a/src/components/providerCatalog.test.ts
+++ b/src/components/providerCatalog.test.ts
@@ -13,6 +13,7 @@ import {
     companyInCategory,
     companyLaunchProtocol,
     companyTier,
+    companyTierInCategory,
 } from './providerCatalog';
 
 describe('CLI catalog drift guard', () => {
@@ -160,6 +161,31 @@ describe('commercial tier model: free / free-card / paid', () => {
     it('no-card free tiers classify as plain free', () => {
         expect(tierOf('TAB.DIGITAL')).toBe('free');
         expect(tierOf('MEGA')).toBe('free');
+    });
+
+    it('category-aware tier: a hybrid provider is paid in the category where its only protocol is paid-only (F1)', () => {
+        // MEGA is a free cloud drive (cloud-storage/webdav), but its S4/S3 object
+        // storage is paid-only. The list-view tier filter must classify per the
+        // ACTIVE category, else MEGA S4 is unreachable from Paid and MEGA wrongly
+        // shows under S3 + Free tier.
+        const mega = PROVIDER_CATALOG.find(x => x.company === 'MEGA');
+        expect(mega, 'MEGA present').toBeDefined();
+        expect(companyTierInCategory(mega!, 'object-storage'), 'MEGA under S3 tab').toBe('paid');
+        expect(companyTierInCategory(mega!, 'cloud-storage'), 'MEGA under Cloud tab').toBe('free');
+        expect(companyTierInCategory(mega!, 'webdav'), 'MEGA under WebDAV tab').toBe('free');
+        // 'all' falls back to the whole-company tier (unchanged behavior).
+        expect(companyTierInCategory(mega!, 'all'), 'MEGA under All == whole-company').toBe(companyTier(mega!));
+        expect(companyTierInCategory(mega!, 'all'), 'MEGA under All == free').toBe('free');
+        // A paid-only company stays paid inside its category too.
+        const wasabi = PROVIDER_CATALOG.find(x => x.company === 'Wasabi');
+        expect(wasabi, 'Wasabi present').toBeDefined();
+        expect(companyTierInCategory(wasabi!, 'object-storage'), 'Wasabi under S3 tab').toBe('paid');
+        // A card-gated free tier stays free-card per-category, NOT paid: its free
+        // allowance IS the S3 product (paid-flagged method), so it must land under
+        // Free + card, never leak into Paid nor vanish from Free + card.
+        const aws = PROVIDER_CATALOG.find(x => x.company === 'Amazon Web Services (AWS)');
+        expect(aws, 'AWS present').toBeDefined();
+        expect(companyTierInCategory(aws!, 'object-storage'), 'AWS under S3 tab').toBe('free-card');
     });
 
     it('freeRequiresCard companies are never reported as paid-only by the CLI projection', () => {

--- a/src/components/providerCatalog.ts
+++ b/src/components/providerCatalog.ts
@@ -374,6 +374,32 @@ export function companyTier(c: CatalogCompany): CompanyTier {
     return hasFreeTier(c) ? 'free' : 'paid';
 }
 
+/**
+ * Tier of a company *as seen inside a specific category tab*. A company that is
+ * free-to-enter overall can still be paid-only within one category: MEGA is a
+ * free cloud drive (`cloud-storage`) yet its object-storage product (S4/S3) is
+ * paid-only, so under the S3 tab MEGA is `paid`, not `free`. The list-view tier
+ * filter (Free tier / Paid) must classify by the protocols in the ACTIVE
+ * category, else a provider that is paid-only in this category is unreachable
+ * from Paid and wrongly listed under Free tier. `'all'` (or a category the
+ * company has no protocol in) falls back to the whole-company [`companyTier`].
+ */
+export function companyTierInCategory(
+    c: CatalogCompany,
+    category: CatalogCategoryId | 'all',
+): CompanyTier {
+    if (category === 'all') return companyTier(c);
+    const inCat = c.protocols.filter(p => p.category === category);
+    if (inCat.length === 0) return companyTier(c);
+    // A card-gated free tier keeps the company in the 'free-card' bucket even
+    // per-category: its free allowance IS this category's product (e.g. AWS S3
+    // free tier is that same paid-flagged S3 method). Mirrors companyTier's
+    // precedence and keeps free-card OUT of paid. Only companies with NO free
+    // tier at all fall through to the per-category paid/free split below.
+    if (c.freeRequiresCard) return 'free-card';
+    return inCat.some(p => !p.paid) ? 'free' : 'paid';
+}
+
 /** True when any of the company's connection methods belongs to `category`. */
 export function companyInCategory(c: CatalogCompany, category: CatalogCategoryId): boolean {
     return c.protocols.some(p => p.category === category);


### PR DESCRIPTION
The Discover / Add-Service **list view** tier tabs (Free tier / Free + card / Paid) classified by the whole-company tier, ignoring the active category, so hybrid providers were misfiled:

- **MEGA** (free cloud drive + paid-only S4/S3 object storage) showed under **S3 + Free tier** and was absent from **S3 + Paid**.

Adds `companyTierInCategory(c, category)` and uses the active `category` prop (already on `CatalogTable`) in the tier filter:

- `'all'` (or a category the company has no protocol in) -> whole-company `companyTier` (unchanged).
- `freeRequiresCard` companies stay **free-card** per-category (AWS / Google Cloud / Azure / Oracle / Cloudflare R2 / Alibaba / Yandex - their free allowance IS the S3 product), so they never leak into Paid nor vanish from Free + card.
- otherwise **free** if any in-category protocol is non-paid, else **paid**.

No catalog split (MEGA stays one row with the `S4 (S3)` badge, per Ehud EF-14/15); cards view and the `All` tab unchanged.

**Verification:** `tsc --noEmit` clean; `vitest` **504/504** (new MEGA + AWS free-card + Wasabi per-category assertions). Visually verified in-app across S3 / Cloud Storage / WebDAV x Free tier / Free + card / Paid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Tier filters now accurately reflect each provider’s pricing tier within the selected catalog category.
  - Providers may now appear correctly as free, card-gated free, or paid depending on the active category.
  - Corrected cases where providers were incorrectly classified, hidden, or shown in paid-only results.
  - The “All” category continues to use the provider’s overall tier classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->