### PR TITLE
fix(providers): 4shared WebDAV grid tile shows the 4shared logo

### DIFF
--- a/src/components/ProviderLogos.tsx
+++ b/src/components/ProviderLogos.tsx
@@ -560,6 +560,7 @@ export const PROVIDER_LOGOS: Record<string, React.FC<LogoProps>> = {
     'drivehq': DriveHQLogo,
     '4shared': FourSharedLogo,
     'fourshared': FourSharedLogo,
+    '4shared-webdav': FourSharedLogo,
     'seafile': SeafileLogo,
     'cloudme': CloudMeLogo,
     'zohoworkdrive': ZohoWorkDriveLogo,


### PR DESCRIPTION
The 4shared WebDAV Quick-Connect preset (`5ca59335f`, #274/#347) added the `4shared-webdav` registry entry but not its logo mapping. The Discover **grid** resolves a tile's logo via `PROVIDER_LOGOS[providerId]` ([DiscoverPanel.tsx:105](src/components/IntroHub/DiscoverPanel.tsx#L105)); every other WebDAV variant has its `<id>-webdav` key (`megacmd-webdav`, `pcloud-webdav`, `opendrive-webdav`, `filelu-webdav`, `yandexdisk-webdav`, ...), so the missing `4shared-webdav` key fell back to the generic `webdav` cloud icon.

Add `'4shared-webdav': FourSharedLogo` to `PROVIDER_LOGOS`.

Found during F2 live-test. `tsc --noEmit` clean; brand logo verified in-app (WebDAV & Self-hosted grid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)