### PR TITLE
fix(oauth): OneDrive redirect URI must be localhost, not 127.0.0.1 (Ehud #397)

### DIFF
--- a/src/components/DropboxTrashManager.tsx
+++ b/src/components/DropboxTrashManager.tsx
@@ -95,33 +95,10 @@ export function DropboxTrashManager({ onClose, onRefreshFiles, currentPath }: Dr
     }
   };
 
-  const [pendingDeleteConfirm, setPendingDeleteConfirm] = useState(false);
-
-  const handlePermanentDelete = () => {
-    if (selected.size === 0) return;
-    setPendingDeleteConfirm(true);
-  };
-
-  const confirmPermanentDelete = async () => {
-    setPendingDeleteConfirm(false);
-    const paths = Array.from(selected);
-    if (paths.length === 0) return;
-    const logId = humanLog.logRaw('activity.trash_delete_start', 'INFO', { provider: 'Dropbox', count: paths.length });
-    setActionLoading('delete');
-    try {
-      for (const path of paths) {
-        await invoke('dropbox_permanent_delete', { path });
-      }
-      humanLog.updateEntry(logId, { status: 'success', message: `[Dropbox] Permanently deleted ${paths.length} item(s) from trash` });
-      await loadTrash();
-      onRefreshFiles?.();
-    } catch (err) {
-      humanLog.updateEntry(logId, { status: 'error', message: `[Dropbox] Failed to permanently delete from trash` });
-      setError(String(err));
-    } finally {
-      setActionLoading(null);
-    }
-  };
+  // Permanent delete / Empty Trash are intentionally NOT offered for Dropbox:
+  // the files/permanent_delete API requires a Business/Team account with the
+  // files.permanent_delete scope (unavailable for personal accounts). Trash
+  // auto-empties after 30 days. See the note at the end of this component.
 
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {

--- a/src/components/OAuthConnect.tsx
+++ b/src/components/OAuthConnect.tsx
@@ -98,7 +98,7 @@ const REDIRECT_URIS: Record<string, { uri: string; note?: string }> = {
   googledrive: { uri: 'http://127.0.0.1 (auto-assigned port)', note: 'redirectUriNoteGoogle' },
   googlephotos: { uri: 'http://127.0.0.1 (auto-assigned port)', note: 'redirectUriNoteGoogle' },
   dropbox: { uri: 'http://127.0.0.1:17548/callback' },
-  onedrive: { uri: 'http://127.0.0.1:27154/callback' },
+  onedrive: { uri: 'http://localhost:27154/callback' },
   box: { uri: 'http://127.0.0.1:9484/callback' },
   pcloud: { uri: 'http://localhost:17384/callback' },
   zohoworkdrive: { uri: 'http://127.0.0.1:18765/callback' },


### PR DESCRIPTION
## Ehud #397 OAuth residuals

Closes the two code-actionable residuals from [@EhudKirsh](https://github.com/EhudKirsh)'s [#397 follow-up](https://github.com/axpdev-lab/aeroftp/issues/397#issuecomment-5003387314).

### OneDrive: `invalid_request: redirect_uri is not valid` (the real fix)
The connect UI told users to register `http://127.0.0.1:27154/callback`, but the app actually requests `http://localhost:27154/callback` (Entra ID requires `localhost`; fixed port 27154, backend `oauth2.rs:293`). Microsoft treats `localhost` and `127.0.0.1` as **distinct** registered redirect URIs, so minting a new OneDrive token failed exactly as reported, blocking trash **and** every re-auth. `rclone` worked because it ships its own app with a matching registration.

Audited all 8 OAuth providers: OneDrive was the **only** host mismatch (Dropbox/Box/Zoho backends use `127.0.0.1`; pCloud/Yandex use `localhost`; all their UI strings already match).

### Dropbox: dead permanent-delete handlers removed
`handlePermanentDelete` / `confirmPermanentDelete` / `pendingDeleteConfirm` were defined but never wired to any button. Dropbox `files/permanent_delete` needs a Business/Team scope unavailable to personal accounts (trash auto-empties after 30 days), so the missing red/orange buttons are **by design**. Removed the dead code so the component matches its own note.

### Not in this PR
pCloud's residual `Log in required` (finding #4): the trash path is already correct (query-param auth + `get_valid_token` refresh since v3.1.4; crypt fix `d1e0bef90`). No code defect remains, it needs a live re-auth re-test.

**Verified green:** `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the Dropbox permanent-delete and empty-trash option. Dropbox trash is automatically emptied after 30 days.
  * Updated the OneDrive sign-in redirect address for improved local connection handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->