### PR TITLE
test(aerorsync): pin xattr apply before the rename

### DIFF
--- a/src-tauri/src/aerorsync/streaming_writer.rs
+++ b/src-tauri/src/aerorsync/streaming_writer.rs
@@ -588,4 +588,75 @@ mod tests {
             );
         }
     }
+
+    /// R4: `apply_xattrs` runs on the temp file **before** the rename, so a
+    /// kill-9 never exposes a target that is missing its metadata. Nothing on
+    /// the success path can tell the two orders apart, since either way the
+    /// final file ends up carrying the attributes. The failure path can: feed
+    /// a blob that `apply_xattrs` rejects, and a target that exists afterwards
+    /// can only mean the rename had already happened, which is precisely the
+    /// block sitting in the wrong place.
+    ///
+    /// The rejection is `sanitize_xattrs_for_apply` refusing a name outside
+    /// the `user.` namespace, which happens before any platform-specific code,
+    /// so this pin holds on Windows as well as Unix.
+    #[tokio::test]
+    async fn xattr_apply_precedes_the_rename_so_a_rejection_leaves_no_target() {
+        use crate::aerorsync::real_wire::XattrPair;
+
+        let dir = fresh_tempdir();
+        let target = dir.path().join("payload.bin");
+
+        let mut w = StreamingAtomicWriter::new(&target).await.expect("new");
+        w.write_all(b"NEW PAYLOAD").await.expect("write");
+        let temp = w.temp_path().to_path_buf();
+
+        let poisoned = vec![XattrPair::inline("trusted.nope", b"v".to_vec())];
+        let err = w
+            .finalize(None, None, Some(poisoned), false)
+            .await
+            .expect_err("a rejected xattr blob must fail finalize");
+        match err {
+            WriteAtomicError::PostOpen { stage, .. } => assert_eq!(stage, "xattr"),
+            other => panic!("expected PostOpen{{stage: \"xattr\"}}, got {other:?}"),
+        }
+
+        assert!(
+            !target.exists(),
+            "target exists after a rejected xattr apply: the rename ran first"
+        );
+        assert!(
+            !temp.exists(),
+            "temp must be cleaned up on the failure path"
+        );
+    }
+
+    /// Same invariant seen from the other side: when the target already
+    /// exists, a rejected xattr blob must leave the old bytes in place. If the
+    /// apply moved after the rename, the cutover would have happened and the
+    /// old content would be gone even though finalize reported a failure.
+    #[tokio::test]
+    async fn xattr_rejection_does_not_cut_over_an_existing_target() {
+        use crate::aerorsync::real_wire::XattrPair;
+
+        let dir = fresh_tempdir();
+        let target = dir.path().join("doc.txt");
+        tokio::fs::write(&target, b"OLD BYTES")
+            .await
+            .expect("seed target");
+
+        let mut w = StreamingAtomicWriter::new(&target).await.expect("new");
+        w.write_all(b"NEW PAYLOAD").await.expect("write");
+
+        let poisoned = vec![XattrPair::inline("trusted.nope", b"v".to_vec())];
+        w.finalize(None, None, Some(poisoned), false)
+            .await
+            .expect_err("a rejected xattr blob must fail finalize");
+
+        let bytes = tokio::fs::read(&target).await.expect("read target");
+        assert_eq!(
+            bytes, b"OLD BYTES",
+            "the target was cut over despite the xattr rejection"
+        );
+    }
 }


### PR DESCRIPTION
`StreamingAtomicWriter::finalize` applies extended attributes to the temp file and only then renames it onto the target. X.4 states that as a guarantee: a kill-9 never leaves a visible target without its metadata. The order on `main` is correct. Nothing defended it.

## Why it was undefended

Every `finalize` call in the existing tests passes `None, false` for the xattr arguments, so the block was never entered under test. The live lane 3 acceptance added in #471 cannot cover it either: those tests assert that the attribute arrives at the destination, and it arrives either way. Move `apply_xattrs` after `fs::rename` and they all stay green, because the only thing that changed is the width of the kill-9 window, which nothing was looking at.

## How you pin an ordering with no observable difference

On the success path there is none: both orders end with a target that carries the attributes. The **rejection** path has one. Feed a blob that `sanitize_xattrs_for_apply` refuses, and then:

- apply before rename: finalize fails, the rename never runs, **the target does not exist**;
- apply after rename: the cutover has already happened, so the target **is** there, with the new bytes, even though finalize reported a failure.

Two tests, one per side of that:

| Test | Asserts |
|---|---|
| `xattr_apply_precedes_the_rename_so_a_rejection_leaves_no_target` | finalize fails at `stage: "xattr"`, the target does not exist, the temp is cleaned up |
| `xattr_rejection_does_not_cut_over_an_existing_target` | a pre-existing target still reads `OLD BYTES` afterwards |

## Verified to be pins, not decoration

Both were run against a deliberately moved block (`apply_xattrs` after the rename, applied to the target), and both fail:

```
target exists after a rejected xattr apply: the rename ran first

assertion `left == right` failed: the target was cut over despite the xattr rejection
  left:  [78, 69, 87, ...]   // NEW PAYLOAD
  right: [79, 76, 68, ...]   // OLD BYTES
```

The rejection used is a name outside the `user.` namespace, which `sanitize_xattrs_for_apply` refuses before any platform-specific code runs, so these hold on Windows as well as on Unix and need no xattr-capable filesystem.

## Gates

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | pass |
| `cargo clippy --lib --features aerorsync --all-targets -- -D warnings` | pass |
| `cargo test --features aerorsync --lib aerorsync` | **595 passed**, 0 failed (593 before this branch) |
| `RUSTFLAGS='--cfg ci_lane3' cargo check --features aerorsync --lib --tests` | pass |

Tests only, no production code touched.

## Provenance

Residual R4 of the independent audit of #467, `BATON-aerorsync-residui-post-B3.md`.

Not merged: opened for review while the owner is away.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
