### PR TITLE
fix(crypt-overlay): snap decrypted names in, drop cosmetic reveal puff + laser sweep

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1224,10 +1224,6 @@ const App: React.FC = () => {
     kind: 'rclone-crypt' | 'aerocrypt';
   } | null>(null);
   const [overlayDecrypting, setOverlayDecrypting] = useState(false);
-  // T2: brief grace window after decryption ends so the just-landed decrypted
-  // names stay wrapped in DecryptingText long enough to play the reveal ("puff")
-  // instead of unmounting to plain text mid-transition.
-  const [overlayRevealing, setOverlayRevealing] = useState(false);
   // The owner of the active (or in-progress) encrypted overlay. Both the provider
   // decorator state and the decryption animation are gated on
   // this owner matching the active session, so an overlay can NEVER bleed onto
@@ -1246,16 +1242,6 @@ const App: React.FC = () => {
   const [cryptOverlayOwner, setCryptOverlayOwner] = useState<
     { savedServerId: string | null; sessionId: string | null } | null
   >(null);
-  const prevOverlayDecryptingRef = useRef(false);
-  useEffect(() => {
-    const was = prevOverlayDecryptingRef.current;
-    prevOverlayDecryptingRef.current = overlayDecrypting;
-    if (was && !overlayDecrypting) {
-      setOverlayRevealing(true);
-      const id = setTimeout(() => setOverlayRevealing(false), 900);
-      return () => clearTimeout(id);
-    }
-  }, [overlayDecrypting]);
   // Guards the post-unlock reload against double-firing (React 18 StrictMode
   // double-invokes the effect in dev; a stable ref keyed by the activated vault
   // id makes the decrypted reload + activity log run exactly once per unlock).
@@ -3769,10 +3755,13 @@ interface UpdateVerificationInfo {
     return false;
   })();
 
-  // T2: the decryption animation is allowed only on the tab that owns the
-  // overlay, so it never plays on another connected server's panel and stops as
-  // soon as you switch tabs.
-  const overlayAnimActive = (overlayDecrypting || overlayRevealing) && cryptOverlayOwnerMatchesActive;
+  // The decryption scramble is allowed only on the tab that owns the overlay, so
+  // it never plays on another connected server's panel and stops as soon as you
+  // switch tabs. It runs ONLY while the unlock is in flight (overlayDecrypting):
+  // the moment the decrypted names land, they paint immediately with no reveal
+  // "puff" (the ~0.8s cosmetic tail was cut so the toggle feels as fast as the
+  // real Argon2id + re-list work allows).
+  const overlayAnimActive = overlayDecrypting && cryptOverlayOwnerMatchesActive;
 
   // Path-bar crypt overlay TOGGLE badge state. The badge is shown for any overlay
   // tab (capability persists across lock) so it can be clicked to lock/unlock:
@@ -18030,7 +18019,6 @@ interface UpdateVerificationInfo {
                         formatBytes={formatBytes}
                         showFileExtensions={true}
                         decrypting={overlayAnimActive && overlayDecrypting}
-                        revealing={overlayAnimActive && overlayRevealing}
                       />
                     ) : (
                       /* Grid View */

--- a/src/components/DecryptingText.tsx
+++ b/src/components/DecryptingText.tsx
@@ -101,7 +101,6 @@ export const DecryptingText: React.FC<DecryptingTextProps> = ({
             title={title ?? text}
         >
             {display}
-            {active && !reduceMotion && <span className="aerocrypt-scan-bar" aria-hidden="true" />}
         </span>
     );
 };

--- a/src/components/LargeIconsGrid.tsx
+++ b/src/components/LargeIconsGrid.tsx
@@ -60,10 +60,9 @@ interface LargeIconsGridProps {
   sameNameLeakLabel?: string;
   sameNameLeakTooltip?: string;
   // AeroCrypt overlay decryption animation (remote panel only): scramble names
-  // while unlocking, then reveal. `revealing` keeps the cards animated through
-  // the brief reveal window after `decrypting` flips false.
+  // while the unlock is in flight. When `decrypting` flips false the decrypted
+  // names paint immediately (no reveal "puff").
   decrypting?: boolean;
-  revealing?: boolean;
 }
 
 // --- Individual file card (memoized) ---
@@ -89,7 +88,6 @@ interface LargeIconCardProps {
   formatBytes: (bytes: number) => string;
   showFileExtensions?: boolean;
   decrypting?: boolean;
-  revealing?: boolean;
   cardIndex?: number;
   lock?: ArchiveLock;
   lockedLabel?: string;
@@ -120,7 +118,6 @@ const LargeIconCard = React.memo<LargeIconCardProps>(({
   formatBytes,
   showFileExtensions = true,
   decrypting = false,
-  revealing = false,
   cardIndex = 0,
   lock = null,
   lockedLabel,
@@ -132,7 +129,7 @@ const LargeIconCard = React.memo<LargeIconCardProps>(({
   const renameRef = useRef<HTMLInputElement>(null);
   const isRenaming = inlineRename?.path === file.path;
   const isImage = IMAGE_EXTENSIONS.test(file.name);
-  const animateName = (decrypting || revealing) && file.name !== '..';
+  const animateName = decrypting && file.name !== '..';
 
   const handleClick = useCallback((e: React.MouseEvent) => {
     onFileClick(file, e);
@@ -314,7 +311,6 @@ export function LargeIconsGrid({
   formatBytes,
   showFileExtensions = true,
   decrypting = false,
-  revealing = false,
   archiveLockOf,
   lockedLabel,
   unlockedLabel,
@@ -368,7 +364,6 @@ export function LargeIconsGrid({
         formatBytes={formatBytes}
         showFileExtensions={showFileExtensions}
         decrypting={decrypting}
-        revealing={revealing}
         cardIndex={index}
         lock={archiveLockOf ? archiveLockOf(file) : null}
         lockedLabel={lockedLabel}
@@ -381,7 +376,7 @@ export function LargeIconsGrid({
   }, [files, selectedFiles, dragOverTarget, currentPath, getFileIcon, onFileClick,
     onFileDoubleClick, onContextMenu, onDragStart, onDragOver, onDrop, onDragLeave,
     onDragEnd, inlineRename, onInlineRenameChange, onInlineRenameCommit,
-    onInlineRenameCancel, formatBytes, showFileExtensions, decrypting, revealing,
+    onInlineRenameCancel, formatBytes, showFileExtensions, decrypting,
     archiveLockOf, lockedLabel, unlockedLabel,
     sameNameLeakOf, sameNameLeakLabel, sameNameLeakTooltip]);
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -413,36 +413,6 @@ table::-webkit-scrollbar-thumb:hover {
   }
 }
 
-/* AeroCrypt decryption "scan" cursor: a soft accent band that sweeps across a
-   name while it is being decrypted. The loop (1.6s) is deliberately slower than
-   the per-character scramble so the two motions read as distinct layers. */
-@keyframes aerocrypt-scan {
-  0% {
-    transform: translateX(-130%);
-  }
-  100% {
-    transform: translateX(230%);
-  }
-}
-
-.aerocrypt-scan-bar {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  width: 38%;
-  pointer-events: none;
-  background: linear-gradient(90deg, transparent, var(--color-accent, #34d399), transparent);
-  opacity: 0.35;
-  animation: aerocrypt-scan 1.6s ease-in-out infinite;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .aerocrypt-scan-bar {
-    display: none;
-  }
-}
-
 /* ======================================
    Utility Classes
    ====================================== */


### PR DESCRIPTION
## What

The AeroCrypt / rclone-crypt overlay unlock played a ~0.8s reveal **puff** plus a sweeping **laser** scan cursor *after* the decrypted names had already landed — holding readable names back for no reason.

This keeps the scramble that honestly covers the real unlock wait (key derivation + folder re-list) and paints the names **the instant they arrive**.

## Changes
- remove the `overlayRevealing` 900ms grace window and its effect
- gate the name animation on `overlayDecrypting` only (no post-unlock reveal)
- drop the now-dead `revealing` prop across `LargeIconsGrid`
- remove the `aerocrypt-scan-bar` sweep (span + keyframes/CSS)

Net **-48 lines**.

## Verification
- `tsc --noEmit` clean
- `vite build` green
- 508/508 unit tests pass
- Livetested in dev: scramble during the real wait, names snap in, no puff/laser

Refs #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the cryptographic overlay transition by removing the extra reveal phase.
  * Synchronized decryption animations across overlays and icon cards for a more consistent experience.
  * Removed the decryption scan cursor effect from text and animations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->