### PR TITLE
fix(ci): the lane 3 gate reports Docker Hub failures instead of exiting 0

### DIFF
--- a/.github/workflows/aerorsync-protocol.yml
+++ b/.github/workflows/aerorsync-protocol.yml
@@ -136,10 +136,15 @@ jobs:
         run: |
           set -u
           for attempt in 1 2 3 4; do
+            # Capture the status in the `else` branch: after a plain `if` with
+            # no `else`, `$?` is the status of the `if` itself, which is 0 when
+            # the condition was false, so `exit "$status"` below would have
+            # exited 0 and painted this step green with the registry down.
             if docker pull debian:bookworm-slim; then
               exit 0
+            else
+              status=$?
             fi
-            status=$?
             if [ "$attempt" -eq 4 ]; then
               echo "::error::Docker Hub unreachable after ${attempt} attempts pulling debian:bookworm-slim (registry-1.docker.io). Not a protocol regression — registry/network failure."
               exit "$status"
@@ -154,10 +159,14 @@ jobs:
           set -u
           chmod 600 keys/id_ed25519
           for attempt in 1 2 3; do
+            # Same as the pre-pull step above: `$?` after a plain `if` is the
+            # status of the `if`, not of the condition, so the status has to be
+            # taken in an `else` branch or the final `exit "$status"` exits 0.
             if docker compose -f docker-compose.real-rsync.yml up -d --build; then
               exit 0
+            else
+              status=$?
             fi
-            status=$?
             if [ "$attempt" -eq 3 ]; then
               echo "::error::real-rsync harness build/start failed after ${attempt} attempts. If the log shows registry-1.docker.io / DeadlineExceeded / i/o timeout, this is Docker Hub, not a protocol regression."
               exit "$status"


### PR DESCRIPTION
The lane 3 gate exits 0 when Docker Hub is unreachable, which is the opposite of what `92202590a` set out to do: its stated constraint was that the gate stays hard, no `continue-on-error`, only recoverable retries.

## The defect

Both retry loops in `.github/workflows/aerorsync-protocol.yml`, "Pre-pull harness base image" and "Start real-rsync harness", have this shape:

```bash
if docker pull debian:bookworm-slim; then
  exit 0
fi
status=$?          # <- status of the `if`, not of `docker pull`
if [ "$attempt" -eq 4 ]; then
  echo "::error::Docker Hub unreachable after ..."
  exit "$status"   # <- exits 0
fi
```

In bash, an `if` whose condition is false and which has no `else` returns 0. So `$?` on the next line is 0, not the exit status of `docker pull`, and the final `exit "$status"` exits 0.

**Effect**: with the registry down, four attempts fail, the step prints `::error::Docker Hub unreachable ...` and **turns green**. The job then dies further along on "Wait for sshd (port 2224)", so the red appears in the wrong place and the real cause is buried inside a step that reported success.

## The fix

Take the status in an `else` branch, where `$?` really is the condition's:

```bash
if docker pull debian:bookworm-slim; then
  exit 0
else
  status=$?
fi
```

Applied to both steps, with a comment at each site explaining why the `else` is load-bearing so it does not get tidied away.

## Proof

Same shape as the loops, with a command that returns 7:

| Form | Captured `status` | Script exit |
|---|---|---|
| old (`fi` then `status=$?`) | 0 | **0** |
| new (`else status=$?`) | 7 | **7** |

The YAML parses (`yaml.safe_load`).

Note this cannot be exercised by CI without taking Docker Hub down, so the evidence is the shell semantics above and not a red run.

## Provenance

Found by the independent residual audit of #467, tracked as R1 in `BATON-aerorsync-residui-post-B3.md`. It touches the same workflow file as #471, which is why it waited for that merge.

Not merged: opened for review while the owner is away.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker workflow error handling for image pulls and harness startup failures.
  * Failed operations now correctly report a non-zero status after the final retry, providing more accurate failure notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->