### PR TITLE
fix(aerorsync): lane3 Docker retry, preamble flush, B3 xattrs

### DIFF
--- a/.github/workflows/aerorsync-protocol.yml
+++ b/.github/workflows/aerorsync-protocol.yml
@@ -124,11 +124,47 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev \
             librsvg2-dev libssl-dev pkg-config libzstd-dev netcat-openbsd
+      # Docker Hub (registry-1.docker.io) occasionally times out on GHA runners
+      # (observed 2026-07-26 06:49Z: dial tcp ...:443: i/o timeout while loading
+      # debian:bookworm-slim metadata for Dockerfile.real-rsync-sshd). That used
+      # to paint the whole lane red before any test ran, indistinguishable from
+      # a protocol regression. Pull the base image first with its own retry so
+      # a registry blip is named in the log; then retry compose up --build.
+      # Gate stays hard: no continue-on-error — only recoverable retries.
+      - name: Pre-pull harness base image
+        shell: bash
+        run: |
+          set -u
+          for attempt in 1 2 3 4; do
+            if docker pull debian:bookworm-slim; then
+              exit 0
+            fi
+            status=$?
+            if [ "$attempt" -eq 4 ]; then
+              echo "::error::Docker Hub unreachable after ${attempt} attempts pulling debian:bookworm-slim (registry-1.docker.io). Not a protocol regression — registry/network failure."
+              exit "$status"
+            fi
+            echo "::warning::Docker Hub pull of debian:bookworm-slim failed on attempt ${attempt}/4 (registry-1.docker.io); retrying"
+            sleep $((attempt * 15))
+          done
       - name: Start real-rsync harness
         working-directory: src-tauri/src/aerorsync/capture
+        shell: bash
         run: |
+          set -u
           chmod 600 keys/id_ed25519
-          docker compose -f docker-compose.real-rsync.yml up -d --build
+          for attempt in 1 2 3; do
+            if docker compose -f docker-compose.real-rsync.yml up -d --build; then
+              exit 0
+            fi
+            status=$?
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::real-rsync harness build/start failed after ${attempt} attempts. If the log shows registry-1.docker.io / DeadlineExceeded / i/o timeout, this is Docker Hub, not a protocol regression."
+              exit "$status"
+            fi
+            echo "::warning::real-rsync harness compose up --build failed on attempt ${attempt}/3; retrying"
+            sleep $((attempt * 15))
+          done
       - name: Wait for sshd (real rsync, port 2224)
         run: |
           for i in $(seq 1 30); do

--- a/src-tauri/src/aerorsync/delta_transport_impl.rs
+++ b/src-tauri/src/aerorsync/delta_transport_impl.rs
@@ -112,6 +112,12 @@ static TEMP_SUFFIX_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::At
 pub struct AerorsyncDeltaTransport {
     ssh_config: SshTransportConfig,
     min_file_size: u64,
+    /// When true, negotiate `-X` and carry `user.*` xattrs (B3).
+    /// Default off so frozen wire oracles and non-xattr paths stay
+    /// byte-identical until a caller opts in via [`Self::with_xattrs`].
+    preserve_xattrs: bool,
+    /// X.5: turn ENOTSUP / metadata-loss warnings into hard errors.
+    fail_on_metadata_loss: bool,
 }
 
 impl AerorsyncDeltaTransport {
@@ -121,7 +127,23 @@ impl AerorsyncDeltaTransport {
         Self {
             ssh_config,
             min_file_size,
+            preserve_xattrs: false,
+            fail_on_metadata_loss: false,
         }
+    }
+
+    /// Opt this transport into extended attributes (`-X` + local
+    /// read/apply of `user.*`). Off by default: see field docs.
+    pub fn with_xattrs(mut self, preserve_xattrs: bool) -> Self {
+        self.preserve_xattrs = preserve_xattrs;
+        self
+    }
+
+    /// X.5: when the destination cannot store xattrs, fail the transfer
+    /// instead of continuing with a typed warning.
+    pub fn with_fail_on_metadata_loss(mut self, fail: bool) -> Self {
+        self.fail_on_metadata_loss = fail;
+        self
     }
 
     /// Convenience constructor that maps the production `RsyncConfig`
@@ -321,6 +343,7 @@ impl AerorsyncDeltaTransport {
                 self.min_file_size,
                 preamble_profile,
                 progress,
+                self.preserve_xattrs,
             )
             .await
         } else {
@@ -333,6 +356,7 @@ impl AerorsyncDeltaTransport {
                 self.min_file_size,
                 preamble_profile,
                 progress,
+                self.preserve_xattrs,
             )
             .await
         }
@@ -361,6 +385,7 @@ async fn do_upload<T>(
     min_file_size: u64,
     preamble_profile: PreambleProfile,
     progress: Option<crate::delta_transport::DeltaProgressSink>,
+    preserve_xattrs: bool,
 ) -> Result<RsyncStats, RsyncError>
 where
     T: RawRemoteShellTransport + 'static,
@@ -389,6 +414,7 @@ where
             preamble_profile,
             progress,
             start,
+            preserve_xattrs,
         )
         .await;
     }
@@ -418,7 +444,14 @@ where
     // identifies the negotiated algorithm. The placeholder stays empty
     // here so upload cannot accidentally advertise xxh128 bytes to an
     // xxh64/xxh3/md5 receiver.
-    let source_entry = build_source_entry(local_path, file_size, &metadata, Vec::new(), None);
+    let source_entry = build_source_entry(
+        local_path,
+        file_size,
+        &metadata,
+        Vec::new(),
+        None,
+        preserve_xattrs,
+    );
 
     let source_file = fs::File::open(local_path).await.map_err(RsyncError::Io)?;
 
@@ -433,7 +466,8 @@ where
     // (WrapperParity flavor) instead of the dev helper
     // `aerorsync_serve`. The wrapper command line is byte-pinned
     // against rsync 3.2.7 capture by `upload_remote_command_matches_capture`.
-    let spec = RemoteCommandSpec::upload(remote_path);
+    // B3: `-X` rides on the same switch as local xattr read/apply.
+    let spec = RemoteCommandSpec::upload(remote_path).with_xattrs(preserve_xattrs);
     let drive_res = driver
         .drive_upload_through_delta_streaming(
             spec,
@@ -484,6 +518,7 @@ async fn do_upload_symlink<T>(
     preamble_profile: PreambleProfile,
     progress: Option<crate::delta_transport::DeltaProgressSink>,
     start: Instant,
+    preserve_xattrs: bool,
 ) -> Result<RsyncStats, RsyncError>
 where
     T: RawRemoteShellTransport + 'static,
@@ -498,6 +533,7 @@ where
             preamble_profile,
             progress,
             start,
+            preserve_xattrs,
         );
         return Err(RsyncError::HardRejection(format!(
             "symlink upload is not supported on this platform: {} is a symbolic link and \
@@ -519,8 +555,14 @@ where
         };
         // rsync F_LENGTH convention for links: st_size == strlen(target).
         let target_len = target.len() as u64;
-        let source_entry =
-            build_source_entry(local_path, target_len, metadata, Vec::new(), Some(target));
+        let source_entry = build_source_entry(
+            local_path,
+            target_len,
+            metadata,
+            Vec::new(),
+            Some(target),
+            preserve_xattrs,
+        );
 
         let mut driver = AerorsyncDriver::new(transport, cancel)
             .with_preamble_profile(preamble_profile)
@@ -528,7 +570,7 @@ where
         let warnings = new_warnings_sink();
         let mut bridge = build_event_bridge(warnings.clone());
 
-        let spec = RemoteCommandSpec::upload(remote_path);
+        let spec = RemoteCommandSpec::upload(remote_path).with_xattrs(preserve_xattrs);
         if let Err(e) = driver
             .drive_upload_symlink(spec, source_entry, &mut bridge)
             .await
@@ -577,6 +619,8 @@ impl AerorsyncDeltaTransport {
                 local_path,
                 preamble_profile,
                 progress,
+                self.preserve_xattrs,
+                self.fail_on_metadata_loss,
             )
             .await
         } else {
@@ -588,6 +632,8 @@ impl AerorsyncDeltaTransport {
                 local_path,
                 preamble_profile,
                 progress,
+                self.preserve_xattrs,
+                self.fail_on_metadata_loss,
             )
             .await
         }
@@ -847,6 +893,7 @@ fn hex_checksum(bytes: &[u8]) -> String {
 /// a long-lived transport instead of allocating a fresh SSH session per
 /// file. Pinned by `cargo test --features aerorsync --lib aerorsync::`
 /// 453/453.
+#[allow(clippy::too_many_arguments)]
 async fn do_download<T>(
     transport: T,
     cancel: CancelHandle,
@@ -854,6 +901,8 @@ async fn do_download<T>(
     local_path: &Path,
     preamble_profile: PreambleProfile,
     progress: Option<crate::delta_transport::DeltaProgressSink>,
+    preserve_xattrs: bool,
+    fail_on_metadata_loss: bool,
 ) -> Result<RsyncStats, RsyncError>
 where
     T: RawRemoteShellTransport + 'static,
@@ -950,7 +999,8 @@ where
     // B.1: production dispatch now talks to stock `rsync --server --sender`
     // (WrapperParity flavor). Pinned against rsync 3.2.7 capture by
     // `download_remote_command_matches_capture`.
-    let spec = RemoteCommandSpec::download(remote_path);
+    // B3: `-X` rides on the same switch as local xattr apply.
+    let spec = RemoteCommandSpec::download(remote_path).with_xattrs(preserve_xattrs);
     // CLAUDE-AV-B3-12: hash the reconstruction as it streams to disk so
     // the whole-file trailer can be checked below. The shim borrows
     // `writer` only for the drive; the digest outlives the scope so
@@ -1172,16 +1222,30 @@ where
         }
     }
 
-    // Atomic commit: flush + sync_all + chmod (Unix) + set_mtime + rename.
-    // Failures here are post-commit-cutover and surface as
-    // `HardRejection` via `map_write_atomic_error`.
-    writer
-        .finalize(preserve_mode, preserve_mtime)
+    // B3 / X.4: xattrs must land on the temp file before rename so a
+    // kill-9 never leaves a visible target without its metadata.
+    let apply_xattrs = remote_entry
+        .as_ref()
+        .and_then(|e| e.xattrs.as_ref())
+        .filter(|_| preserve_xattrs)
+        .cloned();
+
+    // Atomic commit: flush + sync_all + chmod (Unix) + set_mtime +
+    // xattrs + rename. Failures here are post-commit-cutover and surface
+    // as `HardRejection` via `map_write_atomic_error`.
+    let xattr_warnings = writer
+        .finalize(
+            preserve_mode,
+            preserve_mtime,
+            apply_xattrs,
+            fail_on_metadata_loss,
+        )
         .await
         .map_err(map_write_atomic_error)?;
 
     let duration_ms = start.elapsed().as_millis() as u64;
-    let warnings = drain_warnings(warnings);
+    let mut warnings = drain_warnings(warnings);
+    warnings.extend(xattr_warnings);
     Ok(build_stats(
         driver.session_stats(),
         file_size,
@@ -1322,6 +1386,7 @@ impl DeltaBatch for AerorsyncBatch {
             self.min_file_size,
             preamble_profile.clone(),
             None,
+            false,
         )
         .await;
         if let Err(ref e) = first {
@@ -1359,6 +1424,7 @@ impl DeltaBatch for AerorsyncBatch {
                     self.min_file_size,
                     preamble_profile,
                     None,
+                    false,
                 )
                 .await?
             }
@@ -1391,6 +1457,8 @@ impl DeltaBatch for AerorsyncBatch {
             local_path,
             preamble_profile.clone(),
             None,
+            false,
+            false,
         )
         .await;
         if let Err(ref e) = first {
@@ -1424,6 +1492,8 @@ impl DeltaBatch for AerorsyncBatch {
                     local_path,
                     preamble_profile,
                     None,
+                    false,
+                    false,
                 )
                 .await?
             }
@@ -1487,6 +1557,7 @@ fn build_source_entry(
     metadata: &std::fs::Metadata,
     file_checksum: Vec<u8>,
     symlink_target: Option<String>,
+    preserve_xattrs: bool,
 ) -> FileListEntry {
     // 0x2c00 = USER_NAME_FOLLOWS (1<<10) | GROUP_NAME_FOLLOWS (1<<11) | MOD_NSEC (1<<13).
     const BASELINE_FLAGS: u32 = (1 << 10) | (1 << 11) | (1 << 13);
@@ -1499,6 +1570,16 @@ fn build_source_entry(
     let (uid_value, gid_value) = file_owner_components(metadata);
     let uid_name = lookup_user_name(uid_value);
     let gid_name = lookup_group_name(gid_value);
+    // B3 / X.3: when the session negotiates `-X`, read `user.*` xattrs
+    // via libc. `None` when xattrs are off keeps the encoder emitting
+    // zero xattr bytes (frozen oracles stay byte-identical). `Some(vec)`
+    // — empty or not — when on matches the codec contract for negotiated
+    // sessions.
+    let xattrs = if preserve_xattrs {
+        Some(crate::aerorsync::xattr_fs::read_user_xattrs(local_path).unwrap_or_default())
+    } else {
+        None
+    };
     // P3-T01 W1.3: caller computes xxh128 via streaming pass over the
     // file (`compute_xxh128_file_streaming`) so we no longer require a
     // fully-buffered `source_data: &[u8]` argument here. xxh128 over
@@ -1522,11 +1603,7 @@ fn build_source_entry(
         gid_name: Some(gid_name),
         checksum: file_checksum,
         symlink_target,
-        // X.2a: no xattr is read from the local file yet — that is X.3,
-        // which slots in beside `file_owner_components` below. `None`
-        // keeps the sender emitting zero xattr bytes, matching the
-        // `preserve_xattrs: false` the driver puts in its flist options.
-        xattrs: None,
+        xattrs,
     }
 }
 
@@ -2399,6 +2476,8 @@ mod tests {
             &local_path,
             profile,
             None,
+            false,
+            false,
         )
         .await;
         (result, local_path)
@@ -2907,7 +2986,14 @@ mod tests {
         let dir = fresh_tempdir();
         let path = dir.path().join("payload.bin");
         let meta = metadata_for(&path);
-        let entry = build_source_entry(&path, 1_234_567, &meta, xxh128_digest_bytes(&[]), None);
+        let entry = build_source_entry(
+            &path,
+            1_234_567,
+            &meta,
+            xxh128_digest_bytes(&[]),
+            None,
+            false,
+        );
         assert_eq!(entry.path, "payload.bin");
         assert_eq!(entry.size, 1_234_567);
         // U-07 regression pin: mtime MUST be populated from metadata;
@@ -2948,7 +3034,14 @@ mod tests {
         // a source (a directory is fine for the fallback check).
         let dir = fresh_tempdir();
         let meta = std::fs::metadata(dir.path()).unwrap();
-        let entry = build_source_entry(Path::new("/"), 0, &meta, xxh128_digest_bytes(&[]), None);
+        let entry = build_source_entry(
+            Path::new("/"),
+            0,
+            &meta,
+            xxh128_digest_bytes(&[]),
+            None,
+            false,
+        );
         assert_eq!(entry.path, "source.bin");
     }
 
@@ -2962,7 +3055,7 @@ mod tests {
             std::fs::File::create(&path).unwrap();
             std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o640)).unwrap();
             let meta = std::fs::metadata(&path).unwrap();
-            let entry = build_source_entry(&path, 0, &meta, xxh128_digest_bytes(&[]), None);
+            let entry = build_source_entry(&path, 0, &meta, xxh128_digest_bytes(&[]), None, false);
             // `mode` is the raw `st_mode` value; the low 12 bits carry
             // the permission bits we just set.
             assert_eq!((entry.mode as u32) & 0o7777, 0o640);
@@ -2990,6 +3083,7 @@ mod tests {
             &meta,
             Vec::new(),
             Some(target.to_string()),
+            false,
         );
 
         assert_eq!(entry.mode & 0o170000, 0o120000, "S_IFLNK mode bits");
@@ -3211,6 +3305,7 @@ mod tests {
             10_000_000,
             PreambleProfile::default(),
             None,
+            false,
         )
         .await
         .expect("symlink upload must succeed despite the min_file_size gate");
@@ -3241,6 +3336,7 @@ mod tests {
             0,
             PreambleProfile::default(),
             None,
+            false,
         )
         .await
         .unwrap_err();
@@ -3346,6 +3442,8 @@ mod tests {
             &local,
             PreambleProfile::default(),
             None,
+            false,
+            false,
         )
         .await
         .expect("symlink download must create the link");
@@ -3382,6 +3480,8 @@ mod tests {
             &local,
             PreambleProfile::default(),
             None,
+            false,
+            false,
         )
         .await
         .expect("symlink download over an existing regular file");
@@ -3508,6 +3608,7 @@ mod tests {
             1_000_000, // prohibitive threshold: symlinks must bypass TooSmall
             PreambleProfile::for_host("127.0.0.1"),
             None,
+            false,
         )
         .await
         .expect("live symlink upload against stock rsync");
@@ -3566,6 +3667,8 @@ mod tests {
             &local,
             PreambleProfile::for_host("127.0.0.1"),
             None,
+            false,
+            false,
         )
         .await
         .expect("live symlink download against stock rsync");

--- a/src-tauri/src/aerorsync/frame_io.rs
+++ b/src-tauri/src/aerorsync/frame_io.rs
@@ -11,7 +11,11 @@ pub fn write_length_prefixed_frame<W: Write>(writer: &mut W, frame: &[u8]) -> io
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "frame too large"))?;
     writer.write_all(&len.to_be_bytes())?;
     writer.write_all(frame)?;
-    writer.flush()?;
+    // No `flush()` here. When `W` is `ssh2::Channel`, `Write::flush` maps
+    // to `libssh2_channel_flush_ex`, which discards the *read* buffer
+    // rather than pushing the send queue (see the raw-worker Write arm in
+    // `ssh_transport.rs`). Buffered writers that need an explicit flush
+    // must do it at the call site.
     Ok(())
 }
 

--- a/src-tauri/src/aerorsync/mod.rs
+++ b/src-tauri/src/aerorsync/mod.rs
@@ -43,5 +43,6 @@ pub mod streaming_writer;
 pub mod tests;
 pub mod transport;
 pub mod types;
+pub mod xattr_fs;
 
 pub const CURRENT_PROTOCOL_VERSION: u32 = 31;

--- a/src-tauri/src/aerorsync/real_wire.rs
+++ b/src-tauri/src/aerorsync/real_wire.rs
@@ -3770,6 +3770,48 @@ mod tests {
         ));
     }
 
+    /// Pin for known issue #3 (tracker #458): `InvalidProtocolVersion
+    /// { value: 2015297409 }` is not random garbage. It is the LE u32 of
+    /// the four bytes that follow a stock server's 4-byte protocol version
+    /// in the capability preamble — i.e. a decode that started at offset
+    /// +4 into a valid frame.
+    ///
+    /// Root cause (2026-07-26): `ssh2::Channel::flush` after the client
+    /// preamble write discarded those first 4 version bytes from the
+    /// libssh2 read buffer when the server had already replied. See the
+    /// raw-worker Write arm in `ssh_transport.rs`.
+    #[test]
+    fn invalid_protocol_version_2015297409_is_server_preamble_at_offset_4() {
+        // Alpine 3.19 / rsync 3.4.1 shape observed live against the
+        // sftp-rsync fixture (checksum algos length 0x1e = 30, starting
+        // with "xxh128..."):
+        //   20 00 00 00 | 81 ff 1e 78 78 68 ...
+        //   ^ version 32  ^ compat 0x01FF + len + first 'x'
+        let mut preamble = Vec::new();
+        preamble.extend_from_slice(&encode_protocol_version(32));
+        preamble.extend_from_slice(&[0x81, 0xff]); // varint(0x01FF)
+        preamble.push(0x1e); // checksum_algos len
+        preamble.extend_from_slice(b"xxh128 xxh3 xxh64 md5 md4 none");
+        preamble.push(0x18); // compression_algos len
+        preamble.extend_from_slice(b"zstd lz4 zlibx zlib none");
+        preamble.extend_from_slice(&0x1234_5678u32.to_le_bytes());
+        assert_eq!(&preamble[4..8], &[0x81, 0xff, 0x1e, 0x78]);
+        let misaligned = u32::from_le_bytes(preamble[4..8].try_into().unwrap());
+        assert_eq!(misaligned, 2015297409);
+        // A decoder that starts at offset 4 must hard-reject with exactly
+        // this value — the historical CI failure signature.
+        match decode_protocol_version(&preamble[4..]) {
+            Err(RealWireError::InvalidProtocolVersion { value }) => {
+                assert_eq!(value, 2015297409);
+            }
+            other => panic!("expected InvalidProtocolVersion(2015297409), got {other:?}"),
+        }
+        // Full buffer at offset 0 must still decode cleanly.
+        let decoded = decode_server_preamble(&preamble).expect("full preamble at offset 0");
+        assert_eq!(decoded.protocol_version, 32);
+        assert_eq!(decoded.compat_flags, 0x01ff);
+    }
+
     // -------------------------------------------------------------------------
     // Multiplex header
     // -------------------------------------------------------------------------

--- a/src-tauri/src/aerorsync/ssh_transport.rs
+++ b/src-tauri/src/aerorsync/ssh_transport.rs
@@ -788,16 +788,31 @@ fn spawn_raw_worker(
             }
             match receiver.recv_timeout(idle_poll) {
                 Ok(RawWorkerCommand::Write(bytes, reply)) => {
-                    // B.2: `channel.write_all` on ssh2 buffers into an
-                    // internal libssh2 send queue; small payloads (e.g.
-                    // a 50-byte rsync preamble) never reach the wire
-                    // until something flushes the channel. Stock
-                    // `rsync --server` then blocks in `read()` waiting
-                    // for bytes we've already "written" client-side.
-                    // `flush()` forces the queue through the TCP socket.
+                    // Do NOT call `channel.flush()` after write.
+                    //
+                    // `ssh2::Channel::flush` maps to `libssh2_channel_flush_ex`,
+                    // which flushes the *read* buffer: it discards unread
+                    // CHANNEL_DATA already queued for this stream (see
+                    // libssh2 docs: "Flush the read buffer for a given
+                    // channel instance"). It does not push the send queue
+                    // to TCP.
+                    //
+                    // Race (known issue #3 / InvalidProtocolVersion
+                    // 2015297409): stock rsync often replies with its
+                    // 4-byte protocol version as soon as it has read ours.
+                    // That reply can land in the libssh2 packet queue
+                    // during `write_all`. A following `flush()` then
+                    // drops those 4 bytes, so the next `read` starts at
+                    // offset +4 of the server preamble (`81 ff 1e 78` =
+                    // compat_flags varint + algo-list length + first 'x'
+                    // of "xxh128..."), which decodes as version
+                    // 2015297409. Intermittent on contended CI; green
+                    // when the server response arrives after flush.
+                    //
+                    // Blocking `write_all` is enough: libssh2 ships the
+                    // CHANNEL_DATA packet before returning.
                     let result = channel
                         .write_all(&bytes)
-                        .and_then(|_| channel.flush())
                         .map_err(|e| RawWorkerError::Other(format!("write_bytes: {e}")));
                     let _ = reply.send(result);
                 }

--- a/src-tauri/src/aerorsync/streaming_writer.rs
+++ b/src-tauri/src/aerorsync/streaming_writer.rs
@@ -158,8 +158,11 @@ impl StreamingAtomicWriter {
     ///      cannot map the bits faithfully).
     ///   4. apply `mtime` (seconds + nanoseconds) to the temp via the
     ///      `filetime` crate, matching `write_atomic_chunked` semantics.
-    ///   5. `rename` temp → target.
+    ///   5. apply `xattrs` to the temp (B3 / X.4). **Before rename**, so
+    ///      a kill-9 never leaves a visible target without metadata.
+    ///   6. `rename` temp → target.
     ///
+    /// Returns any soft metadata-loss warnings (X.5 ENOTSUP path).
     /// Errors map to `WriteAtomicError::PostOpen { stage, source }` so
     /// the caller can route them through the same R3 cutover-boundary
     /// classification as `write_atomic_chunked` (a rename failure is a
@@ -170,7 +173,9 @@ impl StreamingAtomicWriter {
         self,
         mode: Option<u32>,
         mtime: Option<(i64, u32)>,
-    ) -> Result<(), WriteAtomicError> {
+        xattrs: Option<Vec<crate::aerorsync::real_wire::XattrPair>>,
+        fail_on_metadata_loss: bool,
+    ) -> Result<Vec<String>, WriteAtomicError> {
         let Self {
             target,
             temp,
@@ -178,7 +183,17 @@ impl StreamingAtomicWriter {
             bytes_written: _,
             mut committed,
         } = self;
-        let result = finalize_steps(&target, &temp, file, mode, mtime, &mut committed).await;
+        let result = finalize_steps(
+            &target,
+            &temp,
+            file,
+            mode,
+            mtime,
+            xattrs.as_deref(),
+            fail_on_metadata_loss,
+            &mut committed,
+        )
+        .await;
         if result.is_err() {
             // Best-effort cleanup; we are already on the failure path.
             let _ = fs::remove_file(&temp).await;
@@ -190,14 +205,17 @@ impl StreamingAtomicWriter {
 /// Drives the commit pipeline. Split into a free function so `finalize`
 /// can consume `self` cleanly (destructuring up front) and still recover
 /// the temp path for cleanup on the error arm.
+#[allow(clippy::too_many_arguments)]
 async fn finalize_steps(
     target: &Path,
     temp: &Path,
     mut file: tokio::fs::File,
     mode: Option<u32>,
     mtime: Option<(i64, u32)>,
+    xattrs: Option<&[crate::aerorsync::real_wire::XattrPair]>,
+    fail_on_metadata_loss: bool,
     committed: &mut bool,
-) -> Result<(), WriteAtomicError> {
+) -> Result<Vec<String>, WriteAtomicError> {
     use tokio::io::AsyncWriteExt;
 
     file.flush().await.map_err(|e| WriteAtomicError::PostOpen {
@@ -239,6 +257,23 @@ async fn finalize_steps(
         })?;
     }
 
+    // X.4: xattrs on the temp, before rename. Never after: that would
+    // open a window where the target is visible without metadata.
+    let mut warnings = Vec::new();
+    if let Some(pairs) = xattrs {
+        use crate::aerorsync::xattr_fs::{apply_xattrs, XattrApplyOutcome};
+        match apply_xattrs(temp, pairs, fail_on_metadata_loss) {
+            XattrApplyOutcome::Applied { .. } => {}
+            XattrApplyOutcome::Unsupported { warnings: w } => warnings.extend(w),
+            XattrApplyOutcome::Failed { message } => {
+                return Err(WriteAtomicError::PostOpen {
+                    stage: "xattr",
+                    source: std::io::Error::other(message),
+                });
+            }
+        }
+    }
+
     *committed = true;
     fs::rename(temp, target)
         .await
@@ -246,7 +281,7 @@ async fn finalize_steps(
             stage: "rename",
             source: e,
         })?;
-    Ok(())
+    Ok(warnings)
 }
 
 impl AsyncWrite for StreamingAtomicWriter {
@@ -303,7 +338,7 @@ mod tests {
         w.write_all(b"world").await.expect("chunk3");
         assert_eq!(w.bytes_written(), 21);
         let temp = w.temp_path().to_path_buf();
-        w.finalize(None, None).await.expect("finalize");
+        w.finalize(None, None, None, false).await.expect("finalize");
 
         let bytes = tokio::fs::read(&target).await.expect("read target");
         assert_eq!(bytes, b"hello streaming world");
@@ -323,7 +358,7 @@ mod tests {
 
         let mut w = StreamingAtomicWriter::new(&target).await.expect("new");
         w.write_all(b"NEW PAYLOAD").await.expect("write");
-        w.finalize(None, None).await.expect("finalize");
+        w.finalize(None, None, None, false).await.expect("finalize");
 
         let bytes = tokio::fs::read(&target).await.expect("read");
         assert_eq!(bytes, b"NEW PAYLOAD");
@@ -375,7 +410,7 @@ mod tests {
         w.write_all(b"data").await.expect("write");
         // Use a fixed historical timestamp so the assertion is exact.
         let mtime = (1_700_000_000_i64, 123_456_000_u32);
-        w.finalize(Some(0o600), Some(mtime))
+        w.finalize(Some(0o600), Some(mtime), None, false)
             .await
             .expect("finalize");
 
@@ -407,7 +442,7 @@ mod tests {
         assert_eq!(w.bytes_written(), 5);
         w.write_all(b"fghij").await.expect("w3");
         assert_eq!(w.bytes_written(), 10);
-        w.finalize(None, None).await.expect("finalize");
+        w.finalize(None, None, None, false).await.expect("finalize");
 
         let bytes = tokio::fs::read(&target).await.expect("read");
         assert_eq!(bytes, b"abcdefghij");
@@ -433,7 +468,9 @@ mod tests {
 
         // Build a fresh writer, finalize it, ensure the target lands.
         let w2 = StreamingAtomicWriter::new(&target).await.expect("new2");
-        w2.finalize(None, None).await.expect("finalize");
+        w2.finalize(None, None, None, false)
+            .await
+            .expect("finalize");
         assert!(target.exists(), "target landed after finalize");
     }
 
@@ -454,7 +491,7 @@ mod tests {
 
         let mut w = StreamingAtomicWriter::new(&target).await.expect("new");
         w.write_all(b"FRESH").await.expect("write");
-        w.finalize(None, None).await.expect("finalize");
+        w.finalize(None, None, None, false).await.expect("finalize");
 
         let bytes = tokio::fs::read(&target).await.expect("read");
         assert_eq!(
@@ -504,7 +541,10 @@ mod tests {
             .expect("apply_delta_streaming");
         assert_eq!(n as usize, expected.len(), "byte count matches");
         assert_eq!(writer.bytes_written(), n);
-        writer.finalize(None, None).await.expect("finalize");
+        writer
+            .finalize(None, None, None, false)
+            .await
+            .expect("finalize");
 
         let on_disk = tokio::fs::read(&target).await.expect("read target");
         assert_eq!(on_disk, expected);
@@ -537,7 +577,7 @@ mod tests {
             w.write_all(&[i; 256]).await.expect("write");
             tokio::time::sleep(Duration::from_millis(0)).await;
         }
-        w.finalize(None, None).await.expect("finalize");
+        w.finalize(None, None, None, false).await.expect("finalize");
 
         let bytes = tokio::fs::read(&target).await.expect("read");
         assert_eq!(bytes.len(), 16 * 256);

--- a/src-tauri/src/aerorsync/xattr_fs.rs
+++ b/src-tauri/src/aerorsync/xattr_fs.rs
@@ -154,6 +154,70 @@ pub fn read_user_xattrs(path: &Path) -> Option<Vec<XattrPair>> {
     }
 }
 
+/// Thin libc wrappers: Linux and macOS disagree on xattr signatures.
+/// Linux: listxattr(3), getxattr(4), setxattr(5, flags), removexattr(2).
+/// macOS: listxattr(4, options), getxattr/setxattr(6, position+options),
+/// removexattr(3, options). We always follow symlinks (options/flags = 0)
+/// and use position 0 (whole attribute).
+#[cfg(unix)]
+mod sys {
+    use std::os::raw::{c_char, c_void};
+
+    pub unsafe fn listxattr(path: *const c_char, list: *mut c_char, size: usize) -> isize {
+        #[cfg(any(target_os = "macos", target_os = "ios"))]
+        {
+            libc::listxattr(path, list, size, 0)
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+        {
+            libc::listxattr(path, list, size)
+        }
+    }
+
+    pub unsafe fn getxattr(
+        path: *const c_char,
+        name: *const c_char,
+        value: *mut c_void,
+        size: usize,
+    ) -> isize {
+        #[cfg(any(target_os = "macos", target_os = "ios"))]
+        {
+            libc::getxattr(path, name, value, size, 0, 0)
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+        {
+            libc::getxattr(path, name, value, size)
+        }
+    }
+
+    pub unsafe fn setxattr(
+        path: *const c_char,
+        name: *const c_char,
+        value: *const c_void,
+        size: usize,
+    ) -> i32 {
+        #[cfg(any(target_os = "macos", target_os = "ios"))]
+        {
+            libc::setxattr(path, name, value, size, 0, 0)
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+        {
+            libc::setxattr(path, name, value, size, 0)
+        }
+    }
+
+    pub unsafe fn removexattr(path: *const c_char, name: *const c_char) -> i32 {
+        #[cfg(any(target_os = "macos", target_os = "ios"))]
+        {
+            libc::removexattr(path, name, 0)
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+        {
+            libc::removexattr(path, name)
+        }
+    }
+}
+
 #[cfg(unix)]
 fn read_user_xattrs_unix(path: &Path) -> Option<Vec<XattrPair>> {
     use std::ffi::CString;
@@ -161,7 +225,7 @@ fn read_user_xattrs_unix(path: &Path) -> Option<Vec<XattrPair>> {
 
     let c_path = CString::new(path.as_os_str().as_bytes()).ok()?;
     // Size probe first (listxattr with size 0 returns needed length).
-    let needed = unsafe { libc::listxattr(c_path.as_ptr(), std::ptr::null_mut(), 0) };
+    let needed = unsafe { sys::listxattr(c_path.as_ptr(), std::ptr::null_mut(), 0) };
     if needed < 0 {
         return None;
     }
@@ -170,7 +234,7 @@ fn read_user_xattrs_unix(path: &Path) -> Option<Vec<XattrPair>> {
     }
     let mut buf = vec![0u8; needed as usize];
     let written = unsafe {
-        libc::listxattr(
+        sys::listxattr(
             c_path.as_ptr(),
             buf.as_mut_ptr() as *mut libc::c_char,
             buf.len(),
@@ -193,13 +257,13 @@ fn read_user_xattrs_unix(path: &Path) -> Option<Vec<XattrPair>> {
             continue;
         };
         let vlen =
-            unsafe { libc::getxattr(c_path.as_ptr(), c_name.as_ptr(), std::ptr::null_mut(), 0) };
+            unsafe { sys::getxattr(c_path.as_ptr(), c_name.as_ptr(), std::ptr::null_mut(), 0) };
         if vlen < 0 {
             continue;
         }
         let mut value = vec![0u8; vlen as usize];
         let got = unsafe {
-            libc::getxattr(
+            sys::getxattr(
                 c_path.as_ptr(),
                 c_name.as_ptr(),
                 value.as_mut_ptr() as *mut libc::c_void,
@@ -303,12 +367,11 @@ fn apply_xattrs_unix(
             };
         };
         let rc = unsafe {
-            libc::setxattr(
+            sys::setxattr(
                 c_path.as_ptr(),
                 c_name.as_ptr(),
                 value.as_ptr() as *const libc::c_void,
                 value.len(),
-                0,
             )
         };
         if rc != 0 {
@@ -390,16 +453,15 @@ fn probe_xattr_support(dir: &Path) -> bool {
     };
     let probe = b"1";
     let rc = unsafe {
-        libc::setxattr(
+        sys::setxattr(
             c_path.as_ptr(),
             c_name.as_ptr(),
             probe.as_ptr() as *const libc::c_void,
             probe.len(),
-            0,
         )
     };
     if rc == 0 {
-        let _ = unsafe { libc::removexattr(c_path.as_ptr(), c_name.as_ptr()) };
+        let _ = unsafe { sys::removexattr(c_path.as_ptr(), c_name.as_ptr()) };
         return true;
     }
     let err = std::io::Error::last_os_error();
@@ -505,12 +567,11 @@ mod tests {
             let c_name = CString::new("user.aeroftp.test").unwrap();
             let val = b"hello-xattr";
             let rc = unsafe {
-                libc::setxattr(
+                sys::setxattr(
                     c_path.as_ptr(),
                     c_name.as_ptr(),
                     val.as_ptr() as *const libc::c_void,
                     val.len(),
-                    0,
                 )
             };
             if rc != 0 {

--- a/src-tauri/src/aerorsync/xattr_fs.rs
+++ b/src-tauri/src/aerorsync/xattr_fs.rs
@@ -1,0 +1,543 @@
+//! Local extended-attribute I/O for B3 (X.3 / X.4 / X.4b / X.5).
+//!
+//! Wire codec lives in [`crate::aerorsync::real_wire`]; this module is the
+//! filesystem side: read `user.*` xattrs from a source path, sanitize a
+//! peer-supplied blob before apply, and write xattrs onto a temp file
+//! **before** rename (kill-9 invariant of `StreamingAtomicWriter`).
+//!
+//! Scope pins (owner-decided, appendix X.3–X.5):
+//! - default namespace filter: `user.*` only
+//! - ENOTSUP on the destination: typed warning + continue, unless
+//!   `fail_on_metadata_loss` turns it into a hard error
+//! - capability probe once per destination directory, not per file
+
+#![cfg(feature = "aerorsync")]
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use crate::aerorsync::real_wire::{XattrDatum, XattrPair};
+
+/// Only attributes whose name starts with this prefix are read or applied.
+pub const USER_XATTR_PREFIX: &str = "user.";
+
+/// Hard ceiling on how many attributes one entry may carry after sanitize.
+/// Hostile peers cannot inflate destination metadata beyond this.
+pub const MAX_XATTR_PAIRS: usize = 256;
+
+/// Hard ceiling on a single attribute name (including the `user.` prefix).
+pub const MAX_XATTR_NAME_LEN: usize = 255;
+
+/// Hard ceiling on the total size of all attribute values on one entry.
+pub const MAX_XATTR_TOTAL_BYTES: usize = 1024 * 1024;
+
+/// Why a received xattr blob was refused (X.4b). These are always hard
+/// errors: a malformed or hostile peer must not write to disk.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum XattrSanitizeError {
+    EmptyName,
+    NameTooLong { len: usize },
+    NamespaceNotAllowed { name: String },
+    TooManyPairs { count: usize },
+    TotalBytesTooLarge { total: usize },
+    DeferredUnresolved { name: String },
+}
+
+impl std::fmt::Display for XattrSanitizeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EmptyName => write!(f, "xattr name is empty"),
+            Self::NameTooLong { len } => {
+                write!(f, "xattr name length {len} exceeds {MAX_XATTR_NAME_LEN}")
+            }
+            Self::NamespaceNotAllowed { name } => {
+                write!(
+                    f,
+                    "xattr name {name:?} is outside the allowed {USER_XATTR_PREFIX:?} namespace"
+                )
+            }
+            Self::TooManyPairs { count } => {
+                write!(f, "xattr pair count {count} exceeds {MAX_XATTR_PAIRS}")
+            }
+            Self::TotalBytesTooLarge { total } => {
+                write!(
+                    f,
+                    "xattr total value size {total} exceeds {MAX_XATTR_TOTAL_BYTES}"
+                )
+            }
+            Self::DeferredUnresolved { name } => {
+                write!(
+                    f,
+                    "xattr {name:?} still carries a deferred digest; out-of-band section was not resolved"
+                )
+            }
+        }
+    }
+}
+
+/// Outcome of applying xattrs to a path (X.4 + X.5).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum XattrApplyOutcome {
+    /// Every pair was written.
+    Applied { count: usize },
+    /// Destination filesystem does not support xattrs (ENOTSUP). No pair
+    /// was written; caller may continue the transfer with a warning.
+    Unsupported { warnings: Vec<String> },
+    /// Hard failure (not ENOTSUP), or ENOTSUP with fail-on-metadata-loss.
+    Failed { message: String },
+}
+
+/// Sanitize peer-supplied xattrs before they touch the local filesystem.
+///
+/// Rejects empty names, non-`user.*` namespaces, over-long names, too many
+/// pairs, oversized total payload, and unresolved deferred digests.
+pub fn sanitize_xattrs_for_apply(
+    pairs: &[XattrPair],
+) -> Result<Vec<(String, Vec<u8>)>, XattrSanitizeError> {
+    if pairs.len() > MAX_XATTR_PAIRS {
+        return Err(XattrSanitizeError::TooManyPairs { count: pairs.len() });
+    }
+    let mut out = Vec::with_capacity(pairs.len());
+    let mut total_bytes = 0usize;
+    for pair in pairs {
+        if pair.name.is_empty() {
+            return Err(XattrSanitizeError::EmptyName);
+        }
+        if pair.name.len() > MAX_XATTR_NAME_LEN {
+            return Err(XattrSanitizeError::NameTooLong {
+                len: pair.name.len(),
+            });
+        }
+        if !pair.name.starts_with(USER_XATTR_PREFIX) || pair.name == USER_XATTR_PREFIX {
+            return Err(XattrSanitizeError::NamespaceNotAllowed {
+                name: pair.name.clone(),
+            });
+        }
+        // Names must be plain ASCII path-ish tokens; reject embedded NULs
+        // or control characters that would confuse setxattr.
+        if pair.name.bytes().any(|b| b < 0x20 || b == 0x7f) {
+            return Err(XattrSanitizeError::NamespaceNotAllowed {
+                name: pair.name.clone(),
+            });
+        }
+        let value = match &pair.datum {
+            XattrDatum::Inline(v) => v.clone(),
+            XattrDatum::Deferred { .. } => {
+                return Err(XattrSanitizeError::DeferredUnresolved {
+                    name: pair.name.clone(),
+                });
+            }
+        };
+        total_bytes = total_bytes.saturating_add(value.len());
+        if total_bytes > MAX_XATTR_TOTAL_BYTES {
+            return Err(XattrSanitizeError::TotalBytesTooLarge { total: total_bytes });
+        }
+        out.push((pair.name.clone(), value));
+    }
+    Ok(out)
+}
+
+/// Read `user.*` xattrs from `path` (X.3). Returns `None` on non-Unix or
+/// when the path has no readable user attributes. Soft errors (e.g. the
+/// source filesystem has no xattr support) also yield `None` so a
+/// transfer of content still proceeds.
+pub fn read_user_xattrs(path: &Path) -> Option<Vec<XattrPair>> {
+    #[cfg(unix)]
+    {
+        read_user_xattrs_unix(path)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        None
+    }
+}
+
+#[cfg(unix)]
+fn read_user_xattrs_unix(path: &Path) -> Option<Vec<XattrPair>> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let c_path = CString::new(path.as_os_str().as_bytes()).ok()?;
+    // Size probe first (listxattr with size 0 returns needed length).
+    let needed = unsafe { libc::listxattr(c_path.as_ptr(), std::ptr::null_mut(), 0) };
+    if needed < 0 {
+        return None;
+    }
+    if needed == 0 {
+        return Some(Vec::new());
+    }
+    let mut buf = vec![0u8; needed as usize];
+    let written = unsafe {
+        libc::listxattr(
+            c_path.as_ptr(),
+            buf.as_mut_ptr() as *mut libc::c_char,
+            buf.len(),
+        )
+    };
+    if written < 0 {
+        return None;
+    }
+    buf.truncate(written as usize);
+
+    let mut pairs = Vec::new();
+    for name in buf.split(|&b| b == 0).filter(|s| !s.is_empty()) {
+        let Ok(name_str) = std::str::from_utf8(name) else {
+            continue;
+        };
+        if !name_str.starts_with(USER_XATTR_PREFIX) || name_str == USER_XATTR_PREFIX {
+            continue;
+        }
+        let Ok(c_name) = CString::new(name) else {
+            continue;
+        };
+        let vlen =
+            unsafe { libc::getxattr(c_path.as_ptr(), c_name.as_ptr(), std::ptr::null_mut(), 0) };
+        if vlen < 0 {
+            continue;
+        }
+        let mut value = vec![0u8; vlen as usize];
+        let got = unsafe {
+            libc::getxattr(
+                c_path.as_ptr(),
+                c_name.as_ptr(),
+                value.as_mut_ptr() as *mut libc::c_void,
+                value.len(),
+            )
+        };
+        if got < 0 {
+            continue;
+        }
+        value.truncate(got as usize);
+        pairs.push(XattrPair::inline(name_str, value));
+    }
+    Some(pairs)
+}
+
+/// Apply sanitized xattrs to `path` (X.4). On ENOTSUP (X.5), returns
+/// [`XattrApplyOutcome::Unsupported`] unless `fail_on_metadata_loss`.
+///
+/// Callers must invoke this on the **temp file before rename**.
+pub fn apply_xattrs(
+    path: &Path,
+    pairs: &[XattrPair],
+    fail_on_metadata_loss: bool,
+) -> XattrApplyOutcome {
+    let sanitized = match sanitize_xattrs_for_apply(pairs) {
+        Ok(v) => v,
+        Err(e) => {
+            return XattrApplyOutcome::Failed {
+                message: e.to_string(),
+            };
+        }
+    };
+    if sanitized.is_empty() {
+        return XattrApplyOutcome::Applied { count: 0 };
+    }
+
+    #[cfg(unix)]
+    {
+        apply_xattrs_unix(path, &sanitized, fail_on_metadata_loss)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        if fail_on_metadata_loss {
+            XattrApplyOutcome::Failed {
+                message: "xattr apply is not supported on this platform".into(),
+            }
+        } else {
+            XattrApplyOutcome::Unsupported {
+                warnings: vec![
+                    "xattr apply skipped: extended attributes are not supported on this platform"
+                        .into(),
+                ],
+            }
+        }
+    }
+}
+
+#[cfg(unix)]
+fn apply_xattrs_unix(
+    path: &Path,
+    pairs: &[(String, Vec<u8>)],
+    fail_on_metadata_loss: bool,
+) -> XattrApplyOutcome {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    if let Some(parent) = path.parent() {
+        if !fs_supports_xattrs(parent) {
+            let warning = format!(
+                "destination filesystem does not support extended attributes ({}); \
+                 skipping {} xattr(s) on {}",
+                parent.display(),
+                pairs.len(),
+                path.display()
+            );
+            return if fail_on_metadata_loss {
+                XattrApplyOutcome::Failed { message: warning }
+            } else {
+                XattrApplyOutcome::Unsupported {
+                    warnings: vec![warning],
+                }
+            };
+        }
+    }
+
+    let Ok(c_path) = CString::new(path.as_os_str().as_bytes()) else {
+        return XattrApplyOutcome::Failed {
+            message: format!(
+                "xattr apply: path contains interior NUL: {}",
+                path.display()
+            ),
+        };
+    };
+
+    let mut applied = 0usize;
+    for (name, value) in pairs {
+        let Ok(c_name) = CString::new(name.as_bytes()) else {
+            return XattrApplyOutcome::Failed {
+                message: format!("xattr apply: name contains interior NUL: {name:?}"),
+            };
+        };
+        let rc = unsafe {
+            libc::setxattr(
+                c_path.as_ptr(),
+                c_name.as_ptr(),
+                value.as_ptr() as *const libc::c_void,
+                value.len(),
+                0,
+            )
+        };
+        if rc != 0 {
+            let err = std::io::Error::last_os_error();
+            let enotsup = err.raw_os_error() == Some(libc::ENOTSUP)
+                || err.raw_os_error() == Some(libc::EOPNOTSUPP);
+            if enotsup {
+                // Cache the negative probe so later files on the same fs skip.
+                if let Some(parent) = path.parent() {
+                    remember_xattr_support(parent, false);
+                }
+                let warning = format!(
+                    "setxattr ENOTSUP on {} for {name:?}; destination does not support xattrs",
+                    path.display()
+                );
+                return if fail_on_metadata_loss {
+                    XattrApplyOutcome::Failed { message: warning }
+                } else {
+                    XattrApplyOutcome::Unsupported {
+                        warnings: vec![warning],
+                    }
+                };
+            }
+            return XattrApplyOutcome::Failed {
+                message: format!("setxattr({name:?}) on {}: {err}", path.display()),
+            };
+        }
+        applied += 1;
+    }
+    XattrApplyOutcome::Applied { count: applied }
+}
+
+// --- capability probe cache (once per destination directory) ---------------
+
+static XATTR_SUPPORT_CACHE: Mutex<Option<HashMap<PathBuf, bool>>> = Mutex::new(None);
+
+fn remember_xattr_support(dir: &Path, supported: bool) {
+    let Ok(mut guard) = XATTR_SUPPORT_CACHE.lock() else {
+        return;
+    };
+    let map = guard.get_or_insert_with(HashMap::new);
+    map.insert(dir.to_path_buf(), supported);
+}
+
+/// Probe whether `dir`'s filesystem accepts user xattrs. Cached per path.
+#[cfg(unix)]
+pub fn fs_supports_xattrs(dir: &Path) -> bool {
+    if let Ok(guard) = XATTR_SUPPORT_CACHE.lock() {
+        if let Some(map) = guard.as_ref() {
+            if let Some(&known) = map.get(dir) {
+                return known;
+            }
+        }
+    }
+    let supported = probe_xattr_support(dir);
+    remember_xattr_support(dir, supported);
+    supported
+}
+
+#[cfg(not(unix))]
+pub fn fs_supports_xattrs(_dir: &Path) -> bool {
+    false
+}
+
+#[cfg(unix)]
+fn probe_xattr_support(dir: &Path) -> bool {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    // Prefer probing the directory itself with a throwaway user xattr.
+    // If the directory is not writable / not an xattr carrier, fall back
+    // to "supported" optimistically so a later setxattr on the temp file
+    // can still try (and map ENOTSUP to the soft path).
+    let Ok(c_path) = CString::new(dir.as_os_str().as_bytes()) else {
+        return true;
+    };
+    let Ok(c_name) = CString::new("user.aeroftp.xattr_probe") else {
+        return true;
+    };
+    let probe = b"1";
+    let rc = unsafe {
+        libc::setxattr(
+            c_path.as_ptr(),
+            c_name.as_ptr(),
+            probe.as_ptr() as *const libc::c_void,
+            probe.len(),
+            0,
+        )
+    };
+    if rc == 0 {
+        let _ = unsafe { libc::removexattr(c_path.as_ptr(), c_name.as_ptr()) };
+        return true;
+    }
+    let err = std::io::Error::last_os_error();
+    let enotsup =
+        err.raw_os_error() == Some(libc::ENOTSUP) || err.raw_os_error() == Some(libc::EOPNOTSUPP);
+    !enotsup
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_accepts_plain_user_attrs() {
+        let pairs = vec![
+            XattrPair::inline("user.a", b"v1".to_vec()),
+            XattrPair::inline("user.b", vec![0u8, 1, 2]),
+        ];
+        let got = sanitize_xattrs_for_apply(&pairs).expect("ok");
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].0, "user.a");
+        assert_eq!(got[1].1, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn sanitize_rejects_empty_name() {
+        let pairs = vec![XattrPair::inline("", b"v".to_vec())];
+        assert_eq!(
+            sanitize_xattrs_for_apply(&pairs),
+            Err(XattrSanitizeError::EmptyName)
+        );
+    }
+
+    #[test]
+    fn sanitize_rejects_non_user_namespace() {
+        for name in [
+            "security.selinux",
+            "trusted.foo",
+            "system.posix_acl_access",
+            "user.",
+        ] {
+            let pairs = vec![XattrPair::inline(name, b"v".to_vec())];
+            match sanitize_xattrs_for_apply(&pairs) {
+                Err(XattrSanitizeError::NamespaceNotAllowed { name: n }) => {
+                    assert_eq!(n, name);
+                }
+                other => panic!("expected NamespaceNotAllowed for {name}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn sanitize_rejects_too_many_pairs() {
+        let pairs: Vec<_> = (0..MAX_XATTR_PAIRS + 1)
+            .map(|i| XattrPair::inline(format!("user.n{i}"), b"x".to_vec()))
+            .collect();
+        assert!(matches!(
+            sanitize_xattrs_for_apply(&pairs),
+            Err(XattrSanitizeError::TooManyPairs { .. })
+        ));
+    }
+
+    #[test]
+    fn sanitize_rejects_oversized_total() {
+        let big = vec![b'Z'; MAX_XATTR_TOTAL_BYTES / 2 + 1];
+        let pairs = vec![
+            XattrPair::inline("user.a", big.clone()),
+            XattrPair::inline("user.b", big),
+        ];
+        assert!(matches!(
+            sanitize_xattrs_for_apply(&pairs),
+            Err(XattrSanitizeError::TotalBytesTooLarge { .. })
+        ));
+    }
+
+    #[test]
+    fn sanitize_rejects_unresolved_deferred() {
+        let pairs = vec![XattrPair {
+            name: "user.big".into(),
+            datum: XattrDatum::Deferred {
+                len: 64,
+                digest: [0u8; 16],
+            },
+        }];
+        assert!(matches!(
+            sanitize_xattrs_for_apply(&pairs),
+            Err(XattrSanitizeError::DeferredUnresolved { .. })
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn read_and_apply_user_xattr_round_trip_on_tempfile() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("payload.bin");
+        std::fs::write(&path, b"data").expect("write");
+
+        // set via libc so we do not depend on xattr crate.
+        {
+            use std::ffi::CString;
+            use std::os::unix::ffi::OsStrExt;
+            let c_path = CString::new(path.as_os_str().as_bytes()).unwrap();
+            let c_name = CString::new("user.aeroftp.test").unwrap();
+            let val = b"hello-xattr";
+            let rc = unsafe {
+                libc::setxattr(
+                    c_path.as_ptr(),
+                    c_name.as_ptr(),
+                    val.as_ptr() as *const libc::c_void,
+                    val.len(),
+                    0,
+                )
+            };
+            if rc != 0 {
+                // Filesystem may not support xattrs (e.g. some CI mounts).
+                eprintln!(
+                    "skipping round-trip: setxattr unsupported: {}",
+                    std::io::Error::last_os_error()
+                );
+                return;
+            }
+        }
+
+        let pairs = read_user_xattrs(&path).expect("read");
+        assert!(
+            pairs.iter().any(|p| p.name == "user.aeroftp.test"
+                && p.datum.bytes() == Some(b"hello-xattr".as_slice())),
+            "expected user.aeroftp.test in {pairs:?}"
+        );
+
+        let dest = dir.path().join("dest.bin");
+        std::fs::write(&dest, b"data").expect("write dest");
+        match apply_xattrs(&dest, &pairs, false) {
+            XattrApplyOutcome::Applied { count } => assert!(count >= 1),
+            XattrApplyOutcome::Unsupported { warnings } => {
+                eprintln!("apply unsupported: {warnings:?}");
+            }
+            XattrApplyOutcome::Failed { message } => panic!("apply failed: {message}"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Isolated aerorsync-only PR (no snap/packaging). Three commits on top of `main` (`b926656e7`):

1. **CI lane3 Docker Hub retry** — pre-pull `debian:bookworm-slim` with backoff + retry on `compose up --build`. Gate stays hard (no `continue-on-error`). Addresses intermittent Docker Hub timeouts that failed the harness before any protocol tests ran.

2. **libssh2 flush preamble discard (tracker #458 known issue #3)** — `InvalidProtocolVersion 2015297409` (`81 ff 1e 78` = server preamble at offset +4). Root cause: `ssh2::Channel::flush` → `libssh2_channel_flush_ex` **empties the read buffer**, not force-send. Race under contended CI. Fix: remove flush from raw write path + `frame_io`; unit pin for the 2015297409 encoding.

3. **B3 local xattr read/apply** — new `xattr_fs` module + wiring (X.3 read `user.*`, X.4 apply on temp before rename, X.4b sanitization, X.5 ENOTSUP → warning / hard with `fail_on_metadata_loss`). Default **off** (`with_xattrs(true)` to enable). Wire oracles unchanged. B4 live Docker acceptance is out of scope.

## Scope

8 files under aerorsync + protocol workflow only. Does **not** touch snap branches/PRs (#463, #466).

## Local gates (pre-push)

- `cargo fmt --all -- --check` → ok
- `cargo clippy --lib --features aerorsync --all-targets -- -D warnings` → ok
- `cargo test --features aerorsync --lib aerorsync` → 593 passed
- `RUSTFLAGS='--cfg ci_lane3' cargo check --features aerorsync --lib --tests` → ok

## Merge note

Do **not** merge while snap release validation is in flight unless owner explicitly OKs. Prefer green CI + ready baton.

## Test plan

- [x] Local clippy + aerorsync unit suite
- [ ] GitHub **Checks** (fmt/clippy/default tests)
- [ ] **Aerorsync Protocol** (lane3 Docker harness)
- [ ] **Delta Sync Integration** (preamble flake surface)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for preserving `user.*` extended attributes during transfers.
  - Added stricter failure behavior for metadata-loss scenarios.
  - Introduced an xattr filesystem module with peer-supplied xattr validation and apply outcomes.

- **Bug Fixes**
  - Prevented protocol/version misalignment by removing unsafe channel flushes in SSH and frame writing.
  - Hardened integration-test harness startup against intermittent registry timeouts with retry logic.
  - Added regression coverage for misaligned protocol-version decoding.

- **Tests**
  - Updated atomic writer behavior and tests for xattr-aware finalize behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->