### PR TITLE
fix(snap): stop shipping a noble-built payload in a core22 base

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -669,10 +669,10 @@ jobs:
 
       # Guard the snap version BEFORE packaging. Kept even though this job now
       # runs behind `needs: build-and-release` (whose R10 gate covers the same
-      # ground): it costs a second, it is the only guard on the snap-refresh
-      # rebuild path, and it is what caught v4.0.9 shipping a Sigstore-signed
-      # 4.0.8 snap as an asset of the 4.0.9 release. Parsed with grep/sed
-      # because there is no node in this job any more.
+      # ground): it costs a second, and it is what caught v4.0.9 shipping a
+      # Sigstore-signed 4.0.8 snap as an asset of the 4.0.9 release. The
+      # snap-refresh rebuild path carries its own copy of this guard. Parsed
+      # with grep/sed because there is no node in this job any more.
       - name: R10-snap version guard (snapcraft.yaml vs tag)
         shell: bash
         run: |
@@ -766,10 +766,12 @@ jobs:
       # ----------------------------------------------------------------------
       - name: Gate G1 - snap ABI floor vs base
         shell: bash
+        env:
+          SNAP_FILE: ${{ steps.snap-check.outputs.snap }}
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends squashfs-tools binutils file
-          ./scripts/snap-abi-check.sh "${{ steps.snap-check.outputs.snap }}"
+          ./scripts/snap-abi-check.sh "$SNAP_FILE"
 
       # ----------------------------------------------------------------------
       # Gate G2 - install the snap and run a command that actually reaches the
@@ -781,10 +783,11 @@ jobs:
       # ----------------------------------------------------------------------
       - name: Gate G2 - install the snap and exercise the payload
         shell: bash
+        env:
+          SNAP_FILE: ${{ steps.snap-check.outputs.snap }}
         run: |
           set -euo pipefail
-          SNAP="${{ steps.snap-check.outputs.snap }}"
-          sudo snap install --dangerous "$SNAP"
+          sudo snap install --dangerous "$SNAP_FILE"
           echo "--- aeroftp ls --help (routes to the CLI payload) ---"
           out="$(/snap/bin/aeroftp ls --help 2>&1)" || {
             echo "::error::the installed snap cannot run 'aeroftp ls --help'"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -246,15 +246,20 @@ jobs:
               exit 1
             fi
           done
-          tar -cf "$RUNNER_TEMP/linux-payload.tar" "${PAYLOAD[@]}"
-          ls -l "$RUNNER_TEMP/linux-payload.tar"
+          # Staged inside the workspace, not in RUNNER_TEMP: an artifact whose
+          # source lies outside the workspace is stored under a relative path
+          # that `gh run download` rejects as path traversal, which is exactly
+          # when you need it - debugging a failed release from a laptop.
+          mkdir -p "$GITHUB_WORKSPACE/payload-stage"
+          tar -cf "$GITHUB_WORKSPACE/payload-stage/linux-payload.tar" "${PAYLOAD[@]}"
+          ls -l "$GITHUB_WORKSPACE/payload-stage/linux-payload.tar"
 
       - name: Upload Linux payload for the snap job
         if: matrix.target == 'linux' && (startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch')
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: aeroftp-linux-payload-${{ github.sha }}
-          path: ${{ runner.temp }}/linux-payload.tar
+          path: payload-stage/linux-payload.tar
           if-no-files-found: error
           retention-days: 1
 
@@ -742,6 +747,17 @@ jobs:
           echo "Snap produced: $SNAP ($(du -h "$SNAP" | cut -f1))"
           echo "snap=$SNAP" >> "$GITHUB_OUTPUT"
 
+      # Uploaded BEFORE the gates on purpose: when a gate rejects a snap, the
+      # rejected artifact is exactly what you need in hand to diagnose it.
+      # Publishing still happens only after both gates pass.
+      - name: Upload Snap as workflow artifact (validation runs)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: aeroftp-snap-${{ github.sha }}
+          path: ${{ steps.snap-check.outputs.snap }}
+          if-no-files-found: error
+          retention-days: 1
+
       # ----------------------------------------------------------------------
       # Gate G1 - static ABI floor. Every ELF in the snap must fit the glibc the
       # `base:` snap provides; the ceiling is read from the base itself, never
@@ -781,16 +797,6 @@ jobs:
             exit 1
           fi
           sudo snap remove --purge aeroftp || true
-
-      # Persist the .snap as a workflow artifact so workflow_dispatch
-      # validation runs (no tag) leave behind something downloadable.
-      - name: Upload Snap as workflow artifact (validation runs)
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: aeroftp-snap-${{ github.sha }}
-          path: ${{ steps.snap-check.outputs.snap }}
-          if-no-files-found: error
-          retention-days: 1
 
       # Sigstore keyless signing of the .snap: only on tags.
       - name: Install Cosign

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,19 +120,10 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libfuse3-dev
-          # Install Snapcraft with retry on transient snap-store outages
-          for i in 1 2 3 4 5; do
-            if sudo snap install snapcraft --classic; then
-              echo "snapcraft installed (attempt $i)"
-              break
-            fi
-            if [ "$i" -eq 5 ]; then
-              echo "snapcraft install still failing after 5 attempts; continuing: Snap step is continue-on-error"
-              break
-            fi
-            echo "snap install failed (attempt $i/5), retry in 60s..."
-            sleep 60
-          done
+          # No snapcraft here any more: this leg stopped building the snap when
+          # PR #172 moved it to its own job, and snapcore/action-build brings
+          # its own snapcraft. The leftover install (5 retries, 60 s apart on a
+          # store hiccup) was pure cost on every PR run.
 
       - name: Install npm dependencies
         run: npm ci
@@ -228,6 +219,44 @@ jobs:
           done
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # The snap is packaged in the dedicated `build-snap` job below, but its
+      # payload MUST be compiled on the same Ubuntu release as the snap's
+      # `base:` - core22 means jammy, i.e. THIS ubuntu-22.04 leg. Between
+      # 2026-05-06 (PR #172) and 2026-07-25 the snap job compiled its own
+      # payload on ubuntu-24.04, so ~30 published revisions demanded
+      # GLIBC_2.38/2.39 from a 2.35 runtime and died at exec with
+      # "version 'GLIBC_2.38' not found" - the app could not start at all.
+      # See issue #460 for the full analysis.
+      #
+      # Handing the jammy binaries to the snap job means .deb/.rpm/.AppImage
+      # and .snap all ship the exact same bytes, so the mismatch cannot return.
+      # Tarred because GitHub artifacts do not preserve the executable bit and
+      # snapcraft's override-build copies these binaries verbatim.
+      - name: Package Linux payload for the snap job
+        if: matrix.target == 'linux' && (startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch')
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd src-tauri/target/release
+          PAYLOAD=(aeroftp aeroftp-dispatch-bundle/aeroftp-cli aeroftp-dispatch-bundle/aeroftp-dispatch)
+          for f in "${PAYLOAD[@]}"; do
+            if [ ! -f "$f" ]; then
+              echo "::error::missing payload binary $f - the snap job cannot be fed"
+              exit 1
+            fi
+          done
+          tar -cf "$RUNNER_TEMP/linux-payload.tar" "${PAYLOAD[@]}"
+          ls -l "$RUNNER_TEMP/linux-payload.tar"
+
+      - name: Upload Linux payload for the snap job
+        if: matrix.target == 'linux' && (startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch')
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: aeroftp-linux-payload-${{ github.sha }}
+          path: ${{ runner.temp }}/linux-payload.tar
+          if-no-files-found: error
+          retention-days: 1
 
       - name: Build Tauri app
         if: matrix.target != 'linux' && (matrix.target != 'macos' || matrix.arch == 'aarch64')
@@ -594,18 +623,37 @@ jobs:
   # zero-byte snaps because `snap/snapcraft.yaml`'s `override-build` step
   # copies a *pre-built* `src-tauri/target/release/aeroftp` binary into
   # the snap layout. The original inline step inherited that binary from
-  # the matrix Linux job's `npm run tauri build` earlier in the same
-  # workflow; the dedicated job did not. We now reproduce the full
-  # pre-build (Node + Rust + system deps + `npm run tauri build`) inside
-  # this job before invoking snapcore/action-build, which then packages
-  # the freshly-built binary. The workflow_dispatch validation lane
-  # exercises the same path so failures show up before tagging.
+  # the matrix Linux job's `npm run tauri build`; the dedicated job did not,
+  # so it reproduced the whole pre-build (Node + Rust + `npm run tauri build`)
+  # here instead.
+  #
+  # NOTE 2026-07-26: that pre-build was the bug. It ran on THIS ubuntu-24.04
+  # runner (glibc 2.39) while `snap/snapcraft.yaml` stayed on `base: core22`
+  # (glibc 2.35), so from v3.7.2 to v4.1.6 every published revision shipped a
+  # payload the core22 loader refuses - "version 'GLIBC_2.38' not found" - and
+  # the app could not start at all. ~30 releases, caught by nobody because the
+  # only assertion was "the .snap exists and is >10 MB".
+  #
+  # The job is now packaging-only: it consumes the jammy binaries built by the
+  # ubuntu-22.04 `linux` leg, so the snap ships the same bytes as the
+  # .deb/.rpm/.AppImage and the build environment matches the base by
+  # construction. Two blocking gates below prove it before anything is
+  # published. Full analysis: issue #460.
+  #
+  # `needs:` is the point, not a detail: the payload must come from the jammy
+  # leg. It costs ~15 min of release wall clock and saves a whole duplicate
+  # Rust build (~60 min of runner time).
   #
   # Triggers:
   # - Tag pushes: full pipeline (build + sign + release upload + Snap Store)
   # - workflow_dispatch: build only (validation runs without cutting a tag)
   build-snap:
-    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+    # `!cancelled()` rather than the implicit success(): the snap only truly
+    # depends on the ubuntu-22.04 leg's payload, so a flaky macOS or Windows leg
+    # must not block it. If the Linux leg is the one that failed, the payload
+    # artifact is missing and this job fails on the download - which is right.
+    if: ${{ !cancelled() && (startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch') }}
+    needs: build-and-release
     runs-on: ubuntu-24.04
     permissions:
       contents: write   # required for softprops/action-gh-release
@@ -614,15 +662,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
-      # Guard the snap version BEFORE any build. This job has no `needs:` and runs
-      # in parallel with the R10 gate in build-and-release, so an R10 failure there
-      # cannot stop this job from having already built and uploaded a snap. That is
-      # exactly how v4.0.9 shipped: snapcraft.yaml was left at 4.0.8 and a
-      # Sigstore-signed 4.0.8 snap was published as an asset of the 4.0.9 release.
-      # A `needs: build-and-release` would fix it but serialize the whole pipeline
-      # (the snap would wait for every platform) to pay for a one-second check, so
-      # the guard lives here and fails in a second instead. No node yet (this runs
-      # before Setup Node.js), so both versions are parsed with grep/sed.
+      # Guard the snap version BEFORE packaging. Kept even though this job now
+      # runs behind `needs: build-and-release` (whose R10 gate covers the same
+      # ground): it costs a second, it is the only guard on the snap-refresh
+      # rebuild path, and it is what caught v4.0.9 shipping a Sigstore-signed
+      # 4.0.8 snap as an asset of the 4.0.9 release. Parsed with grep/sed
+      # because there is no node in this job any more.
       - name: R10-snap version guard (snapcraft.yaml vs tag)
         shell: bash
         run: |
@@ -644,44 +689,28 @@ jobs:
             fi
           fi
 
-      - name: Setup Node.js
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      # The payload comes from the ubuntu-22.04 leg, never from this runner:
+      # jammy binaries for a jammy (core22) base. Nothing here compiles Rust.
+      - name: Download Linux payload built on jammy
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          node-version: '20'
-          cache: 'npm'
+          name: aeroftp-linux-payload-${{ github.sha }}
+          path: ${{ runner.temp }}/payload
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          toolchain: stable
-
-      - name: Rust cache
-        uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
-        with:
-          workspaces: './src-tauri -> target'
-          # Same prefix as build.yml main matrix to keep cache keys
-          # aligned across jobs in this workflow.
-          prefix-key: 'v2-whisper-vs18'
-
-      - name: Install Linux build dependencies
+      - name: Restore payload into src-tauri/target/release
+        shell: bash
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libwebkit2gtk-4.1-dev \
-            libappindicator3-dev \
-            librsvg2-dev \
-            patchelf \
-            libfuse3-dev
-
-      - name: Install npm dependencies
-        run: npm ci
-
-      # Produces src-tauri/target/release/aeroftp, which the
-      # snap/snapcraft.yaml `override-build` step copies into the snap.
-      - name: Build Tauri release binary (Linux x64)
-        run: npm run tauri build
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          set -euo pipefail
+          mkdir -p src-tauri/target/release
+          tar -xf "$RUNNER_TEMP/payload/linux-payload.tar" -C src-tauri/target/release
+          cd src-tauri/target/release
+          # The executable bit does not survive a GitHub artifact round-trip in
+          # every path, and snapcraft copies these binaries as-is.
+          chmod +x aeroftp aeroftp-dispatch-bundle/aeroftp-cli aeroftp-dispatch-bundle/aeroftp-dispatch
+          for f in aeroftp aeroftp-dispatch-bundle/aeroftp-cli aeroftp-dispatch-bundle/aeroftp-dispatch; do
+            [ -x "$f" ] || { echo "::error::payload binary $f missing or not executable"; exit 1; }
+            echo "  $(ls -l "$f")"
+          done
 
       # snapcore/action-build@3bdaa03e is the latest pin (no v2 exists,
       # see issue #164 for the analysis). On ubuntu-24.04 the native LXD
@@ -700,7 +729,9 @@ jobs:
           SNAP="${{ steps.snap-build.outputs.snap }}"
           if [ -z "$SNAP" ] || [ ! -f "$SNAP" ]; then
             echo "::error::Snap file not produced by snapcore/action-build"
-            echo "Expected output `steps.snap-build.outputs.snap` was empty or missing on disk."
+            # Single-quoted on purpose: inside double quotes bash would run the
+            # backticked text as a command and mangle its own error message.
+            echo 'Expected output steps.snap-build.outputs.snap was empty or missing on disk.'
             exit 1
           fi
           BYTES=$(stat -c %s "$SNAP")
@@ -710,6 +741,46 @@ jobs:
           fi
           echo "Snap produced: $SNAP ($(du -h "$SNAP" | cut -f1))"
           echo "snap=$SNAP" >> "$GITHUB_OUTPUT"
+
+      # ----------------------------------------------------------------------
+      # Gate G1 - static ABI floor. Every ELF in the snap must fit the glibc the
+      # `base:` snap provides; the ceiling is read from the base itself, never
+      # hardcoded. This is the check whose absence let ~30 unstartable revisions
+      # reach the Snap Store between 2026-05-06 and 2026-07-25.
+      # ----------------------------------------------------------------------
+      - name: Gate G1 - snap ABI floor vs base
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends squashfs-tools binutils file
+          ./scripts/snap-abi-check.sh "${{ steps.snap-check.outputs.snap }}"
+
+      # ----------------------------------------------------------------------
+      # Gate G2 - install the snap and run a command that actually reaches the
+      # payload. `aeroftp --version` is NOT a valid smoke test: a leading dash
+      # routes to DispatchRoute::Gui (needs a display), and the dispatcher can
+      # answer without the payload ever loading. Only a token from
+      # CLI_SUBCOMMANDS (src-tauri/src/cli_dispatch.rs) execs aeroftp-cli and
+      # therefore proves the payload links against the base at runtime.
+      # ----------------------------------------------------------------------
+      - name: Gate G2 - install the snap and exercise the payload
+        shell: bash
+        run: |
+          set -euo pipefail
+          SNAP="${{ steps.snap-check.outputs.snap }}"
+          sudo snap install --dangerous "$SNAP"
+          echo "--- aeroftp ls --help (routes to the CLI payload) ---"
+          out="$(/snap/bin/aeroftp ls --help 2>&1)" || {
+            echo "::error::the installed snap cannot run 'aeroftp ls --help'"
+            echo "$out"
+            exit 1
+          }
+          echo "$out" | head -20
+          if ! grep -qiE 'usage|aeroftp' <<<"$out"; then
+            echo "::error::unexpected output from the snap CLI payload"
+            exit 1
+          fi
+          sudo snap remove --purge aeroftp || true
 
       # Persist the .snap as a workflow artifact so workflow_dispatch
       # validation runs (no tag) leave behind something downloadable.

--- a/.github/workflows/snap-refresh.yml
+++ b/.github/workflows/snap-refresh.yml
@@ -64,12 +64,18 @@ jobs:
         with:
           fetch-depth: 0
 
+      # The dispatch input goes through the environment, never through `${{ }}`
+      # in the script body: an expression is substituted before bash parses the
+      # line, so a crafted tag would execute as a command in a workflow that
+      # later holds SNAPCRAFT_STORE_CREDENTIALS. Quoting does not help.
       - name: Resolve the release tag to rebuild
         id: resolve
         shell: bash
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
-          TAG="${{ inputs.tag }}"
+          TAG="${INPUT_TAG:-}"
           if [ -z "$TAG" ]; then
             TAG=$(git tag --list 'v*' --sort=-v:refname | head -1)
           fi
@@ -177,6 +183,24 @@ jobs:
         with:
           ref: ${{ needs.audit.outputs.tag }}
 
+      # Same guard as the release pipeline, and here it earns its keep: this job
+      # publishes to the Store from an arbitrary tag, so the snapcraft.yaml it
+      # just checked out must be the version that tag claims to be.
+      - name: R10-snap version guard (snapcraft.yaml vs rebuilt tag)
+        shell: bash
+        env:
+          TAG: ${{ needs.audit.outputs.tag }}
+        run: |
+          set -euo pipefail
+          SNAP_VERSION=$(grep -m1 '^version:' snap/snapcraft.yaml | sed "s/.*['\"]\(.*\)['\"].*/\1/")
+          EXPECTED="${TAG#v}"
+          echo "snapcraft.yaml: $SNAP_VERSION"
+          echo "tag:            $EXPECTED"
+          if [ "$SNAP_VERSION" != "$EXPECTED" ]; then
+            echo "::error::snap version drift: snapcraft.yaml=$SNAP_VERSION does not match tag=$EXPECTED"
+            exit 1
+          fi
+
       - name: Download the jammy payload
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -236,16 +260,20 @@ jobs:
 
       - name: Gate G1 - snap ABI floor vs base
         shell: bash
+        env:
+          SNAP_FILE: ${{ steps.snap-check.outputs.snap }}
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends squashfs-tools binutils file
-          ./ci-tools/scripts/snap-abi-check.sh "${{ steps.snap-check.outputs.snap }}" snap/snapcraft.yaml
+          ./ci-tools/scripts/snap-abi-check.sh "$SNAP_FILE" snap/snapcraft.yaml
 
       - name: Gate G2 - install the snap and exercise the payload
         shell: bash
+        env:
+          SNAP_FILE: ${{ steps.snap-check.outputs.snap }}
         run: |
           set -euo pipefail
-          sudo snap install --dangerous "${{ steps.snap-check.outputs.snap }}"
+          sudo snap install --dangerous "$SNAP_FILE"
           out="$(/snap/bin/aeroftp ls --help 2>&1)" || {
             echo "::error::the rebuilt snap cannot run 'aeroftp ls --help'"
             echo "$out"
@@ -266,20 +294,25 @@ jobs:
         if: ${{ github.event_name == 'schedule' || inputs.publish }}
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+          SNAP_FILE: ${{ steps.snap-check.outputs.snap }}
         run: |
           set -euo pipefail
           if ! command -v snapcraft >/dev/null 2>&1; then
             sudo snap install snapcraft --classic
           fi
-          snapcraft upload --release=stable "${{ steps.snap-check.outputs.snap }}"
+          snapcraft upload --release=stable "$SNAP_FILE"
 
       - name: Summary
         if: always()
         shell: bash
+        env:
+          TAG: ${{ needs.audit.outputs.tag }}
+          STALE_COUNT: ${{ needs.audit.outputs.count }}
+          PUBLISHED: ${{ github.event_name == 'schedule' || inputs.publish }}
         run: |
           {
-            echo "### Snap refresh - ${{ needs.audit.outputs.tag }}"
+            echo "### Snap refresh - $TAG"
             echo ""
-            echo "- stale packages found by the audit: ${{ needs.audit.outputs.count }}"
-            echo "- published to the Store: ${{ github.event_name == 'schedule' || inputs.publish }}"
+            echo "- stale packages found by the audit: $STALE_COUNT"
+            echo "- published to the Store: $PUBLISHED"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/snap-refresh.yml
+++ b/.github/workflows/snap-refresh.yml
@@ -169,18 +169,11 @@ jobs:
     needs: [audit, payload]
     runs-on: ubuntu-24.04
     steps:
-      # The tag provides the sources and snapcraft.yaml; the CI tooling
-      # (gates, scripts) comes from the branch this workflow runs on, so old
-      # tags can be rebuilt with today's checks.
+      # The tag provides the sources and snapcraft.yaml.
       - name: Checkout the release tag (snap sources)
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ needs.audit.outputs.tag }}
-
-      - name: Checkout current CI tooling
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-        with:
-          path: ci-tools
 
       - name: Download the jammy payload
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -219,6 +212,16 @@ jobs:
           fi
           echo "Snap produced: $SNAP ($(du -h "$SNAP" | cut -f1))"
           echo "snap=$SNAP" >> "$GITHUB_OUTPUT"
+
+      # Only now, after snapcraft has copied the project into its build
+      # environment: the part uses `source: .`, so a second checkout present
+      # during the build would be copied in along with everything else.
+      # The gates come from the branch this workflow runs on, not from the tag,
+      # so an old tag is rebuilt with today's checks.
+      - name: Checkout current CI tooling
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          path: ci-tools
 
       - name: Gate G1 - snap ABI floor vs base
         shell: bash

--- a/.github/workflows/snap-refresh.yml
+++ b/.github/workflows/snap-refresh.yml
@@ -1,0 +1,279 @@
+name: Snap security refresh
+
+# A snap freezes every stage-package at build time. Because the snap is only
+# built on release tags, its vendored Ubuntu libraries age between releases
+# until the Snap Store mails "aeroftp contains outdated Ubuntu packages"
+# (USN-8584-1 on r216, 2026-07-22). Rebuilding is the documented fix.
+#
+# This workflow closes that loop without cutting a version: it audits the
+# published revision every week and, only when the archive really has newer
+# packages, rebuilds the latest release tag and pushes a new revision. The
+# version string does not change, so the in-app updater stays quiet - the Store
+# simply serves a fresher revision of the same release.
+#
+# It is also the rebuild path used when the *pipeline* was wrong rather than the
+# packages: dispatch it with `force: true` to rebuild a tag on demand.
+#
+# The payload is compiled on ubuntu-22.04 because `base: core22` means jammy.
+# Compiling it on a newer runner is what broke every revision published between
+# 2026-05-06 and 2026-07-25; see
+# issue #460.
+
+on:
+  schedule:
+    # Mondays 04:17 UTC, after the archive's weekend publishing settles.
+    - cron: '17 4 * * 1'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to rebuild (default: newest v* tag)'
+        required: false
+        type: string
+      force:
+        description: 'Rebuild even when no staged package is stale'
+        required: false
+        default: false
+        type: boolean
+      publish:
+        description: 'Upload the rebuilt snap to the Snap Store (stable)'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: snap-refresh
+  cancel-in-progress: false
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # 1. Is a rebuild actually owed? Compares the published revision's own
+  #    primed-stage-packages against the live archive. Cheap: ~30 s, no build.
+  # ---------------------------------------------------------------------------
+  audit:
+    runs-on: ubuntu-24.04
+    outputs:
+      stale: ${{ steps.audit.outputs.stale }}
+      count: ${{ steps.audit.outputs.count }}
+      tag: ${{ steps.resolve.outputs.tag }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
+
+      - name: Resolve the release tag to rebuild
+        id: resolve
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${{ inputs.tag }}"
+          if [ -z "$TAG" ]; then
+            TAG=$(git tag --list 'v*' --sort=-v:refname | head -1)
+          fi
+          if [ -z "$TAG" ] || ! git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "::error::cannot resolve a release tag to rebuild (got '$TAG')"
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Rebuild candidate: $TAG"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: '20'
+
+      - name: Install audit tooling
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends squashfs-tools
+
+      - name: Audit published revision against the Ubuntu archive
+        id: audit
+        run: node scripts/snap-stale-packages.mjs --name aeroftp --channel stable
+
+  # ---------------------------------------------------------------------------
+  # 2. Compile the payload on jammy - the release the core22 base is built from.
+  #    Same command as the release pipeline so the two cannot drift.
+  # ---------------------------------------------------------------------------
+  payload:
+    needs: audit
+    if: ${{ needs.audit.outputs.stale == 'true' || inputs.force }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout the release tag
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ needs.audit.outputs.tag }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        with:
+          workspaces: './src-tauri -> target'
+          prefix-key: 'v2-whisper-vs18'
+
+      - name: Install Linux build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            libfuse3-dev
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Build Tauri release binaries
+        run: npm run tauri build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Package the payload
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd src-tauri/target/release
+          PAYLOAD=(aeroftp aeroftp-dispatch-bundle/aeroftp-cli aeroftp-dispatch-bundle/aeroftp-dispatch)
+          for f in "${PAYLOAD[@]}"; do
+            [ -f "$f" ] || { echo "::error::missing payload binary $f"; exit 1; }
+          done
+          tar -cf "$RUNNER_TEMP/linux-payload.tar" "${PAYLOAD[@]}"
+          ls -l "$RUNNER_TEMP/linux-payload.tar"
+
+      - name: Upload the payload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: snap-refresh-payload-${{ needs.audit.outputs.tag }}
+          path: ${{ runner.temp }}/linux-payload.tar
+          if-no-files-found: error
+          retention-days: 1
+
+  # ---------------------------------------------------------------------------
+  # 3. Pack, gate, publish. ubuntu-24.04 for LXD headroom (issue #164); nothing
+  #    is compiled here, so the runner's glibc never reaches the snap.
+  # ---------------------------------------------------------------------------
+  pack:
+    needs: [audit, payload]
+    runs-on: ubuntu-24.04
+    steps:
+      # The tag provides the sources and snapcraft.yaml; the CI tooling
+      # (gates, scripts) comes from the branch this workflow runs on, so old
+      # tags can be rebuilt with today's checks.
+      - name: Checkout the release tag (snap sources)
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ needs.audit.outputs.tag }}
+
+      - name: Checkout current CI tooling
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          path: ci-tools
+
+      - name: Download the jammy payload
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: snap-refresh-payload-${{ needs.audit.outputs.tag }}
+          path: ${{ runner.temp }}/payload
+
+      - name: Restore payload into src-tauri/target/release
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p src-tauri/target/release
+          tar -xf "$RUNNER_TEMP/payload/linux-payload.tar" -C src-tauri/target/release
+          cd src-tauri/target/release
+          chmod +x aeroftp aeroftp-dispatch-bundle/aeroftp-cli aeroftp-dispatch-bundle/aeroftp-dispatch
+          ls -l aeroftp aeroftp-dispatch-bundle/aeroftp-cli aeroftp-dispatch-bundle/aeroftp-dispatch
+
+      - name: Build Snap package
+        id: snap-build
+        uses: snapcore/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79 # v1
+
+      - name: Confirm Snap was built
+        id: snap-check
+        shell: bash
+        run: |
+          set -euo pipefail
+          SNAP="${{ steps.snap-build.outputs.snap }}"
+          if [ -z "$SNAP" ] || [ ! -f "$SNAP" ]; then
+            echo "::error::Snap file not produced by snapcore/action-build"
+            exit 1
+          fi
+          BYTES=$(stat -c %s "$SNAP")
+          if [ "$BYTES" -lt 10485760 ]; then
+            echo "::error::Snap file is suspiciously small ($BYTES bytes)"
+            exit 1
+          fi
+          echo "Snap produced: $SNAP ($(du -h "$SNAP" | cut -f1))"
+          echo "snap=$SNAP" >> "$GITHUB_OUTPUT"
+
+      - name: Gate G1 - snap ABI floor vs base
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends squashfs-tools binutils file
+          ./ci-tools/scripts/snap-abi-check.sh "${{ steps.snap-check.outputs.snap }}" snap/snapcraft.yaml
+
+      - name: Gate G2 - install the snap and exercise the payload
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo snap install --dangerous "${{ steps.snap-check.outputs.snap }}"
+          out="$(/snap/bin/aeroftp ls --help 2>&1)" || {
+            echo "::error::the rebuilt snap cannot run 'aeroftp ls --help'"
+            echo "$out"
+            exit 1
+          }
+          echo "$out" | head -20
+          grep -qiE 'usage|aeroftp' <<<"$out" || {
+            echo "::error::unexpected output from the snap CLI payload"
+            exit 1
+          }
+          sudo snap remove --purge aeroftp || true
+
+      - name: Upload the rebuilt snap
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: aeroftp-snap-refresh-${{ needs.audit.outputs.tag }}
+          path: ${{ steps.snap-check.outputs.snap }}
+          if-no-files-found: error
+          retention-days: 7
+
+      # Store-only by design: published GitHub Release assets are immutable in
+      # this repo (`overwrite_files: false`), so a security rebuild must not
+      # rewrite the tag's assets. The Store revision may therefore be newer than
+      # the .snap attached to the release; the version is identical.
+      - name: Publish to Snap Store (stable)
+        if: ${{ github.event_name == 'schedule' || inputs.publish }}
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        run: |
+          set -euo pipefail
+          if ! command -v snapcraft >/dev/null 2>&1; then
+            sudo snap install snapcraft --classic
+          fi
+          snapcraft upload --release=stable "${{ steps.snap-check.outputs.snap }}"
+
+      - name: Summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "### Snap refresh - ${{ needs.audit.outputs.tag }}"
+            echo ""
+            echo "- stale packages found by the audit: ${{ needs.audit.outputs.count }}"
+            echo "- published to the Store: ${{ github.event_name == 'schedule' || inputs.publish }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/snap-refresh.yml
+++ b/.github/workflows/snap-refresh.yml
@@ -150,14 +150,16 @@ jobs:
           for f in "${PAYLOAD[@]}"; do
             [ -f "$f" ] || { echo "::error::missing payload binary $f"; exit 1; }
           done
-          tar -cf "$RUNNER_TEMP/linux-payload.tar" "${PAYLOAD[@]}"
-          ls -l "$RUNNER_TEMP/linux-payload.tar"
+          # Inside the workspace so `gh run download` can fetch it (see build.yml).
+          mkdir -p "$GITHUB_WORKSPACE/payload-stage"
+          tar -cf "$GITHUB_WORKSPACE/payload-stage/linux-payload.tar" "${PAYLOAD[@]}"
+          ls -l "$GITHUB_WORKSPACE/payload-stage/linux-payload.tar"
 
       - name: Upload the payload
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: snap-refresh-payload-${{ needs.audit.outputs.tag }}
-          path: ${{ runner.temp }}/linux-payload.tar
+          path: payload-stage/linux-payload.tar
           if-no-files-found: error
           retention-days: 1
 
@@ -213,6 +215,15 @@ jobs:
           echo "Snap produced: $SNAP ($(du -h "$SNAP" | cut -f1))"
           echo "snap=$SNAP" >> "$GITHUB_OUTPUT"
 
+      # Before the gates: a rejected snap is exactly what you need to inspect.
+      - name: Upload the rebuilt snap
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: aeroftp-snap-refresh-${{ needs.audit.outputs.tag }}
+          path: ${{ steps.snap-check.outputs.snap }}
+          if-no-files-found: error
+          retention-days: 7
+
       # Only now, after snapcraft has copied the project into its build
       # environment: the part uses `source: .`, so a second checkout present
       # during the build would be copied in along with everything else.
@@ -246,14 +257,6 @@ jobs:
             exit 1
           }
           sudo snap remove --purge aeroftp || true
-
-      - name: Upload the rebuilt snap
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: aeroftp-snap-refresh-${{ needs.audit.outputs.tag }}
-          path: ${{ steps.snap-check.outputs.snap }}
-          if-no-files-found: error
-          retention-days: 7
 
       # Store-only by design: published GitHub Release assets are immutable in
       # this repo (`overwrite_files: false`), so a security rebuild must not

--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,9 @@ run-clean.sh
 !/scripts/gen-cli-catalog.ts
 # Exception: release step, publishes a curated asset subset to SourceForge
 !/scripts/publish-sourceforge.sh
+# Exception: snap gates - ABI floor check and stage-package staleness audit (#460)
+!/scripts/snap-abi-check.sh
+!/scripts/snap-stale-packages.mjs
 # Exception: regenerates the providers table from the GUI SSOT (#270 17104681)
 !/scripts/gen-providers-table.ts
 # Exception: single pre-release smoke entrypoint (`npm run smoke`, #408 row 1)

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -164,9 +164,55 @@ The pipeline runs automatically when a tag matching `v*` is pushed.
 ## Snap Store Integration
 
 ### How It Works
-1. GitHub Actions builds snap using `snapcore/action-build@v1`
-2. Uploads to Snap Store with `snapcraft upload --release=stable`
-3. Users with AeroFTP installed via snap get auto-updates
+1. The `ubuntu-22.04` Linux leg builds the payload and hands it to `build-snap` as an artifact
+2. `build-snap` (on `ubuntu-24.04`, for LXD headroom) packages it with `snapcore/action-build@v1`
+3. Two blocking gates run before anything is published (see below)
+4. Uploads to Snap Store with `snapcraft upload --release=stable`
+5. Users with AeroFTP installed via snap get auto-updates
+
+### The one invariant: build host release == snap base
+
+**The payload must be compiled on the same Ubuntu release the snap's `base:` is built
+from.** `base: core22` means jammy, so the binaries must come from the `ubuntu-22.04`
+leg — never from the `ubuntu-24.04` runner that packages the snap.
+
+A snap never ships its own glibc: it comes from the base snap (core22 → GLIBC_2.35
+ceiling). A payload compiled on a newer runner asks for symbols the base cannot provide
+and the loader refuses it — the app installs and then dies with
+`version 'GLIBC_2.38' not found`. That shipped for ~30 releases (v3.7.2 → v4.1.6,
+issue #460) because nothing in CI ever ran the snap it published.
+
+If `base:` is ever bumped (e.g. to `core24`), the payload leg must move with it —
+and note that moving the Linux leg raises the glibc floor of the `.deb`/`.rpm`/
+`.AppImage` too, which is a user-facing compatibility decision, not a CI convenience.
+
+Two gates enforce this on every snap build:
+
+| Gate | What it does | Why |
+|------|--------------|-----|
+| **G1** `scripts/snap-abi-check.sh` | Every ELF in the built snap must fit the glibc ceiling *derived from the base snap itself* | Deterministic, ~5 s, catches the mismatch before publishing |
+| **G2** install + smoke | `snap install --dangerous`, then `aeroftp ls --help` | Proves the payload actually loads at runtime |
+
+> G2 deliberately uses a CLI subcommand. `aeroftp --version` is **not** a valid smoke
+> test: a leading dash routes to `DispatchRoute::Gui` (which needs a display), and the
+> dispatcher can answer without the payload ever being loaded.
+
+### Keeping a published revision fresh (`snap-refresh.yml`)
+
+The snap freezes its `stage-packages` at build time, so the published revision ages
+between releases until the Snap Store mails *"contains outdated Ubuntu packages"*.
+The `Snap security refresh` workflow runs weekly, compares the published revision's
+`primed-stage-packages` against the live Ubuntu archive, and rebuilds **only when
+something is genuinely stale**. The version string does not change — the Store just
+serves a newer revision — so the in-app updater stays quiet.
+
+It is also the on-demand rebuild path: dispatch it with `force: true` (and
+`publish: true` when you mean it) to rebuild any tag with today's pipeline.
+
+```bash
+gh workflow run snap-refresh.yml -f tag=v4.1.6 -f force=true -f publish=false
+node scripts/snap-stale-packages.mjs        # same audit, locally
+```
 
 ### Required Secret
 The workflow requires `SNAPCRAFT_STORE_CREDENTIALS` in GitHub repository secrets.

--- a/scripts/snap-abi-check.sh
+++ b/scripts/snap-abi-check.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+#
+# Gate G1 - snap ABI floor check.
+#
+# A snap never ships its own glibc: the C library comes from the `base:` snap
+# (core22 -> Ubuntu 22.04 -> glibc 2.35). If any ELF inside the snap was
+# compiled against a newer glibc, the dynamic loader refuses it at exec time
+# with `version 'GLIBC_2.x' not found` and the app cannot start at all.
+#
+# That is exactly what shipped between 2026-05-06 (PR #172 moved the snap build
+# to an ubuntu-24.04 runner while `base:` stayed core22) and 2026-07-25: about
+# thirty releases whose payload demanded GLIBC_2.38/2.39 from a 2.35 runtime.
+# Nothing caught it because CI only asserted that the .snap file existed and
+# was larger than 10 MB. This script is the check that would have failed PR #172
+# on the day it was opened.
+#
+# The ceiling is DERIVED from the base snap itself, never hardcoded, so bumping
+# `base:` in snapcraft.yaml automatically moves the bar with it.
+#
+# Usage:
+#   scripts/snap-abi-check.sh <snap-file> [snapcraft-yaml]
+#   scripts/snap-abi-check.sh <snap-file> --ceiling 2.39   # self-test override
+#
+# Exit codes: 0 = every ELF fits the base, 1 = at least one is too new,
+#             2 = usage / environment error.
+
+set -euo pipefail
+
+SNAP_FILE=""
+SNAPCRAFT_YAML="snap/snapcraft.yaml"
+CEILING_OVERRIDE=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --ceiling)
+      CEILING_OVERRIDE="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      sed -n '2,30p' "$0"
+      exit 0
+      ;;
+    *)
+      if [ -z "$SNAP_FILE" ]; then
+        SNAP_FILE="$1"
+      else
+        SNAPCRAFT_YAML="$1"
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$SNAP_FILE" ] || [ ! -f "$SNAP_FILE" ]; then
+  echo "usage: $0 <snap-file> [snapcraft-yaml] [--ceiling X.YZ]" >&2
+  exit 2
+fi
+
+for tool in unsquashfs objdump file strings; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "::error::snap-abi-check needs '$tool' (apt: squashfs-tools binutils file)" >&2
+    exit 2
+  }
+done
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Highest GLIBC_x.y token in a stream of `GLIBC_2.35`-style strings, or empty.
+max_glibc() { grep -oE 'GLIBC_[0-9]+\.[0-9]+' | sort -uV | tail -1; }
+
+# ---------------------------------------------------------------------------
+# 1. The ceiling: the newest glibc version the base snap's libc.so.6 defines.
+# ---------------------------------------------------------------------------
+if [ -n "$CEILING_OVERRIDE" ]; then
+  CEILING="GLIBC_${CEILING_OVERRIDE#GLIBC_}"
+  BASE="(override)"
+else
+  if [ ! -f "$SNAPCRAFT_YAML" ]; then
+    echo "::error::cannot read $SNAPCRAFT_YAML to resolve the snap base" >&2
+    exit 2
+  fi
+  BASE="$(awk '/^base:[[:space:]]/ {print $2; exit}' "$SNAPCRAFT_YAML")"
+  if [ -z "$BASE" ]; then
+    echo "::error::no 'base:' key in $SNAPCRAFT_YAML" >&2
+    exit 2
+  fi
+
+  # Prefer an already-installed base (dev machines); otherwise pull it from the
+  # store. `snap download` needs no root and no login.
+  # `find -L`: /snap/<base>/current is a symlink, and an unfollowed symlink
+  # argument is never descended into.
+  LIBC=""
+  if [ -e "/snap/$BASE/current" ]; then
+    LIBC="$(find -L "/snap/$BASE/current" -name 'libc.so.6' -print -quit 2>/dev/null || true)"
+  fi
+  if [ -z "$LIBC" ]; then
+    echo "Downloading base snap '$BASE' to derive its glibc ceiling..."
+    ( cd "$TMP" && snap download "$BASE" >/dev/null )
+    BASE_SNAP="$(find "$TMP" -maxdepth 1 -name "${BASE}_*.snap" -print -quit)"
+    [ -n "$BASE_SNAP" ] || { echo "::error::could not download base snap '$BASE'" >&2; exit 2; }
+    # Extracted whole: unsquashfs globs do not cross '/', so a filter for
+    # usr/lib/<triplet>/libc.so.6 is brittle across architectures. A base snap
+    # is ~80 MB, so the full extraction costs a couple of seconds.
+    unsquashfs -q -n -f -d "$TMP/base" "$BASE_SNAP" >/dev/null
+    LIBC="$(find "$TMP/base" -name 'libc.so.6' -print -quit 2>/dev/null || true)"
+  fi
+  [ -n "$LIBC" ] || { echo "::error::no libc.so.6 found in base snap '$BASE'" >&2; exit 2; }
+
+  CEILING="$(strings -a "$LIBC" | grep -E '^GLIBC_[0-9]+\.[0-9]+$' | max_glibc)"
+  [ -n "$CEILING" ] || { echo "::error::could not read glibc versions from $LIBC" >&2; exit 2; }
+fi
+
+echo "Snap:     $SNAP_FILE"
+echo "Base:     $BASE"
+echo "Ceiling:  $CEILING"
+
+# ---------------------------------------------------------------------------
+# 2. Every ELF in the snap - payload binaries AND staged libraries.
+# ---------------------------------------------------------------------------
+unsquashfs -q -n -f -d "$TMP/app" "$SNAP_FILE" >/dev/null
+
+mapfile -t ELVES < <(
+  find "$TMP/app" -type f -print0 \
+    | xargs -0 -r file -h --mime-type -F $'\t' -- \
+    | awk -F'\t' '$2 ~ /x-(executable|pie-executable|sharedlib)/ {print $1}'
+)
+
+if [ "${#ELVES[@]}" -eq 0 ]; then
+  echo "::error::no ELF files found inside $SNAP_FILE - is it a valid snap?" >&2
+  exit 2
+fi
+
+FAILED=0
+for elf in "${ELVES[@]}"; do
+  required="$(objdump -T "$elf" 2>/dev/null | max_glibc || true)"
+  [ -n "$required" ] || continue
+  # sort -V puts the newer version last; if that is not the ceiling, the ELF wins
+  # and therefore demands more than the base can provide.
+  newest="$(printf '%s\n%s\n' "$required" "$CEILING" | sort -V | tail -1)"
+  if [ "$newest" != "$CEILING" ]; then
+    rel="${elf#"$TMP/app/"}"
+    echo "::error::$rel requires $required but base $BASE provides at most $CEILING"
+    # Name the symbols that pushed it over the line - without them the failure
+    # is a mystery, with them the cause (C23 stdio, pidfd spawn, ...) is obvious.
+    # Kept in a `set +e` subshell: this is diagnostics, and an empty grep here
+    # must never abort the scan of the remaining files.
+    ( set +e +o pipefail
+      objdump -T "$elf" 2>/dev/null | grep -oE 'GLIBC_[0-9]+\.[0-9]+' | sort -uV | while read -r ver; do
+        [ -n "$ver" ] || continue
+        [ "$(printf '%s\n%s\n' "$ver" "$CEILING" | sort -V | tail -1)" != "$CEILING" ] || continue
+        # objdump prints required versions as "(GLIBC_2.39) symbol" and defined
+        # ones as "GLIBC_2.39  symbol"; match both, with the dots escaped.
+        ver_re="${ver//./\\.}"
+        syms="$(objdump -T "$elf" 2>/dev/null | grep -E "\(${ver_re}\)|[[:space:]]${ver_re}[[:space:]]" \
+                | awk '{print $NF}' | sort -u | head -8 | paste -sd', ' -)"
+        echo "    $ver: ${syms:-<unknown>}"
+      done
+    ) || true
+    FAILED=$((FAILED + 1))
+  fi
+done
+
+echo "Scanned:  ${#ELVES[@]} ELF files"
+
+if [ "$FAILED" -gt 0 ]; then
+  echo
+  echo "::error::$FAILED file(s) exceed the glibc floor of base '$BASE'."
+  echo "The snap would fail at exec with \"version 'GLIBC_x.y' not found\"."
+  echo "Cause is almost always a payload compiled on a newer Ubuntu than the base:"
+  echo "build the binaries on the release that matches '$BASE' (core22 -> ubuntu-22.04)."
+  exit 1
+fi
+
+echo "OK: every ELF fits within $CEILING."

--- a/scripts/snap-abi-check.sh
+++ b/scripts/snap-abi-check.sh
@@ -88,22 +88,41 @@ else
 
   # Prefer an already-installed base (dev machines); otherwise pull it from the
   # store. `snap download` needs no root and no login.
+  # Two shapes to handle: from glibc 2.34 on, libc.so.6 IS the ELF; before that
+  # it is a symlink to libc-<version>.so. `-type f` therefore matters, and the
+  # pattern must stay tight enough not to match libcrypt.so.1 and friends.
+  find_libc() { find -L "$1" -type f \( -name 'libc.so.6' -o -name 'libc-*.so' \) -print -quit 2>/dev/null || true; }
+
   # `find -L`: /snap/<base>/current is a symlink, and an unfollowed symlink
   # argument is never descended into.
   LIBC=""
   if [ -e "/snap/$BASE/current" ]; then
-    LIBC="$(find -L "/snap/$BASE/current" -name 'libc.so.6' -print -quit 2>/dev/null || true)"
+    LIBC="$(find_libc "/snap/$BASE/current")"
   fi
   if [ -z "$LIBC" ]; then
     echo "Downloading base snap '$BASE' to derive its glibc ceiling..."
     ( cd "$TMP" && snap download "$BASE" >/dev/null )
     BASE_SNAP="$(find "$TMP" -maxdepth 1 -name "${BASE}_*.snap" -print -quit)"
     [ -n "$BASE_SNAP" ] || { echo "::error::could not download base snap '$BASE'" >&2; exit 2; }
-    # Extracted whole: unsquashfs globs do not cross '/', so a filter for
-    # usr/lib/<triplet>/libc.so.6 is brittle across architectures. A base snap
-    # is ~80 MB, so the full extraction costs a couple of seconds.
-    unsquashfs -q -n -f -d "$TMP/base" "$BASE_SNAP" >/dev/null
-    LIBC="$(find "$TMP/base" -name 'libc.so.6' -print -quit 2>/dev/null || true)"
+    # Named paths, not a full extraction: a base snap carries device nodes
+    # (/dev/null, /dev/random, ...) and file capabilities, and unsquashfs
+    # cannot recreate those as a normal user - it prints
+    # "could not create character device ... because you're not superuser"
+    # and exits non-zero. On a CI runner (no base snap installed) that turned
+    # the whole gate into an environment failure. unsquashfs globs do not
+    # cross '/', so the paths are spelled out per architecture.
+    for triplet in x86_64-linux-gnu aarch64-linux-gnu; do
+      unsquashfs -q -n -f -no-xattrs -d "$TMP/base" "$BASE_SNAP" \
+        "usr/lib/$triplet/libc.so.6" "usr/lib/$triplet/libc-*.so" \
+        "lib/$triplet/libc.so.6" "lib/$triplet/libc-*.so" >/dev/null 2>&1 || true
+    done
+    LIBC="$(find_libc "$TMP/base")"
+    if [ -z "$LIBC" ]; then
+      # Unknown layout: fall back to a whole-snap extraction and tolerate the
+      # unavoidable device-node failures, since only libc matters here.
+      unsquashfs -q -n -f -no-xattrs -d "$TMP/base-full" "$BASE_SNAP" >/dev/null 2>&1 || true
+      LIBC="$(find_libc "$TMP/base-full")"
+    fi
   fi
   [ -n "$LIBC" ] || { echo "::error::no libc.so.6 found in base snap '$BASE'" >&2; exit 2; }
 
@@ -118,7 +137,11 @@ echo "Ceiling:  $CEILING"
 # ---------------------------------------------------------------------------
 # 2. Every ELF in the snap - payload binaries AND staged libraries.
 # ---------------------------------------------------------------------------
-unsquashfs -q -n -f -d "$TMP/app" "$SNAP_FILE" >/dev/null
+# -no-xattrs: an app snap can carry file capabilities that a non-root
+# unsquashfs refuses to restore, and that must not read as "the snap is
+# broken". A genuine extraction failure still stops the gate: a partial tree
+# would silently narrow the scan.
+unsquashfs -q -n -f -no-xattrs -d "$TMP/app" "$SNAP_FILE" >/dev/null
 
 mapfile -t ELVES < <(
   find "$TMP/app" -type f -print0 \

--- a/scripts/snap-stale-packages.mjs
+++ b/scripts/snap-stale-packages.mjs
@@ -1,0 +1,371 @@
+#!/usr/bin/env node
+/**
+ * Audit a published snap revision against the live Ubuntu archive.
+ *
+ * A snap freezes every `stage-packages` dependency at build time, so a snap that
+ * is only rebuilt on release tags slowly accumulates known-vulnerable libraries
+ * between releases. That is what the Snap Store "contains outdated Ubuntu
+ * packages" mails are about (e.g. USN-8584-1 on r216, 2026-07-22).
+ *
+ * This script answers the question those mails ask, before they are sent:
+ * for every entry of `primed-stage-packages` in the snap's own
+ * `snap/manifest.yaml`, is a newer version published in the archive for the
+ * suite the snap's base pins (core22 -> jammy)?
+ *
+ * Usage:
+ *   node scripts/snap-stale-packages.mjs                       # audit latest/stable
+ *   node scripts/snap-stale-packages.mjs --snap ./aeroftp.snap
+ *   node scripts/snap-stale-packages.mjs --name aeroftp --channel candidate
+ *   node scripts/snap-stale-packages.mjs --json
+ *   node scripts/snap-stale-packages.mjs --self-test
+ *
+ * Exit code is 0 whether or not packages are stale (staleness is data, not an
+ * error); it is non-zero only when the audit itself could not be performed.
+ * When $GITHUB_OUTPUT is set it writes `stale=true|false` and `count=<n>`.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { gunzipSync } from 'node:zlib';
+import { mkdtempSync, rmSync, readFileSync, readdirSync, appendFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const MIRROR = process.env.UBUNTU_MIRROR ?? 'http://archive.ubuntu.com/ubuntu';
+const COMPONENTS = ['main', 'universe', 'restricted', 'multiverse'];
+const POCKETS = ['', '-updates', '-security'];
+const BASE_SUITE = {
+  core: 'xenial',
+  core18: 'bionic',
+  core20: 'focal',
+  core22: 'jammy',
+  core24: 'noble',
+};
+
+// ---------------------------------------------------------------------------
+// dpkg version comparison (deb-version(7)), faithful to dpkg's verrevcmp().
+// Implemented here rather than shelling out to `dpkg --compare-versions`: the
+// archive indexes hold ~1.5 M entries, and one process per comparison would
+// turn a 20-second audit into a coffee break.
+// ---------------------------------------------------------------------------
+const isDigit = (ch) => ch >= '0' && ch <= '9';
+
+/** dpkg's character ordering: '~' first, then digits, letters, everything else. */
+function order(ch) {
+  if (ch === undefined) return 0; // end of string
+  if (isDigit(ch)) return 0;
+  if (ch === '~') return -1;
+  const code = ch.charCodeAt(0);
+  const isAlpha = (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z');
+  return isAlpha ? code : code + 256;
+}
+
+function verrevcmp(a, b) {
+  let i = 0;
+  let j = 0;
+  while (i < a.length || j < b.length) {
+    let firstDiff = 0;
+
+    while ((i < a.length && !isDigit(a[i])) || (j < b.length && !isDigit(b[j]))) {
+      const ac = order(a[i]);
+      const bc = order(b[j]);
+      if (ac !== bc) return ac - bc;
+      i += 1;
+      j += 1;
+    }
+
+    while (a[i] === '0') i += 1;
+    while (b[j] === '0') j += 1;
+
+    while (isDigit(a[i]) && isDigit(b[j])) {
+      if (firstDiff === 0) firstDiff = a.charCodeAt(i) - b.charCodeAt(j);
+      i += 1;
+      j += 1;
+    }
+
+    if (isDigit(a[i])) return 1;
+    if (isDigit(b[j])) return -1;
+    if (firstDiff !== 0) return firstDiff;
+  }
+  return 0;
+}
+
+function splitVersion(version) {
+  let rest = version;
+  let epoch = 0;
+  const colon = rest.indexOf(':');
+  if (colon !== -1 && /^\d+$/.test(rest.slice(0, colon))) {
+    epoch = Number.parseInt(rest.slice(0, colon), 10);
+    rest = rest.slice(colon + 1);
+  }
+  const dash = rest.lastIndexOf('-');
+  const upstream = dash === -1 ? rest : rest.slice(0, dash);
+  const revision = dash === -1 ? '' : rest.slice(dash + 1);
+  return { epoch, upstream, revision };
+}
+
+export function compareDebVersions(v1, v2) {
+  const a = splitVersion(v1);
+  const b = splitVersion(v2);
+  if (a.epoch !== b.epoch) return a.epoch - b.epoch;
+  const up = verrevcmp(a.upstream, b.upstream);
+  if (up !== 0) return up;
+  return verrevcmp(a.revision, b.revision);
+}
+
+// ---------------------------------------------------------------------------
+// Archive indexes
+// ---------------------------------------------------------------------------
+
+/** Parse a Packages file into the newest version seen per binary package. */
+function absorbPackages(text, suiteLabel, best) {
+  let pos = 0;
+  let name = null;
+  let version = null;
+  const len = text.length;
+
+  while (pos < len) {
+    let eol = text.indexOf('\n', pos);
+    if (eol === -1) eol = len;
+
+    if (text.startsWith('Package: ', pos)) {
+      name = text.slice(pos + 9, eol).trim();
+    } else if (text.startsWith('Version: ', pos)) {
+      version = text.slice(pos + 9, eol).trim();
+    } else if (eol === pos) {
+      // blank line: end of stanza
+      if (name && version) {
+        const current = best.get(name);
+        if (!current || compareDebVersions(version, current.version) > 0) {
+          best.set(name, { version, suite: suiteLabel });
+        }
+      }
+      name = null;
+      version = null;
+    }
+    pos = eol + 1;
+  }
+
+  if (name && version) {
+    const current = best.get(name);
+    if (!current || compareDebVersions(version, current.version) > 0) {
+      best.set(name, { version, suite: suiteLabel });
+    }
+  }
+}
+
+async function fetchArchiveIndex(suite, arch) {
+  const best = new Map();
+  const jobs = [];
+  for (const pocket of POCKETS) {
+    for (const component of COMPONENTS) {
+      const label = `${suite}${pocket}/${component}`;
+      const url = `${MIRROR}/dists/${suite}${pocket}/${component}/binary-${arch}/Packages.gz`;
+      jobs.push(
+        (async () => {
+          const res = await fetch(url);
+          if (!res.ok) {
+            // A pocket/component can legitimately be absent (e.g. no
+            // -security/multiverse for some suites); only a total miss matters.
+            if (res.status === 404) return null;
+            throw new Error(`GET ${url} -> HTTP ${res.status}`);
+          }
+          const gz = Buffer.from(await res.arrayBuffer());
+          return { label, text: gunzipSync(gz).toString('utf8') };
+        })(),
+      );
+    }
+  }
+
+  const results = await Promise.all(jobs);
+  let loaded = 0;
+  for (const result of results) {
+    if (!result) continue;
+    absorbPackages(result.text, result.label, best);
+    loaded += 1;
+  }
+  if (loaded === 0) throw new Error(`no archive index could be fetched for ${suite}/${arch}`);
+  return { best, loaded };
+}
+
+// ---------------------------------------------------------------------------
+// The snap under audit
+// ---------------------------------------------------------------------------
+
+function sh(cmd, args, opts = {}) {
+  return execFileSync(cmd, args, { encoding: 'utf8', ...opts });
+}
+
+function readSnapMetadata(snapFile, workDir) {
+  sh('unsquashfs', ['-q', '-n', '-f', '-d', join(workDir, 'x'), snapFile, 'snap/manifest.yaml', 'meta/snap.yaml']);
+  const manifest = readFileSync(join(workDir, 'x', 'snap', 'manifest.yaml'), 'utf8');
+  let snapYaml = '';
+  try {
+    snapYaml = readFileSync(join(workDir, 'x', 'meta', 'snap.yaml'), 'utf8');
+  } catch {
+    /* optional */
+  }
+
+  const base = (manifest.match(/^base:\s*(\S+)/m) ?? snapYaml.match(/^base:\s*(\S+)/m) ?? [])[1];
+  const version = (manifest.match(/^version:\s*['"]?([^'"\n]+)/m) ?? [])[1];
+  const arch =
+    (snapYaml.match(/^architectures:\s*\n\s*-\s*(\S+)/m) ?? [])[1] ??
+    (manifest.match(/^architectures:\s*\n\s*-\s*(\S+)/m) ?? [])[1] ??
+    'amd64';
+
+  // `primed-stage-packages` is the flat, deduplicated list of everything that
+  // actually made it into the squashfs - the same list the Store scanner reads.
+  const block = manifest.match(/^primed-stage-packages:\n((?:-\s.*\n)+)/m);
+  if (!block) throw new Error('no primed-stage-packages block in snap/manifest.yaml');
+  const packages = block[1]
+    .split('\n')
+    .filter((line) => line.startsWith('- '))
+    .map((line) => {
+      const entry = line.slice(2).trim();
+      const eq = entry.lastIndexOf('=');
+      return { name: entry.slice(0, eq), version: entry.slice(eq + 1) };
+    });
+
+  return { base, version, arch, packages };
+}
+
+// ---------------------------------------------------------------------------
+// Self-test: dpkg's own documented ordering plus the versions this audit hinges
+// on. Cheap insurance for a comparator that is easy to get subtly wrong.
+// ---------------------------------------------------------------------------
+function selfTest() {
+  const cases = [
+    ['1.0', '1.0', 0],
+    ['1.0', '1.1', -1],
+    ['1.10', '1.9', 1],
+    ['1.0~beta', '1.0', -1],
+    ['1.0~beta1', '1.0~beta2', -1],
+    ['1:1.0', '2.0', 1],
+    ['1.0-1', '1.0-2', -1],
+    ['1.20.3-0ubuntu1.7', '1.20.3-0ubuntu1.1', 1],
+    ['1.20.3-0ubuntu1.7', '1.20.3-0ubuntu1.7', 0],
+    ['1.20.3-0ubuntu1.10', '1.20.3-0ubuntu1.9', 1],
+    ['2.37-2build1', '2.37-2build2', -1],
+    ['1.24.2-1ubuntu1.5', '1.20.3-0ubuntu1.7', 1],
+    ['41.0-1ubuntu1', '41.0-1ubuntu1', 0],
+  ];
+  let failed = 0;
+  for (const [a, b, expected] of cases) {
+    const got = Math.sign(compareDebVersions(a, b));
+    if (got !== expected) {
+      console.error(`FAIL  ${a} vs ${b}: expected ${expected}, got ${got}`);
+      failed += 1;
+    }
+  }
+  if (failed > 0) {
+    console.error(`${failed}/${cases.length} version-comparison cases failed`);
+    process.exit(1);
+  }
+  console.log(`self-test OK (${cases.length} version-comparison cases)`);
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+async function main() {
+  const argv = process.argv.slice(2);
+  const flag = (name, fallback = undefined) => {
+    const i = argv.indexOf(name);
+    return i === -1 ? fallback : argv[i + 1];
+  };
+
+  if (argv.includes('--self-test')) {
+    selfTest();
+    return;
+  }
+  selfTest();
+
+  const asJson = argv.includes('--json');
+  const snapName = flag('--name', 'aeroftp');
+  const channel = flag('--channel', 'stable');
+  let snapFile = flag('--snap');
+
+  const workDir = mkdtempSync(join(tmpdir(), 'snap-audit-'));
+  try {
+    if (!snapFile) {
+      console.log(`Downloading ${snapName} from latest/${channel}...`);
+      sh('snap', ['download', snapName, `--channel=${channel}`], { cwd: workDir, stdio: 'inherit' });
+      const found = readdirSync(workDir).find((f) => f.endsWith('.snap'));
+      if (!found) throw new Error(`snap download produced no .snap for ${snapName}`);
+      snapFile = join(workDir, found);
+    }
+
+    const { base, version, arch, packages } = readSnapMetadata(snapFile, workDir);
+    const suite = BASE_SUITE[base];
+    if (!suite) throw new Error(`unknown snap base '${base}' - extend BASE_SUITE`);
+
+    console.log(`Snap:      ${snapFile}`);
+    console.log(`Version:   ${version}  (base ${base} -> ${suite}, ${arch})`);
+    console.log(`Packages:  ${packages.length} primed stage packages`);
+
+    const { best, loaded } = await fetchArchiveIndex(suite, arch);
+    console.log(`Archive:   ${best.size} binary packages from ${loaded} index files`);
+
+    const stale = [];
+    const unknown = [];
+    for (const pkg of packages) {
+      const candidate = best.get(pkg.name);
+      if (!candidate) {
+        unknown.push(pkg);
+        continue;
+      }
+      if (compareDebVersions(candidate.version, pkg.version) > 0) {
+        stale.push({ ...pkg, archive: candidate.version, suite: candidate.suite });
+      }
+    }
+
+    stale.sort((a, b) => a.name.localeCompare(b.name));
+
+    if (asJson) {
+      console.log(JSON.stringify({ snap: snapName, version, base, suite, stale, unknown }, null, 2));
+    } else {
+      console.log('');
+      if (stale.length === 0) {
+        console.log(`OK: all ${packages.length} staged packages are at the newest archive version.`);
+      } else {
+        console.log(`STALE: ${stale.length} of ${packages.length} staged packages have newer archive versions`);
+        for (const s of stale) {
+          console.log(`  ${s.name}: snap=${s.version}  archive=${s.archive}  (${s.suite})`);
+        }
+      }
+      if (unknown.length > 0) {
+        console.log(`\nNot found in the archive indexes (${unknown.length}):`);
+        for (const u of unknown) console.log(`  ${u.name}=${u.version}`);
+      }
+    }
+
+    if (process.env.GITHUB_OUTPUT) {
+      appendFileSync(
+        process.env.GITHUB_OUTPUT,
+        `stale=${stale.length > 0}\ncount=${stale.length}\nversion=${version}\n`,
+      );
+    }
+    if (process.env.GITHUB_STEP_SUMMARY) {
+      const lines = [
+        `### Snap package audit - ${snapName} ${version} (base ${base}/${suite})`,
+        '',
+        stale.length === 0
+          ? `All **${packages.length}** staged packages are current.`
+          : `**${stale.length}** stale package(s) out of ${packages.length}:`,
+        ...stale.map((s) => `- \`${s.name}\` snap \`${s.version}\` -> archive \`${s.archive}\` (${s.suite})`),
+      ];
+      appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${lines.join('\n')}\n`);
+    }
+  } finally {
+    rmSync(workDir, { recursive: true, force: true });
+  }
+}
+
+// Only audit when run directly, so `compareDebVersions` can be imported by a
+// differential test against dpkg itself.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    console.error(`::error::snap package audit failed: ${err.message}`);
+    process.exit(2);
+  });
+}


### PR DESCRIPTION
Fixes #460.

## What was broken

The Snap Store build has not been able to start since **2026-05-06**. It installs, then dies with `version 'GLIBC_2.38' not found`. About **30 releases** are affected (v3.7.2 → v4.1.6). `.deb`, `.rpm` and `.AppImage` are fine — they are still built on `ubuntu-22.04`.

`base: core22` means glibc comes from the core22 snap, ceiling **GLIBC_2.35**, and a snap never ships its own libc (no `libc.so.6`, no `ld-linux`, no `libc6` in `primed-stage-packages`). Since PR #172 the `build-snap` job compiled the payload on the **ubuntu-24.04** runner (glibc 2.39) and packaged it into that core22 base. Verified on the published r217 (4.1.6) and r216 (4.1.5): `__isoc23_sscanf` / `__isoc23_strtol` (2.38) and `pidfd_getpid` / `pidfd_spawnp` (2.39).

The failure is total: `usr/bin/aeroftp` (the dispatcher) links fine at 2.34, but it only ever `exec()`s a payload and `route_from_argv` sends every invocation to `aeroftp.bin` or `aeroftp-cli` — both unloadable. No reachable code path works.

CI never noticed because the only assertion after the build was *"the file exists and is larger than 10 MB"*.

## What this PR does

**Restores the invariant by construction.** `build-snap` is packaging-only: it consumes the jammy binaries built by the `ubuntu-22.04` leg as an artifact, so `.deb`/`.rpm`/`.AppImage`/`.snap` ship the exact same bytes. Costs ~15 min of release wall clock, saves a duplicate ~60 min Rust build.

**Gate G1 — `scripts/snap-abi-check.sh`.** Every ELF in the built snap must fit the glibc ceiling *derived from the base snap itself* (never hardcoded, so a future `base:` bump moves the bar with it). Tested against the real broken artifact:

```
$ ./scripts/snap-abi-check.sh aeroftp_217.snap
Base:     core22
Ceiling:  GLIBC_2.35
::error::usr/lib/aeroftp/aeroftp.bin requires GLIBC_2.39 but base core22 provides at most GLIBC_2.35
    GLIBC_2.38: __isoc23_sscanf,__isoc23_strtol
    GLIBC_2.39: pidfd_getpid,pidfd_spawnp
::error::usr/lib/aeroftp/aeroftp-cli requires GLIBC_2.39 ...
Scanned:  389 ELF files
```

Two hits out of 389 ELFs, and with the ceiling raised to 2.39 the same snap passes clean — no false positives on the 387 staged jammy libraries. Runs in under two seconds; it would have stopped PR #172 the day it was opened.

**Gate G2 — install and exercise.** `snap install --dangerous`, then `aeroftp ls --help`. A CLI subcommand on purpose: `aeroftp --version` routes to `DispatchRoute::Gui` (needs a display) and the dispatcher can answer it *without the payload ever loading*, so it is not a valid smoke test.

**`snap-refresh.yml` — weekly security refresh.** Answers the Snap Store "outdated Ubuntu packages" mails before they are sent: `scripts/snap-stale-packages.mjs` compares the published revision's `primed-stage-packages` against the live Ubuntu archive (base + updates + security × 4 components) and the rebuild runs **only when something is genuinely stale**. The version string never changes, so the in-app updater stays quiet. It doubles as the on-demand rebuild path for any tag (`force: true`), which is how the fix for #460 ships without cutting a version.

The deb version comparator is implemented in JS (one `dpkg` process per comparison would take minutes over ~1.5 M archive entries) and is **differential-tested against `dpkg --compare-versions` itself over 1200 real archive version pairs: 0 mismatches**. It also self-tests 13 documented ordering cases on every run. Cross-checked end to end: it reproduces the same verdict as the dpkg-based audit on r217 — 187/187 packages current, 0 stale.

## Two side fixes found on the way

- The `linux` leg still installed snapcraft (with 5×60 s retries on a store hiccup) even though it stopped building the snap in #172 — pure cost on every PR run.
- `Confirm Snap was built` had backticks inside double quotes, so bash executed them and mangled its own error message — in the diagnostic path that matters most when a snap build fails.

## Validation

- `actionlint` + `shellcheck` clean on the new script and the new steps (the remaining info-level findings are pre-existing, in untouched steps).
- G1 verified against both the real broken snap (fails, 2 hits) and the same snap with a raised ceiling (passes, 0 hits).
- Audit script cross-validated against dpkg.
- Full pipeline dispatched on this branch to exercise the artifact hand-off and both gates end to end before merge.

## Not in this PR

Migrating to `base: core24` (+ the `gnome` extension to shrink the 187-package vendored surface) is a runtime change that needs its own test pass — tracked separately, see #460.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated weekly “Snap security refresh” that audits stable staged-package freshness and rebuilds/publishes when stale (or when forced).
  * Added stronger snap publishing gates, including ABI-floor validation and an install-and-run smoke test.
* **Documentation**
  * Expanded Snap release-process documentation with clearer rebuild steps, compatibility rationale, and workflow usage.
* **Maintenance**
  * Improved build pipeline consistency by separating Linux payload packaging from snap packaging and adding stricter validation/fail-fast checks.
  * Added snap staleness audit tooling and tightened workflow messaging/output expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->