### PR TITLE
fix: Ehud triage 2026-07-28 (#274 #277 #347 #369) + copy affordance on form links

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ AeroFTP organizes integrations on three tiers, so what you see in the catalog is
 | Drime | FR | 20 GB | API |
 | DriveHQ | US | 5 GB | WebDAV |
 | Dropbox | US | 2 GB | OAuth |
-| Felicloud | - | 10 GB (Nextcloud host) | WebDAV |
+| Felicloud | EU | 10 GB (Nextcloud host) | WebDAV |
 | FileLu | US | 10 GB | API, FTP, WebDAV, S5 (S3) |
 | Filen | DE | 10 GB (E2E) | API, S3, WebDAV |
 | GitHub | US | repo storage | API |

--- a/docs/CLI-GUIDE.md
+++ b/docs/CLI-GUIDE.md
@@ -1455,6 +1455,23 @@ aeroftp-cli benchmark --profile "server" --file-count 5000 --file-size 4K --json
 
 When `--file-count N` is set (`--file-size` defaults to `64K`), the run adds five dedicated operations: **`upload-all`**, **`list-dir`** (one listing of the N-file directory), **`stat-all`**, **`download-all`**, and **`delete-all`**. Each reports **`files_per_second`** and a per-file latency distribution (`latency_ms`, whose p50 is the mean per-file time) alongside raw `throughput_mbps` for the transfer ops. The aggregate payload (`file-count` x `file-size`) is capped at 5 GiB and `--file-count` at 100000.
 
+#### Selecting what to benchmark
+
+```bash
+# Every saved profile (--all is the same flag)
+aeroftp-cli benchmark standard --all-profiles
+
+# Every saved profile, over every transport mode its provider offers
+aeroftp-cli benchmark standard --all-profiles --all-protocols
+
+# One account over each of its modes
+aeroftp-cli benchmark --profile "Koofr" --all-protocols
+```
+
+`--all-profiles` selects; `--all-protocols` expands a selection. Profiles that fail to connect, and modes whose credentials or endpoint cannot be resolved, are reported as skipped rather than measured as zero. Both combine with `--compare`, `--group` and the `-i` / `--tui` pickers.
+
+The comparison tables and the profile pickers show a **Server** column (who and where: `Koofr`, `TAB.DIGITAL`, `MEGA`, or `Custom` for a plain transport aimed at a host of your own) next to a **Protocol** column (how: `WebDAV`, `SFTP`, `S3`, `OAuth 2.0`, `REST API`). A preconfigured Koofr profile connected over WebDAV reads `Koofr / WebDAV`; a custom WebDAV server reads `Custom / WebDAV`.
+
 #### v4.1.0 improvements (#368)
 
 - The scratch base directory is removed after a run (guarded), honouring `--test-root-prefix`.

--- a/docs/COMMUNITY-BENCHMARK.md
+++ b/docs/COMMUNITY-BENCHMARK.md
@@ -98,6 +98,26 @@ aeroftp-cli benchmark standard --compare "S3 Backblaze,SFTP Lab,WebDAV Nextcloud
 Use `-i` to type the profiles interactively, or `--tui` for a full-screen
 checklist.
 
+Benchmark everything you have saved, with no list to type and no checklist to
+tick:
+
+```bash
+aeroftp-cli benchmark standard --all-profiles
+```
+
+`--all-profiles` (also spelled `--all`) is the whole-vault selection; profiles
+that fail to connect are reported as skipped, not fatal. It pairs with
+`--all-protocols`, which expands each selected profile into one run per
+transport mode its provider offers, so the two together measure every account
+over every surface:
+
+```bash
+aeroftp-cli benchmark standard --all-profiles --all-protocols
+```
+
+A mode whose credentials or endpoint cannot be resolved is listed as skipped,
+never measured as zero.
+
 Run only metadata operations:
 
 ```bash
@@ -140,8 +160,18 @@ whose parent did not yet exist.
 
 A few presentation details make multi-profile runs easier to read:
 
-- The per-profile header and the comparison tables carry a protocol / transport
-  column, so it is clear which transport each row was measured over.
+- The per-profile header, the profile pickers and the comparison tables carry a
+  **Server** column and a **Protocol** column. Server answers *who and where*
+  (`Koofr`, `TAB.DIGITAL`, `MEGA`), Protocol answers *how* (`WebDAV`, `SFTP`,
+  `S3`, `OAuth 2.0`, `REST API`). The two never repeat each other: a profile
+  that is a plain transport aimed at a host of your own reads `Custom / WebDAV`,
+  not `WebDAV / WebDAV`, and a preconfigured Koofr profile connected over
+  WebDAV reads `Koofr / WebDAV`.
+- The one-line `Benchmark complete:` summary quotes its values
+  (`server="Koofr" protocol="REST API"`), because several of them contain a
+  space. The escaping is JSON string escaping, so any JSON reader can unquote
+  it. For anything beyond a glance, use `--json`, which is the machine-readable
+  form.
 - A public-IP fairness snapshot flags a run as not-comparable if your public IP
   changed mid-sweep (for example, the connection dropped and reconnected on a
   different address), since that breaks the apples-to-apples comparison.

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -29,7 +29,7 @@ aeroftp.app / docs.aeroftp.app provider tables mirror this list.
 | Drime | FR | 20 GB | API |
 | DriveHQ | US | 5 GB | WebDAV |
 | Dropbox | US | 2 GB | OAuth |
-| Felicloud | - | 10 GB (Nextcloud host) | WebDAV |
+| Felicloud | EU | 10 GB (Nextcloud host) | WebDAV |
 | FileLu | US | 10 GB | API, FTP, WebDAV, S5 (S3) |
 | Filen | DE | 10 GB (E2E) | API, S3, WebDAV |
 | GitHub | US | repo storage | API |

--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -1999,7 +1999,11 @@ enum Commands {
         /// with -i/--tui. Combine with --group to run all members of those groups,
         /// or with -i/--tui to pre-tick the whole list. Profiles that fail to
         /// connect are reported as skipped, not fatal.
-        #[arg(long)]
+        ///
+        /// `--all-profiles` is an accepted spelling: it pairs read-for-read with
+        /// `--all-protocols`, and the two combine to benchmark every profile
+        /// over every transport mode its provider offers.
+        #[arg(long, alias = "all-profiles")]
         all: bool,
         /// Expand every selected profile into one run per transport mode of its
         /// provider (Ehud #277): a Koofr profile is benchmarked over both its
@@ -5583,6 +5587,13 @@ struct BenchmarkReport {
     // native ones (OAuth 2.0, OAuth 1.0, REST API). Additive to schema v1.
     #[serde(default)]
     access: String,
+    // Service identity of the profile (issue #277): the catalog company for a
+    // preconfigured preset (`Koofr`, `TAB.DIGITAL`), the provider itself for a
+    // native API, or `Custom` for a generic transport aimed at the user's own
+    // host. A fixed vocabulary drawn from the embedded catalog, never user
+    // text, so the report stays as anonymous as it was. Additive to schema v1.
+    #[serde(default)]
+    service: String,
     // Transport mode this run measured when `--all-protocols` expanded one
     // profile into several runs (issue #277 B4): `api`, `webdav`, `s3` or `ftp`.
     // Absent for an ordinary single-mode run. Without it a JSON consumer cannot
@@ -41038,6 +41049,14 @@ async fn cmd_benchmark(
     // the live provider type so it reflects the transport the factory actually
     // built (e.g. a Koofr-over-WebDAV profile reports `WebDAV`, native `REST API`).
     let access = provider.provider_type().access_label().to_string();
+    // Service identity for the "Server" column (issue #277, Ehud): the preset's
+    // company when the profile is preconfigured, the provider for a native API,
+    // `Custom` for a plain transport aimed at the user's own host. Resolved
+    // from the saved profile, since the built provider only knows the transport.
+    let service = benchmark_service_label(
+        provider.provider_type(),
+        benchmark_profile_provider_id(cli, profile_for_connect, synth_profile).as_deref(),
+    );
 
     let report_id = uuid::Uuid::new_v4().to_string();
     let (bench_base, test_root) = match test_root_prefix_override {
@@ -41650,6 +41669,7 @@ async fn cmd_benchmark(
         },
         level,
         access: access.clone(),
+        service: service.clone(),
         // Set by the compare sweep for a fan-out run; a standalone run has no mode.
         mode: None,
         environment,
@@ -41766,18 +41786,45 @@ fn benchmark_report_access(report: &BenchmarkReport) -> String {
     }
 }
 
+/// Service label for a report (issue #277): the "Server" column value, e.g.
+/// `Koofr`, `TAB.DIGITAL`, `Custom`. Falls back to the transport/provider
+/// display name for reports produced before the field existed.
+fn benchmark_report_service(report: &BenchmarkReport) -> String {
+    if report.service.is_empty() {
+        benchmark_report_protocol(report)
+    } else {
+        report.service.clone()
+    }
+}
+
+/// Quote a value for the one-line `Benchmark complete:` summary (issue #277,
+/// Ehud). The line is `key=value` pairs and several values contain spaces
+/// (`REST API`, `Yandex Disk`), so an unquoted line cannot be split on
+/// whitespace. Double-quote everything and backslash-escape `"` and `\`, which
+/// is the same escaping the shell and CSV readers already understand. The
+/// machine-readable form remains `--format json`.
+fn benchmark_quote(value: &str) -> String {
+    let escaped = value.replace('\\', "\\\\").replace('"', "\\\"");
+    format!("\"{escaped}\"")
+}
+
 fn print_benchmark_text_report(report: &BenchmarkReport) {
     let color_on = use_color();
-    // Identity line (issue #277): the service name (Type) and the access-method
-    // class (Protocol), matching the comparison-table column semantics.
-    let type_name = benchmark_report_protocol(report);
+    // Identity line (issue #277): the service name (Server) and the
+    // access-method class (Protocol), matching the comparison-table column
+    // semantics. Values are quoted because several of them contain spaces.
+    let service = benchmark_report_service(report);
     let access = benchmark_report_access(report);
-    let identity_cell = if type_name.is_empty() {
+    let identity_cell = if service.is_empty() {
         String::new()
-    } else if access.is_empty() || access == type_name {
-        format!(" type={}", type_name)
+    } else if access.is_empty() || access == service {
+        format!(" server={}", benchmark_quote(&service))
     } else {
-        format!(" type={} protocol={}", type_name, access)
+        format!(
+            " server={} protocol={}",
+            benchmark_quote(&service),
+            benchmark_quote(&access)
+        )
     };
     println!(
         "Benchmark complete: level={:?}{} runs={} bytes={} duration={}ms",
@@ -42438,14 +42485,14 @@ fn print_benchmark_comparison(entries: &[(String, BenchmarkReport)], color_on: b
     if entries.len() < 2 {
         return;
     }
-    // Column semantics (issue #277): the "Type" cell is the service identity
-    // (kDrive, Koofr, WebDAV, S3, ...) taken from the live provider display
-    // name, and the "Protocol" cell is the access-method class (SFTP, WebDAV,
-    // OAuth 2.0, REST API, ...). Previously "type" read a lowercase providerId
-    // and "protocol" read the same display name, so the two columns duplicated
-    // each other for native providers. Falls back to a dash when unknown.
-    let type_of = |r: &BenchmarkReport| -> String {
-        let name = benchmark_report_protocol(r);
+    // Column semantics (issue #277, Ehud): the "server" cell is the service
+    // identity (kDrive, Koofr, TAB.DIGITAL, or `Custom` for a generic transport
+    // pointed at the user's own host), and the "protocol" cell is the
+    // access-method class (SFTP, WebDAV, OAuth 2.0, REST API, ...). The two
+    // never repeat each other: a custom WebDAV profile reads `Custom / WebDAV`,
+    // not `WebDAV / WebDAV`. Falls back to a dash when unknown.
+    let server_of = |r: &BenchmarkReport| -> String {
+        let name = benchmark_report_service(r);
         if name.is_empty() {
             "-".to_string()
         } else {
@@ -42464,14 +42511,14 @@ fn print_benchmark_comparison(entries: &[(String, BenchmarkReport)], color_on: b
         .iter()
         .any(|(_, r)| r.results.iter().any(|x| x.files_per_second.is_some()));
     if has_many {
-        let mut headers: Vec<&str> = vec!["profile", "type", "protocol"];
+        let mut headers: Vec<&str> = vec!["profile", "server", "protocol"];
         headers.extend_from_slice(&many_ops);
         let mut aligns = vec![true, true, true];
         aligns.extend(many_ops.iter().map(|_| false));
         let rows: Vec<Vec<String>> = entries
             .iter()
             .map(|(name, r)| {
-                let mut row = vec![name.clone(), type_of(r), benchmark_report_access(r)];
+                let mut row = vec![name.clone(), server_of(r), benchmark_report_access(r)];
                 for op in many_ops {
                     let cell = r
                         .results
@@ -42504,7 +42551,7 @@ fn print_benchmark_comparison(entries: &[(String, BenchmarkReport)], color_on: b
     if has_single {
         let headers = [
             "profile",
-            "type",
+            "server",
             "protocol",
             "upload Mbps",
             "download Mbps",
@@ -42523,7 +42570,7 @@ fn print_benchmark_comparison(entries: &[(String, BenchmarkReport)], color_on: b
                 };
                 vec![
                     name.clone(),
-                    type_of(r),
+                    server_of(r),
                     benchmark_report_access(r),
                     cell(single_ops[0]),
                     cell(single_ops[1]),
@@ -42573,16 +42620,104 @@ fn benchmark_pick_in_pool(
 /// not resolve to a known provider type (matching the benchmark comparison
 /// table semantics, where Type is the service name and Protocol the transport).
 fn benchmark_profile_identity(p: &serde_json::Value) -> (String, String) {
-    let raw = p
+    // The transport is what the profile is SAVED as, so a Koofr-over-WebDAV
+    // profile reads WebDAV here even though its preset id is `koofr`. Reading
+    // the preset id first (as this did) reported the native REST API for it.
+    let protocol = p
+        .get("protocol")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let provider_id = p
         .get("providerId")
         .and_then(|v| v.as_str())
-        .or_else(|| p.get("provider_id").and_then(|v| v.as_str()))
-        .or_else(|| p.get("protocol").and_then(|v| v.as_str()))
-        .unwrap_or("");
-    match ProviderType::from_lowercase(raw) {
-        Some(pt) => (pt.to_string(), pt.access_label().to_string()),
-        None => (raw.to_string(), raw.to_string()),
+        .or_else(|| p.get("provider_id").and_then(|v| v.as_str()));
+    match ProviderType::from_lowercase(&protocol) {
+        Some(pt) => (
+            benchmark_service_label(pt, provider_id),
+            pt.access_label().to_string(),
+        ),
+        None => (protocol.clone(), protocol),
     }
+}
+
+/// Generic transports: the ones a user points at a host of their own, so the
+/// profile carries no service identity beyond what the Protocol column says.
+/// Every other provider type IS a service (Koofr, kDrive, MEGA, ...).
+fn is_generic_transport(provider_type: ProviderType) -> bool {
+    matches!(
+        provider_type,
+        ProviderType::Ftp
+            | ProviderType::Ftps
+            | ProviderType::Sftp
+            | ProviderType::WebDav
+            | ProviderType::S3
+            | ProviderType::Swift
+    )
+}
+
+/// Company display name for a catalog preset id, e.g. `koofr` -> `Koofr`,
+/// `mega-s4` -> `MEGA`, `tabdigital` -> `TAB.DIGITAL`. `None` when the id is
+/// not a known preset. Only ever used as a lookup key: the value returned comes
+/// from the embedded catalog, never from user text, so it cannot leak anything
+/// into a benchmark report.
+fn catalog_company_for_provider_id(provider_id: &str) -> Option<String> {
+    load_cli_catalog().ok()?.into_iter().find_map(|c| {
+        c.protocols
+            .iter()
+            .any(|m| m.provider_id.as_deref() == Some(provider_id))
+            .then_some(c.company)
+    })
+}
+
+/// Service identity for the benchmark "Server" column (issue #277, Ehud).
+///
+/// The column answers "who and where", so it must never repeat the Protocol
+/// column, which answers "how". A profile built on a preconfigured preset
+/// reports its service (`Koofr`, `TAB.DIGITAL`, `MEGA`); a native-API profile
+/// reports the provider itself; and a profile that is only a generic transport
+/// aimed at the user's own host reports `Custom`, because the old "WebDAV /
+/// WebDAV" pair told the reader nothing the Protocol column had not said.
+fn benchmark_service_label(provider_type: ProviderType, provider_id: Option<&str>) -> String {
+    if let Some(company) = provider_id
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .and_then(catalog_company_for_provider_id)
+    {
+        return company;
+    }
+    if is_generic_transport(provider_type) {
+        return "Custom".to_string();
+    }
+    provider_type.to_string()
+}
+
+/// Best-effort lookup of a saved profile's preset id, for the benchmark
+/// "Server" column. Resolves the name exactly as the connect path does. Any
+/// failure (locked vault, ambiguous name) yields `None`, which downgrades the
+/// column to the provider type: identity labelling must never fail a run.
+fn benchmark_profile_provider_id(
+    cli: &Cli,
+    profile_name: Option<&str>,
+    synth_profile: Option<&serde_json::Value>,
+) -> Option<String> {
+    let owned = |p: &serde_json::Value| -> Option<String> {
+        p.get("providerId")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+    };
+    // `--all-protocols` connects a profile synthesized in memory, so its preset
+    // id is the authoritative one for the mode actually being measured.
+    if let Some(synth) = synth_profile {
+        return owned(synth);
+    }
+    let name = profile_name?;
+    let store = open_vault(cli).ok()?;
+    let profiles = load_active_user_profiles(cli, &store).ok()?;
+    let idx = resolve_profile_selector(&profiles, name).ok()?;
+    owned(profiles.get(idx)?)
 }
 
 fn benchmark_pick_profiles_inline(profiles: &[serde_json::Value]) -> std::io::Result<Vec<usize>> {
@@ -42595,7 +42730,7 @@ fn benchmark_pick_profiles_inline(profiles: &[serde_json::Value]) -> std::io::Re
         err,
         "{}",
         paint_dim(
-            &format!("      {:<14}{:<12}{}", "Type", "Protocol", "Profile"),
+            &format!("      {:<14}{:<12}{}", "Server", "Protocol", "Profile"),
             color_on
         )
     )?;
@@ -42752,7 +42887,7 @@ fn benchmark_pick_profiles(profiles: &[serde_json::Value]) -> std::io::Result<Ve
             err,
             "{}",
             paint_dim(
-                &format!("          {:<14}{:<12}{}", "Type", "Protocol", "Profile"),
+                &format!("          {:<14}{:<12}{}", "Server", "Protocol", "Profile"),
                 color_on
             )
         )?;
@@ -65469,6 +65604,133 @@ mod tests {
     }
 
     #[test]
+    fn service_label_says_custom_for_a_plain_transport() {
+        // Ehud #277: the Server column must not echo the Protocol column. A
+        // WebDAV/SFTP/S3 profile aimed at the user's own host has no service
+        // identity, so it reads `Custom`, never `WebDAV / WebDAV`.
+        for pt in [
+            ProviderType::WebDav,
+            ProviderType::Sftp,
+            ProviderType::Ftp,
+            ProviderType::Ftps,
+            ProviderType::S3,
+            ProviderType::Swift,
+        ] {
+            assert_eq!(benchmark_service_label(pt, None), "Custom", "{pt}");
+            assert_eq!(benchmark_service_label(pt, Some("  ")), "Custom", "{pt}");
+        }
+    }
+
+    #[test]
+    fn service_label_resolves_a_preset_to_its_company() {
+        // A preconfigured profile names the service even when the transport is
+        // generic: Koofr over WebDAV is `Koofr / WebDAV`, not `WebDAV / WebDAV`.
+        assert_eq!(
+            benchmark_service_label(ProviderType::WebDav, Some("koofr")),
+            "Koofr"
+        );
+        assert_eq!(
+            benchmark_service_label(ProviderType::WebDav, Some("tabdigital")),
+            "TAB.DIGITAL"
+        );
+        assert_eq!(
+            benchmark_service_label(ProviderType::S3, Some("mega-s4")),
+            "MEGA"
+        );
+        // An unknown id is not a preset: fall back to the transport rule.
+        assert_eq!(
+            benchmark_service_label(ProviderType::WebDav, Some("not-a-preset")),
+            "Custom"
+        );
+    }
+
+    #[test]
+    fn service_label_keeps_native_providers_as_themselves() {
+        // Native APIs carry their own identity and have no preset id.
+        assert_eq!(benchmark_service_label(ProviderType::Koofr, None), "Koofr");
+        assert_eq!(
+            benchmark_service_label(ProviderType::KDrive, None),
+            "kDrive"
+        );
+        assert_eq!(benchmark_service_label(ProviderType::Mega, None), "MEGA");
+    }
+
+    #[test]
+    fn profile_identity_reads_the_saved_transport_not_the_preset() {
+        // Regression (#277): reading the preset id first reported a Koofr
+        // WebDAV profile as `REST API`, the mode it is NOT saved in.
+        let webdav = json!({
+            "name": "Koofr", "protocol": "webdav", "providerId": "koofr"
+        });
+        assert_eq!(
+            benchmark_profile_identity(&webdav),
+            ("Koofr".to_string(), "WebDAV".to_string())
+        );
+        let native = json!({"name": "Koofr API", "protocol": "koofr"});
+        assert_eq!(
+            benchmark_profile_identity(&native),
+            ("Koofr".to_string(), "REST API".to_string())
+        );
+        let custom = json!({"name": "My NAS", "protocol": "webdav"});
+        assert_eq!(
+            benchmark_profile_identity(&custom),
+            ("Custom".to_string(), "WebDAV".to_string())
+        );
+    }
+
+    #[test]
+    fn benchmark_quote_survives_a_round_trip_through_json() {
+        // The summary line is `key="value"` because several values contain a
+        // space (`REST API`, `Yandex Disk`). The escaping is JSON string
+        // escaping, so a reader can unquote it with any JSON parser.
+        assert_eq!(benchmark_quote("REST API"), "\"REST API\"");
+        for raw in ["REST API", "a\"b", "back\\slash", "Custom"] {
+            let quoted = benchmark_quote(raw);
+            let parsed: String = serde_json::from_str(&quoted).unwrap();
+            assert_eq!(parsed, raw);
+        }
+    }
+
+    #[test]
+    fn benchmark_all_profiles_is_an_accepted_spelling_of_all() {
+        // Ehud #277 #3: `--all-profiles` must exist and pair with
+        // `--all-protocols`, which is how the two read together.
+        use clap::Parser;
+        let parse = |args: &[&str]| {
+            let cli = Cli::try_parse_from(args).expect("flags should parse");
+            match cli.command {
+                Commands::Benchmark {
+                    all, all_protocols, ..
+                } => (all, all_protocols),
+                _ => panic!("expected the benchmark subcommand"),
+            }
+        };
+        // The command tree is large enough to blow a test thread's default
+        // 2 MiB stack while clap builds it, so give the parse its own.
+        std::thread::Builder::new()
+            .stack_size(16 * 1024 * 1024)
+            .spawn(move || {
+                assert_eq!(parse(&["aeroftp-cli", "benchmark", "--all"]), (true, false));
+                assert_eq!(
+                    parse(&["aeroftp-cli", "benchmark", "--all-profiles"]),
+                    (true, false)
+                );
+                assert_eq!(
+                    parse(&[
+                        "aeroftp-cli",
+                        "benchmark",
+                        "--all-profiles",
+                        "--all-protocols"
+                    ]),
+                    (true, true)
+                );
+            })
+            .expect("spawn parse thread")
+            .join()
+            .expect("flag parsing should not panic");
+    }
+
+    #[test]
     fn fanout_expands_koofr_into_both_modes() {
         // The reporter's acceptance case (#277, comment 17737942): one Koofr
         // profile must produce a Koofr API row and a Koofr WebDAV row.
@@ -69715,6 +69977,7 @@ mod tests {
             },
             level: BenchmarkLevel::Quick,
             access: "SFTP".into(),
+            service: "Custom".into(),
             mode: None,
             environment: BenchmarkEnvironment {
                 asn_bucket: None,

--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -40953,6 +40953,9 @@ async fn cmd_benchmark(
     // so it is passed as a value instead of being looked up by name. None for
     // every ordinary run.
     synth_profile: Option<&serde_json::Value>,
+    // The saved profile this row is running, when the caller already resolved
+    // it. Only the "Server" column reads it; the connect path is unchanged.
+    source_profile: Option<&serde_json::Value>,
     cli: &Cli,
     format: OutputFormat,
 ) -> i32 {
@@ -41055,7 +41058,8 @@ async fn cmd_benchmark(
     // from the saved profile, since the built provider only knows the transport.
     let service = benchmark_service_label(
         provider.provider_type(),
-        benchmark_profile_provider_id(cli, profile_for_connect, synth_profile).as_deref(),
+        benchmark_profile_provider_id(cli, profile_for_connect, synth_profile, source_profile)
+            .as_deref(),
     );
 
     let report_id = uuid::Uuid::new_v4().to_string();
@@ -42377,6 +42381,8 @@ async fn cmd_benchmark_compare(
             } else {
                 Some(&synth)
             },
+            // Already resolved by index above: no second vault open per row.
+            Some(&profiles[i]),
             cli,
             format,
         )
@@ -42693,13 +42699,23 @@ fn benchmark_service_label(provider_type: ProviderType, provider_id: Option<&str
 }
 
 /// Best-effort lookup of a saved profile's preset id, for the benchmark
-/// "Server" column. Resolves the name exactly as the connect path does. Any
-/// failure (locked vault, ambiguous name) yields `None`, which downgrades the
-/// column to the provider type: identity labelling must never fail a run.
+/// "Server" column. Any failure (locked vault, ambiguous name) yields `None`,
+/// which downgrades the column to the provider type: identity labelling must
+/// never fail a run.
+///
+/// Three sources, most authoritative first. `--all-protocols` connects a
+/// profile synthesized in memory, so its preset id is the one for the mode
+/// actually being measured. A compare sweep has already loaded the profile
+/// list and knows the exact index of the row it is running, so it hands the
+/// record straight over: that avoids reopening the vault once per row, and it
+/// is also more precise than the fallback, which starts from the name again
+/// and can be ambiguous where an index cannot. The by-name lookup is left for
+/// the single-profile path, which has no list in hand.
 fn benchmark_profile_provider_id(
     cli: &Cli,
     profile_name: Option<&str>,
     synth_profile: Option<&serde_json::Value>,
+    source_profile: Option<&serde_json::Value>,
 ) -> Option<String> {
     let owned = |p: &serde_json::Value| -> Option<String> {
         p.get("providerId")
@@ -42708,10 +42724,11 @@ fn benchmark_profile_provider_id(
             .filter(|s| !s.is_empty())
             .map(str::to_string)
     };
-    // `--all-protocols` connects a profile synthesized in memory, so its preset
-    // id is the authoritative one for the mode actually being measured.
     if let Some(synth) = synth_profile {
         return owned(synth);
+    }
+    if let Some(source) = source_profile {
+        return owned(source);
     }
     let name = profile_name?;
     let store = open_vault(cli).ok()?;
@@ -62730,6 +62747,7 @@ async fn main() {
                     *pre_delete,
                     *file_count,
                     file_size,
+                    None,
                     None,
                     None,
                     None,

--- a/src-tauri/src/cli_catalog.json
+++ b/src-tauri/src/cli_catalog.json
@@ -780,11 +780,13 @@
   {
     "company": "Felicloud",
     "logoId": "felicloud",
-    "country": "",
+    "country": "EU",
     "freeGb": 10,
     "freeNote": "Nextcloud host",
     "freeRequiresCard": false,
-    "regions": [],
+    "regions": [
+      "EU"
+    ],
     "protocols": [
       {
         "label": "WebDAV",

--- a/src/components/AeroCryptUnlock.tsx
+++ b/src/components/AeroCryptUnlock.tsx
@@ -20,7 +20,7 @@ import { open, save } from '@tauri-apps/plugin-dialog';
 import { writeTextFile } from '@tauri-apps/plugin-fs';
 import { Lock, Unlock, Loader2, X, FileKey } from 'lucide-react';
 import { useTranslation } from '../i18n';
-import { AEROCRYPT_DEFAULT_SALT_V1_HEX, AEROCRYPT_DEFAULT_SALT_V1_PREIMAGE, formatDefaultSaltForDisplay } from '../utils/aerocryptDefaultSalt';
+import { DefaultSaltDisclosure } from './common/DefaultSaltDisclosure';
 import { PasswordInput } from './common/PasswordInput';
 import { PasswordMatchHint } from './common/PasswordMatchHint';
 import { InlinePasswordGenerator } from './common/InlinePasswordGenerator';
@@ -680,20 +680,8 @@ export const AeroCryptUnlock: React.FC<AeroCryptUnlockProps> = ({
                                             {/* Ehud #369: the radios read as "the salt is 128/256-bit".
                                                 They are a password requirement; the salt is a single
                                                 32-byte public constant, printed here so it can be
-                                                read and backed up. */}
-                                            <div className="ml-5 text-gray-500 dark:text-gray-400 leading-relaxed">
-                                                <div>{t('aerocryptProfile.defaultSaltTierMeaning')}</div>
-                                                <div className="mt-1">
-                                                    {t('aerocryptProfile.defaultSaltValueLabel')}{' '}
-                                                    <code className="font-mono">&quot;{AEROCRYPT_DEFAULT_SALT_V1_PREIMAGE}&quot;</code>:{' '}
-                                                    <code
-                                                        className="font-mono select-all break-all text-gray-600 dark:text-gray-300"
-                                                        title={AEROCRYPT_DEFAULT_SALT_V1_HEX}
-                                                    >
-                                                        {formatDefaultSaltForDisplay()}
-                                                    </code>
-                                                </div>
-                                            </div>
+                                                read, copied and backed up. */}
+                                            <DefaultSaltDisclosure className="ml-5" />
                                             <label className="ml-5 flex items-start gap-1.5">
                                                 <input type="checkbox" checked={aeroCryptDefaultSaltAttested} onChange={(e)=>setAeroCryptDefaultSaltAttested(e.target.checked)} />
                                                 <span>{t('aerocryptNative.defaultSaltAttestation')}</span>

--- a/src/components/AeroCryptUnlock.tsx
+++ b/src/components/AeroCryptUnlock.tsx
@@ -20,6 +20,7 @@ import { open, save } from '@tauri-apps/plugin-dialog';
 import { writeTextFile } from '@tauri-apps/plugin-fs';
 import { Lock, Unlock, Loader2, X, FileKey } from 'lucide-react';
 import { useTranslation } from '../i18n';
+import { AEROCRYPT_DEFAULT_SALT_V1_HEX, AEROCRYPT_DEFAULT_SALT_V1_PREIMAGE, formatDefaultSaltForDisplay } from '../utils/aerocryptDefaultSalt';
 import { PasswordInput } from './common/PasswordInput';
 import { PasswordMatchHint } from './common/PasswordMatchHint';
 import { InlinePasswordGenerator } from './common/InlinePasswordGenerator';
@@ -675,6 +676,23 @@ export const AeroCryptUnlock: React.FC<AeroCryptUnlockProps> = ({
                                             <div className="ml-5 flex gap-3">
                                                 <label><input type="radio" name="mstrength" checked={aeroCryptDefaultSaltStrength==='128'} onChange={() => setAeroCryptDefaultSaltStrength('128')} /> {t('aerocryptNative.defaultSaltStrength128')}</label>
                                                 <label><input type="radio" name="mstrength" checked={aeroCryptDefaultSaltStrength==='256'} onChange={() => setAeroCryptDefaultSaltStrength('256')} /> {t('aerocryptNative.defaultSaltStrength256')}</label>
+                                            </div>
+                                            {/* Ehud #369: the radios read as "the salt is 128/256-bit".
+                                                They are a password requirement; the salt is a single
+                                                32-byte public constant, printed here so it can be
+                                                read and backed up. */}
+                                            <div className="ml-5 text-gray-500 dark:text-gray-400 leading-relaxed">
+                                                <div>{t('aerocryptProfile.defaultSaltTierMeaning')}</div>
+                                                <div className="mt-1">
+                                                    {t('aerocryptProfile.defaultSaltValueLabel')}{' '}
+                                                    <code className="font-mono">&quot;{AEROCRYPT_DEFAULT_SALT_V1_PREIMAGE}&quot;</code>:{' '}
+                                                    <code
+                                                        className="font-mono select-all break-all text-gray-600 dark:text-gray-300"
+                                                        title={AEROCRYPT_DEFAULT_SALT_V1_HEX}
+                                                    >
+                                                        {formatDefaultSaltForDisplay()}
+                                                    </code>
+                                                </div>
                                             </div>
                                             <label className="ml-5 flex items-start gap-1.5">
                                                 <input type="checkbox" checked={aeroCryptDefaultSaltAttested} onChange={(e)=>setAeroCryptDefaultSaltAttested(e.target.checked)} />

--- a/src/components/ConnectionScreen.tsx
+++ b/src/components/ConnectionScreen.tsx
@@ -34,6 +34,7 @@ import { loadModeCredentials, storeModeCredentials, deleteModeCredentials, type 
 import { openUrl } from '../utils/openUrl';
 import { safePickerStartDir } from '../utils/safePickerDir';
 import { isValidOverlayScope, resolveOverlayScope } from '../utils/overlayScope';
+import { AEROCRYPT_DEFAULT_SALT_V1_HEX, AEROCRYPT_DEFAULT_SALT_V1_PREIMAGE, formatDefaultSaltForDisplay } from '../utils/aerocryptDefaultSalt';
 import { OAuthConnect } from './OAuthConnect';
 import { ProviderSelector } from './ProviderSelector';
 import { AlertDialog } from './Dialogs';
@@ -3291,6 +3292,32 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                                                             />
                                                             <span>{t('aerocryptProfile.defaultSaltTier256') || '256-bit (stricter, needs a 39+ character password)'}</span>
                                                         </label>
+                                                    </div>
+                                                )}
+
+                                                {/* Ehud #369: the radios were being read as "the salt is
+                                                    128/256-bit", and the salt itself was nowhere on screen.
+                                                    Say what the radios actually set, then print the one
+                                                    public salt so it can be read and backed up. */}
+                                                {aeroCryptKind === 'aerocrypt' && (
+                                                    <div className="ml-12 mt-1.5 text-xs text-gray-500 dark:text-gray-400 leading-relaxed">
+                                                        <div>
+                                                            {t('aerocryptProfile.defaultSaltTierMeaning')
+                                                                || 'The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.'}
+                                                        </div>
+                                                        <div className="mt-1 flex flex-wrap items-baseline gap-x-1.5">
+                                                            <span>
+                                                                {t('aerocryptProfile.defaultSaltValueLabel')
+                                                                    || 'Public default salt (AeroCrypt v3), SHA-256 of'}{' '}
+                                                                <code className="font-mono">&quot;{AEROCRYPT_DEFAULT_SALT_V1_PREIMAGE}&quot;</code>:
+                                                            </span>
+                                                            <code
+                                                                className="font-mono select-all break-all text-gray-600 dark:text-gray-300"
+                                                                title={AEROCRYPT_DEFAULT_SALT_V1_HEX}
+                                                            >
+                                                                {formatDefaultSaltForDisplay()}
+                                                            </code>
+                                                        </div>
                                                     </div>
                                                 )}
 

--- a/src/components/ConnectionScreen.tsx
+++ b/src/components/ConnectionScreen.tsx
@@ -405,7 +405,7 @@ const FourSharedConnect: React.FC<FourSharedConnectProps> = ({
                 <div className="p-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg space-y-3">
                     <div className="flex items-center justify-between">
                         <h4 className="font-medium text-sm">{t('connection.fourshared.oauth1Credentials')}</h4>
-                        <span className="inline-flex items-center gap-0.5 shrink-0">
+                        <span className="inline-flex items-center shrink-0">
                             <button
                                 onClick={() => openUrl('https://www.4shared.com/developer/docs/app/')}
                                 className="text-xs text-blue-500 hover:text-blue-600 flex items-center gap-1"
@@ -2771,7 +2771,7 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                 shared between all of them and the copy would drift to the far
                 right, away from the link it belongs to. */}
             {accountSignupUrl && (
-                <span className="inline-flex items-center gap-0.5 shrink-0">
+                <span className="inline-flex items-center shrink-0">
                     <a
                         href={`${accountSignupUrl}${accountSignupUrl.includes('?') ? '&' : '?'}utm_source=aeroftp`}
                         target="_blank"
@@ -2791,7 +2791,7 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
         <div className="flex items-center justify-between gap-2 mb-1.5">
             <label className="block text-sm font-medium">{overrideText ?? getPasswordLabel()}</label>
             {accountPasswordGenUrl && (
-                <span className="inline-flex items-center gap-0.5 shrink-0">
+                <span className="inline-flex items-center shrink-0">
                     <a
                         href={accountPasswordGenUrl}
                         target="_blank"
@@ -3707,16 +3707,22 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                                 return (
                                     <div className="flex flex-col items-end gap-0.5">
                                         <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
-                                            <a
-                                                href={docsUrl}
-                                                target="_blank"
-                                                rel="noopener noreferrer"
-                                                className="inline-flex items-center gap-1 text-xs text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300"
-                                            >
-                                                <ExternalLink size={10} />
-                                                Docs
-                                            </a>
-                                            <CopyLinkButton url={docsUrl} />
+                                            {/* Grouped like every other link row: this row is
+                                                gap-2, which would stack on top of the button's own
+                                                margin and leave the copy visibly further from Docs
+                                                than everywhere else in the app. */}
+                                            <span className="inline-flex items-center shrink-0">
+                                                <a
+                                                    href={docsUrl}
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    className="inline-flex items-center gap-1 text-xs text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300"
+                                                >
+                                                    <ExternalLink size={10} />
+                                                    Docs
+                                                </a>
+                                                <CopyLinkButton url={docsUrl} />
+                                            </span>
                                             {LogoComponent && <LogoComponent size={20} />}
                                             <span className="font-medium">{providerName}</span>
                                         </div>
@@ -4473,7 +4479,7 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                                             <div>
                                                 <div className="flex items-center justify-between gap-2 mb-1.5">
                                                     <label className="block text-sm font-medium">{t('connection.jottacloudToken')}</label>
-                                                    <span className="inline-flex items-center gap-0.5 shrink-0">
+                                                    <span className="inline-flex items-center shrink-0">
                                                         <a
                                                             href="https://www.jottacloud.com/web/secure"
                                                             target="_blank"
@@ -5171,7 +5177,7 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                                         <div>
                                             <div className="flex items-center justify-between gap-2 mb-1.5">
                                                 <label className="block text-sm font-medium">{t('connection.kdriveDriveId')}</label>
-                                                <span className="inline-flex items-center gap-0.5 shrink-0">
+                                                <span className="inline-flex items-center shrink-0">
                                                     <a
                                                         href="https://ksuite.infomaniak.com/all/kdrive"
                                                         target="_blank"
@@ -5205,7 +5211,7 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                                         <div>
                                             <div className="flex items-center justify-between gap-2 mb-1.5">
                                                 <label className="block text-sm font-medium">{t('connection.kdriveToken')}</label>
-                                                <span className="inline-flex items-center gap-0.5 shrink-0">
+                                                <span className="inline-flex items-center shrink-0">
                                                     <a
                                                         href="https://manager.infomaniak.com/v3/ng/profile/user/token/list"
                                                         target="_blank"
@@ -5986,7 +5992,7 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                                                     >
                                                         {t('connection.downloadMegacmd')}
                                                     </a>
-                                                    <CopyLinkButton url="https://mega.io/cmd" size={11} className="ml-1" />
+                                                    <CopyLinkButton url="https://mega.io/cmd" size={11} />
                                                     </>
                                                 )}
                                             </p>
@@ -6385,7 +6391,7 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                                                         <ExternalLink size={11} />
                                                         {t('protocol.openProviderDocs', { provider: selectedProvider.name })}
                                                     </a>
-                                                    <CopyLinkButton url={selectedProvider.helpUrl} size={11} className="ml-1" />
+                                                    <CopyLinkButton url={selectedProvider.helpUrl} size={11} />
                                                     </>
                                                 )}
                                             </CollapsibleSetupBox>
@@ -6830,7 +6836,7 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                                 <ExternalLink size={14} />
                                 {gitHubDeviceFlow.verificationUri}
                             </a>
-                            <CopyLinkButton url={gitHubDeviceFlow.verificationUri} size={14} className="ml-1.5" />
+                            <CopyLinkButton url={gitHubDeviceFlow.verificationUri} size={14} />
                         </div>
                         <div className="flex justify-end gap-2 px-5 py-3 bg-gray-50 dark:bg-gray-800/50 border-t border-gray-200 dark:border-gray-700">
                             <button

--- a/src/components/ConnectionScreen.tsx
+++ b/src/components/ConnectionScreen.tsx
@@ -34,7 +34,8 @@ import { loadModeCredentials, storeModeCredentials, deleteModeCredentials, type 
 import { openUrl } from '../utils/openUrl';
 import { safePickerStartDir } from '../utils/safePickerDir';
 import { isValidOverlayScope, resolveOverlayScope } from '../utils/overlayScope';
-import { AEROCRYPT_DEFAULT_SALT_V1_HEX, AEROCRYPT_DEFAULT_SALT_V1_PREIMAGE, formatDefaultSaltForDisplay } from '../utils/aerocryptDefaultSalt';
+import { DefaultSaltDisclosure } from './common/DefaultSaltDisclosure';
+import { CopyLinkButton } from './common/CopyLinkButton';
 import { OAuthConnect } from './OAuthConnect';
 import { ProviderSelector } from './ProviderSelector';
 import { AlertDialog } from './Dialogs';
@@ -404,12 +405,15 @@ const FourSharedConnect: React.FC<FourSharedConnectProps> = ({
                 <div className="p-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg space-y-3">
                     <div className="flex items-center justify-between">
                         <h4 className="font-medium text-sm">{t('connection.fourshared.oauth1Credentials')}</h4>
-                        <button
-                            onClick={() => openUrl('https://www.4shared.com/developer/docs/app/')}
-                            className="text-xs text-blue-500 hover:text-blue-600 flex items-center gap-1"
-                        >
-                            {t('settings.getCredentials')} <ExternalLink size={12} />
-                        </button>
+                        <span className="inline-flex items-center gap-0.5 shrink-0">
+                            <button
+                                onClick={() => openUrl('https://www.4shared.com/developer/docs/app/')}
+                                className="text-xs text-blue-500 hover:text-blue-600 flex items-center gap-1"
+                            >
+                                {t('settings.getCredentials')} <ExternalLink size={12} />
+                            </button>
+                            <CopyLinkButton url="https://www.4shared.com/developer/docs/app/" size={12} />
+                        </span>
                     </div>
                     <p className="text-xs text-gray-500 dark:text-gray-400">
                         {t('connection.fourshared.createAppInstructions')}
@@ -2762,16 +2766,23 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
     const renderUsernameLabel = (overrideText?: string) => (
         <div className="flex items-center justify-between gap-2 mb-1.5">
             <label className="block text-sm font-medium">{overrideText ?? getUsernameLabel()}</label>
+            {/* Link and its copy button are one group: the row is
+                justify-between, so as three loose children the space would be
+                shared between all of them and the copy would drift to the far
+                right, away from the link it belongs to. */}
             {accountSignupUrl && (
-                <a
-                    href={`${accountSignupUrl}${accountSignupUrl.includes('?') ? '&' : '?'}utm_source=aeroftp`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1 text-xs text-emerald-500 hover:text-emerald-600 dark:text-emerald-400 dark:hover:text-emerald-300"
-                >
-                    <ExternalLink size={10} />
-                    {t('connection.createAccount')}
-                </a>
+                <span className="inline-flex items-center gap-0.5 shrink-0">
+                    <a
+                        href={`${accountSignupUrl}${accountSignupUrl.includes('?') ? '&' : '?'}utm_source=aeroftp`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 text-xs text-emerald-500 hover:text-emerald-600 dark:text-emerald-400 dark:hover:text-emerald-300"
+                    >
+                        <ExternalLink size={10} />
+                        {t('connection.createAccount')}
+                    </a>
+                    <CopyLinkButton url={`${accountSignupUrl}${accountSignupUrl.includes('?') ? '&' : '?'}utm_source=aeroftp`} />
+                </span>
             )}
         </div>
     );
@@ -2780,15 +2791,18 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
         <div className="flex items-center justify-between gap-2 mb-1.5">
             <label className="block text-sm font-medium">{overrideText ?? getPasswordLabel()}</label>
             {accountPasswordGenUrl && (
-                <a
-                    href={accountPasswordGenUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1 text-xs text-amber-500 hover:text-amber-600 dark:text-amber-400 dark:hover:text-amber-300"
-                >
-                    <KeyRound size={10} />
-                    {t('connection.generatePassword')}
-                </a>
+                <span className="inline-flex items-center gap-0.5 shrink-0">
+                    <a
+                        href={accountPasswordGenUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 text-xs text-amber-500 hover:text-amber-600 dark:text-amber-400 dark:hover:text-amber-300"
+                    >
+                        <KeyRound size={10} />
+                        {t('connection.generatePassword')}
+                    </a>
+                    <CopyLinkButton url={accountPasswordGenUrl} />
+                </span>
             )}
         </div>
     );
@@ -3298,27 +3312,9 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                                                 {/* Ehud #369: the radios were being read as "the salt is
                                                     128/256-bit", and the salt itself was nowhere on screen.
                                                     Say what the radios actually set, then print the one
-                                                    public salt so it can be read and backed up. */}
+                                                    public salt so it can be read, copied and backed up. */}
                                                 {aeroCryptKind === 'aerocrypt' && (
-                                                    <div className="ml-12 mt-1.5 text-xs text-gray-500 dark:text-gray-400 leading-relaxed">
-                                                        <div>
-                                                            {t('aerocryptProfile.defaultSaltTierMeaning')
-                                                                || 'The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.'}
-                                                        </div>
-                                                        <div className="mt-1 flex flex-wrap items-baseline gap-x-1.5">
-                                                            <span>
-                                                                {t('aerocryptProfile.defaultSaltValueLabel')
-                                                                    || 'Public default salt (AeroCrypt v3), SHA-256 of'}{' '}
-                                                                <code className="font-mono">&quot;{AEROCRYPT_DEFAULT_SALT_V1_PREIMAGE}&quot;</code>:
-                                                            </span>
-                                                            <code
-                                                                className="font-mono select-all break-all text-gray-600 dark:text-gray-300"
-                                                                title={AEROCRYPT_DEFAULT_SALT_V1_HEX}
-                                                            >
-                                                                {formatDefaultSaltForDisplay()}
-                                                            </code>
-                                                        </div>
-                                                    </div>
+                                                    <DefaultSaltDisclosure className="ml-12 mt-1.5 text-xs" />
                                                 )}
 
                                                 {/* Attestation (required to enable default salt) */}
@@ -3720,6 +3716,7 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                                                 <ExternalLink size={10} />
                                                 Docs
                                             </a>
+                                            <CopyLinkButton url={docsUrl} />
                                             {LogoComponent && <LogoComponent size={20} />}
                                             <span className="font-medium">{providerName}</span>
                                         </div>
@@ -4451,6 +4448,7 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                                                 >
                                                     <ExternalLink size={12} />
                                                 </a>
+                                                <CopyLinkButton url="https://filelu.com/5253515355.html" size={12} />
                                             </p>
                                         </div>
 
@@ -4475,15 +4473,18 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                                             <div>
                                                 <div className="flex items-center justify-between gap-2 mb-1.5">
                                                     <label className="block text-sm font-medium">{t('connection.jottacloudToken')}</label>
-                                                    <a
-                                                        href="https://www.jottacloud.com/web/secure"
-                                                        target="_blank"
-                                                        rel="noopener noreferrer"
-                                                        className="inline-flex items-center gap-1 text-xs text-amber-500 hover:text-amber-600 dark:text-amber-400 dark:hover:text-amber-300"
-                                                    >
-                                                        <KeyRound size={10} />
-                                                        {t('connection.generatePersonalLoginToken')}
-                                                    </a>
+                                                    <span className="inline-flex items-center gap-0.5 shrink-0">
+                                                        <a
+                                                            href="https://www.jottacloud.com/web/secure"
+                                                            target="_blank"
+                                                            rel="noopener noreferrer"
+                                                            className="inline-flex items-center gap-1 text-xs text-amber-500 hover:text-amber-600 dark:text-amber-400 dark:hover:text-amber-300"
+                                                        >
+                                                            <KeyRound size={10} />
+                                                            {t('connection.generatePersonalLoginToken')}
+                                                        </a>
+                                                        <CopyLinkButton url="https://www.jottacloud.com/web/secure" />
+                                                    </span>
                                                 </div>
                                                 <div className="relative">
                                                     <input
@@ -4931,6 +4932,7 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                                                         <a href="https://github.com/settings/personal-access-tokens/new" target="_blank" rel="noopener noreferrer" className="text-[var(--color-accent)] hover:underline">
                                                             Generate token
                                                         </a>
+                                                        <CopyLinkButton url="https://github.com/settings/personal-access-tokens/new" />
                                                     </p>
                                                 </div>
                                             )}
@@ -5087,6 +5089,7 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                                                         <a href="https://github.com/settings/apps" target="_blank" rel="noopener noreferrer" className="text-[var(--color-accent)] hover:underline">
                                                             {t('github.manageApps')}
                                                         </a>
+                                                        <CopyLinkButton url="https://github.com/settings/apps" />
                                                     </p>
                                                 </div>
                                             )}
@@ -5168,16 +5171,19 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                                         <div>
                                             <div className="flex items-center justify-between gap-2 mb-1.5">
                                                 <label className="block text-sm font-medium">{t('connection.kdriveDriveId')}</label>
-                                                <a
-                                                    href="https://ksuite.infomaniak.com/all/kdrive"
-                                                    target="_blank"
-                                                    rel="noopener noreferrer"
-                                                    title={t('connection.kdriveFindDriveIdHint')}
-                                                    className="inline-flex items-center gap-1 text-xs text-emerald-500 hover:text-emerald-600 dark:text-emerald-400 dark:hover:text-emerald-300"
-                                                >
-                                                    <ExternalLink size={10} />
-                                                    {t('connection.kdriveFindDriveId')}
-                                                </a>
+                                                <span className="inline-flex items-center gap-0.5 shrink-0">
+                                                    <a
+                                                        href="https://ksuite.infomaniak.com/all/kdrive"
+                                                        target="_blank"
+                                                        rel="noopener noreferrer"
+                                                        title={t('connection.kdriveFindDriveIdHint')}
+                                                        className="inline-flex items-center gap-1 text-xs text-emerald-500 hover:text-emerald-600 dark:text-emerald-400 dark:hover:text-emerald-300"
+                                                    >
+                                                        <ExternalLink size={10} />
+                                                        {t('connection.kdriveFindDriveId')}
+                                                    </a>
+                                                    <CopyLinkButton url="https://ksuite.infomaniak.com/all/kdrive" />
+                                                </span>
                                             </div>
                                             <input
                                                 type="text"
@@ -5199,15 +5205,18 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                                         <div>
                                             <div className="flex items-center justify-between gap-2 mb-1.5">
                                                 <label className="block text-sm font-medium">{t('connection.kdriveToken')}</label>
-                                                <a
-                                                    href="https://manager.infomaniak.com/v3/ng/profile/user/token/list"
-                                                    target="_blank"
-                                                    rel="noopener noreferrer"
-                                                    className="inline-flex items-center gap-1 text-xs text-amber-500 hover:text-amber-600 dark:text-amber-400 dark:hover:text-amber-300"
-                                                >
-                                                    <ExternalLink size={10} />
-                                                    {t('connection.kdriveCreateToken')}
-                                                </a>
+                                                <span className="inline-flex items-center gap-0.5 shrink-0">
+                                                    <a
+                                                        href="https://manager.infomaniak.com/v3/ng/profile/user/token/list"
+                                                        target="_blank"
+                                                        rel="noopener noreferrer"
+                                                        className="inline-flex items-center gap-1 text-xs text-amber-500 hover:text-amber-600 dark:text-amber-400 dark:hover:text-amber-300"
+                                                    >
+                                                        <ExternalLink size={10} />
+                                                        {t('connection.kdriveCreateToken')}
+                                                    </a>
+                                                    <CopyLinkButton url="https://manager.infomaniak.com/v3/ng/profile/user/token/list" />
+                                                </span>
                                             </div>
                                             <div className="relative">
                                                 <input
@@ -5968,6 +5977,7 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                                             <p className="opacity-80">
                                                 {isMegaCmdMode ? t('connection.megaRequirementDesc') : t('connection.megaNativeNoticeDesc')}
                                                 {isMegaCmdMode && (
+                                                    <>
                                                     <a
                                                         href="https://mega.io/cmd"
                                                         target="_blank"
@@ -5976,6 +5986,8 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                                                     >
                                                         {t('connection.downloadMegacmd')}
                                                     </a>
+                                                    <CopyLinkButton url="https://mega.io/cmd" size={11} className="ml-1" />
+                                                    </>
                                                 )}
                                             </p>
                                         </div>
@@ -6076,7 +6088,7 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                                             </div>
                                             <p className="text-xs text-gray-400 mt-1.5">
                                                 {t('gitlab.tokenHint')}{' '}
-                                                <a href="https://gitlab.com/-/user_settings/personal_access_tokens" target="_blank" rel="noopener noreferrer" className="underline hover:text-orange-400">{t('gitlab.createToken')}</a>
+                                                <a href="https://gitlab.com/-/user_settings/personal_access_tokens" target="_blank" rel="noopener noreferrer" className="underline hover:text-orange-400">{t('gitlab.createToken')}</a><CopyLinkButton url="https://gitlab.com/-/user_settings/personal_access_tokens" />
                                             </p>
                                         </div>
 
@@ -6363,6 +6375,7 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                                                     ))}
                                                 </ol>
                                                 {selectedProvider.helpUrl && (
+                                                    <>
                                                     <a
                                                         href={selectedProvider.helpUrl}
                                                         target="_blank"
@@ -6372,6 +6385,8 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                                                         <ExternalLink size={11} />
                                                         {t('protocol.openProviderDocs', { provider: selectedProvider.name })}
                                                     </a>
+                                                    <CopyLinkButton url={selectedProvider.helpUrl} size={11} className="ml-1" />
+                                                    </>
                                                 )}
                                             </CollapsibleSetupBox>
                                         )}
@@ -6815,6 +6830,7 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                                 <ExternalLink size={14} />
                                 {gitHubDeviceFlow.verificationUri}
                             </a>
+                            <CopyLinkButton url={gitHubDeviceFlow.verificationUri} size={14} className="ml-1.5" />
                         </div>
                         <div className="flex justify-end gap-2 px-5 py-3 bg-gray-50 dark:bg-gray-800/50 border-t border-gray-200 dark:border-gray-700">
                             <button

--- a/src/components/DevTools/DevToolsV2.tsx
+++ b/src/components/DevTools/DevToolsV2.tsx
@@ -636,19 +636,24 @@ export const DevToolsV2: React.FC<DevToolsV2Props> = ({
                             <MessageSquare size={12} />
                             {t('devtools.agent')}
                         </button>
+                        {/* Security Tools sits with the other three launchers and
+                            carries its full label (Ehud #347): icon-only next to
+                            the Maximise/Close buttons read as a window control, so
+                            the entry point was being missed. */}
+                        {onShowCyberTools && (
+                            <button
+                                onClick={onShowCyberTools}
+                                className={`flex items-center gap-1.5 px-2 py-1 rounded text-xs transition-colors ${theme.buttonInactive}`}
+                                title={t('cyberTools.title')}
+                            >
+                                <CyberShieldIcon size={12} />
+                                {t('cyberTools.title')}
+                            </button>
+                        )}
                     </div>
                 </div>
 
                 <div className="flex items-center gap-1">
-                    {onShowCyberTools && (
-                        <button
-                            onClick={onShowCyberTools}
-                            className={`p-1 ${theme.buttonHover} rounded transition-colors`}
-                            title={t('cyberTools.title')}
-                        >
-                            <CyberShieldIcon size={14} />
-                        </button>
-                    )}
                     <button
                         onClick={() => { const next = !isMaximized; setIsMaximized(next); onMaximizeChange?.(next); }}
                         className={`p-1 ${theme.buttonHover} rounded transition-colors`}

--- a/src/components/IntroHub/IntroHubHeader.tsx
+++ b/src/components/IntroHub/IntroHubHeader.tsx
@@ -4,6 +4,7 @@ import { Server, PlusCircle, Cloud, FolderOpen, Search, X } from 'lucide-react';
 import { ProtocolIcon } from '../ProtocolSelector';
 import { PROVIDER_LOGOS } from '../ProviderLogos';
 import { useTranslation } from '../../i18n';
+import { middleClickClose } from '../../utils/middleClick';
 import type { ServerProfile, ProviderType } from '../../types';
 
 export type IntroHubTab = 'my-servers' | 'discover';
@@ -123,6 +124,10 @@ export function IntroHubHeader({
                                     : 'text-gray-500 dark:text-gray-400 border border-transparent hover:bg-gray-100 dark:hover:bg-gray-700/50 hover:border-gray-200 dark:hover:border-gray-600/50 hover:shadow-[0_1px_3px_rgba(0,0,0,0.08)] dark:hover:shadow-[0_1px_3px_rgba(0,0,0,0.3)]'
                             }`}
                             onClick={() => onTabChange(ft.id)}
+                            // Middle click closes the tab (Ehud #274), on the ✖ and
+                            // anywhere else on the chip: the counterpart of the
+                            // middle-click-opens-in-background gesture on Discover.
+                            {...middleClickClose(() => onCloseFormTab(ft.id))}
                             onContextMenu={(e) => { e.preventDefault(); setCtxMenu({ x: e.clientX, y: e.clientY, tabId: ft.id }); }}
                         >
                             <span className="shrink-0"><FormTabIcon tab={ft} /></span>

--- a/src/components/LocalPathTabs.tsx
+++ b/src/components/LocalPathTabs.tsx
@@ -12,6 +12,7 @@ import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { X, Plus, Folder } from 'lucide-react';
 import type { LocalTab } from '../types/aerofile';
 import { useTranslation } from '../i18n';
+import { middleClickClose } from '../utils/middleClick';
 
 // ============================================================================
 // Props
@@ -135,12 +136,7 @@ export const LocalPathTabs: React.FC<LocalPathTabsProps> = ({
                 : 'hover:bg-gray-200 dark:hover:bg-gray-700/50'
             } ${dragIdx === idx ? 'scale-95' : ''} ${isDragTarget ? 'border-l-2 border-blue-500' : ''}`}
             onClick={() => onTabClick(tab.id)}
-            onAuxClick={(e) => {
-              if (e.button === 1) { // Middle click
-                e.preventDefault();
-                onTabClose(tab.id);
-              }
-            }}
+            {...middleClickClose(() => onTabClose(tab.id))}
             onContextMenu={(e) => {
               e.preventDefault();
               setContextMenu({ x: e.clientX, y: e.clientY, tabId: tab.id });

--- a/src/components/OAuthConnect.tsx
+++ b/src/components/OAuthConnect.tsx
@@ -14,7 +14,6 @@ import { Checkbox } from './ui/Checkbox';
 import { useOAuth2, OAuthProvider, OAUTH_APPS } from '../hooks/useOAuth2';
 import { useI18n } from '../i18n';
 import { openUrl } from '../utils/openUrl';
-import { getProviderDocsUrl, PROVIDER_DOCS_INDEX } from '../providers/docsLinks';
 import { logger } from '../utils/logger';
 import { CopyLinkButton } from './common/CopyLinkButton';
 import { useClipboardCopy } from '../hooks/useClipboardCopy';
@@ -619,15 +618,15 @@ export const OAuthConnect: React.FC<OAuthConnectProps> = ({
       <div className="p-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg space-y-3">
           <div className="flex items-center justify-between">
             <h4 className="font-medium text-sm">{t('connection.oauth.oauth2Credentials')}</h4>
-            <div className="flex items-center gap-3">
-              {/* AeroFTP docs link on every Quick Connect page (#270). */}
-              <button
-                onClick={() => openUrl(getProviderDocsUrl(provider, provider) || PROVIDER_DOCS_INDEX)}
-                className="text-xs text-blue-500 hover:text-blue-600 flex items-center gap-1"
-              >
-                Docs <ExternalLink className="w-3 h-3" />
-              </button>
-              <CopyLinkButton url={getProviderDocsUrl(provider, provider) || PROVIDER_DOCS_INDEX} size={12} className="-ml-2" />
+            {/* The AeroFTP docs link that used to sit here was the SAME page as
+                the one in the Quick Connect header: same helper, same arguments,
+                twice on one screen (Ehud #347). The header keeps it, because it
+                is the copy that renders on every Quick Connect page rather than
+                only the OAuth ones, and it resolves better (mode-group provider
+                id, and the provider's own help URL as a fallback before the
+                generic index). Only "Get credentials" belongs here: it points at
+                the provider's developer console, next to the fields it fills. */}
+            <div className="flex items-center gap-1">
               <button
                 onClick={() => openUrl(oauthApp.help_url)}
                 className="text-xs text-blue-500 hover:text-blue-600 flex items-center gap-1"
@@ -637,7 +636,7 @@ export const OAuthConnect: React.FC<OAuthConnectProps> = ({
                     "Get credentials" wording for their developer console. */}
                 {t(provider === 'pcloud' ? 'settings.manageCredentials' : 'settings.getCredentials')} <ExternalLink className="w-3 h-3" />
               </button>
-              <CopyLinkButton url={oauthApp.help_url} size={12} className="-ml-2" />
+              <CopyLinkButton url={oauthApp.help_url} size={12} />
             </div>
           </div>
 

--- a/src/components/OAuthConnect.tsx
+++ b/src/components/OAuthConnect.tsx
@@ -16,6 +16,8 @@ import { useI18n } from '../i18n';
 import { openUrl } from '../utils/openUrl';
 import { getProviderDocsUrl, PROVIDER_DOCS_INDEX } from '../providers/docsLinks';
 import { logger } from '../utils/logger';
+import { CopyLinkButton } from './common/CopyLinkButton';
+import { useClipboardCopy } from '../hooks/useClipboardCopy';
 
 interface OAuthConnectProps {
   provider: 'googledrive' | 'googlephotos' | 'dropbox' | 'onedrive' | 'box' | 'pcloud' | 'zohoworkdrive' | 'yandexdisk';
@@ -212,7 +214,10 @@ export const OAuthConnect: React.FC<OAuthConnectProps> = ({
   const [wantsNewAccount, setWantsNewAccount] = useState(false);
   const [showSecret, setShowSecret] = useState(false);
   const [zohoRegion, setZohoRegion] = useState('us');
-  const [copiedUri, setCopiedUri] = useState(false);
+  // Redirect URI copy: the shared hook, so it goes through the Rust command
+  // like every other copy in the app instead of navigator.clipboard, which
+  // WebKitGTK rejects outside a secure context.
+  const { copied: copiedUri, copy: copyRedirectUri } = useClipboardCopy();
   // Edit-mode toggle: reveals Client ID / Secret / Region inputs from the
   // active state so users can rotate credentials without leaving Edit.
   const [showEditCredentials, setShowEditCredentials] = useState(false);
@@ -622,6 +627,7 @@ export const OAuthConnect: React.FC<OAuthConnectProps> = ({
               >
                 Docs <ExternalLink className="w-3 h-3" />
               </button>
+              <CopyLinkButton url={getProviderDocsUrl(provider, provider) || PROVIDER_DOCS_INDEX} size={12} className="-ml-2" />
               <button
                 onClick={() => openUrl(oauthApp.help_url)}
                 className="text-xs text-blue-500 hover:text-blue-600 flex items-center gap-1"
@@ -631,6 +637,7 @@ export const OAuthConnect: React.FC<OAuthConnectProps> = ({
                     "Get credentials" wording for their developer console. */}
                 {t(provider === 'pcloud' ? 'settings.manageCredentials' : 'settings.getCredentials')} <ExternalLink className="w-3 h-3" />
               </button>
+              <CopyLinkButton url={oauthApp.help_url} size={12} className="-ml-2" />
             </div>
           </div>
 
@@ -648,11 +655,7 @@ export const OAuthConnect: React.FC<OAuthConnectProps> = ({
                 </code>
                 <button
                   type="button"
-                  onClick={() => {
-                    navigator.clipboard.writeText(REDIRECT_URIS[provider].uri);
-                    setCopiedUri(true);
-                    setTimeout(() => setCopiedUri(false), 2000);
-                  }}
+                  onClick={() => { void copyRedirectUri(REDIRECT_URIS[provider].uri); }}
                   className="shrink-0 p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
                   title={t('common.copy')}
                 >

--- a/src/components/OAuthConnect.tsx
+++ b/src/components/OAuthConnect.tsx
@@ -626,7 +626,7 @@ export const OAuthConnect: React.FC<OAuthConnectProps> = ({
                 id, and the provider's own help URL as a fallback before the
                 generic index). Only "Get credentials" belongs here: it points at
                 the provider's developer console, next to the fields it fills. */}
-            <div className="flex items-center gap-1">
+            <div className="flex items-center">
               <button
                 onClick={() => openUrl(oauthApp.help_url)}
                 className="text-xs text-blue-500 hover:text-blue-600 flex items-center gap-1"

--- a/src/components/ProtocolSelector.tsx
+++ b/src/components/ProtocolSelector.tsx
@@ -29,6 +29,7 @@ import {
 import { ProviderType, FtpTlsMode } from '../types';
 import { useTranslation } from '../i18n';
 import { getProviderById, resolveS3Endpoint } from '../providers';
+import { CopyLinkButton } from './common/CopyLinkButton';
 import { BoxLogo, PCloudLogo, AzureLogo, FilenLogo, FourSharedLogo, ZohoWorkDriveLogo, InternxtLogo, KDriveLogo, JottacloudLogo, DrimeCloudLogo, FileLuLogo, KoofrLogo, OpenDriveLogo, YandexDiskLogo, GitHubLogo, BlompLogo, FeliCloudLogo, TabDigitalLogo, ImmichLogo, ImageKitLogo, UploadcareLogo, CloudinaryLogo } from './ProviderLogos';
 
 // Official brand logos as inline SVGs
@@ -794,8 +795,8 @@ export const ProtocolFields: React.FC<ProtocolFieldsProps> = ({
                                     SourceForge requires SSH key authentication. Generate a key with{' '}
                                     <code className="bg-amber-100 dark:bg-amber-900/30 px-1 rounded text-[11px]">ssh-keygen -t ed25519</code>{' '}
                                     and upload it to{' '}
-                                    <a href="https://sourceforge.net/auth/shell_services" target="_blank" rel="noopener noreferrer" className="underline hover:text-amber-600 dark:hover:text-amber-300">SSH Settings</a>.{' '}
-                                    <a href={providerConfig?.helpUrl || 'https://docs.aeroftp.app/providers/sourceforge'} target="_blank" rel="noopener noreferrer" className="underline hover:text-amber-600 dark:hover:text-amber-300">Full guide</a>
+                                    <a href="https://sourceforge.net/auth/shell_services" target="_blank" rel="noopener noreferrer" className="underline hover:text-amber-600 dark:hover:text-amber-300">SSH Settings</a><CopyLinkButton url="https://sourceforge.net/auth/shell_services" />.{' '}
+                                    <a href={providerConfig?.helpUrl || 'https://docs.aeroftp.app/providers/sourceforge'} target="_blank" rel="noopener noreferrer" className="underline hover:text-amber-600 dark:hover:text-amber-300">Full guide</a><CopyLinkButton url={providerConfig?.helpUrl || 'https://docs.aeroftp.app/providers/sourceforge'} />
                                 </span>
                             </div>
                         )}

--- a/src/components/SessionTabs.tsx
+++ b/src/components/SessionTabs.tsx
@@ -9,6 +9,7 @@ import type { LocalTab } from '../types/aerofile';
 import { MegaLogo, BoxLogo, PCloudLogo, AzureLogo, FilenLogo, FourSharedLogo, ZohoWorkDriveLogo, InternxtLogo, KDriveLogo, JottacloudLogo, DrimeCloudLogo, FileLuLogo, KoofrLogo, OpenDriveLogo, YandexDiskLogo, GitHubLogo, GitLabLogo, ImmichLogo, PROVIDER_LOGOS } from './ProviderLogos';
 import { useTranslation } from '../i18n';
 import { getGitHubConnectionBadge, getMegaConnectionBadge } from '../utils/providerConnectionMeta';
+import { middleClickClose } from '../utils/middleClick';
 
 interface CloudTabState {
     enabled: boolean;
@@ -381,6 +382,10 @@ export const SessionTabs: React.FC<SessionTabsProps> = ({
                                 : 'hover:bg-gray-200 dark:hover:bg-gray-700/50 cursor-pointer'
                             } ${dragIdx === idx ? 'scale-95' : ''} ${isDragTarget ? 'border-l-2 border-blue-500' : ''}`}
                         onClick={() => { if (!isLocked) onTabClick(session.id); }}
+                        // Middle click closes the tab (Ehud #274), on the ✖ and
+                        // anywhere else on the chip. Never while the tab is locked
+                        // by a running transfer, which is what blocks the ✖ too.
+                        {...middleClickClose(() => onTabClose(session.id), !isLocked)}
                         onContextMenu={(e) => {
                             e.preventDefault();
                             if (!isLocked) setContextMenu({ x: e.clientX, y: e.clientY, sessionId: session.id });
@@ -457,9 +462,7 @@ export const SessionTabs: React.FC<SessionTabsProps> = ({
                                         : 'hover:bg-gray-200 dark:hover:bg-gray-700/50'
                                 }`}
                                 onClick={() => onLocalTabClick?.(tab.id)}
-                                onAuxClick={(e) => {
-                                    if (e.button === 1 && canClose) { e.preventDefault(); onLocalTabClose?.(tab.id); }
-                                }}
+                                {...middleClickClose(() => onLocalTabClose?.(tab.id), canClose)}
                                 onContextMenu={(e) => {
                                     e.preventDefault();
                                     setLocalCtxMenu({ x: e.clientX, y: e.clientY, tabId: tab.id });
@@ -510,9 +513,7 @@ export const SessionTabs: React.FC<SessionTabsProps> = ({
                                                 : 'hover:bg-gray-200 dark:hover:bg-gray-700/50'
                                         }`}
                                         onClick={() => onLocalTabClick2?.(tab.id)}
-                                        onAuxClick={(e) => {
-                                            if (e.button === 1 && canClose) { e.preventDefault(); onLocalTabClose2?.(tab.id); }
-                                        }}
+                                        {...middleClickClose(() => onLocalTabClose2?.(tab.id), canClose)}
                                         onContextMenu={(e) => e.preventDefault()}
                                         title={tab.path}
                                     >

--- a/src/components/common/CopyLinkButton.tsx
+++ b/src/components/common/CopyLinkButton.tsx
@@ -39,7 +39,12 @@ export const CopyLinkButton: React.FC<CopyLinkButtonProps> = ({ url, size = 10, 
             onClick={(e) => { e.preventDefault(); e.stopPropagation(); void copy(url); }}
             title={copied ? t('common.copied') : `${t('common.copy')}: ${url}`}
             aria-label={`${t('common.copy')}: ${url}`}
-            className={`inline-flex items-center justify-center shrink-0 rounded p-0.5 align-middle text-current opacity-50 hover:opacity-100 hover:bg-black/5 dark:hover:bg-white/10 transition-opacity cursor-pointer ${className}`}
+            // ml-1.5 is not decoration: butted straight against the link the
+            // button is a ~14px target sharing an edge with a click that
+            // navigates, so aiming at it is fiddly and a near miss opens the
+            // page instead of copying. The gap is the separation, and it lives
+            // here rather than at each call site so all 19 of them match.
+            className={`inline-flex items-center justify-center shrink-0 ml-1.5 rounded p-0.5 align-middle text-current opacity-50 hover:opacity-100 hover:bg-black/5 dark:hover:bg-white/10 transition-opacity cursor-pointer ${className}`}
         >
             {copied
                 ? <Check size={size} className="text-green-500 opacity-100" />

--- a/src/components/common/CopyLinkButton.tsx
+++ b/src/components/common/CopyLinkButton.tsx
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+import * as React from 'react';
+import { Check, Copy } from 'lucide-react';
+import { useTranslation } from '../../i18n';
+import { useClipboardCopy } from '../../hooks/useClipboardCopy';
+
+interface CopyLinkButtonProps {
+    /** The URL to put on the clipboard. Exactly what the sibling link opens. */
+    url: string;
+    /** Icon size in px. 10 next to a 10px link glyph, 11-14 for standalone rows. */
+    size?: number;
+    className?: string;
+}
+
+/**
+ * The small copy affordance that sits beside an external link in a form
+ * (Ehud #274).
+ *
+ * Clicking the link still opens it, which is what most people want. This is for
+ * the other case: wanting to see where a "Create account" or "Generate an app
+ * password" link actually goes before trusting it, or needing to open it on a
+ * different device (the OAuth device-flow URL above all). Copying is the
+ * cheapest way to do either, and it was previously impossible without a right
+ * click and a context menu that the webview does not always offer.
+ *
+ * Deliberately not a link itself: it never navigates, so it cannot be mistaken
+ * for a second destination. `stopPropagation` keeps it inert inside rows that
+ * are themselves clickable.
+ */
+export const CopyLinkButton: React.FC<CopyLinkButtonProps> = ({ url, size = 10, className = '' }) => {
+    const t = useTranslation();
+    const { copied, copy } = useClipboardCopy();
+
+    return (
+        <button
+            type="button"
+            onClick={(e) => { e.preventDefault(); e.stopPropagation(); void copy(url); }}
+            title={copied ? t('common.copied') : `${t('common.copy')}: ${url}`}
+            aria-label={`${t('common.copy')}: ${url}`}
+            className={`inline-flex items-center justify-center shrink-0 rounded p-0.5 align-middle text-current opacity-50 hover:opacity-100 hover:bg-black/5 dark:hover:bg-white/10 transition-opacity cursor-pointer ${className}`}
+        >
+            {copied
+                ? <Check size={size} className="text-green-500 opacity-100" />
+                : <Copy size={size} />}
+        </button>
+    );
+};

--- a/src/components/common/DefaultSaltDisclosure.tsx
+++ b/src/components/common/DefaultSaltDisclosure.tsx
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+import * as React from 'react';
+import { Check, Copy } from 'lucide-react';
+import { useTranslation } from '../../i18n';
+import { useClipboardCopy } from '../../hooks/useClipboardCopy';
+import {
+    AEROCRYPT_DEFAULT_SALT_V1_HEX,
+    AEROCRYPT_DEFAULT_SALT_V1_PREIMAGE,
+    formatDefaultSaltForDisplay,
+} from '../../utils/aerocryptDefaultSalt';
+
+interface DefaultSaltDisclosureProps {
+    /** Indentation class so the block lines up under whichever radios it follows. */
+    className?: string;
+}
+
+/**
+ * The public default salt, shown under the 128-bit / 256-bit radios (Ehud #369).
+ *
+ * Two create surfaces offer default-salt mode (the Quick Connect form and the
+ * native AeroCrypt dialog) and both were showing the radios with no salt and no
+ * statement of what the radios set, which is what made them read as "the salt is
+ * 128/256-bit". One component so the two cannot drift apart, and so the copy
+ * state exists once.
+ *
+ * The whole salt is a copy button: it is 64 hex characters, and selecting that
+ * by hand off a screen is exactly the chore the button removes. Copy goes
+ * through the Rust `copy_to_clipboard` command, the same path the password forge
+ * uses, because WebKitGTK's `navigator.clipboard` is not reliable here. Nothing
+ * secret is on the clipboard (the salt is public and versioned), so unlike a
+ * password there is no auto-clear timer.
+ */
+export const DefaultSaltDisclosure: React.FC<DefaultSaltDisclosureProps> = ({ className = '' }) => {
+    const t = useTranslation();
+    const { copied, copy } = useClipboardCopy();
+
+    return (
+        <div className={`text-gray-500 dark:text-gray-400 leading-relaxed ${className}`}>
+            <div>{t('aerocryptProfile.defaultSaltTierMeaning')}</div>
+            <div className="mt-1 flex flex-wrap items-baseline gap-x-1.5">
+                <span>
+                    {t('aerocryptProfile.defaultSaltValueLabel')}{' '}
+                    <code className="font-mono">&quot;{AEROCRYPT_DEFAULT_SALT_V1_PREIMAGE}&quot;</code>:
+                </span>
+                <button
+                    type="button"
+                    onClick={() => { void copy(AEROCRYPT_DEFAULT_SALT_V1_HEX); }}
+                    title={copied ? t('common.copied') : t('common.copy')}
+                    aria-label={`${t('common.copy')}: ${AEROCRYPT_DEFAULT_SALT_V1_HEX}`}
+                    className="inline-flex items-baseline gap-1 rounded px-1 -mx-1 font-mono text-left break-all text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700/60 transition-colors cursor-pointer"
+                >
+                    <span>{formatDefaultSaltForDisplay()}</span>
+                    <span className="shrink-0 self-center">
+                        {copied
+                            ? <Check size={12} className="text-green-500" />
+                            : <Copy size={12} className="opacity-60" />}
+                    </span>
+                </button>
+            </div>
+        </div>
+    );
+};

--- a/src/components/providerCatalog.ts
+++ b/src/components/providerCatalog.ts
@@ -263,7 +263,7 @@ export const PROVIDER_CATALOG: CatalogCompany[] = [
     { company: 'Jianguoyun', logoId: 'jianguoyun', countryCode: 'CN', freeStorageGb: 1,
       freeNote: 'monthly traffic cap',
       protocols: [{ label: 'WebDAV', protocol: 'webdav', providerId: 'jianguoyun', category: 'webdav' }] },
-    { company: 'Felicloud', logoId: 'felicloud', countryCode: '', freeStorageGb: 10,
+    { company: 'Felicloud', logoId: 'felicloud', countryCode: 'EU', freeStorageGb: 10,
       freeNote: 'Nextcloud host',
       protocols: [{ label: 'WebDAV', protocol: 'webdav', providerId: 'felicloud', category: 'webdav' }] },
     { company: 'Cloudinary', logoId: 'cloudinary', countryCode: 'US', freeStorageGb: null,

--- a/src/hooks/useClipboardCopy.ts
+++ b/src/hooks/useClipboardCopy.ts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+
+/**
+ * Copy-to-clipboard with the "green tick for a moment" acknowledgement the app
+ * uses everywhere (Ehud #369, #274).
+ *
+ * Copy goes through the Rust `copy_to_clipboard` command rather than
+ * `navigator.clipboard`, which is what every other copy affordance in the app
+ * does: under WebKitGTK the web clipboard API is only available in a secure
+ * context and silently rejects often enough that the button would look broken.
+ *
+ * `copied` flips back to false after `resetMs`, and the pending timer is
+ * dropped on unmount, since a dialog closed right after a copy would otherwise
+ * set state on a gone component.
+ */
+export function useClipboardCopy(resetMs = 2000) {
+    const [copied, setCopied] = useState(false);
+    const resetRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const copy = useCallback(async (text: string) => {
+        try {
+            await invoke('copy_to_clipboard', { text });
+            setCopied(true);
+            if (resetRef.current) clearTimeout(resetRef.current);
+            resetRef.current = setTimeout(() => setCopied(false), resetMs);
+            return true;
+        } catch {
+            // Clipboard access is best-effort: never turn a failed copy into an
+            // error dialog, the user can still select the text by hand.
+            return false;
+        }
+    }, [resetMs]);
+
+    useEffect(() => () => {
+        if (resetRef.current) clearTimeout(resetRef.current);
+    }, []);
+
+    return { copied, copy };
+}

--- a/src/i18n/locales/bg.json
+++ b/src/i18n/locales/bg.json
@@ -5288,7 +5288,9 @@
             "defaultSaltAttestation": "Генерирах тази парола с мениджър на пароли и разбирам компромиса със свързваемостта.",
             "defaultSaltNeedsStronger": "Въведете силна генерирана парола, за да включите солта по подразбиране.",
             "defaultSaltTier128": "128-bit (препоръчително, изисква парола от 20+ знака)",
-            "defaultSaltTier256": "256-bit (по-строго, изисква парола от 39+ знака)"
+            "defaultSaltTier256": "256-bit (по-строго, изисква парола от 39+ знака)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "Операция в ход",

--- a/src/i18n/locales/bn.json
+++ b/src/i18n/locales/bn.json
@@ -5288,7 +5288,9 @@
             "defaultSaltAttestation": "আমি পাসওয়ার্ড ম্যানেজার দিয়ে এই পাসওয়ার্ড তৈরি করেছি এবং লিঙ্কযোগ্যতার ট্রেডঅফ বুঝতে পেরেছি।",
             "defaultSaltNeedsStronger": "ডিফল্ট সল্ট চালু করতে একটি শক্তিশালী জেনারেট করা পাসওয়ার্ড লিখুন।",
             "defaultSaltTier128": "128-bit (প্রস্তাবিত, একটি 20+ অক্ষরের পাসওয়ার্ড প্রয়োজন)",
-            "defaultSaltTier256": "256-bit (আরও কঠোর, একটি 39+ অক্ষরের পাসওয়ার্ড প্রয়োজন)"
+            "defaultSaltTier256": "256-bit (আরও কঠোর, একটি 39+ অক্ষরের পাসওয়ার্ড প্রয়োজন)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "অপারেশন চলছে",

--- a/src/i18n/locales/ca.json
+++ b/src/i18n/locales/ca.json
@@ -5307,7 +5307,9 @@
             "defaultSaltAttestation": "He generat aquesta contrasenya amb un gestor de contrasenyes i entenc el compromís de vinculabilitat.",
             "defaultSaltNeedsStronger": "Introduïu una contrasenya generada forta per activar la sal predeterminada.",
             "defaultSaltTier128": "128-bit (recomanat, necessita una contrasenya de 20+ caràcters)",
-            "defaultSaltTier256": "256-bit (més estricte, necessita una contrasenya de 39+ caràcters)"
+            "defaultSaltTier256": "256-bit (més estricte, necessita una contrasenya de 39+ caràcters)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "Operació en curs",

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -5288,7 +5288,9 @@
             "defaultSaltAttestation": "Vygeneroval jsem toto heslo pomocí správce hesel a rozumím kompromisu ohledně propojování.",
             "defaultSaltNeedsStronger": "Zadejte silné vygenerované heslo pro zapnutí výchozího saltu.",
             "defaultSaltTier128": "128-bit (doporučeno, vyžaduje heslo o délce 20+ znaků)",
-            "defaultSaltTier256": "256-bit (přísnější, vyžaduje heslo o délce 39+ znaků)"
+            "defaultSaltTier256": "256-bit (přísnější, vyžaduje heslo o délce 39+ znaků)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "Probíhá operace",

--- a/src/i18n/locales/cy.json
+++ b/src/i18n/locales/cy.json
@@ -5307,7 +5307,9 @@
             "defaultSaltAttestation": "Fe wnes i gynhyrchu'r cyfrinair hwn gyda rheolwr cyfrineiriau ac rwy'n deall y cyfaddawd cysylltedd.",
             "defaultSaltNeedsStronger": "Rhowch gyfrinair cryf wedi'i gynhyrchu i droi'r salt rhagosodedig ymlaen.",
             "defaultSaltTier128": "128-bit (argymhellir, angen cyfrinair o 20+ nod)",
-            "defaultSaltTier256": "256-bit (llymach, angen cyfrinair o 39+ nod)"
+            "defaultSaltTier256": "256-bit (llymach, angen cyfrinair o 39+ nod)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "Gweithrediad ar y gweill",

--- a/src/i18n/locales/da.json
+++ b/src/i18n/locales/da.json
@@ -5288,7 +5288,9 @@
             "defaultSaltAttestation": "Jeg genererede denne adgangskode med en adgangskodehåndtering og forstår linkbarheds-kompromiset.",
             "defaultSaltNeedsStronger": "Indtast en stærk genereret adgangskode for at aktivere standardsaltet.",
             "defaultSaltTier128": "128-bit (anbefales, kræver en adgangskode på 20+ tegn)",
-            "defaultSaltTier256": "256-bit (strengere, kræver en adgangskode på 39+ tegn)"
+            "defaultSaltTier256": "256-bit (strengere, kræver en adgangskode på 39+ tegn)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "Handling i gang",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -5288,7 +5288,9 @@
             "defaultSaltAttestation": "Ich habe dieses Passwort mit einem Passwort-Manager generiert und verstehe den Linkbarkeits-Kompromiss.",
             "defaultSaltNeedsStronger": "Geben Sie ein starkes generiertes Passwort ein, um den Standard-Salt zu aktivieren.",
             "defaultSaltTier128": "128-bit (empfohlen, erfordert ein Passwort mit 20+ Zeichen)",
-            "defaultSaltTier256": "256-bit (strenger, erfordert ein Passwort mit 39+ Zeichen)"
+            "defaultSaltTier256": "256-bit (strenger, erfordert ein Passwort mit 39+ Zeichen)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "Vorgang läuft",

--- a/src/i18n/locales/el.json
+++ b/src/i18n/locales/el.json
@@ -5288,7 +5288,9 @@
             "defaultSaltAttestation": "Δημιούργησα αυτόν τον κωδικό με έναν διαχειριστή κωδικών και κατανοώ την αντιστάθμιση της συνδεσιμότητας.",
             "defaultSaltNeedsStronger": "Εισαγάγετε έναν ισχυρό δημιουργημένο κωδικό πρόσβασης για να ενεργοποιήσετε το προεπιλεγμένο salt.",
             "defaultSaltTier128": "128-bit (συνιστάται, απαιτεί κωδικό πρόσβασης 20+ χαρακτήρων)",
-            "defaultSaltTier256": "256-bit (αυστηρότερο, απαιτεί κωδικό πρόσβασης 39+ χαρακτήρων)"
+            "defaultSaltTier256": "256-bit (αυστηρότερο, απαιτεί κωδικό πρόσβασης 39+ χαρακτήρων)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "Λειτουργία σε εξέλιξη",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1664,8 +1664,8 @@
             "markerMissingRestoreFailedTitle": "AeroCrypt marker still missing",
             "markerMissingRestoreFailedBody": "Unlocked from the local keystore, but the remote safety net could not be restored: {error}",
             "defaultSaltLabel": "Default salt (opt-in, password-only portability; requires high entropy and attestation)",
-            "defaultSaltStrength128": "128-bit recommended",
-            "defaultSaltStrength256": "256-bit",
+            "defaultSaltStrength128": "128-bit (recommended, needs a 20+ character password)",
+            "defaultSaltStrength256": "256-bit (stricter, needs a 39+ character password)",
             "defaultSaltAttestation": "I used a password manager and understand the linkability tradeoff.",
             "legacyMarkerNotice": "This vault still uses the legacy .aeroftp-crypt.json marker. Convert it to .aerocrypt.tsv after entering the password or keyfile.",
             "migrateLegacyMarker": "Convert marker",
@@ -5306,7 +5306,9 @@
             "defaultSaltAttestation": "I generated this password with a password manager and understand the linkability tradeoff.",
             "defaultSaltNeedsStronger": "Enter a Strong generated password to turn on default salt.",
             "defaultSaltTier128": "128-bit (recommended, needs a 20+ character password)",
-            "defaultSaltTier256": "256-bit (stricter, needs a 39+ character password)"
+            "defaultSaltTier256": "256-bit (stricter, needs a 39+ character password)",
+            "defaultSaltTierMeaning": "The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalView": {
             "listView": "List view",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -5288,7 +5288,9 @@
             "defaultSaltAttestation": "Generé esta contraseña con un gestor de contraseñas y entiendo el compromiso de vinculabilidad.",
             "defaultSaltNeedsStronger": "Introduce una contraseña generada segura para activar la sal predeterminada.",
             "defaultSaltTier128": "128-bit (recomendado, necesita una contraseña de 20+ caracteres)",
-            "defaultSaltTier256": "256-bit (más estricto, necesita una contraseña de 39+ caracteres)"
+            "defaultSaltTier256": "256-bit (más estricto, necesita una contraseña de 39+ caracteres)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "Operación en curso",

--- a/src/i18n/locales/et.json
+++ b/src/i18n/locales/et.json
@@ -5288,7 +5288,9 @@
             "defaultSaltAttestation": "Lõin selle parooli paroolihalduriga ja mõistan lingitavuse kompromissi.",
             "defaultSaltNeedsStronger": "Vaikimisi salti sisselülitamiseks sisestage tugev genereeritud parool.",
             "defaultSaltTier128": "128-bit (soovitatav, vajab 20+ tähemärgiga parooli)",
-            "defaultSaltTier256": "256-bit (rangem, vajab 39+ tähemärgiga parooli)"
+            "defaultSaltTier256": "256-bit (rangem, vajab 39+ tähemärgiga parooli)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "Toiming käib",

--- a/src/i18n/locales/eu.json
+++ b/src/i18n/locales/eu.json
@@ -5307,7 +5307,9 @@
             "defaultSaltAttestation": "Pasahitz kudeatzaile batekin sortu dut pasahitz hau eta ulertzen dut estekagarritasunaren trukea.",
             "defaultSaltNeedsStronger": "Sartu sortutako pasahitz sendo bat lehenetsitako salt-a aktibatzeko.",
             "defaultSaltTier128": "128-bit (gomendatua, 20+ karaktereko pasahitza behar du)",
-            "defaultSaltTier256": "256-bit (zorrotzagoa, 39+ karaktereko pasahitza behar du)"
+            "defaultSaltTier256": "256-bit (zorrotzagoa, 39+ karaktereko pasahitza behar du)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "Eragiketa abian",

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -5288,7 +5288,9 @@
             "defaultSaltAttestation": "Loin tämän salasanan salasananhallinnalla ja ymmärrän linkitettävyyden kompromissin.",
             "defaultSaltNeedsStronger": "Syötä vahva luotu salasana ottaaksesi oletussaltin käyttöön.",
             "defaultSaltTier128": "128-bit (suositeltu, vaatii 20+ merkin salasanan)",
-            "defaultSaltTier256": "256-bit (tiukempi, vaatii 39+ merkin salasanan)"
+            "defaultSaltTier256": "256-bit (tiukempi, vaatii 39+ merkin salasanan)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "Toiminto käynnissä",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -5288,7 +5288,9 @@
             "defaultSaltAttestation": "J'ai généré ce mot de passe avec un gestionnaire de mots de passe et je comprends le compromis de traçabilité.",
             "defaultSaltNeedsStronger": "Saisissez un mot de passe généré fort pour activer le sel par défaut.",
             "defaultSaltTier128": "128-bit (recommandé, nécessite un mot de passe de 20+ caractères)",
-            "defaultSaltTier256": "256-bit (plus strict, nécessite un mot de passe de 39+ caractères)"
+            "defaultSaltTier256": "256-bit (plus strict, nécessite un mot de passe de 39+ caractères)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "Opération en cours",

--- a/src/i18n/locales/gl.json
+++ b/src/i18n/locales/gl.json
@@ -5307,7 +5307,9 @@
             "defaultSaltAttestation": "Xerei este contrasinal cun xestor de contrasinais e entendo o compromiso de ligabilidade.",
             "defaultSaltNeedsStronger": "Introduce un contrasinal xerado forte para activar o sal predeterminado.",
             "defaultSaltTier128": "128-bit (recomendado, precisa un contrasinal de 20+ caracteres)",
-            "defaultSaltTier256": "256-bit (máis estrito, precisa un contrasinal de 39+ caracteres)"
+            "defaultSaltTier256": "256-bit (máis estrito, precisa un contrasinal de 39+ caracteres)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "Operación en curso",

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -5288,7 +5288,9 @@
             "defaultSaltAttestation": "मैंने इस पासवर्ड को पासवर्ड मैनेजर से जेनरेट किया है और लिंकेबिलिटी ट्रेडऑफ को समझता हूँ।",
             "defaultSaltNeedsStronger": "डिफ़ॉल्ट सॉल्ट चालू करने के लिए एक मजबूत जनरेट किया गया पासवर्ड दर्ज करें।",
             "defaultSaltTier128": "128-bit (अनुशंसित, 20+ वर्णों का पासवर्ड आवश्यक)",
-            "defaultSaltTier256": "256-bit (अधिक सख्त, 39+ वर्णों का पासवर्ड आवश्यक)"
+            "defaultSaltTier256": "256-bit (अधिक सख्त, 39+ वर्णों का पासवर्ड आवश्यक)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "ऑपरेशन जारी है",

--- a/src/i18n/locales/hr.json
+++ b/src/i18n/locales/hr.json
@@ -5288,7 +5288,9 @@
             "defaultSaltAttestation": "Generirao sam ovu lozinku pomoću upravitelja lozinki i razumijem kompromis povezivosti.",
             "defaultSaltNeedsStronger": "Unesite jaku generiranu lozinku da biste uključili zadani salt.",
             "defaultSaltTier128": "128-bit (preporučeno, zahtijeva lozinku od 20+ znakova)",
-            "defaultSaltTier256": "256-bit (strože, zahtijeva lozinku od 39+ znakova)"
+            "defaultSaltTier256": "256-bit (strože, zahtijeva lozinku od 39+ znakova)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "Operacija u tijeku",

--- a/src/i18n/locales/hu.json
+++ b/src/i18n/locales/hu.json
@@ -5288,7 +5288,9 @@
             "defaultSaltAttestation": "Ezt a jelszót jelszókezelővel generáltam, és megértem az összekapcsolhatósági kompromisszumot.",
             "defaultSaltNeedsStronger": "Az alapértelmezett salt bekapcsolásához adjon meg egy erős, generált jelszót.",
             "defaultSaltTier128": "128-bit (ajánlott, 20+ karakteres jelszót igényel)",
-            "defaultSaltTier256": "256-bit (szigorúbb, 39+ karakteres jelszót igényel)"
+            "defaultSaltTier256": "256-bit (szigorúbb, 39+ karakteres jelszót igényel)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "Művelet folyamatban",

--- a/src/i18n/locales/hy.json
+++ b/src/i18n/locales/hy.json
@@ -5288,7 +5288,9 @@
             "defaultSaltAttestation": "Ես այս գաղտնաբառը գեներացրել եմ գաղտնաբառերի կառավարիչով և հասկանում եմ կապելիության փոխզիջումը:",
             "defaultSaltNeedsStronger": "Լռելյայն salt-ը միացնելու համար մուտքագրեք ուժեղ գեներացված գաղտնաբառ։",
             "defaultSaltTier128": "128-bit (խորհուրդ է տրվում, պահանջում է 20+ նիշանոց գաղտնաբառ)",
-            "defaultSaltTier256": "256-bit (ավելի խիստ, պահանջում է 39+ նիշանոց գաղտնաբառ)"
+            "defaultSaltTier256": "256-bit (ավելի խիստ, պահանջում է 39+ նիշանոց գաղտնաբառ)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "Գործողությունն ընթացքի մեջ է",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -5288,7 +5288,9 @@
             "defaultSaltAttestation": "Saya menghasilkan kata sandi ini dengan manajer kata sandi dan memahami trade-off keterkaitan.",
             "defaultSaltNeedsStronger": "Masukkan kata sandi kuat yang dibuat untuk mengaktifkan salt bawaan.",
             "defaultSaltTier128": "128-bit (disarankan, memerlukan kata sandi 20+ karakter)",
-            "defaultSaltTier256": "256-bit (lebih ketat, memerlukan kata sandi 39+ karakter)"
+            "defaultSaltTier256": "256-bit (lebih ketat, memerlukan kata sandi 39+ karakter)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "Operasi berlangsung",

--- a/src/i18n/locales/is.json
+++ b/src/i18n/locales/is.json
@@ -5307,7 +5307,9 @@
             "defaultSaltAttestation": "Ég bjó til þetta lykilorð með lykilorðastjóra og skil tengjanleikaviðskiptin.",
             "defaultSaltNeedsStronger": "Sláðu inn sterkt myndað lykilorð til að kveikja á sjálfgefna saltinu.",
             "defaultSaltTier128": "128-bit (mælt með, þarf lykilorð með 20+ stöfum)",
-            "defaultSaltTier256": "256-bit (strangara, þarf lykilorð með 39+ stöfum)"
+            "defaultSaltTier256": "256-bit (strangara, þarf lykilorð með 39+ stöfum)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "Aðgerð í gangi",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -5296,7 +5296,9 @@
             "defaultSaltAttestation": "Ho generato questa password con un gestore password e comprendo il compromesso di collegabilità.",
             "defaultSaltNeedsStronger": "Inserisci una password generata robusta per attivare il salt predefinito.",
             "defaultSaltTier128": "128-bit (consigliato, richiede una password di 20+ caratteri)",
-            "defaultSaltTier256": "256-bit (più restrittivo, richiede una password di 39+ caratteri)"
+            "defaultSaltTier256": "256-bit (più restrittivo, richiede una password di 39+ caratteri)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "Operazione in corso",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -5288,7 +5288,9 @@
             "defaultSaltAttestation": "このパスワードをパスワードマネージャーで生成し、リンク可能性のトレードオフを理解しています。",
             "defaultSaltNeedsStronger": "デフォルトのソルトを有効にするには、強力な生成済みパスワードを入力してください。",
             "defaultSaltTier128": "128-bit（推奨、20+文字のパスワードが必要）",
-            "defaultSaltTier256": "256-bit（より厳格、39+文字のパスワードが必要）"
+            "defaultSaltTier256": "256-bit（より厳格、39+文字のパスワードが必要）",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "操作の実行中",

--- a/src/i18n/locales/ka.json
+++ b/src/i18n/locales/ka.json
@@ -5288,7 +5288,9 @@
             "defaultSaltAttestation": "მე ეს პაროლი პაროლების მენეჯერით გენერირებული მაქვს და ვხვდები დაკავშირებადობის კომპრომისს.",
             "defaultSaltNeedsStronger": "ნაგულისხმევი salt-ის ჩასართავად შეიყვანეთ ძლიერი გენერირებული პაროლი.",
             "defaultSaltTier128": "128-bit (რეკომენდებულია, საჭიროებს 20+ სიმბოლოს პაროლს)",
-            "defaultSaltTier256": "256-bit (უფრო მკაცრი, საჭიროებს 39+ სიმბოლოს პაროლს)"
+            "defaultSaltTier256": "256-bit (უფრო მკაცრი, საჭიროებს 39+ სიმბოლოს პაროლს)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "მიმდინარეობს ოპერაცია",

--- a/src/i18n/locales/km.json
+++ b/src/i18n/locales/km.json
@@ -5307,7 +5307,9 @@
             "defaultSaltAttestation": "ខ្ញុំបានបង្កើតពាក្យសម្ងាត់នេះដោយប្រើកម្មវិធីគ្រប់គ្រងពាក្យសម្ងាត់ ហើយយល់ពីការផ្លាស់ប្តូរភាពភ្ជាប់បាន។",
             "defaultSaltNeedsStronger": "បញ្ចូលពាក្យសម្ងាត់ដែលបានបង្កើតយ៉ាងរឹងមាំ ដើម្បីបើក salt លំនាំដើម។",
             "defaultSaltTier128": "128-bit (បានណែនាំ ត្រូវការពាក្យសម្ងាត់ 20+ តួអក្សរ)",
-            "defaultSaltTier256": "256-bit (តឹងរឹងជាង ត្រូវការពាក្យសម្ងាត់ 39+ តួអក្សរ)"
+            "defaultSaltTier256": "256-bit (តឹងរឹងជាង ត្រូវការពាក្យសម្ងាត់ 39+ តួអក្សរ)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "ប្រតិបត្តិការកំពុងដំណើរការ",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -5288,7 +5288,9 @@
             "defaultSaltAttestation": "이 비밀번호를 비밀번호 관리자로 생성했으며 연결 가능성의 절충을 이해합니다.",
             "defaultSaltNeedsStronger": "기본 솔트를 켜려면 강력하게 생성된 비밀번호를 입력하세요.",
             "defaultSaltTier128": "128-bit (권장, 20+자 비밀번호 필요)",
-            "defaultSaltTier256": "256-bit (더 엄격함, 39+자 비밀번호 필요)"
+            "defaultSaltTier256": "256-bit (더 엄격함, 39+자 비밀번호 필요)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "작업 진행 중",

--- a/src/i18n/locales/lt.json
+++ b/src/i18n/locales/lt.json
@@ -5288,7 +5288,9 @@
             "defaultSaltAttestation": "Šį slaptažodį sugeneravau naudodamas slaptažodžių tvarkyklę ir suprantu susiejamumo kompromisą.",
             "defaultSaltNeedsStronger": "Įveskite stiprų sugeneruotą slaptažodį, kad įjungtumėte numatytąjį salt.",
             "defaultSaltTier128": "128-bit (rekomenduojama, reikia 20+ simbolių slaptažodžio)",
-            "defaultSaltTier256": "256-bit (griežtesnis, reikia 39+ simbolių slaptažodžio)"
+            "defaultSaltTier256": "256-bit (griežtesnis, reikia 39+ simbolių slaptažodžio)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "Vykdoma operacija",

--- a/src/i18n/locales/lv.json
+++ b/src/i18n/locales/lv.json
@@ -5288,7 +5288,9 @@
             "defaultSaltAttestation": "Es ģenerēju šo paroli ar paroļu pārvaldnieku un saprotu saistāmības kompromisu.",
             "defaultSaltNeedsStronger": "Ievadiet spēcīgu ģenerētu paroli, lai ieslēgtu noklusējuma salt.",
             "defaultSaltTier128": "128-bit (ieteicams, nepieciešama parole ar 20+ rakstzīmēm)",
-            "defaultSaltTier256": "256-bit (stingrāks, nepieciešama parole ar 39+ rakstzīmēm)"
+            "defaultSaltTier256": "256-bit (stingrāks, nepieciešama parole ar 39+ rakstzīmēm)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "Notiek darbība",

--- a/src/i18n/locales/mk.json
+++ b/src/i18n/locales/mk.json
@@ -5307,7 +5307,9 @@
             "defaultSaltAttestation": "Ја генерирав оваа лозинка со менаџер за лозинки и го разбирам компромисот за поврзување.",
             "defaultSaltNeedsStronger": "Внесете силна генерирана лозинка за да ја вклучите стандардната сол.",
             "defaultSaltTier128": "128-bit (препорачано, потребна е лозинка од 20+ знаци)",
-            "defaultSaltTier256": "256-bit (построго, потребна е лозинка од 39+ знаци)"
+            "defaultSaltTier256": "256-bit (построго, потребна е лозинка од 39+ знаци)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "Операција во тек",

--- a/src/i18n/locales/ms.json
+++ b/src/i18n/locales/ms.json
@@ -5288,7 +5288,9 @@
             "defaultSaltAttestation": "Saya menjana kata laluan ini dengan pengurus kata laluan dan memahami pertukaran keboleh-pautan.",
             "defaultSaltNeedsStronger": "Masukkan kata laluan kuat yang dijana untuk menghidupkan salt lalai.",
             "defaultSaltTier128": "128-bit (disyorkan, memerlukan kata laluan 20+ aksara)",
-            "defaultSaltTier256": "256-bit (lebih ketat, memerlukan kata laluan 39+ aksara)"
+            "defaultSaltTier256": "256-bit (lebih ketat, memerlukan kata laluan 39+ aksara)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "Operasi sedang berjalan",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -5288,7 +5288,9 @@
             "defaultSaltAttestation": "Ik heb dit wachtwoord gegenereerd met een wachtwoordbeheerder en begrijp de linkbaarheid-afweging.",
             "defaultSaltNeedsStronger": "Voer een sterk gegenereerd wachtwoord in om de standaard-salt in te schakelen.",
             "defaultSaltTier128": "128-bit (aanbevolen, vereist een wachtwoord van 20+ tekens)",
-            "defaultSaltTier256": "256-bit (strenger, vereist een wachtwoord van 39+ tekens)"
+            "defaultSaltTier256": "256-bit (strenger, vereist een wachtwoord van 39+ tekens)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "Bewerking bezig",

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -5307,7 +5307,9 @@
             "defaultSaltAttestation": "Jeg genererte dette passordet med en passordbehandler og forstår linkbarhets-kompromisset.",
             "defaultSaltNeedsStronger": "Skriv inn et sterkt generert passord for å slå på standardsaltet.",
             "defaultSaltTier128": "128-bit (anbefalt, krever et passord på 20+ tegn)",
-            "defaultSaltTier256": "256-bit (strengere, krever et passord på 39+ tegn)"
+            "defaultSaltTier256": "256-bit (strengere, krever et passord på 39+ tegn)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "Operasjon pågår",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -5288,7 +5288,9 @@
             "defaultSaltAttestation": "Wygenerowałem to hasło za pomocą menedżera haseł i rozumiem kompromis w zakresie powiązywalności.",
             "defaultSaltNeedsStronger": "Wprowadź silne wygenerowane hasło, aby włączyć domyślny salt.",
             "defaultSaltTier128": "128-bit (zalecane, wymaga hasła o długości 20+ znaków)",
-            "defaultSaltTier256": "256-bit (bardziej restrykcyjne, wymaga hasła o długości 39+ znaków)"
+            "defaultSaltTier256": "256-bit (bardziej restrykcyjne, wymaga hasła o długości 39+ znaków)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "Operacja w toku",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -5288,7 +5288,9 @@
             "defaultSaltAttestation": "Gerei esta senha com um gerenciador de senhas e entendo o compromisso de vinculabilidade.",
             "defaultSaltNeedsStronger": "Insira uma senha gerada forte para ativar o sal padrão.",
             "defaultSaltTier128": "128-bit (recomendado, precisa de uma senha de 20+ caracteres)",
-            "defaultSaltTier256": "256-bit (mais rigoroso, precisa de uma senha de 39+ caracteres)"
+            "defaultSaltTier256": "256-bit (mais rigoroso, precisa de uma senha de 39+ caracteres)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "Operação em curso",

--- a/src/i18n/locales/ro.json
+++ b/src/i18n/locales/ro.json
@@ -5288,7 +5288,9 @@
             "defaultSaltAttestation": "Am generat această parolă cu un manager de parole și înțeleg compromisul de conectabilitate.",
             "defaultSaltNeedsStronger": "Introduceți o parolă generată puternică pentru a activa saltul implicit.",
             "defaultSaltTier128": "128-bit (recomandat, necesită o parolă de 20+ caractere)",
-            "defaultSaltTier256": "256-bit (mai strict, necesită o parolă de 39+ caractere)"
+            "defaultSaltTier256": "256-bit (mai strict, necesită o parolă de 39+ caractere)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "Operațiune în curs",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -5288,7 +5288,9 @@
             "defaultSaltAttestation": "Я сгенерировал этот пароль с помощью менеджера паролей и понимаю компромисс связываемости.",
             "defaultSaltNeedsStronger": "Введите надёжный сгенерированный пароль, чтобы включить соль по умолчанию.",
             "defaultSaltTier128": "128-bit (рекомендуется, требуется пароль от 20+ символов)",
-            "defaultSaltTier256": "256-bit (строже, требуется пароль от 39+ символов)"
+            "defaultSaltTier256": "256-bit (строже, требуется пароль от 39+ символов)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "Выполняется операция",

--- a/src/i18n/locales/sk.json
+++ b/src/i18n/locales/sk.json
@@ -5288,7 +5288,9 @@
             "defaultSaltAttestation": "Vygeneroval som toto heslo pomocou správcu hesiel a rozumiem kompromisu prepojiteľnosti.",
             "defaultSaltNeedsStronger": "Zadajte silné vygenerované heslo na zapnutie predvoleného saltu.",
             "defaultSaltTier128": "128-bit (odporúčané, vyžaduje heslo s 20+ znakmi)",
-            "defaultSaltTier256": "256-bit (prísnejšie, vyžaduje heslo s 39+ znakmi)"
+            "defaultSaltTier256": "256-bit (prísnejšie, vyžaduje heslo s 39+ znakmi)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "Prebieha operácia",

--- a/src/i18n/locales/sl.json
+++ b/src/i18n/locales/sl.json
@@ -5288,7 +5288,9 @@
             "defaultSaltAttestation": "To geslo sem ustvaril z upravljalnikom gesel in razumem kompromis povezljivosti.",
             "defaultSaltNeedsStronger": "Vnesite močno ustvarjeno geslo, da vklopite privzeti salt.",
             "defaultSaltTier128": "128-bit (priporočeno, zahteva geslo z 20+ znaki)",
-            "defaultSaltTier256": "256-bit (strožje, zahteva geslo z 39+ znaki)"
+            "defaultSaltTier256": "256-bit (strožje, zahteva geslo z 39+ znaki)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "Operacija poteka",

--- a/src/i18n/locales/sr.json
+++ b/src/i18n/locales/sr.json
@@ -5288,7 +5288,9 @@
             "defaultSaltAttestation": "Генерисао сам ову лозинку помоћу менаџера лозинки и разумем компромис повезивости.",
             "defaultSaltNeedsStronger": "Унесите јаку генерисану лозинку да бисте укључили подразумевани salt.",
             "defaultSaltTier128": "128-bit (препоручено, захтева лозинку од 20+ знакова)",
-            "defaultSaltTier256": "256-bit (строже, захтева лозинку од 39+ знакова)"
+            "defaultSaltTier256": "256-bit (строже, захтева лозинку од 39+ знакова)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "Операција у току",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -5288,7 +5288,9 @@
             "defaultSaltAttestation": "Jag genererade detta lösenord med en lösenordshanterare och förstår länkbarhetskompromissen.",
             "defaultSaltNeedsStronger": "Ange ett starkt genererat lösenord för att aktivera standardsaltet.",
             "defaultSaltTier128": "128-bit (rekommenderas, kräver ett lösenord på 20+ tecken)",
-            "defaultSaltTier256": "256-bit (strängare, kräver ett lösenord på 39+ tecken)"
+            "defaultSaltTier256": "256-bit (strängare, kräver ett lösenord på 39+ tecken)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "Åtgärd pågår",

--- a/src/i18n/locales/sw.json
+++ b/src/i18n/locales/sw.json
@@ -5288,7 +5288,9 @@
             "defaultSaltAttestation": "Nilitengeneza neno hili la siri kwa kutumia kidhibiti cha maneno ya siri na ninaelewa maelewano ya uunganishwaji.",
             "defaultSaltNeedsStronger": "Weka nenosiri imara lililozalishwa ili kuwasha salt chaguo-msingi.",
             "defaultSaltTier128": "128-bit (inapendekezwa, inahitaji nenosiri la herufi 20+)",
-            "defaultSaltTier256": "256-bit (kali zaidi, inahitaji nenosiri la herufi 39+)"
+            "defaultSaltTier256": "256-bit (kali zaidi, inahitaji nenosiri la herufi 39+)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "Operesheni inaendelea",

--- a/src/i18n/locales/th.json
+++ b/src/i18n/locales/th.json
@@ -5288,7 +5288,9 @@
             "defaultSaltAttestation": "ฉันสร้างรหัสผ่านนี้ด้วยตัวจัดการรหัสผ่านและเข้าใจการแลกเปลี่ยนความเชื่อมโยง",
             "defaultSaltNeedsStronger": "ป้อนรหัสผ่านที่สร้างขึ้นและแข็งแกร่งเพื่อเปิดใช้งาน salt เริ่มต้น.",
             "defaultSaltTier128": "128-bit (แนะนำ ต้องใช้รหัสผ่าน 20+ อักขระ)",
-            "defaultSaltTier256": "256-bit (เข้มงวดกว่า ต้องใช้รหัสผ่าน 39+ อักขระ)"
+            "defaultSaltTier256": "256-bit (เข้มงวดกว่า ต้องใช้รหัสผ่าน 39+ อักขระ)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "กำลังดำเนินการ",

--- a/src/i18n/locales/tl.json
+++ b/src/i18n/locales/tl.json
@@ -5307,7 +5307,9 @@
             "defaultSaltAttestation": "Gumawa ako ng password na ito gamit ang password manager at nauunawaan ang trade-off ng kakayahang i-link.",
             "defaultSaltNeedsStronger": "Maglagay ng malakas na binuong password para i-on ang default na salt.",
             "defaultSaltTier128": "128-bit (inirerekomenda, kailangan ng password na 20+ karakter)",
-            "defaultSaltTier256": "256-bit (mas mahigpit, kailangan ng password na 39+ karakter)"
+            "defaultSaltTier256": "256-bit (mas mahigpit, kailangan ng password na 39+ karakter)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "May isinasagawang operasyon",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -5288,7 +5288,9 @@
             "defaultSaltAttestation": "Bu parolayı bir parola yöneticisiyle oluşturdum ve bağlanabilirlik değiş tokuşunu anlıyorum.",
             "defaultSaltNeedsStronger": "Varsayılan salt'ı açmak için güçlü, oluşturulmuş bir parola girin.",
             "defaultSaltTier128": "128-bit (önerilir, 20+ karakterlik bir parola gerektirir)",
-            "defaultSaltTier256": "256-bit (daha katı, 39+ karakterlik bir parola gerektirir)"
+            "defaultSaltTier256": "256-bit (daha katı, 39+ karakterlik bir parola gerektirir)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "İşlem sürüyor",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -5288,7 +5288,9 @@
             "defaultSaltAttestation": "Я згенерував цей пароль за допомогою менеджера паролів і розумію компроміс пов'язаності.",
             "defaultSaltNeedsStronger": "Введіть надійний згенерований пароль, щоб увімкнути стандартну сіль.",
             "defaultSaltTier128": "128-bit (рекомендовано, потрібен пароль від 20+ символів)",
-            "defaultSaltTier256": "256-bit (суворіше, потрібен пароль від 39+ символів)"
+            "defaultSaltTier256": "256-bit (суворіше, потрібен пароль від 39+ символів)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "Виконується операція",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -5288,7 +5288,9 @@
             "defaultSaltAttestation": "Tôi đã tạo mật khẩu này bằng trình quản lý mật khẩu và hiểu sự đánh đổi về khả năng liên kết.",
             "defaultSaltNeedsStronger": "Nhập mật khẩu mạnh đã tạo để bật salt mặc định.",
             "defaultSaltTier128": "128-bit (khuyến nghị, cần mật khẩu 20+ ký tự)",
-            "defaultSaltTier256": "256-bit (nghiêm ngặt hơn, cần mật khẩu 39+ ký tự)"
+            "defaultSaltTier256": "256-bit (nghiêm ngặt hơn, cần mật khẩu 39+ ký tự)",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "Đang thực hiện thao tác",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -5288,7 +5288,9 @@
             "defaultSaltAttestation": "我使用密码管理器生成了此密码，并理解可关联性的权衡。",
             "defaultSaltNeedsStronger": "输入生成的强密码以启用默认盐值。",
             "defaultSaltTier128": "128-bit（推荐，需要 20+ 个字符的密码）",
-            "defaultSaltTier256": "256-bit（更严格，需要 39+ 个字符的密码）"
+            "defaultSaltTier256": "256-bit（更严格，需要 39+ 个字符的密码）",
+            "defaultSaltTierMeaning": "[NEEDS TRANSLATION] The two tiers set how strong your password must be, not the size of the salt: there is one salt, 32 bytes, the same for every default-salt vault.",
+            "defaultSaltValueLabel": "[NEEDS TRANSLATION] Public default salt (AeroCrypt v3), SHA-256 of"
         },
         "modalGuard": {
             "busyTitle": "操作进行中",

--- a/src/utils/aerocryptDefaultSalt.test.ts
+++ b/src/utils/aerocryptDefaultSalt.test.ts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+import { describe, it, expect } from 'vitest';
+import {
+    AEROCRYPT_DEFAULT_SALT_V1_HEX,
+    AEROCRYPT_DEFAULT_SALT_V1_PREIMAGE,
+    formatDefaultSaltForDisplay,
+} from './aerocryptDefaultSalt';
+
+async function sha256Hex(input: string): Promise<string> {
+    const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(input));
+    return Array.from(new Uint8Array(digest))
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join('');
+}
+
+describe('AeroCrypt default salt', () => {
+    it('is exactly SHA-256 of its published preimage', async () => {
+        // Same pin as the Rust side (`default_salt_constant_is_nothing_up_my_sleeve`
+        // in src-tauri/src/aerocrypt/mod.rs): the UI must never show a salt the
+        // backend does not actually use.
+        expect(AEROCRYPT_DEFAULT_SALT_V1_HEX).toBe(
+            await sha256Hex(AEROCRYPT_DEFAULT_SALT_V1_PREIMAGE),
+        );
+    });
+
+    it('is a 32-byte value, not a trap constant', () => {
+        expect(AEROCRYPT_DEFAULT_SALT_V1_HEX).toMatch(/^[0-9a-f]{64}$/);
+        expect(AEROCRYPT_DEFAULT_SALT_V1_HEX).not.toBe('0'.repeat(64));
+        expect(AEROCRYPT_DEFAULT_SALT_V1_HEX).not.toBe('f'.repeat(64));
+    });
+
+    it('groups the display form without changing the value', () => {
+        const shown = formatDefaultSaltForDisplay();
+        expect(shown.replace(/ /g, '')).toBe(AEROCRYPT_DEFAULT_SALT_V1_HEX);
+        expect(shown.split(' ')).toHaveLength(8);
+    });
+});

--- a/src/utils/aerocryptDefaultSalt.ts
+++ b/src/utils/aerocryptDefaultSalt.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+/**
+ * The public default salt of AeroCrypt v3, surfaced in the UI (Ehud #369).
+ *
+ * There is exactly ONE such salt, not one per tier. It is a nothing-up-my-sleeve
+ * constant, `SHA-256("AeroCrypt default salt v1")`, and it is deliberately
+ * public: default-salt mode trades the per-vault random salt for portability
+ * (password alone opens the vault anywhere), which is only safe because the
+ * password itself has to carry the entropy. The 128-bit / 256-bit radios pick
+ * how much entropy that is — they are a password requirement, NOT a salt size.
+ *
+ * Mirrors `AEROCRYPT_DEFAULT_SALT_V1` in `src-tauri/src/aerocrypt/mod.rs`. Both
+ * sides are independently pinned to the same SHA-256 derivation by a test, so
+ * neither can drift silently.
+ */
+export const AEROCRYPT_DEFAULT_SALT_V1_HEX =
+    'cdfc274561c3c3a8771d7dbb787049133b2f3e703696a7143f5ca585c0a1ca63';
+
+/** The preimage the salt is derived from, quoted in the UI and the docs. */
+export const AEROCRYPT_DEFAULT_SALT_V1_PREIMAGE = 'AeroCrypt default salt v1';
+
+/**
+ * The salt in `xxxx xxxx …` groups of 8 hex digits, so it can be read aloud and
+ * copied by hand off the screen without losing your place in 64 characters.
+ */
+export function formatDefaultSaltForDisplay(hex = AEROCRYPT_DEFAULT_SALT_V1_HEX): string {
+    return (hex.match(/.{1,8}/g) ?? []).join(' ');
+}

--- a/src/utils/middleClick.ts
+++ b/src/utils/middleClick.ts
@@ -26,3 +26,29 @@ export function middleClickOpen(open: () => void) {
         },
     };
 }
+
+/**
+ * Counterpart of {@link middleClickOpen} for a tab strip (Ehud #274): a middle
+ * click anywhere on the tab closes it, the way a browser closes a tab. Spread
+ * onto the tab container so the whole chip is a target, not only its ✖ — the
+ * `auxclick` on the ✖ bubbles up to the container, so both spots work with one
+ * handler. `close` is skipped when `enabled` is false (e.g. the last
+ * non-closable tab, or a tab locked by a running transfer).
+ *
+ * The event is stopped as well as default-prevented: tab strips sit inside
+ * panels that may carry their own middle-click behaviour, and closing a tab
+ * should never double as "open this in the background".
+ */
+export function middleClickClose(close: () => void, enabled = true) {
+    return {
+        onAuxClick: (e: MouseEvent) => {
+            if (e.button !== 1) return;
+            e.preventDefault();
+            e.stopPropagation();
+            if (enabled) close();
+        },
+        onMouseDown: (e: MouseEvent) => {
+            if (e.button === 1) e.preventDefault();
+        },
+    };
+}


### PR DESCRIPTION
Five community reports from @EhudKirsh over two days, plus the copy affordance that came out of reviewing them. They are unrelated to each other but each is small, so they ship as one branch rather than five.

Two are cases where an earlier fix was correct and incomplete: the TAB.DIGITAL flag correction fixed the one company reported and never swept the catalog for the same error, and middle-click gained "open in background" without gaining its counterpart.

### What is in here

**#274, Felicloud's flag.** The catalog carried an empty country and rendered a dash. felicloud.com states "100% EU Hosted" three times on its home page, so the flag is 🇪🇺: same conclusion and same four files as `09ef8b672`. The CLI catalog was regenerated rather than hand-edited, so the vitest drift guard stays satisfied.

**#274, middle-click closes a tab.** A shared `middleClickClose()` joins `middleClickOpen()` and is wired to the Quick Connect form tabs (the ones the open gesture creates), the session tabs, and both AeroFile local strips. The two strips already had ad-hoc handlers that never suppressed the middle-button autoscroll, so they were folded into the shared helper rather than left to drift. The whole chip is a target including the ✖, since `auxclick` bubbles, and a tab locked by a running transfer is skipped exactly as its ✖ is.

**#347, Security Tools.** It was an unlabelled icon between Maximise and Close, where it reads as a window control. It moves into the left cluster with Editor, Terminal and AI Agent, under its full name. The Cyber-theme titlebar shortcut is unchanged.

**#277, benchmark identity columns.** The Type column repeated the Protocol column, so a custom WebDAV profile read `WebDAV / WebDAV`. Worse, and this is the part worth reading: the profile picker derived the transport from the **preset id** rather than from what the profile is saved as, so it reported **every** preconfigured multi-mode profile in its provider's native mode. A Koofr-over-WebDAV profile was listed as `REST API`, a mode it is not in. That defect predates the rename and would have survived it.

Type is now **Server**: the catalog company for a preset (`Koofr`, `TAB.DIGITAL`, `MEGA`), the provider for a native API, `Custom` for a plain transport aimed at the user's own host. Values come from the embedded catalog or the provider type, never from user text, so the report stays as anonymous as it was.

**#277, the summary line and `--all-profiles`.** `Benchmark complete:` was `key=value` pairs where several values contain a space, so `protocol=REST API` could not be split on whitespace; values are now quoted with JSON string escaping. On Ehud's related question about restricting characters in profile names, the answer is no: credentials are keyed by the profile's **id**, never its name, so the name is free-form on purpose, and the parse target is `--format json`. `--all-profiles` is accepted as a spelling of `--all`, which is what pairs read-for-read with `--all-protocols`.

**#369, the default salt.** The 128/256 radios were being read as the salt's size. They are a password requirement. There is one salt, 32 bytes, and it was nowhere on screen. Both create surfaces now say what the radios set and print the constant, with a vitest pinning the displayed value to `SHA-256("AeroCrypt default salt v1")` independently of the Rust test that pins the same derivation, so the UI cannot show a salt the backend does not use.

**Copy affordance (second commit).** One hook and one button behind 19 sites: every external link in the forms, plus the salt. Clicking a link still opens it; the copy button never navigates.

### Two defects found along the way

- The Redirect URI copy in the OAuth panel was the last clipboard call on `navigator.clipboard`. Under WebKitGTK that API is only available in a secure context and rejects silently, so the button could show its green tick without having copied anything. Now routed through the same Rust command as every other copy.
- Six link rows are `flex justify-between`. With three loose children the row shared its space between label, link and copy, so the copy drifted to the far right. Link and copy are now one group.

### Docs

`docs.aeroftp.app` documented the legacy `.aeroftp-crypt.json` marker in three places rather than `.aerocrypt.tsv`, and never documented the salt at all. Both fixed in axpdev-lab/docs.aeroftp.app@911feff.

### Verified

`cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (3334 lib tests), `tsc --noEmit`, `vitest run` (526 tests, 54 files), `npm run i18n:validate` (46 locales, 2 new keys synced). GUI verified by hand on a dev build for all four visual changes.

One note on the test run, since it is not mine to fix but should not go unsaid: the first full `cargo test` on this branch failed `transfer_dag_single_file::tests::cancel_token_keeps_durable_multipart_session_for_resume`, the flake #470 closed. The branch contains 1491b5ad1, it passes in isolation, and a second full run was clean, so it is one failure in two runs. Another `cargo` job may have been running on the machine at the time, so this is a data point rather than a diagnosis, but the claim in queued #30 that "there is no load level at which it returns" does not hold as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added copy buttons beside setup, documentation, credential, and redirect links.
  * Added visible AeroCrypt default-salt details with copy support.
  * Middle-click now closes eligible tabs.
  * Benchmark reports distinguish Server from Protocol, with expanded all-profile and all-protocol coverage.
  * Security Tools now includes a labeled launcher.

* **Documentation**
  * Expanded benchmarking guidance, skipped-run behavior, and report interpretation.
  * Updated Felicloud’s headquarters and region to EU.

* **Translations**
  * Added AeroCrypt default-salt guidance across supported locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->