### PR TITLE
fix(mtp): live-test cluster LT3-LT7 (display, form, edit, activity log) + device-id subtitle

### DIFF
--- a/src-tauri/src/providers/mtp/linux_libmtp.rs
+++ b/src-tauri/src/providers/mtp/linux_libmtp.rs
@@ -769,6 +769,93 @@ fn usb_sysfs_serial(bus: u32, devnum: u8) -> Option<String> {
     None
 }
 
+/// Prefer USB iProduct (+ manufacturer) from sysfs over libmtp's stale device DB.
+///
+/// libmtp's built-in VID/PID table is often wrong for newer phones (e.g. Sony
+/// Xperia 1 V `0FCE:020D` is labelled "Xperia 5 II Phone"). Kernel sysfs
+/// exposes the real USB string descriptors: `product` = iProduct (e.g.
+/// "XQ-DQ54"), `manufacturer` = iManufacturer (e.g. "Sony").
+///
+/// Match `idVendor`/`idProduct` as 4-digit lowercase hex. When `serial` is
+/// given, prefer the node whose `serial` matches; otherwise return the first
+/// VID/PID hit. Returns `None` when sysfs has no matching device node (other
+/// platforms, missing perms, empty descriptors) so callers fall back to
+/// friendly/model strings.
+///
+/// Pure over `sysfs_root` so unit tests can pass a fixture directory.
+fn usb_iproduct_for(
+    vid: u16,
+    pid: u16,
+    serial: Option<&str>,
+    sysfs_root: &Path,
+) -> Option<String> {
+    let want_vid = format!("{vid:04x}");
+    let want_pid = format!("{pid:04x}");
+    let want_serial = serial.map(str::trim).filter(|s| !s.is_empty());
+
+    let dir = std::fs::read_dir(sysfs_root).ok()?;
+    let mut fallback: Option<String> = None;
+
+    for entry in dir.flatten() {
+        let path = entry.path();
+        // Device nodes carry idVendor/idProduct; interface nodes (5-1:1.0) skip.
+        let Some(iv) = std::fs::read_to_string(path.join("idVendor"))
+            .ok()
+            .map(|s| s.trim().to_ascii_lowercase())
+            .filter(|s| !s.is_empty())
+        else {
+            continue;
+        };
+        let Some(ip) = std::fs::read_to_string(path.join("idProduct"))
+            .ok()
+            .map(|s| s.trim().to_ascii_lowercase())
+            .filter(|s| !s.is_empty())
+        else {
+            continue;
+        };
+        if iv != want_vid || ip != want_pid {
+            continue;
+        }
+
+        let product = std::fs::read_to_string(path.join("product"))
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+        let manufacturer = std::fs::read_to_string(path.join("manufacturer"))
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+        let display = match (manufacturer.as_deref(), product.as_deref()) {
+            (Some(m), Some(p)) => format!("{m} {p}"),
+            (None, Some(p)) => p.to_string(),
+            (Some(m), None) => m.to_string(),
+            _ => continue,
+        };
+
+        if let Some(want) = want_serial {
+            let sys_serial = std::fs::read_to_string(path.join("serial"))
+                .ok()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty());
+            if sys_serial.as_deref() == Some(want) {
+                return Some(display);
+            }
+            // VID/PID hit without serial match: keep as weak fallback.
+            if fallback.is_none() {
+                fallback = Some(display);
+            }
+        } else {
+            return Some(display);
+        }
+    }
+    fallback
+}
+
+/// Live-path helper: look up iProduct under the real sysfs USB tree.
+fn usb_iproduct_live(vid: u16, pid: u16, serial: Option<&str>) -> Option<String> {
+    usb_iproduct_for(vid, pid, serial, Path::new("/sys/bus/usb/devices"))
+}
+
 /// Brief open → `LIBMTP_Get_Serialnumber` → release, using a pointer into the
 /// live `Detect_Raw_Devices` array (same open rule as `open_raw_by_id_locked`).
 ///
@@ -823,22 +910,31 @@ fn detect_raw_devices_locked(
         for i in 0..num as usize {
             let raw = *raw_ptr.add(i);
             let id = raw_device_id(&raw);
-            let product = cstr_opt(raw.device_entry.product);
-            let vendor = cstr_opt(raw.device_entry.vendor);
-            let display = match (vendor.as_deref(), product.as_deref()) {
-                (Some(v), Some(p)) => format!("{v} {p}"),
-                (None, Some(p)) => p.to_string(),
-                (Some(v), None) => v.to_string(),
-                _ => format!(
-                    "MTP {:04x}:{:04x}",
-                    raw.device_entry.vendor_id, raw.device_entry.product_id
-                ),
-            };
             // Prefer sysfs (no exclusive claim). Fall back to brief open only
             // when iSerial is missing; open failure leaves serial None but
             // vid/pid still support a weak fingerprint.
             let serial = usb_sysfs_serial(raw.bus_location, raw.devnum)
                 .or_else(|| serial_via_brief_open(raw_ptr.add(i)));
+            // Prefer USB iProduct/iManufacturer from sysfs (truthful model code)
+            // over libmtp's stale device_entry product string.
+            let display = usb_iproduct_live(
+                raw.device_entry.vendor_id,
+                raw.device_entry.product_id,
+                serial.as_deref(),
+            )
+            .unwrap_or_else(|| {
+                let product = cstr_opt(raw.device_entry.product);
+                let vendor = cstr_opt(raw.device_entry.vendor);
+                match (vendor.as_deref(), product.as_deref()) {
+                    (Some(v), Some(p)) => format!("{v} {p}"),
+                    (None, Some(p)) => p.to_string(),
+                    (Some(v), None) => v.to_string(),
+                    _ => format!(
+                        "MTP {:04x}:{:04x}",
+                        raw.device_entry.vendor_id, raw.device_entry.product_id
+                    ),
+                }
+            });
             let info = MtpDeviceInfo {
                 device_id: id.clone(),
                 display_name: display,
@@ -908,6 +1004,17 @@ fn open_raw_by_id_locked(device_id: &str) -> Result<(*mut LibmtpMtpDevice, Strin
         ))
     })?;
 
+    // Capture identity fields before free: raw_ptr is released after Open_Raw.
+    let (entry_vid, entry_pid, entry_bus, entry_devnum) = unsafe {
+        let raw = &*raw_ptr.add(idx);
+        (
+            raw.device_entry.vendor_id,
+            raw.device_entry.product_id,
+            raw.bus_location,
+            raw.devnum,
+        )
+    };
+
     let device = unsafe {
         let raw_ref = raw_ptr.add(idx);
         // Uncached first, restoring the order of `6152086cf`: both live-green
@@ -940,29 +1047,40 @@ fn open_raw_by_id_locked(device_id: &str) -> Result<(*mut LibmtpMtpDevice, Strin
         ));
     }
 
-    // Build display name from open device strings (owned, free after copy).
-    let display = unsafe {
-        let friendly = LIBMTP_Get_Friendlyname(device);
-        let model = LIBMTP_Get_Modelname(device);
-        let mfg = LIBMTP_Get_Manufacturername(device);
-        let name = cstr_opt(friendly)
-            .or_else(|| {
-                let m = cstr_opt(model);
-                let v = cstr_opt(mfg);
-                match (v, m) {
-                    (Some(v), Some(m)) => Some(format!("{v} {m}")),
-                    (None, Some(m)) => Some(m),
-                    (Some(v), None) => Some(v),
-                    _ => None,
-                }
-            })
-            .unwrap_or_else(|| device_id.to_string());
-        free_c_string(friendly);
-        free_c_string(model);
-        free_c_string(mfg);
-        let serial = LIBMTP_Get_Serialnumber(device);
-        free_c_string(serial);
-        name
+    // Prefer USB iProduct from sysfs (real model code, e.g. "Sony XQ-DQ54")
+    // over libmtp Friendlyname/Modelname (stale DB: 0FCE:020D → "Xperia 5 II").
+    let display = {
+        let serial = usb_sysfs_serial(entry_bus, entry_devnum).or_else(|| unsafe {
+            let serial_ptr = LIBMTP_Get_Serialnumber(device);
+            let s = cstr_opt(serial_ptr);
+            free_c_string(serial_ptr);
+            s
+        });
+        if let Some(sys) = usb_iproduct_live(entry_vid, entry_pid, serial.as_deref()) {
+            sys
+        } else {
+            unsafe {
+                let friendly = LIBMTP_Get_Friendlyname(device);
+                let model = LIBMTP_Get_Modelname(device);
+                let mfg = LIBMTP_Get_Manufacturername(device);
+                let name = cstr_opt(friendly)
+                    .or_else(|| {
+                        let m = cstr_opt(model);
+                        let v = cstr_opt(mfg);
+                        match (v, m) {
+                            (Some(v), Some(m)) => Some(format!("{v} {m}")),
+                            (None, Some(m)) => Some(m),
+                            (Some(v), None) => Some(v),
+                            _ => None,
+                        }
+                    })
+                    .unwrap_or_else(|| device_id.to_string());
+                free_c_string(friendly);
+                free_c_string(model);
+                free_c_string(mfg);
+                name
+            }
+        }
     };
 
     Ok((device, display))
@@ -1489,5 +1607,48 @@ mod tests {
         // May be empty (no phone) or populated; must not panic.
         let result = b.list_devices().await;
         assert!(result.is_ok(), "list_devices err: {result:?}");
+    }
+
+    #[test]
+    fn usb_iproduct_for_prefers_sysfs_product_over_stale_db() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let node = dir.path().join("5-1");
+        std::fs::create_dir(&node).expect("mkdir node");
+        // Sony Xperia 1 V ground-truth: VID 0FCE PID 020D iProduct XQ-DQ54.
+        std::fs::write(node.join("idVendor"), "0fce\n").unwrap();
+        std::fs::write(node.join("idProduct"), "020d\n").unwrap();
+        std::fs::write(node.join("product"), "XQ-DQ54\n").unwrap();
+        std::fs::write(node.join("manufacturer"), "Sony\n").unwrap();
+        std::fs::write(node.join("serial"), "QV770LUNJD\n").unwrap();
+        // Interface sibling must be ignored (no idVendor).
+        let iface = dir.path().join("5-1:1.0");
+        std::fs::create_dir(&iface).unwrap();
+
+        let got = usb_iproduct_for(0x0fce, 0x020d, Some("QV770LUNJD"), dir.path());
+        assert_eq!(got.as_deref(), Some("Sony XQ-DQ54"));
+
+        // Serial mismatch still falls back to VID/PID hit.
+        let weak = usb_iproduct_for(0x0fce, 0x020d, Some("OTHER"), dir.path());
+        assert_eq!(weak.as_deref(), Some("Sony XQ-DQ54"));
+
+        // No serial filter still matches.
+        let any = usb_iproduct_for(0x0fce, 0x020d, None, dir.path());
+        assert_eq!(any.as_deref(), Some("Sony XQ-DQ54"));
+
+        // Wrong VID → None.
+        assert!(usb_iproduct_for(0x18d1, 0x020d, None, dir.path()).is_none());
+    }
+
+    #[test]
+    fn usb_iproduct_for_product_only_when_no_manufacturer() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let node = dir.path().join("1-2");
+        std::fs::create_dir(&node).unwrap();
+        std::fs::write(node.join("idVendor"), "18D1\n").unwrap(); // uppercase hex
+        std::fs::write(node.join("idProduct"), "4EE1\n").unwrap();
+        std::fs::write(node.join("product"), "Pixel 7\n").unwrap();
+        // no manufacturer file
+        let got = usb_iproduct_for(0x18d1, 0x4ee1, None, dir.path());
+        assert_eq!(got.as_deref(), Some("Pixel 7"));
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5883,8 +5883,14 @@ interface UpdateVerificationInfo {
           try { await invoke('mtp_close_device', { deviceId: null }); } catch { /* ignore */ }
           try { await invoke('provider_disconnect'); } catch { /* ignore */ }
         })();
-        activityLog.log('ERROR', t('sidebar.portable_unplugged'), 'error');
-        notify.error(t('common.error'), t('sidebar.portable_unplugged'));
+        // Activity Log + toast only on user-facing listings (`!silent`).
+        // Silent background refresh / startup-style probes must not spam
+        // "portable device disconnected" into the log (live-test LT3).
+        // Session cleanup above still runs; debug path keeps console.error.
+        if (showBusy) {
+          activityLog.log('ERROR', t('sidebar.portable_unplugged'), 'error');
+          notify.error(t('common.error'), t('sidebar.portable_unplugged'));
+        }
         return null;
       }
       activityLog.log('ERROR', `Failed to list files: ${error}`, 'error');

--- a/src/components/ConnectionScreen.tsx
+++ b/src/components/ConnectionScreen.tsx
@@ -13,7 +13,7 @@ import { readFile } from '@tauri-apps/plugin-fs';
 import { FolderOpen, HardDrive, ChevronRight, ChevronDown, Save, Copy, Cloud, Check, Settings, Clock, Folder, X, Lock, ArrowLeft, Eye, EyeOff, ExternalLink, Shield, ShieldCheck, KeyRound, Loader2, Image, Info, Pencil, Link2, ArrowRightLeft, RefreshCw, Usb } from 'lucide-react';
 import { ConnectionParams, ProviderType, ProviderOptions, DeviceFingerprint, isOAuthProvider, isAeroCloudProvider, isFourSharedProvider, isNativeApiProtocol, isNonFtpProvider, providerServesQuota, providerSupportsCryptOverlay, ServerProfile } from '../types';
 import type { MtpDeviceInfo } from '../types/aerofile';
-import { deviceFingerprintFromMtpInfo } from '../utils/mtpFingerprint';
+import { deviceFingerprintFromMtpInfo, matchLiveDevice } from '../utils/mtpFingerprint';
 import { PROVIDER_LOGOS } from './ProviderLogos';
 import { PasswordStrengthBar } from './vault/PasswordStrengthBar';
 import { PasswordMatchHint } from './common/PasswordMatchHint';
@@ -856,6 +856,8 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
     }, [formOnly, connectionParams.providerId]);
 
     // Hydrate MTP fingerprint when editing a saved device profile (or clear when leaving mtp).
+    // On edit: auto-detect attached devices and preselect the fingerprint match so
+    // the user does not need a manual Detect click (live-test LT5).
     useEffect(() => {
         if (!isMtp) {
             setMtpDevices([]);
@@ -864,11 +866,46 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
             setMtpFingerprint(undefined);
             return;
         }
-        if (editingProfile?.deviceFingerprint) {
-            setMtpFingerprint(editingProfile.deviceFingerprint);
-            setMtpSelectedDeviceId(null);
+        if (!editingProfile?.deviceFingerprint) {
+            return;
         }
-    }, [isMtp, editingProfile?.id, editingProfile?.deviceFingerprint]);
+        setMtpFingerprint(editingProfile.deviceFingerprint);
+        setMtpSelectedDeviceId(null);
+        let cancelled = false;
+        setMtpDetecting(true);
+        setMtpDetectError(null);
+        void (async () => {
+            try {
+                const devices = await invoke<MtpDeviceInfo[]>('list_mtp_devices');
+                if (cancelled) return;
+                setMtpDevices(devices || []);
+                if (!devices || devices.length === 0) {
+                    setMtpDetectError(t('connection.mtpNoDevices'));
+                    return;
+                }
+                const live = matchLiveDevice(
+                    editingProfile.deviceFingerprint?.canonical,
+                    devices,
+                );
+                if (live) {
+                    setMtpSelectedDeviceId(live.deviceId);
+                    // Refresh fingerprint from live row; keep saved profile name.
+                    const fp = deviceFingerprintFromMtpInfo(live);
+                    if (fp) setMtpFingerprint(fp);
+                }
+            } catch (e) {
+                if (cancelled) return;
+                const msg = e instanceof Error ? e.message : String(e);
+                setMtpDevices([]);
+                setMtpDetectError(msg || t('connection.mtpDetectFailed'));
+            } finally {
+                if (!cancelled) setMtpDetecting(false);
+            }
+        })();
+        return () => {
+            cancelled = true;
+        };
+    }, [isMtp, editingProfile?.id, editingProfile?.deviceFingerprint, t]);
 
     const detectMtpDevices = async () => {
         setMtpDetecting(true);
@@ -878,6 +915,17 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
             setMtpDevices(devices || []);
             if (!devices || devices.length === 0) {
                 setMtpDetectError(t('connection.mtpNoDevices'));
+            } else if (editingProfile?.deviceFingerprint?.canonical) {
+                // Manual Detect while editing: re-preselect the saved device.
+                const live = matchLiveDevice(
+                    editingProfile.deviceFingerprint.canonical,
+                    devices,
+                );
+                if (live) {
+                    setMtpSelectedDeviceId(live.deviceId);
+                    const fp = deviceFingerprintFromMtpInfo(live);
+                    if (fp) setMtpFingerprint(fp);
+                }
             }
         } catch (e) {
             const msg = e instanceof Error ? e.message : String(e);
@@ -3989,12 +4037,12 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                                         <Usb size={14} />
                                         {t('connection.mtpDevice')}
                                     </label>
-                                    <div className="flex gap-2">
+                                    <div className="flex gap-2 min-w-0">
                                         <button
                                             type="button"
                                             onClick={detectMtpDevices}
                                             disabled={mtpDetecting}
-                                            className="px-3 py-2.5 text-sm font-medium rounded-lg bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 border border-gray-300 dark:border-gray-600 transition-colors flex items-center gap-1.5 disabled:opacity-50"
+                                            className="shrink-0 px-3 py-2.5 text-sm font-medium rounded-lg bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 border border-gray-300 dark:border-gray-600 transition-colors flex items-center gap-1.5 disabled:opacity-50"
                                         >
                                             {mtpDetecting
                                                 ? <Loader2 size={14} className="animate-spin" />
@@ -4005,20 +4053,20 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                                             value={mtpSelectedDeviceId || ''}
                                             onChange={(e) => selectMtpDevice(e.target.value)}
                                             disabled={mtpDevices.length === 0}
-                                            className="flex-1 px-3 py-2.5 bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-sm disabled:opacity-60"
+                                            className="flex-1 min-w-0 max-w-full px-3 py-2.5 bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-sm disabled:opacity-60"
                                         >
                                             <option value="">
                                                 {mtpDevices.length === 0
                                                     ? t('connection.mtpSelectPlaceholderEmpty')
                                                     : t('connection.mtpSelectPlaceholder')}
                                             </option>
+                                            {/* Label: displayName (serial) only. VID:PID stays in the
+                                                fingerprint box below so the native option popup
+                                                fits the card (live-test LT6). */}
                                             {mtpDevices.map((d) => (
                                                 <option key={d.deviceId} value={d.deviceId}>
                                                     {d.displayName}
                                                     {d.serial ? ` (${d.serial})` : ''}
-                                                    {d.vendorId != null && d.productId != null
-                                                        ? ` [${(d.vendorId & 0xffff).toString(16).toUpperCase().padStart(4, '0')}:${(d.productId & 0xffff).toString(16).toUpperCase().padStart(4, '0')}]`
-                                                        : ''}
                                                 </option>
                                             ))}
                                         </select>

--- a/src/components/PlacesSidebar.tsx
+++ b/src/components/PlacesSidebar.tsx
@@ -934,7 +934,10 @@ export const PlacesSidebar: React.FC<PlacesSidebarProps> = ({
             const needsReplug = portableDeviceNeedsReplug(mtpAutomounterPresent, gvfsMount);
             const subtitle = needsReplug
               ? t('sidebar.portable_needs_replug')
-              : (dev.busLocation
+              // Show the full device id (e.g. "usb:5:3"), not the bare
+              // bus:devnum "5:3" which reads as an unlabelled number.
+              : (dev.deviceId
+                || dev.busLocation
                 || (dev.storagesHint > 0
                   ? t('sidebar.portable_storages', { count: dev.storagesHint })
                   : dev.platform));

--- a/src/types.ts
+++ b/src/types.ts
@@ -242,6 +242,9 @@ export const providerServesQuota = (
   // concept. Reporting "serves quota" suppresses the manual-total-bytes field
   // and the used-storage scan in the connection/edit form.
   if (protocol === "peer") return true;
+  // MTP portable devices report real storage free/total from the device; the
+  // manual cap and used-scan checkbox are noise on that form (live-test LT7).
+  if (protocol === "mtp") return true;
   if (isNativeApiProtocol(protocol)) return true;
   if (protocol === "webdav") {
     const host = (server || "").toLowerCase();


### PR DESCRIPTION
## MTP live-test cluster (LT3-LT7) + device-id subtitle

Fixes found in the v4.1.4 GUI live-test with a real Sony Xperia 1 V (`0FCE:020D`, serial `QV770LUNJD`) attached.

- **LT4** (Rust + FE): prefer the USB iProduct/iManufacturer from sysfs over libmtp's stale device DB when building MTP display names (list + open). `0FCE:020D` now shows as "Sony XQ-DQ54" instead of the wrong "Xperia 5 II Phone". Pure `usb_iproduct_for(sysfs_root)` is unit-tested with a fixture tree.
- **LT7** (FE): treat protocol `mtp` as quota-serving so the manual total-storage field and used-scan checkbox stay hidden on the portable-device form (MTP reports real free/total from the device).
- **LT6** (FE): shorten the MTP device `<select>` option to "displayName (serial)" and drop `[VID:PID]` from the label (fingerprint box still carries it) so the native popup fits the card.
- **LT5** (FE): when editing a saved MTP profile, auto-run detect and preselect the fingerprint-matched live device without overwriting the profile name.
- **LT3** (FE): log/notify `sidebar.portable_unplugged` only on user-facing listings (`showBusy`), not silent background/startup probes.
- **Subtitle polish**: the Portable devices sidebar shows the full device id ("usb:5:3") instead of the bare bus:devnum ("5:3").

### Verification
- Gates: `typecheck` 0, `test:unit` 504/504, `cargo clippy --all-targets -D warnings` 0.
- Live (dev app, real device): LT4 backend returns "Sony XQ-DQ54"; edit form auto-detects + preselects the device; option label carries no [VID:PID]; MTP form hides manual-quota + used-scan; no "portable device disconnected" line at startup; sidebar subtitle shows "usb:5:3".

Grok executed the LT3-LT7 code on `fix/mtp-livetest-cluster`; the orchestrator verified each finding in the running dev app and added the subtitle polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MTP device names and serial numbers now use more accurate USB information when available.
  * Existing MTP profiles can automatically match and select the connected device.
  * Device lists now show clearer names, serials, and identifiers.

* **Bug Fixes**
  * Reduced misleading disconnect notifications during background checks.
  * Improved device matching when serial numbers or USB details differ.
  * MTP storage is now handled using the device’s reported capacity without unnecessary manual limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->