### PR TITLE
ci(snap): gate the whole GPU userspace, not two filename patterns

### DIFF
--- a/.github/workflows/snap-refresh.yml
+++ b/.github/workflows/snap-refresh.yml
@@ -266,11 +266,17 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends squashfs-tools binutils file
           ./ci-tools/scripts/snap-abi-check.sh "$SNAP_FILE" snap/snapcraft.yaml
-          if unsquashfs -ll "$SNAP_FILE" | grep -E '/dri/[^/]+_dri\.so|/lib(EGL|GLX)_mesa\.so'; then
-            echo "::error::the application snap still bundles Mesa drivers/loaders; graphics-core22 must provide them"
-            exit 1
-          fi
-          echo "OK: GPU userspace is supplied only by graphics-core22."
+
+      # Was an inline grep for `/dri/*_dri.so` and `libEGL/GLX_mesa` inside G1.
+      # It covered the two loudest patterns and missed the rest of what the
+      # provider owns (libgbm, the vendor libdrm family, vulkan ICDs), and it
+      # never ran the linter whose `gpu:` warnings started this migration.
+      # Both now live in a script that can be run by hand against any .snap.
+      - name: Gate G4 - no bundled GPU userspace
+        shell: bash
+        env:
+          SNAP_FILE: ${{ steps.snap-check.outputs.snap }}
+        run: ./ci-tools/scripts/snap-gpu-lint-check.sh "$SNAP_FILE"
 
       - name: Install the graphics userspace provider
         shell: bash

--- a/scripts/snap-gpu-lint-check.sh
+++ b/scripts/snap-gpu-lint-check.sh
@@ -67,12 +67,41 @@ fi
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
-# Same defensive form as the ABI gate: a snap carries device nodes and file
-# capabilities, so unsquashfs can report restore errors that are not our
-# problem. Tolerate a non-zero exit and judge on what actually landed.
-unsquashfs -q -n -f -no-xattrs -d "$TMP/snap" "$SNAP_FILE" >/dev/null 2>&1 || true
-if [ ! -d "$TMP/snap" ]; then
-  echo "::error::could not unpack $SNAP_FILE" >&2
+# We LIST the image, we do not unpack it.
+#
+# The first version of this gate unpacked with `-d` and tolerated a non-zero
+# exit, on the reasoning that a snap carries device nodes and file
+# capabilities so unsquashfs reports restore errors that are not our problem.
+# That tolerance is unsafe for a gate whose only job is to fail on presence:
+# an extraction that aborts part-way still leaves the destination directory
+# behind, so the scan runs on a truncated tree and finds nothing.
+#
+# Measured, not argued (squashfs-tools 4.6.1): a 301-file image containing
+# `dri/zzz_iris_dri.so`, corrupted mid-image, extracts 182 of 301 files
+# WITHOUT the driver, exits 1, and leaves the directory in place. The old form
+# printed "OK: no provider-owned GPU userspace inside the snap" and exited 0
+# on a snap that does carry one. Reported by CodeRabbit on #485.
+#
+# Listing removes the whole class: the file names come from the directory
+# table in one read, there is no restore step to fail on device nodes or
+# capabilities, and there is no half-success to mistake for a clean result. On
+# that same corrupt image `-l` still reports all 306 entries, the driver among
+# them. A directory table too damaged to read exits non-zero, and that is a
+# hard error here rather than something to work around.
+LIST="$TMP/list.txt"
+if ! unsquashfs -l "$SNAP_FILE" >"$LIST" 2>"$TMP/list.err"; then
+  echo "::error::could not list $SNAP_FILE" >&2
+  sed 's/^/    /' "$TMP/list.err" >&2
+  exit 2
+fi
+
+ENTRIES="$(grep -c '' "$LIST" || true)"
+# A snap that lists as (almost) nothing is a broken read, not a clean snap.
+# Without this, an empty listing would sail through the loop below and be
+# reported as "no provider-owned GPU userspace", which is the same false green
+# in a different disguise.
+if [ "$ENTRIES" -lt 2 ]; then
+  echo "::error::listing $SNAP_FILE produced $ENTRIES entries; refusing to read that as a clean snap" >&2
   exit 2
 fi
 
@@ -82,29 +111,40 @@ fi
 #
 # $SNAP/graphics itself is the mount point for the provider's content and is
 # empty in the built snap, so it is excluded rather than matched.
-mapfile -t OFFENDERS < <(
-  find "$TMP/snap" \
-    -path "$TMP/snap/graphics" -prune -o \
-    \( \
-      -path '*/dri/*_dri.so' -o \
-      -name 'libEGL_mesa.so*' -o \
-      -name 'libGLX_mesa.so*' -o \
-      -name 'libgbm.so*' -o \
-      -name 'libdrm_*.so*' -o \
-      -name 'libdrm.so*' -o \
-      -name 'libvulkan_*.so*' \
-    \) -print 2>/dev/null | sort
-)
+#
+# Each listing line is a whole path and nothing else, so a name containing
+# spaces stays intact; that is why `-l` is used rather than the `-ll` long
+# format, whose trailing path would have to be cut out of columns.
+OFFENDERS=()
+while IFS= read -r entry; do
+  rel="${entry#squashfs-root/}"
+  # The root entry itself carries no prefix to strip: skip it.
+  [ "$rel" = "$entry" ] && continue
+  case "$rel" in
+    graphics | graphics/*) continue ;;
+    # Both forms on purpose: paths are relative once the `squashfs-root/`
+    # prefix is off, so `*/dri/...` alone would miss a `dri/` directory
+    # sitting at the very root of the snap, which the previous absolute-path
+    # `find` did match.
+    */dri/*_dri.so | dri/*_dri.so)
+      OFFENDERS+=("$rel")
+      continue
+      ;;
+  esac
+  case "${rel##*/}" in
+    libEGL_mesa.so* | libGLX_mesa.so* | libgbm.so* | libdrm_*.so* | libdrm.so* | libvulkan_*.so*)
+      OFFENDERS+=("$rel")
+      ;;
+  esac
+done <"$LIST"
 
-echo "Snap:     $SNAP_FILE"
-echo "Unpacked: $(find "$TMP/snap" -type f | wc -l) files"
+echo "Snap:    $SNAP_FILE"
+echo "Listed:  $ENTRIES entries"
 
 if [ "${#OFFENDERS[@]}" -gt 0 ]; then
   echo
   echo "::error::the snap primes ${#OFFENDERS[@]} provider-owned GPU file(s):"
-  for f in "${OFFENDERS[@]}"; do
-    echo "    ${f#"$TMP/snap/"}"
-  done
+  printf '    %s\n' "${OFFENDERS[@]}" | sort
   echo
   echo "GPU userspace must come from the graphics-core22 provider, not from"
   echo "this snap. Check that the 'graphics-core22' part still runs"

--- a/scripts/snap-gpu-lint-check.sh
+++ b/scripts/snap-gpu-lint-check.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+#
+# Gate G4 - the snap must not carry its own GPU userspace.
+#
+# Hardware-specific GL userspace has to come from a graphics content provider
+# (`graphics-core22` / `mesa-core22`), never from the application snap. A snap
+# that primes its own Mesa DRI/EGL/GLX/libdrm stack mixes loader and driver
+# across the confinement boundary, which is what broke swrast while the blank
+# WebKit window of #462 was being diagnosed.
+#
+# `snap/snapcraft.yaml` already does the right thing: the `graphics-core22`
+# part runs Canonical's `graphics-core22-cleanup` at prime time. Nothing
+# checked that it kept working. This is that check, and it is the last open
+# acceptance criterion of #465.
+#
+# Two independent passes, because they fail for different reasons:
+#
+#   1. Content check (authoritative here, always runs). Unpacks the snap and
+#      looks for provider-owned files. It needs only `unsquashfs`, so it never
+#      degrades into "could not verify" on a runner.
+#   2. `snapcraft lint`, when snapcraft is available. Its `gpu:` warnings are
+#      the upstream wording of the same defect, and its remaining `library:`
+#      warnings are printed for a human to judge one by one. Those are NOT
+#      failed on: dynamic loading legitimately looks like an unused library,
+#      and #465 asks for them to be assessed individually rather than
+#      blanket-ignored.
+#
+# Usage:
+#   scripts/snap-gpu-lint-check.sh <snap-file>
+#   scripts/snap-gpu-lint-check.sh <snap-file> --no-snapcraft   # content only
+#
+# Exit codes: 0 = no provider-owned GPU userspace inside the snap,
+#             1 = the snap ships its own, 2 = usage / environment error.
+
+set -euo pipefail
+
+SNAP_FILE=""
+RUN_SNAPCRAFT=1
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --no-snapcraft)
+      RUN_SNAPCRAFT=0
+      shift
+      ;;
+    -h|--help)
+      sed -n '2,33p' "$0"
+      exit 0
+      ;;
+    *)
+      SNAP_FILE="$1"
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$SNAP_FILE" ] || [ ! -f "$SNAP_FILE" ]; then
+  echo "::error::usage: $0 <snap-file> [--no-snapcraft]" >&2
+  exit 2
+fi
+
+if ! command -v unsquashfs >/dev/null 2>&1; then
+  echo "::error::unsquashfs is required to inspect the snap" >&2
+  exit 2
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Same defensive form as the ABI gate: a snap carries device nodes and file
+# capabilities, so unsquashfs can report restore errors that are not our
+# problem. Tolerate a non-zero exit and judge on what actually landed.
+unsquashfs -q -n -f -no-xattrs -d "$TMP/snap" "$SNAP_FILE" >/dev/null 2>&1 || true
+if [ ! -d "$TMP/snap" ]; then
+  echo "::error::could not unpack $SNAP_FILE" >&2
+  exit 2
+fi
+
+# Files the provider owns. Anything matching these inside the app snap is a
+# duplicate of something `mesa-core22` will mount at $SNAP/graphics, which is
+# precisely what `graphics-core22-cleanup` exists to strip.
+#
+# $SNAP/graphics itself is the mount point for the provider's content and is
+# empty in the built snap, so it is excluded rather than matched.
+mapfile -t OFFENDERS < <(
+  find "$TMP/snap" \
+    -path "$TMP/snap/graphics" -prune -o \
+    \( \
+      -path '*/dri/*_dri.so' -o \
+      -name 'libEGL_mesa.so*' -o \
+      -name 'libGLX_mesa.so*' -o \
+      -name 'libgbm.so*' -o \
+      -name 'libdrm_*.so*' -o \
+      -name 'libdrm.so*' -o \
+      -name 'libvulkan_*.so*' \
+    \) -print 2>/dev/null | sort
+)
+
+echo "Snap:     $SNAP_FILE"
+echo "Unpacked: $(find "$TMP/snap" -type f | wc -l) files"
+
+if [ "${#OFFENDERS[@]}" -gt 0 ]; then
+  echo
+  echo "::error::the snap primes ${#OFFENDERS[@]} provider-owned GPU file(s):"
+  for f in "${OFFENDERS[@]}"; do
+    echo "    ${f#"$TMP/snap/"}"
+  done
+  echo
+  echo "GPU userspace must come from the graphics-core22 provider, not from"
+  echo "this snap. Check that the 'graphics-core22' part still runs"
+  echo "graphics-core22-cleanup at prime time in snap/snapcraft.yaml, and that"
+  echo "its 'after:' still lists every part that stages GTK/WebKit."
+  exit 1
+fi
+
+echo "OK: no provider-owned GPU userspace inside the snap."
+
+# ---------------------------------------------------------------------------
+# Second pass, advisory except for `gpu:`.
+# ---------------------------------------------------------------------------
+if [ "$RUN_SNAPCRAFT" -eq 0 ]; then
+  exit 0
+fi
+
+if ! command -v snapcraft >/dev/null 2>&1; then
+  echo "note: snapcraft not on PATH, skipping the linter pass (content check already passed)"
+  exit 0
+fi
+
+echo
+echo "Running snapcraft lint ..."
+LINT_OUT="$TMP/lint.txt"
+# The linter is allowed to fail: it needs a build instance and may be
+# unavailable on a given runner. Its absence must not turn a green content
+# check into a red gate, and its presence must not hide a gpu: warning.
+if ! snapcraft lint "$SNAP_FILE" >"$LINT_OUT" 2>&1; then
+  echo "note: snapcraft lint exited non-zero; output follows"
+fi
+sed 's/^/    /' "$LINT_OUT"
+
+if grep -qE '^\s*gpu:' "$LINT_OUT"; then
+  echo
+  echo "::error::snapcraft lint still reports gpu: warnings, listed above."
+  exit 1
+fi
+
+if grep -qE '^\s*library:' "$LINT_OUT"; then
+  echo
+  echo "::warning::snapcraft lint reports library: warnings. Not a failure:" \
+       "assess each one (dynamically loaded vs genuinely unused) instead of" \
+       "adding a blanket ignore. See #465."
+fi
+
+echo "OK: snapcraft lint reports no gpu: warnings."


### PR DESCRIPTION
Closes the last open acceptance criterion of #465: "confirm `snapcraft lint` no longer emits `gpu:` warnings for bundled drivers; assess remaining library-linter warnings individually rather than blanket-ignore them."

## What was already there

`G1` carried an inline grep for `/dri/*_dri.so` and `libEGL/GLX_mesa`. It caught the two loudest patterns and missed the rest of what the provider owns: `libgbm`, the vendor `libdrm` family, vulkan ICDs. It never ran the linter whose `gpu:` warnings opened the issue.

## What this adds

`scripts/snap-gpu-lint-check.sh`, runnable by hand against any `.snap`, wired as **Gate G4** in place of the inline grep:

1. **content pass**, always runs, needs only `unsquashfs`, so it cannot degrade into "could not verify" on a runner;
2. **`snapcraft lint`** when snapcraft is on PATH. `gpu:` warnings fail the gate. `library:` warnings are printed as warnings and do **not** fail it, because the issue asks for them to be judged one at a time (a dynamically loaded library looks exactly like an unused one) rather than blanket-ignored.

## Verified against three snaps, not just read

| Snap | Result |
|---|---|
| synthetic clean | exit 0 |
| synthetic with Mesa inside | exit 1, all three files listed |
| **aeroftp 4.1.6 from the Store** | exit 1, **27 files listed** |

## The third row is the interesting one

It is not a false positive. The published snap has no `graphics-core22` plug and no `command-chain` at all: `snap-refresh` packs with the snapcraft.yaml **of the tag**, and the newest tag predates the migration.

Which means, and this is worth saying out loud on #465: the graphics-core22 migration is on `main` but **has never been packaged or gated end to end**. The gate commit (`d688efadc`, 2026-07-26 23:01) landed *after* the last run that actually packed a snap (2026-07-26 01:56), and the only run since then skipped `pack`. So "CI: G1, G2 and G3 all pass" is **unverified**, not satisfied, and stays that way until a v4.1.7 tag exists.

Note `scripts/snap-gpu-lint-check.sh` needed `git add -f`: `/scripts/*` is gitignored and every tracked script in there was added the same way.

Not merged: opened for review.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved snap validation to detect a broader range of bundled GPU userspace files.
  * Added checks for GPU-related lint warnings before installation and GUI readiness validation.
  * Prevented provider-owned graphics libraries from being shipped unintentionally while allowing approved graphics mount content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->