### PR TITLE
fix(profiles): a 4shared profile carries its own token and its own app

### DIFF
--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -25982,26 +25982,31 @@ fn create_oauth_provider_by_protocol(
             };
 
             // Read consumer key/secret - try individual keys first (GUI format), then legacy JSON
-            let (ck, cs) = if let (Ok(k), Ok(s)) = (
-                store.get("oauth_fourshared_client_id"),
-                store.get("oauth_fourshared_client_secret"),
-            ) {
-                (k, s)
-            } else {
-                let json = store
-                    .get("fourshared_oauth_settings")
-                    .map_err(|e| format!("No 4shared OAuth settings in vault: {}", e))?;
-                #[derive(serde::Deserialize)]
-                struct Fs {
-                    consumer_key: String,
-                    consumer_secret: String,
+            let (ck, cs) = {
+                let (k, s) = load_oauth_client_config(store, "fourshared");
+                if !k.is_empty() {
+                    (k, s)
+                } else {
+                    let json = store
+                        .get("fourshared_oauth_settings")
+                        .map_err(|e| format!("No 4shared OAuth settings in vault: {}", e))?;
+                    #[derive(serde::Deserialize)]
+                    struct Fs {
+                        consumer_key: String,
+                        consumer_secret: String,
+                    }
+                    let fs: Fs = serde_json::from_str(&json)
+                        .map_err(|e| format!("Failed to parse 4shared settings: {}", e))?;
+                    (fs.consumer_key, fs.consumer_secret)
                 }
-                let fs: Fs = serde_json::from_str(&json)
-                    .map_err(|e| format!("Failed to parse 4shared settings: {}", e))?;
-                (fs.consumer_key, fs.consumer_secret)
             };
             let (at, ats) = {
-                let data = store.get("oauth_fourshared").map_err(|_| {
+                let data = ftp_client_gui_lib::bridge_commands::resolve_profile_oauth_token(
+                    store,
+                    "fourshared",
+                    profile_id,
+                )
+                .ok_or_else(|| {
                     "No 4shared access tokens in vault. Authorize from GUI first.".to_string()
                 })?;
                 data.split_once(':')
@@ -26157,15 +26162,14 @@ async fn try_create_oauth_provider(
                 fourshared::FourSharedProvider, types::FourSharedConfig,
             };
 
-            // GUI stores 4shared credentials as individual vault keys:
-            //   oauth_fourshared_client_id, oauth_fourshared_client_secret (consumer)
-            //   fourshared_access_token, fourshared_access_token_secret (tokens)
-            // Also support legacy JSON format: fourshared_oauth_settings, fourshared_oauth_tokens
-            let (consumer_key, consumer_secret) = if let (Ok(k), Ok(s)) = (
-                store.get("oauth_fourshared_client_id"),
-                store.get("oauth_fourshared_client_secret"),
-            ) {
-                (k, s)
+            // Consumer key/secret are the app-level singletons
+            // `oauth_fourshared_client_id` / `_client_secret`, resolved through
+            // the shared helper so a legacy `config_oauth_clients` blob is
+            // honoured too; `fourshared_oauth_settings` is the older 4shared-only
+            // JSON shape and stays as the last fallback.
+            let fs_app = load_oauth_client_config(store, "fourshared");
+            let (consumer_key, consumer_secret) = if !fs_app.0.is_empty() {
+                fs_app
             } else if let Ok(json) = store.get("fourshared_oauth_settings") {
                 #[derive(serde::Deserialize)]
                 struct FsSettings {
@@ -26184,8 +26188,14 @@ async fn try_create_oauth_provider(
                 return Some(Err(6));
             };
 
-            // Tokens stored as "token:token_secret" in key "oauth_fourshared"
-            let (access_token, access_secret) = if let Ok(data) = store.get("oauth_fourshared") {
+            // Tokens stored as "token:token_secret" under the per-profile key
+            // `oauth_fourshared_<id>`, legacy singleton `oauth_fourshared`.
+            let (access_token, access_secret) = if let Some(data) =
+                ftp_client_gui_lib::bridge_commands::resolve_profile_oauth_token(
+                    store,
+                    "fourshared",
+                    profile_id,
+                ) {
                 if let Some((t, s)) = data.split_once(':') {
                     (t.to_string(), s.to_string())
                 } else {
@@ -26329,41 +26339,13 @@ async fn try_create_oauth_provider(
     Some(Ok((provider, initial_path.to_string())))
 }
 
-/// Load OAuth client_id and client_secret from vault settings
+/// Load OAuth client_id and client_secret from vault settings.
+///
+/// Thin wrapper over the shared resolver: this used to be a second copy of the
+/// same three-shape lookup, and the copy the `.aeroftp` export did NOT use, so
+/// export and connect could disagree about whether an app existed.
 fn load_oauth_client_config(store: &CredentialStore, provider: &str) -> (String, String) {
-    // Format 1: Individual vault keys (current SettingsPanel format)
-    let cid_key = format!("oauth_{}_client_id", provider);
-    let csec_key = format!("oauth_{}_client_secret", provider);
-    if let Ok(cid) = store.get(&cid_key) {
-        if !cid.is_empty() {
-            let csec = store.get(&csec_key).unwrap_or_default();
-            return (cid, csec);
-        }
-    }
-
-    // Format 2: Structured JSON (legacy migration / config_oauth_clients)
-    for key in &["config_oauth_clients", "config_aeroftp_oauth_settings"] {
-        if let Ok(json) = store.get(key) {
-            if let Ok(settings) = serde_json::from_str::<serde_json::Value>(&json) {
-                if let Some(p) = settings.get(provider) {
-                    let cid = p
-                        .get("clientId")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_string();
-                    let csec = p
-                        .get("clientSecret")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_string();
-                    if !cid.is_empty() {
-                        return (cid, csec);
-                    }
-                }
-            }
-        }
-    }
-    (String::new(), String::new())
+    ftp_client_gui_lib::bridge_commands::resolve_oauth_client_config(store, provider)
 }
 
 use ftp_client_gui_lib::credential_store::CredentialStore;
@@ -34170,6 +34152,7 @@ fn cli_oauth_vault_slug_for_protocol(protocol: &str) -> Option<&'static str> {
         "pcloud" => Some("pcloud"),
         "zohoworkdrive" | "zoho_workdrive" | "zoho" => Some("zohoworkdrive"),
         "yandexdisk" | "yandex_disk" | "yandex" => Some("yandexdisk"),
+        "fourshared" | "4shared" => Some("fourshared"),
         _ => None,
     }
 }

--- a/src-tauri/src/bridge_commands.rs
+++ b/src-tauri/src/bridge_commands.rs
@@ -431,9 +431,9 @@ pub async fn import_bridge_config(source: String, file_path: String) -> Result<V
 /// `.aeroftp` export, which is about the vault and not about rclone.
 pub fn rclone_oauth_client_cred_key(protocol: &str) -> Option<&'static str> {
     match protocol.to_lowercase().as_str() {
-        // rclone has no Zoho WorkDrive backend, so a Zoho profile is not
-        // rclone-exportable even though it does have app credentials.
-        "zohoworkdrive" => None,
+        // rclone has no Zoho WorkDrive or 4shared backend, so neither profile is
+        // rclone-exportable even though both do have app credentials.
+        "zohoworkdrive" | "fourshared" => None,
         other => oauth_client_cred_key(other),
     }
 }
@@ -443,9 +443,15 @@ pub fn rclone_oauth_client_cred_key(protocol: &str) -> Option<&'static str> {
 ///
 /// Zoho WorkDrive belongs here and was missing: its app credentials are a vault
 /// singleton exactly like the others (read at connect time through
-/// `load_oauth_client_config`), so a `.aeroftp` profile export carried the Zoho
-/// token but not the app that can refresh it, and an imported profile failed its
-/// first refresh with an unparseable Zoho error instead of connecting.
+/// `resolve_oauth_client_config`), so a `.aeroftp` profile export carried the
+/// Zoho token but not the app that can refresh it, and an imported profile failed
+/// its first refresh with an unparseable Zoho error instead of connecting.
+///
+/// 4shared belongs here for the same reason, one layer worse: it is OAuth1, so
+/// what the connect path reads is the *consumer* key/secret, and they live under
+/// the very same `oauth_fourshared_client_id` / `_client_secret` singletons. With
+/// 4shared out of this map a `.aeroftp` export of a 4shared profile carried
+/// nothing at all and reconnected nowhere.
 pub fn oauth_client_cred_key(protocol: &str) -> Option<&'static str> {
     match protocol.to_lowercase().as_str() {
         "googledrive" | "googlephotos" => Some("googledrive"),
@@ -455,8 +461,87 @@ pub fn oauth_client_cred_key(protocol: &str) -> Option<&'static str> {
         "box" => Some("box"),
         "pcloud" => Some("pcloud"),
         "yandexdisk" => Some("yandexdisk"),
+        "fourshared" => Some("fourshared"),
         _ => None,
     }
+}
+
+/// Read a profile's OAuth token blob: the per-profile key first, then the legacy
+/// per-provider singleton. Mirrors what `collect_provider_secrets_for_server`
+/// does on the export side, so a connect and an export of the same profile can
+/// never resolve to different vault entries.
+///
+/// The singleton fallback is what keeps an install that authorised before the
+/// per-profile layout existed connecting without re-authorising.
+pub fn resolve_profile_oauth_token(
+    store: &CredentialStore,
+    slug: &str,
+    profile_id: &str,
+) -> Option<String> {
+    if !profile_id.is_empty() {
+        if let Ok(Some(value)) = crate::user_partitions::resolve_active_credential(
+            store,
+            &format!("oauth_{}_{}", slug, profile_id),
+        ) {
+            let value = value.to_string();
+            if !value.is_empty() {
+                return Some(value);
+            }
+        }
+    }
+    store
+        .get(&format!("oauth_{}", slug))
+        .ok()
+        .filter(|s| !s.is_empty())
+}
+
+/// Resolve a provider's BYO OAuth app credentials the way the connect paths do:
+/// the modern per-provider singletons first, then the two legacy JSON blobs a
+/// never-migrated install may still be holding them in.
+///
+/// This exists as one function because it used to be two. The CLI connect path
+/// resolved all three shapes while the `.aeroftp` export read only the modern
+/// pair, so an install whose credentials had never left `config_oauth_clients`
+/// exported a profile with no app behind its token, silently: nothing fails at
+/// export time, and the import only discovers it on the first refresh. Export
+/// and connect now ask the same question of the same vault.
+pub fn resolve_oauth_client_config(store: &CredentialStore, slug: &str) -> (String, String) {
+    // Shape 1: individual vault keys, what the settings panel writes today.
+    if let Ok(client_id) = store.get(&format!("oauth_{}_client_id", slug)) {
+        if !client_id.is_empty() {
+            let secret = store
+                .get(&format!("oauth_{}_client_secret", slug))
+                .unwrap_or_default();
+            return (client_id, secret);
+        }
+    }
+
+    // Shape 2: the legacy structured blobs, keyed by provider slug.
+    for key in ["config_oauth_clients", "config_aeroftp_oauth_settings"] {
+        let Ok(json) = store.get(key) else { continue };
+        let Ok(settings) = serde_json::from_str::<Value>(&json) else {
+            continue;
+        };
+        let Some(entry) = settings.get(slug) else {
+            continue;
+        };
+        let client_id = entry
+            .get("clientId")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        if client_id.is_empty() {
+            continue;
+        }
+        let secret = entry
+            .get("clientSecret")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        return (client_id, secret);
+    }
+
+    (String::new(), String::new())
 }
 
 /// #128-D: for an rclone OAuth-token export, gather the per-profile OAuth token

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16512,6 +16512,13 @@ pub(crate) fn oauth_vault_slug_for_protocol(protocol: &str) -> Option<&'static s
         "pcloud" => Some("pcloud"),
         "zohoworkdrive" | "zoho_workdrive" | "zoho" => Some("zohoworkdrive"),
         "yandexdisk" | "yandex_disk" | "yandex" => Some("yandexdisk"),
+        // 4shared is OAuth1, but its access token is a vault entry like any
+        // other and it was the one provider present in the auth-state map and
+        // absent here, which by construction made it a profile whose token did
+        // not travel with an export and whose delete left the singleton behind.
+        // Reads fall back to the legacy singleton `oauth_fourshared`, so an
+        // install that authorised before this keeps connecting untouched.
+        "fourshared" | "4shared" => Some("fourshared"),
         _ => None,
     }
 }
@@ -16600,15 +16607,15 @@ fn collect_provider_secrets_for_server(
     // It is the vault-facing map, not the rclone-facing one: Zoho WorkDrive has
     // app credentials to carry even though rclone has no Zoho backend.
     if let Some(cred_slug) = crate::bridge_commands::oauth_client_cred_key(&protocol) {
-        if let Ok(id) = store.get(&format!("oauth_{}_client_id", cred_slug)) {
-            if !id.is_empty() {
-                out.oauth_client_id = Some(id);
-            }
+        // Resolved through the same helper the connect paths use, so an install
+        // still holding its credentials in a legacy blob exports an app that can
+        // refresh rather than an empty pair nobody notices until the import.
+        let (id, secret) = crate::bridge_commands::resolve_oauth_client_config(store, cred_slug);
+        if !id.is_empty() {
+            out.oauth_client_id = Some(id);
         }
-        if let Ok(secret) = store.get(&format!("oauth_{}_client_secret", cred_slug)) {
-            if !secret.is_empty() {
-                out.oauth_client_secret = Some(secret);
-            }
+        if !secret.is_empty() {
+            out.oauth_client_secret = Some(secret);
         }
         // Zoho's region singleton picks the API host, so it belongs with the app
         // credentials: without it an import silently falls back to `us` and a

--- a/src-tauri/src/profile_auth_state.rs
+++ b/src-tauri/src/profile_auth_state.rs
@@ -197,4 +197,77 @@ mod tests {
             );
         }
     }
+
+    /// The three maps that decide, for one provider, whether it has a stored
+    /// auth blob, whether that blob travels with the profile, and whether the
+    /// app behind it travels too, must agree provider by provider.
+    ///
+    /// They did not, twice, and both times the symptom was an export that
+    /// reconnected nowhere: Zoho WorkDrive was missing from the client-cred map,
+    /// so an imported profile could not refresh, and 4shared was missing from
+    /// both the token map and the client-cred map, so nothing at all travelled.
+    /// A provider added to one map and forgotten in the others now fails here
+    /// instead of shipping.
+    #[test]
+    fn the_three_provider_maps_agree() {
+        for proto in [
+            "googledrive",
+            "googlephotos",
+            "dropbox",
+            "onedrive",
+            "box",
+            "pcloud",
+            "zohoworkdrive",
+            "yandexdisk",
+            "fourshared",
+        ] {
+            assert!(
+                crate::oauth_vault_slug_for_protocol(proto).is_some(),
+                "{proto} has an auth blob but its token would not travel with an export"
+            );
+            assert!(
+                crate::bridge_commands::oauth_client_cred_key(proto).is_some(),
+                "{proto} has an auth blob but the app that refreshes it would not travel"
+            );
+        }
+
+        // Jottacloud is the one legitimate asymmetry: it authenticates with a
+        // personal login token and has no OAuth app at all, so it carries a
+        // refresh blob (handled by its own `jottacloud_refresh_<id>` key) and
+        // must stay out of both OAuth maps rather than be "fixed" into them.
+        assert_eq!(
+            oauth_vault_key_for_protocol("jottacloud"),
+            Some("jottacloud_refresh")
+        );
+        assert_eq!(crate::oauth_vault_slug_for_protocol("jottacloud"), None);
+        assert_eq!(
+            crate::bridge_commands::oauth_client_cred_key("jottacloud"),
+            None
+        );
+
+        // Every provider whose app credentials travel must also have somewhere
+        // to put the token, so the client-cred map can never grow a provider
+        // the token map does not know about. Google Photos is the deliberate
+        // many-to-one: it rides on Google Drive's app.
+        for proto in ["googledrive", "googlephotos", "fourshared"] {
+            assert!(
+                crate::oauth_vault_slug_for_protocol(proto).is_some(),
+                "{proto} carries app credentials but has no per-profile token key"
+            );
+        }
+        assert_eq!(
+            crate::bridge_commands::oauth_client_cred_key("googlephotos"),
+            Some("googledrive")
+        );
+
+        // The rclone-facing view is a strict subset: it drops the providers
+        // rclone has no backend for, and must never add one of its own.
+        for proto in ["zohoworkdrive", "fourshared"] {
+            assert_eq!(
+                crate::bridge_commands::rclone_oauth_client_cred_key(proto),
+                None,
+                "rclone has no {proto} backend, so it must not be offered one"
+            );
+        }
+    }
 }

--- a/src-tauri/src/provider_commands.rs
+++ b/src-tauri/src/provider_commands.rs
@@ -6734,6 +6734,13 @@ pub async fn provider_compare_directories(
 pub struct FourSharedAuthParams {
     pub consumer_key: String,
     pub consumer_secret: String,
+    /// Server profile identifier owning these tokens. When supplied the vault
+    /// stores the 4shared token under `oauth_fourshared_<profile_id>`, so two
+    /// 4shared accounts coexist on the same device and the token travels with
+    /// a profile export. When omitted the legacy singleton key is used, which
+    /// is what an install authorised before this keeps reading.
+    #[serde(default, alias = "profileId")]
+    pub profile_id: String,
     /// #360: connect token for Esc / "still connecting" Cancel (see
     /// `OAuthConnectionParams::connect_token`).
     #[serde(default, alias = "connectToken")]
@@ -6748,17 +6755,34 @@ pub struct FourSharedAuthStarted {
     pub request_token_secret: String,
 }
 
-/// Vault key for 4shared OAuth tokens
+/// Legacy app-global vault key for the 4shared OAuth1 token. Still read (and
+/// still written when no profile owns the flow) so an install authorised before
+/// the per-profile layout keeps connecting untouched.
 const FOURSHARED_TOKEN_KEY: &str = "oauth_fourshared";
 
+/// Vault key holding a given profile's 4shared token, or the legacy singleton
+/// when the caller has no profile in hand.
+fn fourshared_token_key(profile_id: &str) -> String {
+    if profile_id.is_empty() {
+        FOURSHARED_TOKEN_KEY.to_string()
+    } else {
+        format!("{}_{}", FOURSHARED_TOKEN_KEY, profile_id)
+    }
+}
+
 /// Store 4shared tokens in credential vault (same pattern as OAuth2)
-fn store_fourshared_tokens(access_token: &str, access_token_secret: &str) -> Result<(), String> {
+fn store_fourshared_tokens(
+    profile_id: &str,
+    access_token: &str,
+    access_token_secret: &str,
+) -> Result<(), String> {
     let token_data = format!("{}:{}", access_token, access_token_secret);
+    let key = fourshared_token_key(profile_id);
 
     // Try vault first
     if let Some(store) = crate::credential_store::CredentialStore::from_cache() {
         store
-            .store(FOURSHARED_TOKEN_KEY, &token_data)
+            .store(&key, &token_data)
             .map_err(|e| format!("Failed to store tokens: {}", e))?;
         return Ok(());
     }
@@ -6767,7 +6791,7 @@ fn store_fourshared_tokens(access_token: &str, access_token_secret: &str) -> Res
     if crate::credential_store::CredentialStore::init().is_ok() {
         if let Some(store) = crate::credential_store::CredentialStore::from_cache() {
             store
-                .store(FOURSHARED_TOKEN_KEY, &token_data)
+                .store(&key, &token_data)
                 .map_err(|e| format!("Failed to store tokens: {}", e))?;
             return Ok(());
         }
@@ -6776,13 +6800,15 @@ fn store_fourshared_tokens(access_token: &str, access_token_secret: &str) -> Res
     Err("Credential vault not available. Please unlock the vault first.".to_string())
 }
 
-/// Load 4shared tokens from credential vault
-fn load_fourshared_tokens() -> Result<(String, String), String> {
+/// Load 4shared tokens from credential vault: this profile's key first, then
+/// the legacy singleton, through the same resolver the export and the CLI use.
+fn load_fourshared_tokens(profile_id: &str) -> Result<(String, String), String> {
     if let Some(store) = crate::credential_store::CredentialStore::from_cache() {
-        if let Ok(data) = store.get(FOURSHARED_TOKEN_KEY) {
-            let parts: Vec<&str> = data.splitn(2, ':').collect();
-            if parts.len() == 2 {
-                return Ok((parts[0].to_string(), parts[1].to_string()));
+        if let Some(data) =
+            crate::bridge_commands::resolve_profile_oauth_token(&store, "fourshared", profile_id)
+        {
+            if let Some((token, secret)) = data.split_once(':') {
+                return Ok((token.to_string(), secret.to_string()));
             }
         }
     }
@@ -6856,7 +6882,7 @@ pub async fn fourshared_complete_auth(
     )
     .await?;
 
-    store_fourshared_tokens(&access_token, &access_token_secret)?;
+    store_fourshared_tokens(&params.profile_id, &access_token, &access_token_secret)?;
 
     info!("4shared OAuth 1.0 authentication completed successfully");
     Ok("Authentication successful".to_string())
@@ -6952,7 +6978,7 @@ pub async fn fourshared_full_auth(
     )
     .await?;
 
-    store_fourshared_tokens(&access_token, &access_token_secret)?;
+    store_fourshared_tokens(&params.profile_id, &access_token, &access_token_secret)?;
 
     info!("4shared OAuth 1.0 full auth completed successfully");
     Ok("Authentication successful! You can now connect.".to_string())
@@ -7174,7 +7200,7 @@ pub async fn fourshared_connect(
     info!("Connecting to 4shared...");
 
     let connect_token = params.connect_token.clone();
-    let (access_token, access_token_secret) = load_fourshared_tokens()?;
+    let (access_token, access_token_secret) = load_fourshared_tokens(&params.profile_id)?;
 
     let config = FourSharedConfig {
         consumer_key: params.consumer_key,
@@ -8645,17 +8671,22 @@ pub async fn box_list_folder_locks(
         .map_err(|e| format!("Serialize failed: {}", e))
 }
 
-/// Check if 4shared tokens exist
+/// Check if 4shared tokens exist for a profile (empty id asks about the legacy
+/// app-global token).
 #[tauri::command]
-pub async fn fourshared_has_tokens() -> Result<bool, String> {
-    Ok(load_fourshared_tokens().is_ok())
+pub async fn fourshared_has_tokens(profile_id: Option<String>) -> Result<bool, String> {
+    Ok(load_fourshared_tokens(profile_id.as_deref().unwrap_or_default()).is_ok())
 }
 
-/// Clear 4shared tokens (logout)
+/// Clear 4shared tokens (logout). Removes this profile's token; the legacy
+/// singleton is only removed when no profile owns the call, so logging one
+/// profile out cannot sign the others out with it.
 #[tauri::command]
-pub async fn fourshared_logout() -> Result<(), String> {
+pub async fn fourshared_logout(profile_id: Option<String>) -> Result<(), String> {
     if let Some(store) = crate::credential_store::CredentialStore::from_cache() {
-        let _ = store.delete(FOURSHARED_TOKEN_KEY);
+        let _ = store.delete(&fourshared_token_key(
+            profile_id.as_deref().unwrap_or_default(),
+        ));
     }
     info!("Logged out from 4shared");
     Ok(())

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9911,8 +9911,8 @@ const App: React.FC = () => {
           );
           return false;
         }
-        const hasTokens = await invoke<boolean>('fourshared_has_tokens');
-        const params = { consumer_key: consumerKey, consumer_secret: consumerSecret };
+        const hasTokens = await invoke<boolean>('fourshared_has_tokens', { profileId: profile.id });
+        const params = { consumer_key: consumerKey, consumer_secret: consumerSecret, profile_id: profile.id };
         if (!hasTokens) await invoke('fourshared_full_auth', { params });
         try {
           await invoke('fourshared_connect', { params });

--- a/src/components/CloudPanel.tsx
+++ b/src/components/CloudPanel.tsx
@@ -370,8 +370,12 @@ const SetupWizard: React.FC<{
                     logger.error('consumer_key and consumer_secret are required');
                     return;
                 }
+                // The command takes a single `params` object: passing the two
+                // values as top-level arguments made Tauri reject the call for a
+                // missing `params`, so authorising 4shared from this panel could
+                // only ever fail into the catch below.
                 await invoke('fourshared_full_auth', {
-                    consumerKey, consumerSecret
+                    params: { consumer_key: consumerKey, consumer_secret: consumerSecret }
                 });
                 setOauthAuthorized(true);
                 setOauthEmail('4shared');

--- a/src/components/IntroHub/MyServersPanel.tsx
+++ b/src/components/IntroHub/MyServersPanel.tsx
@@ -1222,14 +1222,14 @@ export function MyServersPanel({
 
             setOauthConnecting(server.id);
             try {
-                const hasTokens = await invoke<boolean>('fourshared_has_tokens');
+                const hasTokens = await invoke<boolean>('fourshared_has_tokens', { profileId: server.id });
 
                 // #360: run the 4shared auth + connect under a connect token so
                 // Esc / "still connecting" Cancel can abort the in-flight call.
                 const doFourSharedConnect = async (connectToken?: string) => {
                     const params = connectToken
-                        ? { consumer_key: consumerKey, consumer_secret: consumerSecret, connect_token: connectToken }
-                        : { consumer_key: consumerKey, consumer_secret: consumerSecret };
+                        ? { consumer_key: consumerKey, consumer_secret: consumerSecret, profile_id: server.id, connect_token: connectToken }
+                        : { consumer_key: consumerKey, consumer_secret: consumerSecret, profile_id: server.id };
                     if (!hasTokens) await invoke('fourshared_full_auth', { params });
                     try {
                         return await invoke<{ display_name: string; account_email: string | null }>('fourshared_connect', { params });

--- a/src/components/SavedServers.tsx
+++ b/src/components/SavedServers.tsx
@@ -514,8 +514,8 @@ export const SavedServers: React.FC<SavedServersProps> = ({
 
             setOauthConnecting(server.id);
             try {
-                const params = { consumer_key: consumerKey, consumer_secret: consumerSecret };
-                const hasTokens = await invoke<boolean>('fourshared_has_tokens');
+                const params = { consumer_key: consumerKey, consumer_secret: consumerSecret, profile_id: server.id };
+                const hasTokens = await invoke<boolean>('fourshared_has_tokens', { profileId: server.id });
 
                 if (!hasTokens) {
                     await invoke('fourshared_full_auth', { params });


### PR DESCRIPTION
Follow-up to the Zoho WorkDrive export defect fixed in #468 (`f16b8934d`). That one was found by exporting a profile and importing it into another vault; this asks the question systematically, for every provider: **is every secret the connect path reads also a secret the export carries and the import restores?**

Method: enumerate the vault keys each connect path reads (the CLI factory, which mirrors the GUI's), then diff against `collect_provider_secrets_for_server` on the export side and the restore loop on the import side.

## The three maps that must agree, and did not

| Map | Question it answers |
|---|---|
| `profile_auth_state::oauth_vault_key_for_protocol` | does this profile have a stored auth blob? |
| `lib::oauth_vault_slug_for_protocol` | which token key travels with the profile (export, delete, duplicate) |
| `bridge_commands::oauth_client_cred_key` | which app credentials travel |

`per_profile_vault_keys` documents itself as the single source of truth ("what a profile can store, what its export carries, and what its delete removes are the same list") and derives the token key from the second map. So a provider present in map 1 and absent from map 2 is, by construction, a profile whose auth does not travel and whose delete leaves residue.

That was **4shared**.

## F1. 4shared carried nothing at all

4shared is OAuth1, and it was in map 1 but in neither map 2 nor map 3, so a `.aeroftp` export of a 4shared profile reconnected nowhere and deleting the profile left `oauth_fourshared` behind in the vault. Being OAuth1 changed nothing about the storage: the consumer key/secret live under the very same `oauth_fourshared_client_id` / `_client_secret` singletons every other provider uses.

Same shape as the Zoho defect, one layer worse: for Zoho the token travelled and only the app was missing; for 4shared nothing travelled.

4shared now joins both maps, so the token becomes the per-profile `oauth_fourshared_<id>` that export, delete and duplicate already know how to handle. Every read falls back to the legacy singleton, so an install that authorised before this keeps connecting untouched, and an export still carries the token even when the singleton is all there ever was. The two connect paths and `fourshared_has_tokens` / `fourshared_logout` are profile-scoped through one shared resolver rather than a third copy of the same lookup.

Falling out of it: **two 4shared accounts in one installation**, which the singleton model could not express.

One thing the analysis had not predicted: 4shared has to be kept **out** of the rclone-facing map. `rclone_oauth_client_cred_key` delegates to `oauth_client_cred_key` for everything it does not special-case, so adding 4shared to the vault-facing map would have offered rclone a backend it does not have. It is now excluded explicitly, next to Zoho, for the same stated reason.

## F2. The export read only the modern key shape

Connect resolved app credentials through three shapes: `oauth_<slug>_client_id` / `_client_secret` and then two legacy JSON blobs (`config_oauth_clients`, `config_aeroftp_oauth_settings`). The export read only the first. An install whose credentials had never migrated out of the legacy blob exported a profile that could not refresh, **with no error at export time**: the import only finds out on the first refresh.

That lookup was duplicated in the CLI, and the copy the export did not use was the complete one. It is now a single `resolve_oauth_client_config` that both the export and every connect path call.

## Regression net

A test asserting the three maps agree provider by provider, so a provider added to one and forgotten in the others fails the build instead of shipping an export that cannot reconnect. Jottacloud is pinned as the one legitimate asymmetry (personal login token, no OAuth app, so it belongs in map 1 and in neither other), and the rclone-facing map is pinned as a strict subset.

## Also fixed on the way past

The Add Service panel invoked `fourshared_full_auth` with the two consumer values as top-level arguments instead of the `params` object the command takes, so Tauri rejected the call for a missing `params` and authorising 4shared from that panel could only ever fail into a catch that logs.

## Providers checked and clean

Jottacloud, Yandex Disk, Google Drive, Google Photos, Dropbox, OneDrive, Box, pCloud (its region was covered by `f16b8934d`), Filen, and the whole main-credential family (MEGA, kDrive, Koofr, Drime, FileLu, Internxt, S3/B2/Azure/Swift, the WebDAV family, FTP/SFTP), which authenticate from the main credential or the per-mode snapshot with no side-channel singleton read at connect.

Verified green locally: `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `tsc --noEmit`, `vitest run` (523 passed), and the new map test.

On `cargo test --lib`: an earlier version of this description listed it among the gates verified green, which it was not, since the run had been started but not yet read when this PR was opened. It came back with 3324 passed and 1 failed, and the rerun named the failure: `transfer_dag_single_file::tests::cancel_token_keeps_durable_multipart_session_for_resume`. That is the load-sensitive test addressed in #470, it lives in a file this PR does not touch, and both local runs that hit it were competing with other `cargo` jobs on the same machine. Everything else in the suite passes. The clean verdict on this branch is the `build-and-release (ubuntu-22.04, linux)` job below, which runs the same command on an uncontended runner.

Not live-verified: there is no 4shared account here, so this is verified against the vault layout, the connect paths it mirrors and the new map test, not against a real 4shared export and import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 4shared OAuth credentials and tokens are now stored and managed separately for each saved server profile.
  - Added support for recognizing “4shared” and “fourshared” consistently.

- **Bug Fixes**
  - Fixed 4shared re-authorization from the setup panel.
  - Improved token detection, connection, and logout behavior for individual profiles.
  - Improved OAuth credential recovery for supported providers, including legacy credentials.
  - Prevented unsupported 4shared and Zoho WorkDrive credentials from being exported to rclone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

