### PR TITLE
fix: release triage — Zoho move, Jottacloud trash, profile reorder, pricing filter, TAB.DIGITAL naming

### DIFF
--- a/src-tauri/src/bridge_commands.rs
+++ b/src-tauri/src/bridge_commands.rs
@@ -421,15 +421,37 @@ pub async fn import_bridge_config(source: String, file_path: String) -> Result<V
 /// `client_id`/`client_secret`. The GUI stores them under the raw protocol
 /// (`oauth_googledrive_client_id`, ...) with Google Photos aliased onto Google
 /// Drive's app, distinct from the per-profile token slug used by
-/// `oauth_vault_slug_for_protocol`. Returns `Some` only for the OAuth-token
-/// providers AeroFTP actually exports to rclone, so callers can also use it as
-/// the "is this an rclone-exportable OAuth provider?" predicate. `None` for
-/// non-OAuth protocols and for the ones we deliberately gate (jottacloud/zoho).
+/// `oauth_vault_slug_for_protocol`. `None` for non-OAuth protocols and for
+/// Jottacloud, which has no OAuth app at all (it authenticates with a personal
+/// login token).
+///
+/// This is the rclone-facing view: it answers "can this profile become an
+/// rclone remote that refreshes on its own?", so it stays limited to the
+/// backends rclone actually has. Use [`oauth_client_cred_key`] for the native
+/// `.aeroftp` export, which is about the vault and not about rclone.
 pub fn rclone_oauth_client_cred_key(protocol: &str) -> Option<&'static str> {
+    match protocol.to_lowercase().as_str() {
+        // rclone has no Zoho WorkDrive backend, so a Zoho profile is not
+        // rclone-exportable even though it does have app credentials.
+        "zohoworkdrive" => None,
+        other => oauth_client_cred_key(other),
+    }
+}
+
+/// Every provider whose BYO OAuth app credentials live in the vault under
+/// `oauth_<slug>_client_id` / `_client_secret`, rclone-exportable or not.
+///
+/// Zoho WorkDrive belongs here and was missing: its app credentials are a vault
+/// singleton exactly like the others (read at connect time through
+/// `load_oauth_client_config`), so a `.aeroftp` profile export carried the Zoho
+/// token but not the app that can refresh it, and an imported profile failed its
+/// first refresh with an unparseable Zoho error instead of connecting.
+pub fn oauth_client_cred_key(protocol: &str) -> Option<&'static str> {
     match protocol.to_lowercase().as_str() {
         "googledrive" | "googlephotos" => Some("googledrive"),
         "dropbox" => Some("dropbox"),
         "onedrive" => Some("onedrive"),
+        "zohoworkdrive" => Some("zohoworkdrive"),
         "box" => Some("box"),
         "pcloud" => Some("pcloud"),
         "yandexdisk" => Some("yandexdisk"),
@@ -826,6 +848,39 @@ mod tests {
         ));
         std::fs::write(&path, contents).expect("write temp fixture");
         path
+    }
+
+    #[test]
+    fn zoho_has_app_credentials_to_export_but_is_not_an_rclone_remote() {
+        // The vault-facing map must carry Zoho: its app credentials are a
+        // singleton the connect path reads, and leaving them behind made an
+        // imported profile fail its first token refresh.
+        assert_eq!(
+            oauth_client_cred_key("zohoworkdrive"),
+            Some("zohoworkdrive")
+        );
+        // The rclone-facing map must not: there is no Zoho backend in rclone,
+        // and this predicate also gates "export this profile as a remote".
+        assert_eq!(rclone_oauth_client_cred_key("zohoworkdrive"), None);
+        // Every other provider answers the same on both maps.
+        for p in [
+            "googledrive",
+            "googlephotos",
+            "dropbox",
+            "onedrive",
+            "box",
+            "pcloud",
+            "yandexdisk",
+        ] {
+            assert_eq!(
+                oauth_client_cred_key(p),
+                rclone_oauth_client_cred_key(p),
+                "{p} must not diverge between the two maps"
+            );
+        }
+        // Jottacloud has no OAuth app at all (personal login token).
+        assert_eq!(oauth_client_cred_key("jottacloud"), None);
+        assert_eq!(oauth_client_cred_key("ftp"), None);
     }
 
     fn server_count(v: &Value) -> usize {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16596,9 +16596,10 @@ fn collect_provider_secrets_for_server(
     // cannot work without them, so they travel with every OAuth profile in the
     // export (the struct fields already exist for the #128-D rclone-import
     // recovery path). The client-cred slug differs from the per-profile token
-    // slug: `rclone_oauth_client_cred_key` maps Google Photos onto Google Drive's
-    // app and gates the providers that have no BYO app (jottacloud/zoho).
-    if let Some(cred_slug) = crate::bridge_commands::rclone_oauth_client_cred_key(&protocol) {
+    // slug: `oauth_client_cred_key` maps Google Photos onto Google Drive's app.
+    // It is the vault-facing map, not the rclone-facing one: Zoho WorkDrive has
+    // app credentials to carry even though rclone has no Zoho backend.
+    if let Some(cred_slug) = crate::bridge_commands::oauth_client_cred_key(&protocol) {
         if let Ok(id) = store.get(&format!("oauth_{}_client_id", cred_slug)) {
             if !id.is_empty() {
                 out.oauth_client_id = Some(id);
@@ -16607,6 +16608,14 @@ fn collect_provider_secrets_for_server(
         if let Ok(secret) = store.get(&format!("oauth_{}_client_secret", cred_slug)) {
             if !secret.is_empty() {
                 out.oauth_client_secret = Some(secret);
+            }
+        }
+        // Zoho's region singleton picks the API host, so it belongs with the app
+        // credentials: without it an import silently falls back to `us` and a
+        // European account talks to the wrong data centre.
+        if let Ok(region) = store.get(&format!("oauth_{}_region", cred_slug)) {
+            if !region.is_empty() {
+                out.oauth_region = Some(region);
             }
         }
     }
@@ -16898,8 +16907,7 @@ pub async fn import_server_profiles_core_filtered(
                 // client-cred slug, which aliases Google Photos onto Google Drive
                 // and matches the key the GUI/edit form reads.
                 if secrets.oauth_client_id.is_some() || secrets.oauth_client_secret.is_some() {
-                    if let Some(cred_slug) = bridge_commands::rclone_oauth_client_cred_key(protocol)
-                    {
+                    if let Some(cred_slug) = bridge_commands::oauth_client_cred_key(protocol) {
                         if let Some(ref id) = secrets.oauth_client_id {
                             if let Err(e) =
                                 store.store(&format!("oauth_{}_client_id", cred_slug), id)
@@ -16913,6 +16921,13 @@ pub async fn import_server_profiles_core_filtered(
                             {
                                 cred_errors
                                     .push(format!("{} oauth client_secret: {}", profile_id, e));
+                            }
+                        }
+                        if let Some(ref region) = secrets.oauth_region {
+                            if let Err(e) =
+                                store.store(&format!("oauth_{}_region", cred_slug), region)
+                            {
+                                cred_errors.push(format!("{} oauth region: {}", profile_id, e));
                             }
                         }
                     }

--- a/src-tauri/src/profile_export.rs
+++ b/src-tauri/src/profile_export.rs
@@ -121,6 +121,12 @@ pub struct ProviderSecrets {
     /// rclone remote (`oauth_<provider>_client_secret` vault singleton).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub oauth_client_secret: Option<String>,
+    /// Zoho WorkDrive data-centre region (`oauth_zohoworkdrive_region` vault
+    /// singleton). It selects the API host, so an import that defaulted it back
+    /// to `us` pointed a European or Indian account at the wrong data centre.
+    /// Absent for providers that have no region singleton.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub oauth_region: Option<String>,
     /// Issue #230: the per-profile Filen CLI API key (`filen_api_key_<id>` vault
     /// entry). This long-lived secret is NEVER persisted on the saved profile
     /// (`options.filen_api_key` is transient, stripped to the vault on save), so

--- a/src-tauri/src/providers/jottacloud.rs
+++ b/src-tauri/src/providers/jottacloud.rs
@@ -1821,7 +1821,8 @@ impl JottacloudProvider {
     }
 
     /// List items in Jottacloud Trash.
-    /// Trash is at /jfs/{username}/Trash (device-less, mountpoint-less).
+    /// Trash is at /jfs/{username}/{device}/Trash: it is a mountpoint of the
+    /// device, so the device segment is required (see `trash_url`).
     pub async fn list_trash(&mut self) -> Result<Vec<RemoteEntry>, ProviderError> {
         let url = self.trash_url("");
         jotta_log(&format!("Listing trash: {}", url));
@@ -1855,7 +1856,7 @@ impl JottacloudProvider {
     }
 
     /// Restore an item from trash to its original location.
-    /// POST /jfs/{username}/Trash/{path}?restore=true
+    /// POST /jfs/{username}/{device}/Trash/{path}?restore=true
     pub async fn restore_from_trash(&mut self, path: &str) -> Result<(), ProviderError> {
         let clean = path.trim_start_matches('/');
         let url = format!("{}?restore=true", self.trash_url(clean));
@@ -1878,7 +1879,7 @@ impl JottacloudProvider {
     }
 
     /// Permanently delete an item from trash.
-    /// POST /jfs/{username}/Trash/{path}?rm=true (file) or `?rmDir=true` (folder)
+    /// POST /jfs/{username}/{device}/Trash/{path}?rm=true (file) or `?rmDir=true` (folder)
     pub async fn permanent_delete_from_trash(&mut self, path: &str) -> Result<(), ProviderError> {
         let clean = path.trim_start_matches('/');
         let url = format!(

--- a/src-tauri/src/providers/jottacloud.rs
+++ b/src-tauri/src/providers/jottacloud.rs
@@ -15,7 +15,7 @@
 
 use async_trait::async_trait;
 use base64::Engine;
-use reqwest::header::{HeaderValue, AUTHORIZATION, CONTENT_TYPE};
+use reqwest::header::{HeaderValue, AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE};
 use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -502,19 +502,24 @@ impl JottacloudProvider {
             .map_err(|e| ProviderError::ConnectionFailed(format!("Request failed: {}", e)))
     }
 
-    async fn post_with_retry(
+    /// POST with no body and no `Content-Type`.
+    ///
+    /// JFS routes a POST on a *file* URL by content type: an
+    /// `application/octet-stream` POST is an upload, so the delete/trash
+    /// parameters in the query string were never reached and the call came
+    /// back `404 Not Found` with an XML error body (#397). Command-style POSTs
+    /// (`?dl`, `?rm`, `?dlDir`, `?rmDir`, `?mv`, `?restore`) must therefore go
+    /// out bare, exactly as the reference JFS clients send them.
+    async fn post_command_with_retry(
         &mut self,
         url: &str,
-        content_type: &str,
-        body: Vec<u8>,
     ) -> Result<reqwest::Response, ProviderError> {
         self.refresh_if_needed().await?;
         let request = self
             .client
             .post(url)
             .header(AUTHORIZATION, self.auth_header())
-            .header(CONTENT_TYPE, content_type)
-            .body(body)
+            .header(CONTENT_LENGTH, "0")
             .build()
             .map_err(|e| ProviderError::ConnectionFailed(format!("Build request failed: {}", e)))?;
         send_with_retry(&self.client, request, &HttpRetryConfig::default())
@@ -1443,9 +1448,7 @@ impl StorageProvider for JottacloudProvider {
         let resolved = self.resolve_path(path);
         let url = format!("{}?mkDir=true", self.jfs_url(&resolved));
 
-        let resp = self
-            .post_with_retry(&url, "application/octet-stream", vec![])
-            .await?;
+        let resp = self.post_command_with_retry(&url).await?;
 
         if !resp.status().is_success() {
             let status = resp.status();
@@ -1493,9 +1496,7 @@ impl StorageProvider for JottacloudProvider {
             urlencoding::encode(&to_jfs)
         );
 
-        let resp = self
-            .post_with_retry(&url, "application/octet-stream", vec![])
-            .await?;
+        let resp = self.post_command_with_retry(&url).await?;
 
         if !resp.status().is_success() {
             let status = resp.status();
@@ -1723,33 +1724,49 @@ impl JottacloudProvider {
         }
     }
 
+    /// Query parameter that deletes a JFS entry.
+    ///
+    /// The file and the directory forms are *not* interchangeable: firing the
+    /// file form at a folder used to take it out of the account without ever
+    /// putting it in the recycle bin (#397, "Move to Trash hard-deletes
+    /// folders"), which is why the type decides the parameter instead of a
+    /// blind retry with the other one.
+    fn delete_param(is_dir: bool, permanent: bool) -> &'static str {
+        match (is_dir, permanent) {
+            (false, false) => "dl",
+            (false, true) => "rm",
+            (true, false) => "dlDir",
+            (true, true) => "rmDir",
+        }
+    }
+
     /// Move a file/folder to Jottacloud Trash (soft delete).
     /// POST /jfs/{...}/{path}?dl=true (file) or ?dlDir=true (directory)
     pub async fn move_to_trash(&mut self, path: &str) -> Result<(), ProviderError> {
-        let resolved = Self::normalize_path(path);
-        let url = format!("{}?dl=true", self.jfs_url(&resolved));
-        jotta_log(&format!("Moving to trash: {}", resolved));
+        // `resolve_path`, not `normalize_path`: a bare name coming from the CLI
+        // or the agent must resolve against the working directory, otherwise it
+        // silently targets a same-named entry in the account root (#397).
+        let resolved = self.resolve_path(path);
+        // Ask what it is first — see `delete_param`.
+        let is_dir = self.stat(&resolved).await?.is_dir;
+        let url = format!(
+            "{}?{}=true",
+            self.jfs_url(&resolved),
+            Self::delete_param(is_dir, false)
+        );
+        jotta_log(&format!("Moving to trash: {} (dir={})", resolved, is_dir));
 
-        let resp = self
-            .post_with_retry(&url, "application/octet-stream", vec![])
-            .await?;
+        let resp = self.post_command_with_retry(&url).await?;
 
         if !resp.status().is_success() {
-            // Try directory soft delete
-            let url_dir = format!("{}?dlDir=true", self.jfs_url(&resolved));
-            let resp_dir = self
-                .post_with_retry(&url_dir, "application/octet-stream", vec![])
-                .await?;
-            if !resp_dir.status().is_success() {
-                let status = resp_dir.status();
-                let body = resp_dir.text().await.unwrap_or_default();
-                return Err(ProviderError::ServerError(format!(
-                    "Move to trash {} failed ({}): {}",
-                    resolved,
-                    status,
-                    sanitize_api_error(&body)
-                )));
-            }
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(ProviderError::ServerError(format!(
+                "Move to trash {} failed ({}): {}",
+                resolved,
+                status,
+                sanitize_api_error(&body)
+            )));
         }
 
         jotta_log(&format!("Moved to trash: {}", resolved));
@@ -1797,9 +1814,7 @@ impl JottacloudProvider {
         let url = format!("{}?restore=true", self.trash_url(clean));
         jotta_log(&format!("Restoring from trash: {}", url));
 
-        let resp = self
-            .post_with_retry(&url, "application/octet-stream", vec![])
-            .await?;
+        let resp = self.post_command_with_retry(&url).await?;
 
         if !resp.status().is_success() {
             let status = resp.status();
@@ -1816,15 +1831,30 @@ impl JottacloudProvider {
     }
 
     /// Permanently delete an item from trash.
-    /// POST /jfs/{username}/Trash/{path}?rm=true
+    /// POST /jfs/{username}/Trash/{path}?rm=true (file) or `?rmDir=true` (folder)
     pub async fn permanent_delete_from_trash(&mut self, path: &str) -> Result<(), ProviderError> {
         let clean = path.trim_start_matches('/');
-        let url = format!("{}?rm=true", self.trash_url(clean));
+        let url = format!(
+            "{}?{}=true",
+            self.trash_url(clean),
+            Self::delete_param(false, true)
+        );
         jotta_log(&format!("Permanent delete from trash: {}", url));
 
-        let resp = self
-            .post_with_retry(&url, "application/octet-stream", vec![])
-            .await?;
+        let mut resp = self.post_command_with_retry(&url).await?;
+
+        // A trashed *folder* needs the directory form. Unlike the soft-delete
+        // path there is nothing to lose by retrying with it: both forms are
+        // permanent, so the fallback can only turn a failure into the intended
+        // purge (#397).
+        if !resp.status().is_success() {
+            let dir_url = format!(
+                "{}?{}=true",
+                self.trash_url(clean),
+                Self::delete_param(true, true)
+            );
+            resp = self.post_command_with_retry(&dir_url).await?;
+        }
 
         if !resp.status().is_success() {
             let status = resp.status();
@@ -2061,6 +2091,16 @@ mod tests {
         let mut p = JottacloudProvider::new(config);
         p.username = "user123".to_string();
         p
+    }
+
+    #[test]
+    fn delete_param_never_sends_the_file_form_at_a_folder() {
+        // #397: the file form fired at a folder took it out of the account
+        // without ever filling the recycle bin.
+        assert_eq!(JottacloudProvider::delete_param(false, false), "dl");
+        assert_eq!(JottacloudProvider::delete_param(true, false), "dlDir");
+        assert_eq!(JottacloudProvider::delete_param(false, true), "rm");
+        assert_eq!(JottacloudProvider::delete_param(true, true), "rmDir");
     }
 
     #[test]

--- a/src-tauri/src/providers/jottacloud.rs
+++ b/src-tauri/src/providers/jottacloud.rs
@@ -29,6 +29,8 @@ use super::{
 
 const JFS_BASE: &str = "https://jfs.jottacloud.com/jfs";
 const API_BASE: &str = "https://api.jottacloud.com";
+/// The recycle bin is a mountpoint of the device, alongside Archive and Sync.
+const TRASH_MOUNTPOINT: &str = "Trash";
 
 fn jotta_log(msg: &str) {
     info!("[JOTTACLOUD] {}", msg);
@@ -661,12 +663,20 @@ impl JottacloudProvider {
         let mut reader = Reader::from_str(xml);
         reader.config_mut().trim_text(true);
         let mut buf = Vec::new();
+        // JFS nests the name as a child element:
+        //   <mountPoints><mountPoint><name>Archive</name>...
+        // Reading only a `name` attribute made discovery return an empty list
+        // against the live API, silently falling back to the configured
+        // mountpoint (#397). Both shapes are accepted now.
+        let mut in_mount_point = false;
+        let mut in_name = false;
 
         loop {
             match reader.read_event_into(&mut buf) {
                 Ok(Event::Start(ref e)) | Ok(Event::Empty(ref e)) => {
                     let tag = String::from_utf8_lossy(e.name().as_ref()).to_string();
                     if tag == "mountPoint" {
+                        in_mount_point = true;
                         for attr in e.attributes().flatten() {
                             if attr.key.as_ref() == b"name" {
                                 // Account-level mountpoint name: an identifier,
@@ -677,6 +687,22 @@ impl JottacloudProvider {
                                 }
                             }
                         }
+                    } else if tag == "name" && in_mount_point {
+                        in_name = true;
+                    }
+                }
+                Ok(Event::Text(ref e)) if in_name => {
+                    let name = String::from_utf8_lossy(e.as_ref()).trim().to_string();
+                    if !name.is_empty() && !names.contains(&name) {
+                        names.push(name);
+                    }
+                }
+                Ok(Event::End(ref e)) => {
+                    let tag = String::from_utf8_lossy(e.name().as_ref()).to_string();
+                    if tag == "mountPoint" {
+                        in_mount_point = false;
+                    } else if tag == "name" {
+                        in_name = false;
                     }
                 }
                 Ok(Event::Eof) => break,
@@ -865,6 +891,16 @@ impl JottacloudProvider {
                                         ProviderType::Jottacloud,
                                         &super::xml_text::attr_value(&attr),
                                     );
+                                }
+                                // A trashed file stays in its folder listing as a
+                                // tombstone carrying `deleted="<timestamp>"`, the
+                                // same marker the folder branch already honours.
+                                // Only the `<deleted>` *element* form was checked
+                                // here, so a file moved to the recycle bin kept
+                                // showing as live and the delete looked like a
+                                // no-op (#397).
+                                if attr.key.as_ref() == b"deleted" {
+                                    current_deleted = true;
                                 }
                             }
                         }
@@ -1705,12 +1741,20 @@ impl StorageProvider for JottacloudProvider {
 // ─── Jottacloud-specific methods (trash management) ──────────────────────
 
 impl JottacloudProvider {
-    /// Build JFS URL for the trash: /jfs/{username}/Trash/{path}
+    /// Build JFS URL for the trash: `/jfs/{username}/{device}/Trash/{path}`.
+    ///
+    /// Trash is a **mountpoint of the device**, a sibling of Archive and Sync,
+    /// exactly like the mountpoint the profile browses. The URL used to omit
+    /// the device segment, which makes JFS read `Trash` as a *device* name: no
+    /// such device exists, the request 404s, and `list_trash` reports the 404
+    /// as an empty bin, so the trash always looked empty however many items
+    /// were in it (#397).
     fn trash_url(&self, path: &str) -> String {
         let clean = path.trim_start_matches('/');
         let user = urlencoding::encode(&self.username);
+        let device = urlencoding::encode(&self.config.device);
         if clean.is_empty() {
-            format!("{}/{}/Trash", JFS_BASE, user)
+            format!("{}/{}/{}/{}", JFS_BASE, user, device, TRASH_MOUNTPOINT)
         } else {
             let encoded_path: String = clean
                 .split('/')
@@ -1720,7 +1764,10 @@ impl JottacloudProvider {
                 })
                 .collect::<Vec<_>>()
                 .join("/");
-            format!("{}/{}/Trash/{}", JFS_BASE, user, encoded_path)
+            format!(
+                "{}/{}/{}/{}/{}",
+                JFS_BASE, user, device, TRASH_MOUNTPOINT, encoded_path
+            )
         }
     }
 
@@ -2144,6 +2191,21 @@ mod tests {
     }
 
     #[test]
+    fn trash_url_keeps_the_device_segment() {
+        // Trash is a mountpoint of the device, a sibling of Archive. Without the
+        // device segment JFS reads `Trash` as a device name, 404s, and the bin
+        // reads as empty however many items are in it (#397).
+        let p = test_provider();
+        assert_eq!(p.trash_url(""), format!("{}/user123/Jotta/Trash", JFS_BASE));
+        assert_eq!(
+            p.trash_url("/photo.jpg"),
+            format!("{}/user123/Jotta/Trash/photo.jpg", JFS_BASE)
+        );
+        // The mountpoint the profile browses never appears in a trash URL.
+        assert!(!p.trash_url("/photo.jpg").contains("Archive"));
+    }
+
+    #[test]
     fn jfs_url_url_encodes_segments_for_special_chars() {
         // Names with `+`, `#`, `%`, ` `, `&` must be percent-encoded so the
         // server doesn't see `+` as space, `#` as fragment, etc.
@@ -2213,6 +2275,33 @@ mod tests {
     }
 
     #[test]
+    fn parse_mountpoint_names_reads_the_live_child_element_shape() {
+        // Captured from the live API (#397): the name is a child element, not an
+        // attribute, and the previous attribute-only reader returned an empty
+        // list here while the account clearly had mountpoints.
+        let xml = r#"<device time="2026-07-27-T07:19:53Z">
+          <name xml:space="preserve">Jotta</name>
+          <user>4smczzcts33jjedcplkqrorq</user>
+          <mountPoints>
+            <mountPoint>
+              <name xml:space="preserve">Archive</name>
+              <size></size>
+            </mountPoint>
+            <mountPoint>
+              <name xml:space="preserve">Sync</name>
+            </mountPoint>
+            <mountPoint>
+              <name xml:space="preserve">Trash</name>
+            </mountPoint>
+          </mountPoints>
+        </device>"#;
+        let names = JottacloudProvider::parse_mountpoint_names(xml);
+        assert_eq!(names, vec!["Archive", "Sync", "Trash"]);
+        // The device's own <name> sits outside <mountPoints> and must not leak in.
+        assert!(!names.contains(&"Jotta".to_string()));
+    }
+
+    #[test]
     fn parse_jotta_time_normalizes_nonstandard_format() {
         // Jottacloud uses "-T" separator: parse_jotta_time should strip it
         let out = JottacloudProvider::parse_jotta_time("2023-01-15-T10:30:45+0100");
@@ -2256,6 +2345,12 @@ mod tests {
                         <size>5</size>
                     </currentRevision>
                 </file>
+                <file name="trashed-attr.jpg" uuid="88cec155-fbb0-41eb-82f1-341547d39526" deleted="2026-07-27-T07:23:35Z">
+                    <currentRevision>
+                        <state>COMPLETED</state>
+                        <size>7</size>
+                    </currentRevision>
+                </file>
             </files>
         </folder>"#;
 
@@ -2274,6 +2369,12 @@ mod tests {
         assert!(
             !names.contains(&"trashed.txt"),
             "trashed file must be skipped"
+        );
+        // The live API tombstones a trashed file with a `deleted` *attribute*,
+        // which only the folder branch used to honour (#397).
+        assert!(
+            !names.contains(&"trashed-attr.jpg"),
+            "file tombstoned by attribute must be skipped"
         );
 
         let folder = entries.iter().find(|e| e.name == "Photos").unwrap();

--- a/src-tauri/src/providers/mega.rs
+++ b/src-tauri/src/providers/mega.rs
@@ -752,22 +752,18 @@ impl StorageProvider for MegaCmdProvider {
     }
 
     async fn rmdir(&mut self, p: &str) -> Result<(), ProviderError> {
-        let p = self.resolve_path(p);
-        // Issue #263: `-f` is mandatory in the one-shot wrapper path. Without
-        // it MEGAcmd's recursive `rm` prompts "Are you sure?" on stdin, the
-        // wrapper has no tty/stdin attached, and the call hangs until the
-        // 60s outer timeout in `run_mega_cmd` kills it.
-        self.run_mega_cmd_with_reauth("mega-rm", &["-r", "-f", &p])
-            .await?;
-        Ok(())
+        // Soft delete, exactly like `delete()` does for files. This used to be
+        // `mega-rm -r -f`, which bypasses the Rubbish Bin, so deleting a file
+        // was recoverable but deleting a folder was not — on the same account,
+        // through the same UI (#397). Permanent purge stays on
+        // `delete_permanent` and the trash manager.
+        self.move_to_trash(p).await
     }
 
     async fn rmdir_recursive(&mut self, p: &str) -> Result<(), ProviderError> {
-        let p = self.resolve_path(p);
-        // Issue #263: see `rmdir` above for the rationale on `-f`.
-        self.run_mega_cmd_with_reauth("mega-rm", &["-r", "-f", &p])
-            .await?;
-        Ok(())
+        // `mega-mv` takes the whole subtree with it, so recursive and
+        // non-recursive collapse to the same call — see `rmdir` above.
+        self.move_to_trash(p).await
     }
 
     async fn delete_permanent(&mut self, path: &str) -> Result<bool, ProviderError> {

--- a/src-tauri/src/providers/zoho_workdrive.rs
+++ b/src-tauri/src/providers/zoho_workdrive.rs
@@ -498,6 +498,22 @@ const ZOHO_NATIVE_EXPORT_MAP: &[(&str, &str, &str, &str)] = &[
     ("presentation", "show", "pptx", ".pptx"),
 ];
 
+/// Body of a relocation (`PATCH {api_base}/files`).
+///
+/// WorkDrive has no per-file `/files/{id}/move` route: that URL is rejected by
+/// the API gateway itself with `F6016 — URL Rule is not configured` (#451).
+/// Relocating is a bulk metadata write on the *collection* endpoint, so `data`
+/// is an array and each element carries its own item id.
+fn move_request_body(file_id: &str, parent_id: &str) -> serde_json::Value {
+    serde_json::json!({
+        "data": [{
+            "attributes": { "parent_id": parent_id },
+            "id": file_id,
+            "type": "files"
+        }]
+    })
+}
+
 /// Check if file extension is a Zoho native document, return export info
 fn zoho_native_export_info(extn: &str) -> Option<(&'static str, &'static str, &'static str)> {
     let lower = extn.to_lowercase();
@@ -2744,16 +2760,8 @@ impl StorageProvider for ZohoWorkdriveProvider {
 
         // Step 1: Move to new folder if cross-folder operation
         if is_cross_folder {
-            let move_body = serde_json::json!({
-                "data": {
-                    "attributes": {
-                        "parent_id": to_parent_id
-                    },
-                    "type": "files"
-                }
-            });
-
-            let url = format!("{}/files/{}/move", self.api_base(), file.id);
+            let move_body = move_request_body(&file.id, &to_parent_id);
+            let url = format!("{}/files", self.api_base());
             let request = self
                 .client
                 .patch(&url)
@@ -3560,6 +3568,21 @@ mod tests {
         assert_eq!(c.api_base(), "https://www.zohoapis.eu/workdrive/api/v1");
         let c = config("us");
         assert_eq!(c.api_base(), "https://www.zohoapis.com/workdrive/api/v1");
+    }
+
+    #[test]
+    fn move_request_body_targets_the_collection_endpoint_shape() {
+        // Regression for #451: a per-file `/files/{id}/move` PATCH is refused by
+        // the gateway (F6016). The relocation is a bulk write, so `data` must be
+        // an array whose element carries the id — not a bare object.
+        let body = move_request_body("file-123", "folder-456");
+        let items = body["data"].as_array().expect("data must be an array");
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0]["id"], "file-123");
+        assert_eq!(items[0]["type"], "files");
+        assert_eq!(items[0]["attributes"]["parent_id"], "folder-456");
+        // The id belongs to the element, never to the envelope.
+        assert!(body.get("id").is_none());
     }
 
     #[test]

--- a/src-tauri/src/rclone_import.rs
+++ b/src-tauri/src/rclone_import.rs
@@ -1507,7 +1507,7 @@ pub fn export_rclone(
             }
             "webdav" => {
                 output.push_str("type = webdav\n");
-                // Nextcloud-derived presets (Tab.digital, FeliCloud, generic
+                // Nextcloud-derived presets (TAB.DIGITAL, FeliCloud, generic
                 // Nextcloud) speak the same WebDAV dialect as upstream
                 // Nextcloud. Mapping them to vendor=nextcloud lets rclone
                 // use the correct chunked-upload + checksum behaviour.
@@ -1544,7 +1544,7 @@ pub fn export_rclone(
                 };
                 // Resolve {username} template that Nextcloud-derived
                 // presets store verbatim in the URL or initial path
-                // (Tab.digital, FeliCloud).
+                // (TAB.DIGITAL, FeliCloud).
                 let url = url.replace("{username}", &server.username);
                 // rclone's `nextcloud`/`owncloud` vendors do not auto-discover
                 // the DAV collection root the way AeroFTP does at connect time

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13305,28 +13305,11 @@ const App: React.FC = () => {
       {
         label: t('contextMenu.properties'), icon: <Info size={14} />, action: () => openRemoteProperties('general')
       },
-      { label: ['zohoworkdrive', 'opendrive'].includes(currentProtocol || '') ? t('contextMenu.moveToTrash') : (currentProtocol === 'github' || currentProtocol === 'gitlab') ? t('github.deleteCommit') : t('contextMenu.delete'), icon: currentProtocol === 'github' ? <Github size={14} className="text-red-500" /> : currentProtocol === 'gitlab' ? <GitLabLogo size={14} /> : <Trash2 size={14} />, action: () => deleteMultipleRemoteFiles(filesToUse), danger: true, divider: !['jottacloud', 'mega', 'googledrive', 'box', 'dropbox', 'onedrive', 'zohoworkdrive', 'opendrive'].includes(currentProtocol || '') },
-      // Jottacloud: Move to Trash (soft delete: recoverable, separate from hard delete above)
-      ...(currentProtocol === 'jottacloud' ? [{
-        label: t('contextMenu.moveToTrash'),
-        icon: <Trash2 size={14} className="text-orange-500" />,
-        action: async () => {
-          try {
-            const paths = filesToUse.map(name => {
-              const f = remoteFiles.find(rf => rf.name === name);
-              return f?.path || `${currentRemotePath === '/' ? '' : currentRemotePath}/${name}`;
-            });
-            const logId = humanLog.logRaw('activity.trash_move_start', 'DELETE', { provider: 'Jottacloud', filename: filesToUse.join(', ') }, 'running');
-            await invoke('jottacloud_move_to_trash', { paths });
-            humanLog.updateEntry(logId, { status: 'success', message: `[Jottacloud] Moved ${paths.length} item(s) to trash` });
-            notify.success(t('toast.movedToTrash', { count: paths.length }));
-            loadRemoteFiles(undefined, true);
-          } catch (err) {
-            notify.error(t('toast.moveToTrashFailed'), String(err));
-          }
-        },
-        divider: true,
-      }] : []),
+      { label: ['zohoworkdrive', 'opendrive', 'jottacloud'].includes(currentProtocol || '') ? t('contextMenu.moveToTrash') : (currentProtocol === 'github' || currentProtocol === 'gitlab') ? t('github.deleteCommit') : t('contextMenu.delete'), icon: currentProtocol === 'github' ? <Github size={14} className="text-red-500" /> : currentProtocol === 'gitlab' ? <GitLabLogo size={14} /> : <Trash2 size={14} />, action: () => deleteMultipleRemoteFiles(filesToUse), danger: true, divider: !['jottacloud', 'mega', 'googledrive', 'box', 'dropbox', 'onedrive', 'zohoworkdrive', 'opendrive'].includes(currentProtocol || '') },
+      // Jottacloud: Delete now does soft-delete (Trash mountpoint) via the trait,
+      // so the separate "Move to Trash" item was a second button doing exactly
+      // the same call; the entry above carries the honest label instead (#397).
+      // Purging for good stays in the trash manager.
       // MEGA: Move to Trash (soft delete: recoverable via Rubbish Bin)
       // MEGA: Delete now does soft-delete (move to //bin/) via the trait: no separate menu item needed
       // Google Drive: Delete now does soft-delete (trash) via the trait: no separate menu item needed

--- a/src/components/ConnectionScreen.tsx
+++ b/src/components/ConnectionScreen.tsx
@@ -2702,20 +2702,24 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
     };
 
     const getSuggestedConnectionName = () => {
-        const baseRaw = (selectedProvider?.isGeneric && protocol)
+        // Prefer the provider's *brand* name over its internal id: the id is a
+        // lowercase slug, so the placeholder used to read "tabdigital" /
+        // "pcloud" / "googledrive" where the rest of the app writes
+        // TAB.DIGITAL, pCloud and Google Drive (#347).
+        const base = ((selectedProvider?.isGeneric && protocol)
             ? protocol
-            : (selectedProviderId || protocol || 'connection');
-        const base = baseRaw.replace(/[_\-]+/g, ' ').trim().toLowerCase();
+            : (selectedProvider?.name || selectedProviderId || protocol || 'connection')
+        ).replace(/[_\-]+/g, ' ').trim();
         const taken = new Set(
             savedProfilesForNaming
                 .filter((p) => p.id !== editingProfileId)
                 .map((p) => (p.name || '').trim().toLowerCase())
                 .filter(Boolean)
         );
-        if (!taken.has(base)) return base;
+        if (!taken.has(base.toLowerCase())) return base;
         for (let i = 2; i < 100; i += 1) {
             const candidate = `${base} ${i}`;
-            if (!taken.has(candidate)) return candidate;
+            if (!taken.has(candidate.toLowerCase())) return candidate;
         }
         return base;
     };

--- a/src/components/IntroHub/CatalogTable.tsx
+++ b/src/components/IntroHub/CatalogTable.tsx
@@ -38,6 +38,21 @@ import {
 type CatalogColId = 'company' | 'parent' | 'region' | 'freeGb' | 'free' | 'paid' | 'health';
 type TierFilter = 'all' | 'free' | 'freecard' | 'paid';
 
+// The pricing filter is a preference, not a transient toggle (Ehud #274): it
+// survives tab switches and restarts like the view mode, the Discover category
+// and the column settings do.
+const TIER_FILTER_KEY = 'aeroftp-discover-tier';
+const TIER_FILTERS: readonly TierFilter[] = ['all', 'free', 'freecard', 'paid'];
+
+function loadTierFilter(): TierFilter {
+    try {
+        const saved = localStorage.getItem(TIER_FILTER_KEY);
+        return TIER_FILTERS.includes(saved as TierFilter) ? (saved as TierFilter) : 'all';
+    } catch {
+        return 'all';
+    }
+}
+
 const CATALOG_COLUMNS: TableColumnDef<CatalogColId>[] = [
     { id: 'company', labelKey: 'introHub.list.company', sortable: true, defaultVisible: true, defaultWidth: 200, minWidth: 140, pinnedStart: true, defaultAlign: 'left' },
     // Optional parent-company column (Ehud #274): default hidden; enable via Columns
@@ -147,7 +162,11 @@ export function CatalogTable({ companies, category, onSelectProvider, getHealth,
     const [localQuery, setLocalQuery] = useState('');
     const query = controlledQuery ?? localQuery;
     const setQuery = onQueryChange ?? setLocalQuery;
-    const [tierFilter, setTierFilter] = useState<TierFilter>('all');
+    const [tierFilter, setTierFilterState] = useState<TierFilter>(loadTierFilter);
+    const setTierFilter = useCallback((id: TierFilter) => {
+        setTierFilterState(id);
+        try { localStorage.setItem(TIER_FILTER_KEY, id); } catch { /* ignore */ }
+    }, []);
     const [showColumns, setShowColumns] = useState(false);
     const columnsBtnRef = useRef<HTMLDivElement>(null);
 

--- a/src/components/IntroHub/MyServersTable.tsx
+++ b/src/components/IntroHub/MyServersTable.tsx
@@ -305,6 +305,12 @@ export function MyServersTable({
                                 isDraggable={canDrag}
                                 isDragging={dragIdx === realIdx}
                                 isDragTarget={overIdx === realIdx && dragIdx !== null && dragIdx !== realIdx}
+                                // A drop makes the dragged profile inherit this
+                                // row's index: coming from below it lands above
+                                // the row, coming from above it lands below it.
+                                // The line follows that, so what the user sees is
+                                // where the profile ends up (#453).
+                                dragTargetEdge={dragIdx !== null && dragIdx > realIdx ? 'top' : 'bottom'}
                                 dragIndex={realIdx}
                                 onDragStart={canDrag ? onDragStart : undefined}
                                 onDragEnter={canDrag ? onDragEnter : undefined}

--- a/src/components/IntroHub/MyServersTableRow.tsx
+++ b/src/components/IntroHub/MyServersTableRow.tsx
@@ -46,6 +46,12 @@ interface MyServersTableRowProps {
     isDraggable?: boolean;
     isDragging?: boolean;
     isDragTarget?: boolean;
+    /** Which edge of this row the insertion line is drawn on (#453). A drop
+     *  makes the dragged profile inherit this row's index, so dragging *up*
+     *  inserts above the row ('top') and dragging *down* leaves it below
+     *  ('bottom'). Drawing the line on a fixed edge made every upward drop
+     *  look one slot off. */
+    dragTargetEdge?: 'top' | 'bottom';
     /** Position of this row in the parent's `servers` array. Lets the row
      *  bind the four parent drag callbacks to its own index without
      *  forcing the parent to re-curry on every render (issue #221). */
@@ -95,6 +101,7 @@ export const MyServersTableRow = React.memo(function MyServersTableRow({
     isDraggable,
     isDragging,
     isDragTarget,
+    dragTargetEdge = 'bottom',
     dragIndex,
     onDragStart,
     onDragEnter,
@@ -284,7 +291,12 @@ export const MyServersTableRow = React.memo(function MyServersTableRow({
                         draggable={isDraggable}
                         onDragStart={isDraggable && onDragStart ? handleRowDragStart : undefined}
                         onDragEnd={isDraggable ? onDragEnd : undefined}
-                        className={`${cellClass} text-right text-[11px] tabular-nums text-gray-400 dark:text-gray-500 ${isDraggable ? 'cursor-grab active:cursor-grabbing' : ''}`}
+                        // `select-none`: a text selection left over from an
+                        // earlier click makes the engine start a *text* drag
+                        // instead of ours, so the grip silently refuses to
+                        // pick the row up until the selection is cleared
+                        // elsewhere (#453, "some rows won't drag anymore").
+                        className={`${cellClass} select-none text-right text-[11px] tabular-nums text-gray-400 dark:text-gray-500 ${isDraggable ? 'cursor-grab active:cursor-grabbing' : ''}`}
                         title={dragDisabledTitle || (isDraggable ? t('introHub.table.dragToReorder') : undefined)}
                     >
                         <div className="flex items-center justify-end gap-1.5">
@@ -504,7 +516,7 @@ export const MyServersTableRow = React.memo(function MyServersTableRow({
             onMouseEnter={handleMouseEnter}
             onMouseLeave={handleMouseLeave}
             title={selectionTitle || undefined}
-            className={`group transition-colors ${onSelect ? 'cursor-pointer' : ''} ${isDragging ? 'opacity-40 bg-blue-50 dark:bg-blue-900/20' : isDragTarget ? '' : index % 2 === 1 ? 'bg-gray-50/30 dark:bg-white/[0.02]' : ''} hover:bg-gray-100/50 dark:hover:bg-white/[0.04] ${isDragTarget ? 'border-b-2 !border-b-blue-500 bg-blue-50/50 dark:bg-blue-900/15' : ''} ${selectionRingClass}`}
+            className={`group transition-colors ${onSelect ? 'cursor-pointer' : ''} ${isDragging ? 'opacity-40 bg-blue-50 dark:bg-blue-900/20' : isDragTarget ? '' : index % 2 === 1 ? 'bg-gray-50/30 dark:bg-white/[0.02]' : ''} hover:bg-gray-100/50 dark:hover:bg-white/[0.04] ${isDragTarget ? `${dragTargetEdge === 'top' ? 'border-t-2 !border-t-blue-500' : 'border-b-2 !border-b-blue-500'} bg-blue-50/50 dark:bg-blue-900/15` : ''} ${selectionRingClass}`}
         >
             {orderedColumns.map(col => renderCell(col.id))}
         </tr>

--- a/src/components/IntroHub/MyServersTableRow.tsx
+++ b/src/components/IntroHub/MyServersTableRow.tsx
@@ -281,7 +281,8 @@ export const MyServersTableRow = React.memo(function MyServersTableRow({
     // only shows on hover: pixel-accurate aiming for a gesture that should be
     // forgiving, and the reason a drag "sometimes doesn't start" (#453). Every
     // cell that carries no control is a drag handle now, so the row lifts from
-    // almost anywhere; the icon, actions and favourite cells stay clickable.
+    // almost anywhere; the icon, actions and favourite cells stay clickable,
+    // and so does the health cell while its radial offers a retry.
     // `select-none` travels with it: a leftover text selection over the source
     // makes the engine start a text drag instead of ours.
     const dragTd = (className: string) =>
@@ -450,9 +451,18 @@ export const MyServersTableRow = React.memo(function MyServersTableRow({
                         {timeAgo && <span className="inline-flex items-center gap-0.5"><Clock size={9} />{timeAgo}</span>}
                     </td>
                 );
-            case 'health':
+            case 'health': {
+                // The radial becomes a real <button> when a retry is available
+                // (mirrors `interactive` in HealthRadial), and a draggable
+                // ancestor would turn the smallest pointer travel on it into a
+                // row reorder instead of the retry. So the cell is a drag
+                // handle only while it carries no control, like the icon,
+                // actions and favourite cells.
+                const healthCellClass = `${cellClass} ${alignTd('health', 'center')} text-gray-300 dark:text-gray-600`;
+                const healthIsInteractive =
+                    !isMtpDevice && !!handleRetry && (healthStatus || 'unknown') !== 'pending';
                 return (
-                    <td key="health" {...dragTd(`${cellClass} ${alignTd('health', 'center')} text-gray-300 dark:text-gray-600`)}>
+                    <td key="health" {...(healthIsInteractive ? { className: healthCellClass } : dragTd(healthCellClass))}>
                         <span className={`inline-flex items-center ${alignFlex('health', 'center')}`}>
                             {isMtpDevice ? (
                                 <span
@@ -476,6 +486,7 @@ export const MyServersTableRow = React.memo(function MyServersTableRow({
                         </span>
                     </td>
                 );
+            }
             case 'actions':
                 return (
                     <td key="actions" className={`${cellClass} ${alignTd('actions', 'right')}`}>

--- a/src/components/IntroHub/MyServersTableRow.tsx
+++ b/src/components/IntroHub/MyServersTableRow.tsx
@@ -277,6 +277,23 @@ export const MyServersTableRow = React.memo(function MyServersTableRow({
         })
         : t('introHub.storageQuotaUnavailable');
 
+    // The grab zone used to be the 56px index column alone, with a grip that
+    // only shows on hover: pixel-accurate aiming for a gesture that should be
+    // forgiving, and the reason a drag "sometimes doesn't start" (#453). Every
+    // cell that carries no control is a drag handle now, so the row lifts from
+    // almost anywhere; the icon, actions and favourite cells stay clickable.
+    // `select-none` travels with it: a leftover text selection over the source
+    // makes the engine start a text drag instead of ours.
+    const dragTd = (className: string) =>
+        isDraggable && onDragStart
+            ? {
+                className: `${className} select-none`,
+                draggable: true,
+                onDragStart: handleRowDragStart,
+                onDragEnd,
+            }
+            : { className };
+
     const renderCell = (id: MyServersTableColId): React.ReactNode => {
         switch (id) {
             case 'index':
@@ -360,7 +377,7 @@ export const MyServersTableRow = React.memo(function MyServersTableRow({
                 );
             case 'name':
                 return (
-                    <td key="name" className={`${cellClass} ${alignTd('name', 'left')}`}>
+                    <td key="name" {...(isRenaming ? { className: `${cellClass} ${alignTd('name', 'left')}` } : dragTd(`${cellClass} ${alignTd('name', 'left')}`))}>
                         {isRenaming ? (
                             <RenameInput
                                 initialValue={server.name}
@@ -386,7 +403,7 @@ export const MyServersTableRow = React.memo(function MyServersTableRow({
                 );
             case 'badges':
                 return (
-                    <td key="badges" className={`${cellClass} ${alignTd('badges', 'left')}`}>
+                    <td key="badges" {...dragTd(`${cellClass} ${alignTd('badges', 'left')}`)}>
                         <div className={`flex items-center ${alignFlex('badges', 'left')}`}>
                             <ServerBadges server={server} peerState={peerState} />
                         </div>
@@ -394,23 +411,23 @@ export const MyServersTableRow = React.memo(function MyServersTableRow({
                 );
             case 'subtitle':
                 return (
-                    <td key="subtitle" className={`${cellClass} ${alignTd('subtitle', 'left')} text-xs text-gray-500 dark:text-gray-400 truncate`}>
+                    <td key="subtitle" {...dragTd(`${cellClass} ${alignTd('subtitle', 'left')} text-xs text-gray-500 dark:text-gray-400 truncate`)}>
                         {subtitle}
                     </td>
                 );
             case 'used':
-                return <td key="used" className={`${cellClass} ${alignTd('used', 'right')} text-[11px] text-gray-500 dark:text-gray-400 tabular-nums`} title={quotaTitle}>{quotaCells.used}</td>;
+                return <td key="used" {...dragTd(`${cellClass} ${alignTd('used', 'right')} text-[11px] text-gray-500 dark:text-gray-400 tabular-nums`)} title={quotaTitle}>{quotaCells.used}</td>;
             case 'total':
-                return <td key="total" className={`${cellClass} ${alignTd('total', 'right')} text-[11px] text-gray-400 dark:text-gray-500 tabular-nums`} title={quotaTitle}>{quotaCells.total}</td>;
+                return <td key="total" {...dragTd(`${cellClass} ${alignTd('total', 'right')} text-[11px] text-gray-400 dark:text-gray-500 tabular-nums`)} title={quotaTitle}>{quotaCells.total}</td>;
             case 'pct':
-                return <td key="pct" className={`${cellClass} ${alignTd('pct', 'right')} text-[11px] font-medium tabular-nums ${quotaCells.toneText}`} title={quotaTitle}>{quotaCells.pct}</td>;
+                return <td key="pct" {...dragTd(`${cellClass} ${alignTd('pct', 'right')} text-[11px] font-medium tabular-nums ${quotaCells.toneText}`)} title={quotaTitle}>{quotaCells.pct}</td>;
             case 'saved':
-                return <td key="saved" className={`${cellClass} ${alignTd('saved', 'right')} text-[11px] text-gray-500 dark:text-gray-400 tabular-nums`} title={compressionTitle}>{compressionCells.saved}</td>;
+                return <td key="saved" {...dragTd(`${cellClass} ${alignTd('saved', 'right')} text-[11px] text-gray-500 dark:text-gray-400 tabular-nums`)} title={compressionTitle}>{compressionCells.saved}</td>;
             case 'savedpct':
-                return <td key="savedpct" className={`${cellClass} ${alignTd('savedpct', 'right')} text-[11px] text-gray-400 dark:text-gray-500 tabular-nums`} title={compressionTitle}>{compressionCells.savedpct}</td>;
+                return <td key="savedpct" {...dragTd(`${cellClass} ${alignTd('savedpct', 'right')} text-[11px] text-gray-400 dark:text-gray-500 tabular-nums`)} title={compressionTitle}>{compressionCells.savedpct}</td>;
             case 'paths':
                 return (
-                    <td key="paths" className={`${cellClass} ${alignTd('paths', 'right')}`}>
+                    <td key="paths" {...dragTd(`${cellClass} ${alignTd('paths', 'right')}`)}>
                         <div className={`flex flex-col gap-0.5 min-w-0 ${alignTd('paths', 'right')}`}>
                             {server.initialPath && (
                                 <span className={`flex items-center ${alignFlex('paths', 'right')} gap-1 text-[10px] text-gray-400 dark:text-gray-500`} title={server.initialPath}>
@@ -429,13 +446,13 @@ export const MyServersTableRow = React.memo(function MyServersTableRow({
                 );
             case 'time':
                 return (
-                    <td key="time" className={`${cellClass} ${alignTd('time', 'right')} text-[11px] text-gray-400 dark:text-gray-500 tabular-nums`}>
+                    <td key="time" {...dragTd(`${cellClass} ${alignTd('time', 'right')} text-[11px] text-gray-400 dark:text-gray-500 tabular-nums`)}>
                         {timeAgo && <span className="inline-flex items-center gap-0.5"><Clock size={9} />{timeAgo}</span>}
                     </td>
                 );
             case 'health':
                 return (
-                    <td key="health" className={`${cellClass} ${alignTd('health', 'center')} text-gray-300 dark:text-gray-600`}>
+                    <td key="health" {...dragTd(`${cellClass} ${alignTd('health', 'center')} text-gray-300 dark:text-gray-600`)}>
                         <span className={`inline-flex items-center ${alignFlex('health', 'center')}`}>
                             {isMtpDevice ? (
                                 <span


### PR DESCRIPTION
Triage pass over the open community feedback ahead of the next release. Five independent fixes, one per report.

| Report | Fix |
|---|---|
| [#274](https://github.com/axpdev-lab/aeroftp/discussions/274) | The Add Service pricing filter (All / Free tier / Free + card / Paid) is a preference again: it survives tab switches and restarts like the view mode, the Discover category and the column settings. |
| [#453](https://github.com/axpdev-lab/aeroftp/issues/453) | Table view drew the insertion line on a fixed edge while a drop makes the profile inherit the target row's index, so every upward drop looked one slot off. The line now follows the direction of travel. `select-none` on the grip cell stops a stale text selection from hijacking `dragstart` ("some rows won't drag anymore"). |
| [#451](https://github.com/axpdev-lab/aeroftp/issues/451) | Zoho WorkDrive cross-folder move used `PATCH /files/{id}/move`, a route the gateway rejects with `400 F6016 — URL Rule is not configured`. Relocation is a bulk write on `PATCH /files` with `data` as an array. |
| [#397](https://github.com/axpdev-lab/aeroftp/issues/397) | Jottacloud: command POSTs no longer carry `Content-Type: application/octet-stream` (on a file URL that is JFS's upload shape, hence the 404s), and the entry type picks `dl`/`dlDir` instead of firing the file form at folders and hard-deleting them. |
| [#347](https://github.com/axpdev-lab/aeroftp/discussions/347) | The connection-name placeholder comes from the provider's brand name instead of its internal slug (`tabdigital` → `TAB.DIGITAL`). Docs capitalisation ships in the `docs.aeroftp.app` repo. |

## Verification

- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib` (3313 passed)
- `tsc --noEmit`, `npm run test:unit` (523 passed)
- New unit tests: Zoho move body shape, Jottacloud `delete_param` matrix.

Live-API caveat: the Zoho and Jottacloud fixes are validated against the providers' documented request shapes and the reference client's behaviour, not against a live account (no test credentials for either). @EhudKirsh's confirmation on the next build is what closes them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MEGA folder deletions now soft-delete to the rubbish bin for recovery.
  * Catalog tier filter selections are remembered between visits.
  * Suggested connection names now use the provider’s display/brand name.
  * Zoho WorkDrive data-center region is preserved during profile export/import.
* **Bug Fixes**
  * Improved Jottacloud trash/discovery/listing and deletion behavior (corrected trash URL, improved mountpoint parsing, and proper tombstone skipping), plus refined delete context-menu action.
  * Fixed Zoho WorkDrive cross-folder rename/move requests payload.
  * Refined drag-and-drop row indicators/handles to prevent unwanted text selection.
* **Tests**
  * Added/updated unit tests covering Jottacloud request/URL/XML behaviors, WorkDrive move payload format, and Zoho OAuth export gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->