### PR TITLE
fix(ci): rustfmt usb_iproduct_for (green Checks on main)

### DIFF
--- a/src-tauri/src/providers/mtp/linux_libmtp.rs
+++ b/src-tauri/src/providers/mtp/linux_libmtp.rs
@@ -783,12 +783,7 @@ fn usb_sysfs_serial(bus: u32, devnum: u8) -> Option<String> {
 /// friendly/model strings.
 ///
 /// Pure over `sysfs_root` so unit tests can pass a fixture directory.
-fn usb_iproduct_for(
-    vid: u16,
-    pid: u16,
-    serial: Option<&str>,
-    sysfs_root: &Path,
-) -> Option<String> {
+fn usb_iproduct_for(vid: u16, pid: u16, serial: Option<&str>, sysfs_root: &Path) -> Option<String> {
     let want_vid = format!("{vid:04x}");
     let want_pid = format!("{pid:04x}");
     let want_serial = serial.map(str::trim).filter(|s| !s.is_empty());


### PR DESCRIPTION
## Summary
- Main `Checks` has been red since #432/#433: `cargo fmt --check` fails on `usb_iproduct_for` signature shape in `linux_libmtp.rs`.
- One-line rustfmt-only fix. No behavior change.

## Priority
Unblocks main CI Checks so subsequent work (MTP detect coalesce, etc.) is not gated on a cosmetic red.

## Test plan
- [x] `cargo fmt --all -- --check` clean locally
- [ ] CI Checks green on this PR
- [ ] Merge restores Checks on main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted internal code for improved readability without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->