### PR TITLE
test(dag): cancel the multipart upload from inside the part, not from a poller

### DIFF
--- a/src-tauri/src/transfer_dag_single_file.rs
+++ b/src-tauri/src/transfer_dag_single_file.rs
@@ -2085,6 +2085,10 @@ mod tests {
         /// Part numbers whose upload fails (a scriptable first-run failure so
         /// resume tests are deterministic, not timing-based).
         multipart_failing_parts: Arc<StdMutex<std::collections::HashSet<u32>>>,
+        /// Cancelled from inside `upload_part`, after the part is counted and
+        /// before it returns, so "the cancel lands while a part is in flight"
+        /// is a fact of the call order rather than a wall-clock race.
+        cancel_during_part: Option<CancellationToken>,
     }
 
     impl SlowMockProvider {
@@ -2099,7 +2103,15 @@ mod tests {
                 multipart_aborted: Arc::new(StdMutex::new(false)),
                 multipart_part_started: Arc::new(AtomicU64::new(0)),
                 multipart_failing_parts: Arc::new(StdMutex::new(std::collections::HashSet::new())),
+                cancel_during_part: None,
             }
+        }
+
+        /// Cancel `token` from inside the first `upload_part`, so a cancellation
+        /// test never has to guess when a part is on the wire.
+        fn cancelling_during_part(mut self, token: CancellationToken) -> Self {
+            self.cancel_during_part = Some(token);
+            self
         }
 
         fn with_multipart_state(
@@ -2221,6 +2233,9 @@ mod tests {
                 )));
             }
             self.multipart_part_started.fetch_add(1, Ordering::SeqCst);
+            if let Some(token) = self.cancel_during_part.as_ref() {
+                token.cancel();
+            }
             tokio::time::sleep(std::time::Duration::from_millis(200)).await;
             Ok(UploadedPart {
                 part_number,
@@ -2374,6 +2389,7 @@ mod tests {
         let multipart_completed = Arc::new(StdMutex::new(false));
         let multipart_aborted = Arc::new(StdMutex::new(false));
         let part_started = Arc::new(AtomicU64::new(0));
+        let token = CancellationToken::new();
         let mock = SlowMockProvider::new(
             Arc::new(StdMutex::new(false)),
             Arc::new(StdMutex::new(false)),
@@ -2382,7 +2398,18 @@ mod tests {
             Arc::clone(&multipart_completed),
             Arc::clone(&multipart_aborted),
             Arc::clone(&part_started),
-        );
+        )
+        // Cancel from inside the first `upload_part`, after it has been counted
+        // and before it returns. The previous shape polled `part_started` from a
+        // spawned task and cancelled when it saw the count rise, which reads as
+        // "cancel on the observable precondition" but is still a race: the poll
+        // has a 5ms granularity against a 200ms window, so on a loaded runner the
+        // wake could land after BOTH parts had gone by, the DAG had passed its
+        // checkpoint, and the session was aborted. That is the failure this test
+        // exists to catch, so it was reporting a scheduling accident as the very
+        // regression it guards. Cancelling from the call itself makes "a part is
+        // in flight" a fact of the call order, with no timing assumption left.
+        .cancelling_during_part(token.clone());
         let arc: SharedProvider = Arc::new(Mutex::new(Some(
             Box::new(mock) as Box<dyn crate::providers::StorageProvider>
         )));
@@ -2397,25 +2424,6 @@ mod tests {
         assert_eq!(built.profile.upload_parts, 2);
         let report = Arc::new(AtomicU64::new(20));
         let observer: Arc<dyn DagObserver> = Arc::new(crate::transfer_dag::NoopDagObserver);
-
-        let token = CancellationToken::new();
-        let canceller = token.clone();
-        // Cancel on the observable precondition - a part is on the wire - not on
-        // a wall-clock guess. Time-to-first-`upload_part` has no lower bound, so
-        // a loaded runner can consume a fixed delay before the DAG ever reaches
-        // it, cancelling too early and failing the in-flight assertion below for
-        // scheduling reasons rather than a real regression. The mock holds each
-        // part for 200ms after it counts it, which is the window this lands in.
-        let started_probe = Arc::clone(&part_started);
-        tokio::spawn(async move {
-            for _ in 0..2_000 {
-                if started_probe.load(Ordering::SeqCst) >= 1 {
-                    break;
-                }
-                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
-            }
-            canceller.cancel();
-        });
 
         let res = execute_single_file_dag(
             &built,


### PR DESCRIPTION
`cancel_token_keeps_durable_multipart_session_for_resume` failed once on a loaded machine, asserting `multipart_aborted == false` while the session had in fact been aborted. That is precisely the regression the test exists to catch, so it reported a scheduling accident as the very defect it guards.

## The window that was left

The test cancelled from a spawned task polling `part_started` every 5ms, firing once it saw the count rise. Its own comment calls this "cancel on the observable precondition, not on a wall-clock guess", and it is closer to that than a fixed delay, but a window is still there: between the poll observing the count and `cancel()` landing, the mock's 200ms part hold can elapse, and with `upload_parts == 2` on a single chunk slot the second part can go by too, so the DAG passes its checkpoint and aborts the session before the cancel arrives.

Note the direction: the existing comment guards against cancelling **too early**, and the failure observed was cancelling **too late**. Both ends of the same race.

## The fix

The mock cancels from inside `upload_part`, after counting the part and before returning it, so "the cancel lands while a part is in flight" follows from the call order with no timing assumption left. This is the same shape as `multipart_failing_parts`, which the mock already scripts for exactly this reason ("so resume tests are deterministic, not timing-based").

## Evidence, stated plainly

**It reproduces, and the reproducer is concurrency rather than raw CPU load.** An earlier version of this description said the failure had not been reproduced; that was true when written and is no longer. What did not reproduce it: 5 isolated runs on the branch it appeared on, 5 on `main`, and 8 more on each under synthetic CPU load (`yes` loops). What did: a full `cargo test --lib` running alongside another `cargo` job on the same machine. It has now failed that way twice, and the decisive observation is a pair of consecutive full-suite runs on one unchanged branch where the first came back `3324 passed; 1 failed` on this test and the second came back `3325 passed; 0 failed`.

So the flakiness is established, and the mechanism is competing work rather than a busy CPU, which fits: what stretches is the scheduling of the poller task between observing `part_started` and calling `cancel()`, not the arithmetic. A contended CI runner is the same shape.

The fix removes that window by construction rather than narrowing it, so there is no load level at which it comes back.

The one condition that did produce it was a full `cargo test --lib` running alongside two other `cargo` builds on the same machine, which is the closest local analogue of a contended CI runner.

Verified green: `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, the test itself passing 8/8 under synthetic load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved the reliability and determinism of multipart upload cancellation and resume test coverage.
  * Updated cancellation scenarios to better reflect cancellation occurring during an active upload part.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
