### PR TITLE
fix(cybertools): Hash Forge drag&drop under disable_drag_drop_handler

### DIFF
--- a/src-tauri/src/cyber_tools.rs
+++ b/src-tauri/src/cyber_tools.rs
@@ -135,6 +135,67 @@ pub async fn hash_file(
     }
 }
 
+/// Stage a browser-dropped file (HTML5 `File` blob) to a temp path so
+/// `hash_file` can stream it. Used when the webview has
+/// `disable_drag_drop_handler` (Windows HTML5 requirement) and the
+/// DataTransfer does not expose an absolute OS path — common on WebKitGTK,
+/// where `File.path` is absent and `text/uri-list` is often empty even
+/// though `files[0]` is present with the real contents.
+///
+/// `data_base64` is the raw file bytes as standard base64 (no data-URL
+/// prefix). Cap is 256 MiB to keep IPC + temp write bounded.
+#[tauri::command]
+pub async fn stage_hash_drop(name: String, data_base64: String) -> Result<String, String> {
+    const MAX_STAGE_BYTES: usize = 256 * 1024 * 1024;
+
+    let data = B64
+        .decode(data_base64.as_bytes())
+        .map_err(|e| format!("Invalid base64 drop payload: {e}"))?;
+    if data.len() > MAX_STAGE_BYTES {
+        return Err(format!(
+            "Dropped file is too large to stage ({} bytes, max {})",
+            data.len(),
+            MAX_STAGE_BYTES
+        ));
+    }
+
+    let dir = std::env::temp_dir().join("aeroftp-hash-drops");
+    tokio::fs::create_dir_all(&dir)
+        .await
+        .map_err(|e| format!("Failed to create drop stage dir: {e}"))?;
+
+    let safe: String = std::path::Path::new(&name)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("drop.bin")
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let safe = if safe.is_empty() {
+        "drop.bin".to_string()
+    } else {
+        safe
+    };
+
+    let path = dir.join(format!("{}_{}", uuid::Uuid::new_v4(), safe));
+    tokio::fs::write(&path, &data)
+        .await
+        .map_err(|e| format!("Failed to stage dropped file: {e}"))?;
+
+    log::info!(
+        "[HASHDROP] staged {} bytes as {}",
+        data.len(),
+        path.display()
+    );
+    Ok(path.to_string_lossy().into_owned())
+}
+
 /// Constant-time hash comparison to prevent timing attacks.
 #[tauri::command]
 pub fn compare_hashes(hash_a: String, hash_b: String) -> bool {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -17878,8 +17878,18 @@ pub fn run() {
                 .maximizable(true)
                 .minimizable(true)
                 .closable(true)
-                .visible(false)
-                .disable_drag_drop_handler();
+                .visible(false);
+            // Windows WebView2 intercepts OS file drops unless the native
+            // handler is disabled, which breaks HTML5 DnD (CHANGELOG). On
+            // Linux/WebKitGTK the opposite is true: HTML5 DataTransfer from
+            // Nautilus advertises text/uri-list but getData/files stay empty,
+            // so Hash Forge / vault / local-panel need Tauri's GTK-level
+            // onDragDropEvent paths. Keep the native handler everywhere
+            // except Windows.
+            #[cfg(windows)]
+            let main_builder = main_builder.disable_drag_drop_handler();
+            #[cfg(not(windows))]
+            let main_builder = main_builder;
             // Window chrome (issue #290, macOS Tahoe "no window after splash").
             // A fully borderless window (decorations(false)) cannot become the
             // key window on macOS and fails to present after the splash closes,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -19314,6 +19314,7 @@ pub fn run() {
             // Security Toolkit: Cyber Tools
             cyber_tools::hash_text,
             cyber_tools::hash_file,
+            cyber_tools::stage_hash_drop,
             cyber_tools::compare_hashes,
             cyber_tools::crypto_encrypt_text,
             cyber_tools::crypto_decrypt_text,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5190,11 +5190,12 @@ interface UpdateVerificationInfo {
   // Ehud #2: OS file/folder drag&drop from the system File Explorer onto the
   // AeroFile local panel imports the dropped items into the current local
   // directory (copy_local_file is recursive, so folders are pulled in whole).
-  // Skipped while the vault panel is open (it registers its own drop listener)
-  // or the connection screen is showing (no local target). The webview drop
-  // event is window-global, so this gate is what keeps it from double-firing.
+  // Skipped while the vault panel or the Security Tools modal is open (each
+  // registers its own drop listener - Hash Forge owns the drop) or the
+  // connection screen is showing (no local target). The webview drop event is
+  // window-global, so this gate is what keeps it from double-firing.
   useEffect(() => {
-    if (showVaultPanel || showConnectionScreen) return;
+    if (showVaultPanel || showConnectionScreen || showCyberTools) return;
     const webview = getCurrentWebview();
     return guardedUnlisten(webview.onDragDropEvent(async (event) => {
       if (event.payload.type !== 'drop') return;
@@ -5223,7 +5224,7 @@ interface UpdateVerificationInfo {
         notify.error(t('toast.dropFailed', { count: failures.length.toString() }), failures.join(', '));
       }
     }));
-  }, [showVaultPanel, showConnectionScreen, loadLocalFiles, notify, t]);
+  }, [showVaultPanel, showConnectionScreen, showCyberTools, loadLocalFiles, notify, t]);
 
   // T-AUTO-RECONNECT-IDLE: surface silent reconnect lifecycle as a toast
   // so the user gets feedback that the click that hit a dead session

--- a/src/components/CyberToolsModal.tsx
+++ b/src/components/CyberToolsModal.tsx
@@ -584,7 +584,7 @@ const HashForgeTab: React.FC = () => {
                 <div className="space-y-2">
                     <label className="text-xs font-medium text-gray-500 dark:text-gray-400">{t('cyberTools.hashResult')}</label>
                     <div className="flex items-start gap-2">
-                        <code className={`flex-1 min-w-0 px-3 py-2 text-xs font-mono rounded bg-gray-50 dark:bg-gray-900 whitespace-nowrap overflow-x-auto border border-gray-200 dark:border-gray-700 select-all ${
+                        <code className={`flex-1 min-w-0 px-3 py-2 text-xs font-mono rounded bg-gray-50 dark:bg-gray-900 break-all border border-gray-200 dark:border-gray-700 select-all ${
                             result.startsWith('Error:') ? 'text-red-600 dark:text-red-400' : 'text-gray-800 dark:text-gray-200'
                         }`}>
                             {result}

--- a/src/components/CyberToolsModal.tsx
+++ b/src/components/CyberToolsModal.tsx
@@ -44,7 +44,7 @@ export const CyberToolsModal: React.FC<CyberToolsModalProps> = ({ onClose }) => 
         <div className="fixed inset-0 z-50 flex items-start justify-center pt-[5vh] bg-black/60">
             <div
                 {...modalDrag.panelProps}
-                className="bg-white dark:bg-gray-800 rounded-lg shadow-2xl border border-gray-200 dark:border-gray-700 w-[560px] max-h-[85vh] flex flex-col animate-scale-in"
+                className="bg-white dark:bg-gray-800 rounded-lg shadow-2xl border border-gray-200 dark:border-gray-700 w-[640px] max-h-[85vh] flex flex-col animate-scale-in"
             >
                 {/* Header */}
                 <div
@@ -584,7 +584,7 @@ const HashForgeTab: React.FC = () => {
                 <div className="space-y-2">
                     <label className="text-xs font-medium text-gray-500 dark:text-gray-400">{t('cyberTools.hashResult')}</label>
                     <div className="flex items-start gap-2">
-                        <code className={`flex-1 px-3 py-2 text-xs font-mono rounded bg-gray-50 dark:bg-gray-900 break-all border border-gray-200 dark:border-gray-700 select-all ${
+                        <code className={`flex-1 min-w-0 px-3 py-2 text-xs font-mono rounded bg-gray-50 dark:bg-gray-900 whitespace-nowrap overflow-x-auto border border-gray-200 dark:border-gray-700 select-all ${
                             result.startsWith('Error:') ? 'text-red-600 dark:text-red-400' : 'text-gray-800 dark:text-gray-200'
                         }`}>
                             {result}

--- a/src/components/CyberToolsModal.tsx
+++ b/src/components/CyberToolsModal.tsx
@@ -134,11 +134,11 @@ const PillButton: React.FC<{ active: boolean; onClick: () => void; children: Rea
 const HASH_ALGOS = ['MD5', 'SHA-1', 'SHA-256', 'SHA-512', 'BLAKE3'] as const;
 const HASH_ENCODINGS = ['utf-8', 'base64', 'hex', 'binary'] as const;
 
-// Absolute path of an OS file dropped via HTML drag-and-drop.
-// The main webview always uses `disable_drag_drop_handler` (Windows HTML5
-// requirement), so Tauri's `onDragDropEvent` never fires — only DataTransfer
-// is available. On WebKitGTK, `File.path` is usually absent and `text/uri-list`
-// is often empty; callers must fall back to staging `files[0]` contents.
+// Absolute path from HTML5 DataTransfer (Windows primary path; Linux fallback).
+// On Linux the webview keeps Tauri's native drag handler — Nautilus→WebKitGTK
+// often advertises text/uri-list while getData/files stay empty, so the real
+// path comes from onDragDropEvent. Staging files[0] still covers synthetic
+// drops and engines that expose a File blob without .path.
 function uriOrPathToFsPath(raw: string): string | null {
     const line = raw.trim();
     if (!line || line.startsWith('#')) return null;
@@ -176,15 +176,13 @@ function extractDroppedPath(dt: DataTransfer): string | null {
     }
 
     // 2) MIME types file managers commonly set (must read synchronously in drop)
-    const mimes = ['text/uri-list', 'text/plain', 'text/x-moz-url', 'URL'];
+    const mimes = ['text/uri-list', 'text/plain', 'text/html', 'text/x-moz-url', 'URL'];
     for (const mime of mimes) {
         let raw = '';
         try { raw = dt.getData(mime); } catch { /* ignore */ }
         if (!raw) continue;
-        for (const line of raw.split(/\r?\n/)) {
-            const p = uriOrPathToFsPath(line);
-            if (p) return p;
-        }
+        const fromLines = pathFromUriPayload(raw);
+        if (fromLines) return fromLines;
     }
 
     // 3) Last resort: any type whose payload looks like a file URI / abs path
@@ -193,13 +191,28 @@ function extractDroppedPath(dt: DataTransfer): string | null {
             let raw = '';
             try { raw = dt.getData(t); } catch { /* ignore */ }
             if (!raw) continue;
-            for (const line of raw.split(/\r?\n/)) {
-                const p = uriOrPathToFsPath(line);
-                if (p) return p;
-            }
+            const fromLines = pathFromUriPayload(raw);
+            if (fromLines) return fromLines;
         }
     } catch { /* ignore */ }
 
+    return null;
+}
+
+/** Pull a filesystem path out of uri-list / plain / html drag payloads. */
+function pathFromUriPayload(raw: string): string | null {
+    // Direct lines (uri-list / plain)
+    for (const line of raw.split(/\r?\n/)) {
+        const p = uriOrPathToFsPath(line);
+        if (p) return p;
+    }
+    // HTML from Nautilus sometimes embeds file:// in href/src
+    const hrefMatch = raw.match(/(?:href|src)=["'](file:[^"']+)["']/i)
+        || raw.match(/(file:\/\/[^\s"'<>]+)/i);
+    if (hrefMatch?.[1]) {
+        const p = uriOrPathToFsPath(hrefMatch[1]);
+        if (p) return p;
+    }
     return null;
 }
 
@@ -308,9 +321,10 @@ const HashForgeTab: React.FC = () => {
         }
     }, []);
 
-    // Belt-and-suspenders: if the webview ever re-enables the native drag-drop
-    // handler, prefer its absolute paths (no blob staging). With the current
-    // `disable_drag_drop_handler` this listener never fires on any platform.
+    // Primary drop path on Linux/macOS: Tauri native onDragDropEvent (GTK/WebKit
+    // file URIs). Windows keeps disable_drag_drop_handler so HTML5 handleHtmlDrop
+    // owns drops there. App.tsx gates the local-panel import listener while this
+    // modal is open so the same drop is not double-handled.
     useEffect(() => {
         let unlisten: (() => void) | undefined;
         let cancelled = false;
@@ -322,6 +336,7 @@ const HashForgeTab: React.FC = () => {
                         setDragActive(true);
                     } else if (event.payload.type === 'leave') {
                         setDragActive(false);
+                        dragDepthRef.current = 0;
                     } else if (event.payload.type === 'drop' && event.payload.paths.length > 0) {
                         setDragActive(false);
                         dragDepthRef.current = 0;
@@ -372,10 +387,51 @@ const HashForgeTab: React.FC = () => {
             applyDroppedPath(path);
             return;
         }
+
+        // Some engines advertise uri-list/html but only yield the payload via getAsString.
+        const asyncUri = await new Promise<string | null>(resolve => {
+            let settled = false;
+            const done = (v: string | null) => {
+                if (settled) return;
+                settled = true;
+                resolve(v);
+            };
+            const timer = window.setTimeout(() => done(null), 400);
+            try {
+                const items = Array.from(dt.items || []).filter(i => i.kind === 'string');
+                if (items.length === 0) {
+                    window.clearTimeout(timer);
+                    done(null);
+                    return;
+                }
+                let remaining = items.length;
+                let found: string | null = null;
+                for (const item of items) {
+                    item.getAsString(s => {
+                        if (!found) {
+                            const p = pathFromUriPayload(s || '');
+                            if (p) found = p;
+                        }
+                        remaining -= 1;
+                        if (remaining === 0) {
+                            window.clearTimeout(timer);
+                            done(found);
+                        }
+                    });
+                }
+            } catch {
+                window.clearTimeout(timer);
+                done(null);
+            }
+        });
+        if (asyncUri) {
+            applyDroppedPath(asyncUri);
+            return;
+        }
+
         if (!file) return;
 
-        // WebKitGTK common case: File blob present, no absolute path. Stage
-        // contents so hash_file can stream the real bytes (not the path string).
+        // File blob present, no absolute path: stage contents for hash_file.
         try {
             setLoading(true);
             const dataBase64 = await fileToBase64(file);
@@ -460,12 +516,21 @@ const HashForgeTab: React.FC = () => {
                     <input
                         value={filePath}
                         readOnly
+                        onClick={() => { void selectFile(); }}
+                        onKeyDown={e => {
+                            if (e.key === 'Enter' || e.key === ' ') {
+                                e.preventDefault();
+                                void selectFile();
+                            }
+                        }}
                         placeholder={t('cyberTools.hashSelectFile')}
-                        className="flex-1 px-3 py-2 text-sm rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 truncate"
+                        title={t('cyberTools.hashSelectFile')}
+                        className="flex-1 px-3 py-2 text-sm rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 truncate cursor-pointer hover:border-cyan-500/60 focus:outline-none focus:ring-1 focus:ring-cyan-500"
                     />
                     <button
-                        onClick={selectFile}
+                        onClick={() => { void selectFile(); }}
                         className="px-3 py-2 text-sm rounded bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors cursor-pointer"
+                        title={t('cyberTools.hashSelectFile')}
                     >
                         <FileSearch size={16} />
                     </button>

--- a/src/components/CyberToolsModal.tsx
+++ b/src/components/CyberToolsModal.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
 
-import { useState, useCallback, useEffect, useRef } from 'react';
+import { useState, useCallback, useEffect, useRef, type DragEvent as ReactDragEvent } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { open } from '@tauri-apps/plugin-dialog';
 import { getCurrentWebview } from '@tauri-apps/api/webview';
@@ -134,20 +134,91 @@ const PillButton: React.FC<{ active: boolean; onClick: () => void; children: Rea
 const HASH_ALGOS = ['MD5', 'SHA-1', 'SHA-256', 'SHA-512', 'BLAKE3'] as const;
 const HASH_ENCODINGS = ['utf-8', 'base64', 'hex', 'binary'] as const;
 
-// Absolute path of an OS file dropped via HTML drag-and-drop. On WebKitGTK the
-// drag data carries the real path (files[].path or the text/uri-list); Mac and
-// Windows may not expose it (the native onDragDropEvent listener covers those).
+// Absolute path of an OS file dropped via HTML drag-and-drop.
+// The main webview always uses `disable_drag_drop_handler` (Windows HTML5
+// requirement), so Tauri's `onDragDropEvent` never fires — only DataTransfer
+// is available. On WebKitGTK, `File.path` is usually absent and `text/uri-list`
+// is often empty; callers must fall back to staging `files[0]` contents.
+function uriOrPathToFsPath(raw: string): string | null {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) return null;
+    if (line.startsWith('file:') || line.startsWith('FILE:')) {
+        try {
+            const u = new URL(line);
+            let p = decodeURIComponent(u.pathname);
+            // Windows file URLs: pathname is "/C:/Users/..." → "C:/Users/..."
+            if (/^\/[A-Za-z]:[\\/]/.test(p)) p = p.slice(1);
+            return p || null;
+        } catch {
+            try {
+                return decodeURIComponent(line.replace(/^file:\/\/(localhost)?/i, '')) || null;
+            } catch {
+                return null;
+            }
+        }
+    }
+    // Plain absolute path (some file managers put this in text/plain)
+    if (line.startsWith('/') || /^[A-Za-z]:[\\/]/.test(line)) return line;
+    return null;
+}
+
 function extractDroppedPath(dt: DataTransfer): string | null {
-    const file = dt.files?.[0] as (File & { path?: string }) | undefined;
-    let p = file?.path ?? '';
-    if (!p) {
-        const raw = dt.getData('text/uri-list') || dt.getData('text/plain') || '';
-        p = raw.split(/\r?\n/).map(s => s.trim()).find(s => s && !s.startsWith('#')) ?? '';
+    // 1) Non-standard File.path (Electron / some WebKit builds)
+    for (const f of Array.from(dt.files || [])) {
+        const p = (f as File & { path?: string }).path;
+        if (p && p.trim()) return p.trim();
     }
-    if (p.startsWith('file://')) {
-        try { p = decodeURIComponent(p.replace(/^file:\/\//, '')); } catch { /* keep raw */ }
+    for (let i = 0; i < (dt.items?.length ?? 0); i++) {
+        const item = dt.items[i];
+        if (item.kind !== 'file') continue;
+        const f = item.getAsFile() as (File & { path?: string }) | null;
+        if (f?.path?.trim()) return f.path.trim();
     }
-    return p.trim() || null;
+
+    // 2) MIME types file managers commonly set (must read synchronously in drop)
+    const mimes = ['text/uri-list', 'text/plain', 'text/x-moz-url', 'URL'];
+    for (const mime of mimes) {
+        let raw = '';
+        try { raw = dt.getData(mime); } catch { /* ignore */ }
+        if (!raw) continue;
+        for (const line of raw.split(/\r?\n/)) {
+            const p = uriOrPathToFsPath(line);
+            if (p) return p;
+        }
+    }
+
+    // 3) Last resort: any type whose payload looks like a file URI / abs path
+    try {
+        for (const t of Array.from(dt.types || [])) {
+            let raw = '';
+            try { raw = dt.getData(t); } catch { /* ignore */ }
+            if (!raw) continue;
+            for (const line of raw.split(/\r?\n/)) {
+                const p = uriOrPathToFsPath(line);
+                if (p) return p;
+            }
+        }
+    } catch { /* ignore */ }
+
+    return null;
+}
+
+/** Read a dropped File as standard base64 (no data-URL prefix) for stage_hash_drop. */
+function fileToBase64(file: File): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => {
+            const result = reader.result;
+            if (typeof result !== 'string') {
+                reject(new Error('Failed to read dropped file'));
+                return;
+            }
+            const comma = result.indexOf(',');
+            resolve(comma >= 0 ? result.slice(comma + 1) : result);
+        };
+        reader.onerror = () => reject(reader.error ?? new Error('FileReader failed'));
+        reader.readAsDataURL(file);
+    });
 }
 type HashEncoding = (typeof HASH_ENCODINGS)[number];
 
@@ -164,6 +235,7 @@ const HashForgeTab: React.FC = () => {
     const [match, setMatch] = useState<boolean | null>(null);
     const [loading, setLoading] = useState(false);
     const [dragActive, setDragActive] = useState(false);
+    const dragDepthRef = useRef(0);
     const calcGenRef = useRef(0);
 
     const algoMap: Record<string, string> = { 'MD5': 'md5', 'SHA-1': 'sha1', 'SHA-256': 'sha256', 'SHA-512': 'sha512', 'BLAKE3': 'blake3' };
@@ -236,9 +308,9 @@ const HashForgeTab: React.FC = () => {
         }
     }, []);
 
-    // OS file drag-and-drop via Tauri webview API (HTML drop does not expose
-    // absolute paths in the sandbox). Listener lives for the tab's lifetime —
-    // same house pattern as ExportImportDialog. Drop → file mode + path.
+    // Belt-and-suspenders: if the webview ever re-enables the native drag-drop
+    // handler, prefer its absolute paths (no blob staging). With the current
+    // `disable_drag_drop_handler` this listener never fires on any platform.
     useEffect(() => {
         let unlisten: (() => void) | undefined;
         let cancelled = false;
@@ -252,6 +324,7 @@ const HashForgeTab: React.FC = () => {
                         setDragActive(false);
                     } else if (event.payload.type === 'drop' && event.payload.paths.length > 0) {
                         setDragActive(false);
+                        dragDepthRef.current = 0;
                         setMode('file');
                         setFilePath(event.payload.paths[0]);
                     }
@@ -278,19 +351,70 @@ const HashForgeTab: React.FC = () => {
         }
     }, [expected, result]);
 
+    const applyDroppedPath = useCallback((path: string) => {
+        setMode('file');
+        setFilePath(path);
+    }, []);
+
+    const handleHtmlDrop = useCallback(async (e: ReactDragEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+        dragDepthRef.current = 0;
+        setDragActive(false);
+
+        const dt = e.dataTransfer;
+        // Read DataTransfer synchronously — some engines clear getData after
+        // the drop handler returns (including across await boundaries).
+        const path = extractDroppedPath(dt);
+        const file = dt.files?.[0] ?? null;
+
+        if (path) {
+            applyDroppedPath(path);
+            return;
+        }
+        if (!file) return;
+
+        // WebKitGTK common case: File blob present, no absolute path. Stage
+        // contents so hash_file can stream the real bytes (not the path string).
+        try {
+            setLoading(true);
+            const dataBase64 = await fileToBase64(file);
+            const staged = await invoke<string>('stage_hash_drop', {
+                name: file.name,
+                dataBase64,
+            });
+            applyDroppedPath(staged);
+        } catch (err) {
+            setResult(`Error: ${err}`);
+            setLoading(false);
+        }
+    }, [applyDroppedPath]);
+
     return (
         <div
             className={`relative space-y-4 rounded-md transition-colors ${
                 dragActive ? 'ring-2 ring-cyan-500 ring-offset-2 dark:ring-offset-gray-800 bg-cyan-500/5' : ''
             }`}
-            onDragOver={e => { e.preventDefault(); e.dataTransfer.dropEffect = 'copy'; if (!dragActive) setDragActive(true); }}
-            onDragLeave={e => { if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setDragActive(false); }}
-            onDrop={e => {
+            onDragEnter={e => {
                 e.preventDefault();
-                setDragActive(false);
-                const path = extractDroppedPath(e.dataTransfer);
-                if (path) { setMode('file'); setFilePath(path); }
+                e.stopPropagation();
+                dragDepthRef.current += 1;
+                setDragActive(true);
             }}
+            onDragOver={e => {
+                e.preventDefault();
+                e.stopPropagation();
+                e.dataTransfer.dropEffect = 'copy';
+            }}
+            onDragLeave={e => {
+                e.preventDefault();
+                e.stopPropagation();
+                // Depth counter: entering children fires leave on parent; only
+                // clear the indicator when the pointer actually leaves the zone.
+                dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
+                if (dragDepthRef.current === 0) setDragActive(false);
+            }}
+            onDrop={e => { void handleHtmlDrop(e); }}
         >
             {dragActive && (
                 <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-2 rounded-md border-2 border-dashed border-cyan-500 bg-cyan-500/10 backdrop-blur-[1px] pointer-events-none">

--- a/src/components/CyberToolsModal.tsx
+++ b/src/components/CyberToolsModal.tsx
@@ -38,12 +38,13 @@ export const CyberToolsModal: React.FC<CyberToolsModalProps> = ({ onClose }) => 
         { id: 'password', label: t('cyberTools.passwordForge'), icon: <KeyRound size={15} /> },
     ];
 
+    // No outside-click-to-close: users copy hashes / drag files here, an accidental
+    // backdrop click must not dismiss (close via the X button or Escape).
     return (
-        <div className="fixed inset-0 z-50 flex items-start justify-center pt-[5vh] bg-black/60" onClick={onClose}>
+        <div className="fixed inset-0 z-50 flex items-start justify-center pt-[5vh] bg-black/60">
             <div
                 {...modalDrag.panelProps}
                 className="bg-white dark:bg-gray-800 rounded-lg shadow-2xl border border-gray-200 dark:border-gray-700 w-[560px] max-h-[85vh] flex flex-col animate-scale-in"
-                onClick={e => e.stopPropagation()}
             >
                 {/* Header */}
                 <div
@@ -132,6 +133,22 @@ const PillButton: React.FC<{ active: boolean; onClick: () => void; children: Rea
 
 const HASH_ALGOS = ['MD5', 'SHA-1', 'SHA-256', 'SHA-512', 'BLAKE3'] as const;
 const HASH_ENCODINGS = ['utf-8', 'base64', 'hex', 'binary'] as const;
+
+// Absolute path of an OS file dropped via HTML drag-and-drop. On WebKitGTK the
+// drag data carries the real path (files[].path or the text/uri-list); Mac and
+// Windows may not expose it (the native onDragDropEvent listener covers those).
+function extractDroppedPath(dt: DataTransfer): string | null {
+    const file = dt.files?.[0] as (File & { path?: string }) | undefined;
+    let p = file?.path ?? '';
+    if (!p) {
+        const raw = dt.getData('text/uri-list') || dt.getData('text/plain') || '';
+        p = raw.split(/\r?\n/).map(s => s.trim()).find(s => s && !s.startsWith('#')) ?? '';
+    }
+    if (p.startsWith('file://')) {
+        try { p = decodeURIComponent(p.replace(/^file:\/\//, '')); } catch { /* keep raw */ }
+    }
+    return p.trim() || null;
+}
 type HashEncoding = (typeof HASH_ENCODINGS)[number];
 
 const HashForgeTab: React.FC = () => {
@@ -263,10 +280,24 @@ const HashForgeTab: React.FC = () => {
 
     return (
         <div
-            className={`space-y-4 rounded-md transition-colors ${
+            className={`relative space-y-4 rounded-md transition-colors ${
                 dragActive ? 'ring-2 ring-cyan-500 ring-offset-2 dark:ring-offset-gray-800 bg-cyan-500/5' : ''
             }`}
+            onDragOver={e => { e.preventDefault(); e.dataTransfer.dropEffect = 'copy'; if (!dragActive) setDragActive(true); }}
+            onDragLeave={e => { if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setDragActive(false); }}
+            onDrop={e => {
+                e.preventDefault();
+                setDragActive(false);
+                const path = extractDroppedPath(e.dataTransfer);
+                if (path) { setMode('file'); setFilePath(path); }
+            }}
         >
+            {dragActive && (
+                <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-2 rounded-md border-2 border-dashed border-cyan-500 bg-cyan-500/10 backdrop-blur-[1px] pointer-events-none">
+                    <FileSearch size={28} className="text-cyan-500" />
+                    <span className="text-sm font-medium text-cyan-700 dark:text-cyan-300">{t('cyberTools.hashDropHint')}</span>
+                </div>
+            )}
             <p className="text-xs text-gray-500 dark:text-gray-400">{t('cyberTools.hashDescription')}</p>
             <p className="text-[10px] text-gray-400 dark:text-gray-500">{t('cyberTools.hashDropHint')}</p>
 


### PR DESCRIPTION
## Summary
- Hash Forge file drop was a no-op on WebKitGTK: the main webview uses `disable_drag_drop_handler` (Windows HTML5 requirement), so `onDragDropEvent` never fires, and DOM `DataTransfer` often has a `File` blob without `File.path` / `text/uri-list`.
- Stage dropped blob bytes via new `stage_hash_drop` command, then `hash_file` streams real **contents** (not the path string).
- Harden path extraction when URI/path *is* present; stabilize the drop indicator with a drag-depth counter (less flicker).

## Test plan
- [x] Synthetic HTML5 drop with `File` (no path) → File mode + SHA-256 of contents
- [x] `stage_hash_drop` + `hash_file("hello")` = `2cf24dba...`
- [x] `hash_file` on `/home/axpdev/Documenti/Nuovo documento.txt` = `4d6b56a1...`
- [ ] Manual: OS drag from Nautilus onto Hash Forge tab
- [x] Browse/Sfoglia still works as fallback
- [x] `tsc --noEmit` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced Hash Forge with robust drag-and-drop support across platforms, including URI/path drops and direct file drops.
  - Dropped items are now staged securely in a temporary area (with size limits and sanitized naming) before hashing.

- **Bug Fixes**
  - Prevented drag-and-drop handling while Security Tools, the vault, or the connection screen is open.
  - Fixed drag highlight behavior for nested drop zones and improved drop-path detection reliability.
  - Updated drag/drop handling to work more consistently between web and native drop events.

- **UI/Accessibility**
  - Security Tools modal now closes only via the close button or Escape.
  - Improved keyboard interaction for the “select file” control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->