### PR TITLE
fix(snap): restore GNOME runtime and gate GUI readiness

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -801,6 +801,23 @@ jobs:
           fi
           sudo snap remove --purge aeroftp || true
 
+      # ----------------------------------------------------------------------
+      # Gate G3 - launch the actual confined GUI on a disposable X server.
+      # This checks the frontend readiness log, not merely process liveness,
+      # and catches missing EGL/GLVND wiring such as issue #462.
+      # ----------------------------------------------------------------------
+      - name: Gate G3 - confined GUI readiness under Xvfb
+        shell: bash
+        env:
+          SNAP_FILE: ${{ steps.snap-check.outputs.snap }}
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends xvfb xauth
+          sudo snap install --dangerous "$SNAP_FILE"
+          trap 'sudo snap remove --purge aeroftp || true' EXIT
+          ./scripts/snap-gui-check.sh
+
       # Sigstore keyless signing of the .snap: only on tags.
       - name: Install Cosign
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -820,14 +820,26 @@ jobs:
         shell: bash
         env:
           SNAP_FILE: ${{ steps.snap-check.outputs.snap }}
+          SNAP_GUI_SCREENSHOT: ${{ runner.temp }}/snap-gui-screenshot.png
         run: |
           set -euo pipefail
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends xvfb xauth
+          sudo apt-get install -y --no-install-recommends xvfb x11-apps imagemagick
           sudo snap install --dangerous "$SNAP_FILE"
           trap 'sudo snap remove --purge aeroftp || true' EXIT
           sudo snap connect aeroftp:graphics-core22 mesa-core22:graphics-core22
           ./scripts/snap-gui-check.sh
+
+      # The captured frame is the only human-reviewable evidence that the window
+      # is not the blank one from #462; keep it on failure above all.
+      - name: Upload the confined GUI frame
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: snap-gui-frame-${{ github.sha }}
+          path: ${{ runner.temp }}/snap-gui-screenshot.png
+          if-no-files-found: warn
+          retention-days: 7
 
       # Sigstore keyless signing of the .snap: only on tags.
       - name: Install Cosign

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -772,6 +772,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends squashfs-tools binutils file
           ./scripts/snap-abi-check.sh "$SNAP_FILE"
+          if unsquashfs -ll "$SNAP_FILE" | grep -E '/dri/[^/]+_dri\.so|/lib(EGL|GLX)_mesa\.so'; then
+            echo "::error::the application snap still bundles Mesa drivers/loaders; graphics-core22 must provide them"
+            exit 1
+          fi
+          echo "OK: GPU userspace is supplied only by graphics-core22."
 
       # ----------------------------------------------------------------------
       # Gate G2 - install the snap and run a command that actually reaches the
@@ -781,6 +786,10 @@ jobs:
       # CLI_SUBCOMMANDS (src-tauri/src/cli_dispatch.rs) execs aeroftp-cli and
       # therefore proves the payload links against the base at runtime.
       # ----------------------------------------------------------------------
+      - name: Install the graphics userspace provider
+        shell: bash
+        run: sudo snap install mesa-core22
+
       - name: Gate G2 - install the snap and exercise the payload
         shell: bash
         env:
@@ -788,6 +797,7 @@ jobs:
         run: |
           set -euo pipefail
           sudo snap install --dangerous "$SNAP_FILE"
+          sudo snap connect aeroftp:graphics-core22 mesa-core22:graphics-core22
           echo "--- aeroftp ls --help (routes to the CLI payload) ---"
           out="$(/snap/bin/aeroftp ls --help 2>&1)" || {
             echo "::error::the installed snap cannot run 'aeroftp ls --help'"
@@ -816,6 +826,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends xvfb xauth
           sudo snap install --dangerous "$SNAP_FILE"
           trap 'sudo snap remove --purge aeroftp || true' EXIT
+          sudo snap connect aeroftp:graphics-core22 mesa-core22:graphics-core22
           ./scripts/snap-gui-check.sh
 
       # Sigstore keyless signing of the .snap: only on tags.

--- a/.github/workflows/snap-refresh.yml
+++ b/.github/workflows/snap-refresh.yml
@@ -286,6 +286,18 @@ jobs:
           }
           sudo snap remove --purge aeroftp || true
 
+      - name: Gate G3 - confined GUI readiness under Xvfb
+        shell: bash
+        env:
+          SNAP_FILE: ${{ steps.snap-check.outputs.snap }}
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends xvfb xauth
+          sudo snap install --dangerous "$SNAP_FILE"
+          trap 'sudo snap remove --purge aeroftp || true' EXIT
+          ./ci-tools/scripts/snap-gui-check.sh
+
       # Store-only by design: published GitHub Release assets are immutable in
       # this repo (`overwrite_files: false`), so a security rebuild must not
       # rewrite the tag's assets. The Store revision may therefore be newer than

--- a/.github/workflows/snap-refresh.yml
+++ b/.github/workflows/snap-refresh.yml
@@ -300,14 +300,26 @@ jobs:
         shell: bash
         env:
           SNAP_FILE: ${{ steps.snap-check.outputs.snap }}
+          SNAP_GUI_SCREENSHOT: ${{ runner.temp }}/snap-gui-screenshot.png
         run: |
           set -euo pipefail
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends xvfb xauth
+          sudo apt-get install -y --no-install-recommends xvfb x11-apps imagemagick
           sudo snap install --dangerous "$SNAP_FILE"
           trap 'sudo snap remove --purge aeroftp || true' EXIT
           sudo snap connect aeroftp:graphics-core22 mesa-core22:graphics-core22
           ./ci-tools/scripts/snap-gui-check.sh
+
+      # A rebuild that publishes to the Store must leave behind the frame that
+      # justified publishing it.
+      - name: Upload the confined GUI frame
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: snap-gui-frame-${{ inputs.tag || github.sha }}
+          path: ${{ runner.temp }}/snap-gui-screenshot.png
+          if-no-files-found: warn
+          retention-days: 7
 
       # Store-only by design: published GitHub Release assets are immutable in
       # this repo (`overwrite_files: false`), so a security rebuild must not

--- a/.github/workflows/snap-refresh.yml
+++ b/.github/workflows/snap-refresh.yml
@@ -266,6 +266,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends squashfs-tools binutils file
           ./ci-tools/scripts/snap-abi-check.sh "$SNAP_FILE" snap/snapcraft.yaml
+          if unsquashfs -ll "$SNAP_FILE" | grep -E '/dri/[^/]+_dri\.so|/lib(EGL|GLX)_mesa\.so'; then
+            echo "::error::the application snap still bundles Mesa drivers/loaders; graphics-core22 must provide them"
+            exit 1
+          fi
+          echo "OK: GPU userspace is supplied only by graphics-core22."
+
+      - name: Install the graphics userspace provider
+        shell: bash
+        run: sudo snap install mesa-core22
 
       - name: Gate G2 - install the snap and exercise the payload
         shell: bash
@@ -274,6 +283,7 @@ jobs:
         run: |
           set -euo pipefail
           sudo snap install --dangerous "$SNAP_FILE"
+          sudo snap connect aeroftp:graphics-core22 mesa-core22:graphics-core22
           out="$(/snap/bin/aeroftp ls --help 2>&1)" || {
             echo "::error::the rebuilt snap cannot run 'aeroftp ls --help'"
             echo "$out"
@@ -296,6 +306,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends xvfb xauth
           sudo snap install --dangerous "$SNAP_FILE"
           trap 'sudo snap remove --purge aeroftp || true' EXIT
+          sudo snap connect aeroftp:graphics-core22 mesa-core22:graphics-core22
           ./ci-tools/scripts/snap-gui-check.sh
 
       # Store-only by design: published GitHub Release assets are immutable in

--- a/.gitignore
+++ b/.gitignore
@@ -105,8 +105,9 @@ run-clean.sh
 !/scripts/gen-cli-catalog.ts
 # Exception: release step, publishes a curated asset subset to SourceForge
 !/scripts/publish-sourceforge.sh
-# Exception: snap gates - ABI floor check and stage-package staleness audit (#460)
+# Exception: snap gates and stage-package staleness audit (#460, #462)
 !/scripts/snap-abi-check.sh
+!/scripts/snap-gui-check.sh
 !/scripts/snap-stale-packages.mjs
 # Exception: regenerates the providers table from the GUI SSOT (#270 17104681)
 !/scripts/gen-providers-table.ts

--- a/scripts/snap-gui-check.sh
+++ b/scripts/snap-gui-check.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Gate G3: launch the confined GUI on a disposable X server and prove that the
+# React frontend reached app_ready.  A live process is insufficient: the blank
+# WebKit regression in #462 stayed alive until the splash safety timeout.
+set -euo pipefail
+
+APP="${1:-/snap/bin/aeroftp}"
+WAIT_SECONDS="${SNAP_GUI_WAIT_SECONDS:-25}"
+
+for tool in xvfb-run xauth setsid grep; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "::error::snap-gui-check needs '$tool' (apt: xvfb xauth util-linux grep)" >&2
+    exit 2
+  }
+done
+[ -x "$APP" ] || {
+  echo "::error::GUI launcher is missing or not executable: $APP" >&2
+  exit 2
+}
+
+WORK="$(mktemp -d)"
+LOG="$WORK/aeroftp-gui.log"
+PID=""
+
+cleanup() {
+  if [ -n "$PID" ]; then
+    kill -TERM -- "-$PID" 2>/dev/null || true
+    sleep 1
+    kill -KILL -- "-$PID" 2>/dev/null || true
+    wait "$PID" 2>/dev/null || true
+  fi
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+echo "Launching the confined GUI under Xvfb (timeout: ${WAIT_SECONDS}s)..."
+setsid xvfb-run -a -s "-screen 0 1600x1000x24" "$APP" >"$LOG" 2>&1 &
+PID=$!
+
+ready=false
+for ((second = 1; second <= WAIT_SECONDS; second++)); do
+  if grep -q "app_ready post-show: is_visible=true" "$LOG"; then
+    ready=true
+    break
+  fi
+  if ! kill -0 "$PID" 2>/dev/null; then
+    break
+  fi
+  sleep 1
+done
+
+echo "--- confined GUI log ---"
+sed -n '1,240p' "$LOG"
+
+if grep -qE "EGL_BAD_(PARAMETER|DISPLAY)|Could not create default EGL display" "$LOG"; then
+  echo "::error::WebKit could not initialize EGL inside the snap" >&2
+  exit 1
+fi
+if grep -q "Splash screen safety timeout reached" "$LOG"; then
+  echo "::error::the frontend never signalled app_ready" >&2
+  exit 1
+fi
+if [ "$ready" != true ]; then
+  echo "::error::the snap GUI did not reach a visible app_ready state within ${WAIT_SECONDS}s" >&2
+  exit 1
+fi
+
+echo "OK: confined snap GUI reached app_ready and became visible under Xvfb."

--- a/scripts/snap-gui-check.sh
+++ b/scripts/snap-gui-check.sh
@@ -1,18 +1,37 @@
 #!/usr/bin/env bash
-# Gate G3: launch the confined GUI on a disposable X server and prove that the
-# React frontend reached app_ready.  A live process is insufficient: the blank
-# WebKit regression in #462 stayed alive until the splash safety timeout.
+# Gate G3: launch the confined GUI on a disposable X server and prove two
+# things about it — the React frontend reached app_ready, and WebKit actually
+# painted the window.  A live process is insufficient: the blank WebKit
+# regression in #462 stayed alive until the splash safety timeout, and a
+# process that merely reports "ready" would still let a white window ship.
 set -euo pipefail
 
 APP="${1:-/snap/bin/aeroftp}"
-WAIT_SECONDS="${SNAP_GUI_WAIT_SECONDS:-25}"
+WAIT_SECONDS="${SNAP_GUI_WAIT_SECONDS:-40}"
+# WebKit paints a frame or two after the window is mapped; give it room before
+# the screenshot so a slow first paint is not read as a blank window.
+SETTLE_SECONDS="${SNAP_GUI_SETTLE_SECONDS:-4}"
+# A blank frame is a handful of distinct colours (X root background plus one
+# flat WebKit page).  A rendered AeroFTP frame — themed chrome, icons,
+# antialiased text — is in the thousands.  The floor sits far from both.
+MIN_COLORS="${SNAP_GUI_MIN_COLORS:-64}"
+SHOT="${SNAP_GUI_SCREENSHOT:-$PWD/snap-gui-screenshot.png}"
 
-for tool in xvfb-run xauth setsid grep; do
+for tool in Xvfb xwd setsid grep; do
   command -v "$tool" >/dev/null 2>&1 || {
-    echo "::error::snap-gui-check needs '$tool' (apt: xvfb xauth util-linux grep)" >&2
+    echo "::error::snap-gui-check needs '$tool' (apt: xvfb x11-apps util-linux grep)" >&2
     exit 2
   }
 done
+# ImageMagick 7 renamed the CLI; accept either entry point.
+if command -v magick >/dev/null 2>&1; then
+  IM=magick
+elif command -v convert >/dev/null 2>&1; then
+  IM=convert
+else
+  echo "::error::snap-gui-check needs ImageMagick (apt: imagemagick)" >&2
+  exit 2
+fi
 [ -x "$APP" ] || {
   echo "::error::GUI launcher is missing or not executable: $APP" >&2
   exit 2
@@ -20,38 +39,107 @@ done
 
 WORK="$(mktemp -d)"
 LOG="$WORK/aeroftp-gui.log"
-PID=""
+PIDFILE="$WORK/app.pid"
+APP_PID=""
+XVFB_PID=""
 
 cleanup() {
-  if [ -n "$PID" ]; then
-    kill -TERM -- "-$PID" 2>/dev/null || true
+  if [ -n "$APP_PID" ]; then
+    kill -TERM -- "-$APP_PID" 2>/dev/null || true
     sleep 1
-    kill -KILL -- "-$PID" 2>/dev/null || true
-    wait "$PID" 2>/dev/null || true
+    kill -KILL -- "-$APP_PID" 2>/dev/null || true
+  fi
+  if [ -n "$XVFB_PID" ]; then
+    kill -TERM "$XVFB_PID" 2>/dev/null || true
+    wait "$XVFB_PID" 2>/dev/null || true
   fi
   rm -rf "$WORK"
 }
 trap cleanup EXIT
 
-echo "Launching the confined GUI under Xvfb (timeout: ${WAIT_SECONDS}s)..."
-# Strict snaps have a private /tmp and therefore cannot read the temporary
-# Xauthority cookie created by xvfb-run.  This X server is disposable and only
-# reachable inside the CI runner, so disable access control instead of sharing
-# host credentials with the confined application.
-setsid xvfb-run -a -s "-screen 0 1600x1000x24 -ac" "$APP" >"$LOG" 2>&1 &
-PID=$!
+# Own the X server instead of delegating to xvfb-run: the display number has to
+# be known here so the frame can be captured off it.  Strict snaps also have a
+# private /tmp and cannot read the Xauthority cookie xvfb-run generates, so
+# access control is disabled — this server is disposable and only reachable
+# from inside the runner.
+DISPLAY_NUM=""
+for candidate in $(seq 90 130); do
+  if [ ! -e "/tmp/.X11-unix/X$candidate" ] && [ ! -e "/tmp/.X$candidate-lock" ]; then
+    DISPLAY_NUM="$candidate"
+    break
+  fi
+done
+[ -n "$DISPLAY_NUM" ] || {
+  echo "::error::no free X display between :90 and :130" >&2
+  exit 2
+}
 
+echo "Starting Xvfb on :$DISPLAY_NUM ..."
+Xvfb ":$DISPLAY_NUM" -screen 0 1600x1000x24 -ac >"$WORK/xvfb.log" 2>&1 &
+XVFB_PID=$!
+# Probe the server the same way the capture will use it, rather than trusting
+# the socket to appear: a listening socket is not yet a server that answers.
+server_up=false
+for _ in $(seq 1 50); do
+  if xwd -display ":$DISPLAY_NUM" -root -silent >/dev/null 2>&1; then
+    server_up=true
+    break
+  fi
+  kill -0 "$XVFB_PID" 2>/dev/null || break
+  sleep 0.2
+done
+if [ "$server_up" != true ]; then
+  echo "::error::Xvfb did not come up on :$DISPLAY_NUM" >&2
+  sed -n '1,40p' "$WORK/xvfb.log" >&2
+  exit 2
+fi
+
+echo "Launching the confined GUI (timeout: ${WAIT_SECONDS}s)..."
+# The wrapper records its own pid before exec'ing the app, so the pid below is
+# the session leader the whole process group can be signalled through.
+DISPLAY=":$DISPLAY_NUM" setsid bash -c 'echo $$ >"$1"; exec "$2"' _ "$PIDFILE" "$APP" \
+  >"$LOG" 2>&1 &
+for _ in $(seq 1 50); do
+  [ -s "$PIDFILE" ] && break
+  sleep 0.2
+done
+APP_PID="$(cat "$PIDFILE" 2>/dev/null || true)"
+[ -n "$APP_PID" ] || {
+  echo "::error::the confined GUI never started" >&2
+  sed -n '1,80p' "$LOG" >&2
+  exit 1
+}
+
+# `app_ready post-show` is logged in the same main-thread callback as show(),
+# and GTK/X11 map the window asynchronously — on this platform that line always
+# reads is_visible=false.  The truth lands in the +300ms/+1200ms re-heal
+# diagnostics, so accept visibility from any app_ready diagnostic.  The prefix
+# still carries the real assertion: those lines only exist once the frontend
+# has invoked the app_ready command (src/App.tsx), so a blank page that never
+# boots React can never produce them.
 ready=false
 for ((second = 1; second <= WAIT_SECONDS; second++)); do
-  if grep -q "app_ready post-show: is_visible=true" "$LOG"; then
+  if grep -qE '\[diag #290\] app_ready [^:]+: is_visible=true' "$LOG"; then
     ready=true
     break
   fi
-  if ! kill -0 "$PID" 2>/dev/null; then
+  if ! kill -0 "$APP_PID" 2>/dev/null; then
     break
   fi
   sleep 1
 done
+
+# Capture before asserting: a failed run needs the frame even more than a green
+# one does.
+sleep "$SETTLE_SECONDS"
+captured=false
+if xwd -display ":$DISPLAY_NUM" -root -silent >"$WORK/shot.xwd" 2>"$WORK/xwd.err" &&
+  "$IM" "xwd:$WORK/shot.xwd" "png:$SHOT" 2>"$WORK/im.err"; then
+  captured=true
+else
+  echo "screenshot capture failed:" >&2
+  sed -n '1,20p' "$WORK/xwd.err" "$WORK/im.err" >&2 || true
+fi
 
 echo "--- confined GUI log ---"
 sed -n '1,240p' "$LOG"
@@ -69,4 +157,19 @@ if [ "$ready" != true ]; then
   exit 1
 fi
 
-echo "OK: confined snap GUI reached app_ready and became visible under Xvfb."
+if [ "$captured" != true ]; then
+  echo "::error::could not capture the GUI frame, so blankness cannot be ruled out" >&2
+  exit 1
+fi
+colors="$("$IM" "png:$SHOT" -format %k info: 2>/dev/null | tr -dc '0-9')"
+if [ -z "$colors" ]; then
+  echo "::error::could not measure the captured frame, so blankness cannot be ruled out" >&2
+  exit 1
+fi
+echo "Captured frame: $SHOT (${colors} distinct colours)"
+if [ "$colors" -lt "$MIN_COLORS" ]; then
+  echo "::error::the snap GUI window is blank: only ${colors} distinct colours on screen (floor: ${MIN_COLORS})" >&2
+  exit 1
+fi
+
+echo "OK: confined snap GUI reached app_ready, became visible and painted a real frame under Xvfb."

--- a/scripts/snap-gui-check.sh
+++ b/scripts/snap-gui-check.sh
@@ -34,7 +34,11 @@ cleanup() {
 trap cleanup EXIT
 
 echo "Launching the confined GUI under Xvfb (timeout: ${WAIT_SECONDS}s)..."
-setsid xvfb-run -a -s "-screen 0 1600x1000x24" "$APP" >"$LOG" 2>&1 &
+# Strict snaps have a private /tmp and therefore cannot read the temporary
+# Xauthority cookie created by xvfb-run.  This X server is disposable and only
+# reachable inside the CI runner, so disable access control instead of sharing
+# host credentials with the confined application.
+setsid xvfb-run -a -s "-screen 0 1600x1000x24 -ac" "$APP" >"$LOG" 2>&1 &
 PID=$!
 
 ready=false
@@ -52,7 +56,7 @@ done
 echo "--- confined GUI log ---"
 sed -n '1,240p' "$LOG"
 
-if grep -qE "EGL_BAD_(PARAMETER|DISPLAY)|Could not create default EGL display" "$LOG"; then
+if grep -qE "EGL_BAD_(PARAMETER|DISPLAY)|Could not create default EGL display|libEGL fatal" "$LOG"; then
   echo "::error::WebKit could not initialize EGL inside the snap" >&2
   exit 1
 fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -87,10 +87,15 @@ apps:
   aeroftp:
     command: usr/bin/aeroftp
     desktop: usr/share/applications/aeroftp.desktop
+    # Keep the GTK/WebKit/OpenGL runtime wiring owned by Snapcraft.  Removing
+    # this extension in 3bf266430 left GLVND with no EGL vendor inside strict
+    # confinement and produced a blank WebKit window (issue #462).
+    extensions:
+      - gnome
     environment:
-      # WebKitGTK environment
+      # AeroFTP currently forces X11; the GNOME extension owns the remaining
+      # desktop environment, including GTK_USE_PORTAL and the GL driver paths.
       GDK_BACKEND: x11
-      GTK_USE_PORTAL: "1"
     plugs:
       - home
       - removable-media
@@ -104,26 +109,6 @@ apps:
       - audio-playback
       - unity7
       - gsettings
-
-plugs:
-  gtk-3-themes:
-    interface: content
-    target: $SNAP/data-dir/themes
-    default-provider: gtk-common-themes
-  icon-themes:
-    interface: content
-    target: $SNAP/data-dir/icons
-    default-provider: gtk-common-themes
-  sound-themes:
-    interface: content
-    target: $SNAP/data-dir/sounds
-    default-provider: gtk-common-themes
-
-layout:
-  /usr/lib/x86_64-linux-gnu/webkit2gtk-4.1:
-    symlink: $SNAP/usr/lib/x86_64-linux-gnu/webkit2gtk-4.1
-  /usr/share/xml/iso-codes:
-    symlink: $SNAP/usr/share/xml/iso-codes
 
 parts:
   aeroftp:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -103,13 +103,11 @@ apps:
       # window.  Make the reliable software compositor the Snap default rather
       # than weakening the CI gate with a test-only override.
       WEBKIT_DISABLE_COMPOSITING_MODE: '1'
-      # WebKitGTK's bubblewrap sandbox cannot nest reliably inside snap
-      # confinement: the WebProcess loses access to the X11 socket and graphics
-      # runtime even though the outer application has the x11/opengl plugs.
-      # Snap strict confinement remains the security boundary.  Keep both names
-      # for the WebKitGTK versions supported by core22/gnome-42.
-      WEBKIT_FORCE_SANDBOX: '0'
-      WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS: '1'
+      # GTK 3 otherwise still probes EGL while creating its GL context, before
+      # WebKit's software compositor takes over.  Force Cairo image surfaces so
+      # headless/remote X servers do not depend on a DRI extension.
+      GDK_DEBUG: nogl
+      GDK_RENDERING: image
     plugs:
       - home
       - removable-media

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,4 +1,5 @@
 name: aeroftp
+title: AeroFTP
 version: '4.1.6'
 summary: Modern Multi-Protocol File Transfer & Cloud Client for Humans and Agents
 description: |
@@ -102,6 +103,13 @@ apps:
       # window.  Make the reliable software compositor the Snap default rather
       # than weakening the CI gate with a test-only override.
       WEBKIT_DISABLE_COMPOSITING_MODE: '1'
+      # WebKitGTK's bubblewrap sandbox cannot nest reliably inside snap
+      # confinement: the WebProcess loses access to the X11 socket and graphics
+      # runtime even though the outer application has the x11/opengl plugs.
+      # Snap strict confinement remains the security boundary.  Keep both names
+      # for the WebKitGTK versions supported by core22/gnome-42.
+      WEBKIT_FORCE_SANDBOX: '0'
+      WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS: '1'
     plugs:
       - home
       - removable-media

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -96,6 +96,12 @@ apps:
       # AeroFTP currently forces X11; the GNOME extension owns the remaining
       # desktop environment, including GTK_USE_PORTAL and the GL driver paths.
       GDK_BACKEND: x11
+      # WebKitGTK's accelerated compositor requires a DRI-capable X server.
+      # Strict snaps must also work on software-only/remote X servers (including
+      # the Xvfb readiness gate), where EGL otherwise leaves a live white
+      # window.  Make the reliable software compositor the Snap default rather
+      # than weakening the CI gate with a test-only override.
+      WEBKIT_DISABLE_COMPOSITING_MODE: '1'
     plugs:
       - home
       - removable-media

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -84,8 +84,28 @@ architectures:
 
 icon: icons/AeroFTP_simbol_color_512x512.png
 
+plugs:
+  # GPU userspace must match the host hardware/kernel.  Consume Canonical's
+  # provider instead of shipping Mesa drivers in the application snap.
+  graphics-core22:
+    interface: content
+    target: $SNAP/graphics
+    default-provider: mesa-core22
+
+layout:
+  /usr/share/libdrm:
+    bind: $SNAP/graphics/libdrm
+  /usr/share/drirc.d:
+    symlink: $SNAP/graphics/drirc.d
+  /usr/share/X11/XErrorDB:
+    symlink: $SNAP/graphics/X11/XErrorDB
+  /usr/share/X11/locale:
+    symlink: $SNAP/graphics/X11/locale
+
 apps:
   aeroftp:
+    command-chain:
+      - bin/graphics-core22-wrapper
     command: usr/bin/aeroftp
     desktop: usr/share/applications/aeroftp.desktop
     # Keep the GTK/WebKit/OpenGL runtime wiring owned by Snapcraft.  Removing
@@ -103,11 +123,6 @@ apps:
       # window.  Make the reliable software compositor the Snap default rather
       # than weakening the CI gate with a test-only override.
       WEBKIT_DISABLE_COMPOSITING_MODE: '1'
-      # GTK 3 otherwise still probes EGL while creating its GL context, before
-      # WebKit's software compositor takes over.  Force Cairo image surfaces so
-      # headless/remote X servers do not depend on a DRI extension.
-      GDK_DEBUG: nogl
-      GDK_RENDERING: image
     plugs:
       - home
       - removable-media
@@ -118,6 +133,7 @@ apps:
       - wayland
       - x11
       - opengl
+      - graphics-core22
       - audio-playback
       - unity7
       - gsettings
@@ -215,5 +231,20 @@ parts:
         done
         cp src-tauri/icons/mimetypes/${icon}.svg \
           $SNAPCRAFT_PART_INSTALL/usr/share/icons/hicolor/scalable/mimetypes/${icon}.svg || \
-          { echo "ERROR: Missing SVG icon ${icon}"; exit 1; }
+            { echo "ERROR: Missing SVG icon ${icon}"; exit 1; }
       done
+
+  # Canonical's maintained wrapper selects the provider's EGL/GL/DRI stack at
+  # runtime.  Its cleanup removes duplicate GPU libraries pulled transitively
+  # by GTK/WebKit, preventing the loader/driver ABI mix that broke swrast.
+  graphics-core22:
+    after:
+      - aeroftp
+    source: https://github.com/canonical/gpu-snap.git
+    source-commit: d2b0948e6396ca0fe57da7748dadabbe06f6f7a4
+    plugin: dump
+    override-prime: |
+      craftctl default
+      ${CRAFT_PART_SRC}/bin/graphics-core22-cleanup mesa-core22 nvidia-core22
+    prime:
+      - bin/graphics-core22-wrapper


### PR DESCRIPTION
## Summary

- restore Snapcraft's supported `gnome` extension for the core22 desktop runtime
- remove manual content-plug/layout declarations now owned by the extension
- add blocking G3 coverage that launches the installed, confined snap under Xvfb
- require a positive frontend `app_ready post-show: is_visible=true` signal and reject EGL/splash-timeout regressions
- apply G3 to both release builds and Store refresh builds before either publish step

## Why this direction

Current Snapcraft documentation explicitly supports the `gnome` extension on core22 and its expanded configuration supplies the `gnome-42-2204` platform, desktop launcher, GTK/WebKit 4.1 layouts, and GL runtime wiring. Maintaining only two EGL variables by hand would leave AeroFTP responsible for a partial copy of that integration.

`GTK_USE_PORTAL=1` was removed from AeroFTP's manual app environment because the extension itself owns and sets it. Therefore the observed portal warning is not papered over as the root cause; G3 decides based on actual frontend readiness.

## Verification

- `npm run ci:pre-push` — PASS
  - security regression suite
  - 523 frontend unit tests
  - TypeScript and i18n validation (46/46 locales, zero placeholders)
  - Rust format + strict Clippy
  - 3311 library tests + 482 CLI tests + offline integration suites
  - RustSec audit
- `bash -n scripts/snap-gui-check.sh` — PASS
- `git diff --check` — PASS
- real confined GUI validation is intentionally CI-only under Xvfb

No Store upload has been performed. Closes #462.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved confined Snap GUI startup by switching to the GNOME extension and refining the app’s GTK/WebKit runtime environment for more reliable rendering.

* **Quality Improvements**
  * Added an extra pre-publish verification step that boots the Snap’s confined GUI in a disposable Xvfb session and only proceeds once the interface is confirmed visible.
  * Strengthened detection of common GUI initialization failures and ensured the test environment is cleaned up automatically.

* **Chores**
  * Updated repository ignore rules so the GUI readiness check script is included in the project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->