### PR TITLE
fix(dag): give the durable checkpoint store to the caller instead of reaching for the user's config

### DIFF
--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -9022,6 +9022,8 @@ async fn cli_run_single_file_dag(
         file_size,
         // The CLI relies on process-level Ctrl+C, not the GUI session token.
         None,
+        // The real per-user checkpoint store: this is a production transfer.
+        None,
     )
     .await;
     let provider = arc

--- a/src-tauri/src/provider_commands.rs
+++ b/src-tauri/src/provider_commands.rs
@@ -2296,6 +2296,8 @@ async fn run_dag_download_leaf(
         report_size,
         file_size,
         cancel_token,
+        // The real per-user checkpoint store: this is a production transfer.
+        None,
     )
     .await
     {
@@ -2445,6 +2447,8 @@ async fn run_dag_upload_leaf(
         report_size,
         file_size,
         cancel_token,
+        // The real per-user checkpoint store: this is a production transfer.
+        None,
     )
     .await
     {

--- a/src-tauri/src/transfer_dag_single_file.rs
+++ b/src-tauri/src/transfer_dag_single_file.rs
@@ -714,6 +714,23 @@ pub async fn execute_single_file_dag(
     // instead of running the current file to completion. `None` = no cancel
     // wrapping (the CLI path keeps its own Ctrl+C handling).
     cancel_token: Option<CancellationToken>,
+    // Where durable multipart checkpoints are journaled, and therefore which
+    // orphan records this run is allowed to scavenge and abort. `None` means
+    // the real per-user store under the AeroFTP data root, which is what the
+    // three production call sites pass.
+    //
+    // It is a parameter rather than a `default_store()` call inside the body
+    // because the body also *acts* on what it finds there: it aborts stale
+    // provider sessions whose endpoint matches this one. With no way to
+    // inject it, every test that shaped a multipart upload read and wrote the
+    // developer's own `~/.config/aeroftp-dev/transfer-checkpoints`, so its
+    // result depended on the machine's history rather than on the code. That
+    // is not a hypothetical: it is how
+    // `cancel_token_keeps_durable_multipart_session_for_resume` came to fail
+    // on a residue seven days old (see its comment). Making this explicit at
+    // every call site is deliberate — a new test cannot reach the real store
+    // by forgetting something.
+    checkpoint_store: Option<crate::transfer_dag::TransferCheckpointStore>,
 ) -> Result<(), ProviderError> {
     let direction = built.direction;
     let remote: Arc<str> = Arc::from(remote_path.as_str());
@@ -787,8 +804,11 @@ pub async fn execute_single_file_dag(
             total_parts: layout.total_parts,
             preferred_part_size: layout.preferred_part_size,
         };
-        let store = crate::transfer_dag::TransferCheckpointStore::default_store()
-            .map_err(ProviderError::TransferFailed)?;
+        let store = match checkpoint_store {
+            Some(store) => store,
+            None => crate::transfer_dag::TransferCheckpointStore::default_store()
+                .map_err(ProviderError::TransferFailed)?,
+        };
         // Conservative orphan scavenging: only records past the durable TTL,
         // only for this exact connected endpoint/provider, and only after a
         // successful provider abort. Unknown, current, and failed-abort records
@@ -1486,6 +1506,31 @@ mod tests {
     use crate::providers::{MultipartHandle, ProviderType, RemoteEntry, UploadedPart};
     use crate::transfer_dag::observer::CollectingDagObserver;
     use crate::transfer_dag::{Capability, TransferCapabilities, TransferDagBuilder};
+
+    /// The durable-checkpoint store every test in this module passes to
+    /// [`execute_single_file_dag`], rooted in that test's own temp directory.
+    ///
+    /// Never pass `None` from a test. `None` means the real per-user store
+    /// under the AeroFTP data root, and the multipart path does not merely
+    /// write there: it scavenges orphan records past the TTL whose endpoint
+    /// matches, and aborts the matching provider session. A test that reached
+    /// it therefore inherited every previous run's leftovers, on this machine
+    /// only, so its result depended on the developer's history rather than on
+    /// the code. That is how
+    /// `cancel_token_keeps_durable_multipart_session_for_resume` came to fail
+    /// on 2026-07-28 against four `slow-mock` records written seven days
+    /// earlier, which crossed the TTL that morning; CI never saw it, because a
+    /// fresh runner has no history. See
+    /// `scavenger_only_aborts_stale_records_from_the_injected_store` for the
+    /// behaviour this isolation makes testable on purpose.
+    fn test_checkpoint_store(
+        dir: &std::path::Path,
+    ) -> Option<crate::transfer_dag::TransferCheckpointStore> {
+        Some(
+            crate::transfer_dag::TransferCheckpointStore::new(dir.join("checkpoints"))
+                .expect("per-test checkpoint store"),
+        )
+    }
 
     // DAG-P2-06 (wire-level): the shaped single-file construction point binds
     // learned tuning to its endpoint under the ShapedFile workload key, which is
@@ -2323,6 +2368,7 @@ mod tests {
             report,
             30,
             Some(token),
+            test_checkpoint_store(dir.path()),
         )
         .await;
 
@@ -2369,6 +2415,7 @@ mod tests {
             report,
             30,
             Some(CancellationToken::new()),
+            test_checkpoint_store(dir.path()),
         )
         .await;
 
@@ -2436,6 +2483,7 @@ mod tests {
             report,
             20,
             Some(token),
+            test_checkpoint_store(dir.path()),
         )
         .await;
 
@@ -2456,6 +2504,128 @@ mod tests {
         assert!(
             !*multipart_aborted.lock().unwrap(),
             "a durable checkpoint keeps the provider session for missing-part resume"
+        );
+    }
+
+    /// The orphan scavenger reads the store it was handed, and aborts a stale
+    /// non-terminal record whose endpoint matches this transfer.
+    ///
+    /// This is the mechanism that made the test above fail on 2026-07-28, and
+    /// nothing exercised it: it ran on `default_store()` against whatever the
+    /// developer's machine happened to contain, so it was invisible until it
+    /// misfired and then looked like a timing flake. Pinned here on purpose,
+    /// with both directions asserted, because "aborts too eagerly" and "never
+    /// aborts" are both regressions and one assertion cannot tell them apart.
+    ///
+    /// Two runs against **one** injected directory. The first is the cancelled
+    /// upload above, which leaves a `failed` record: non-terminal, so it is a
+    /// resume candidate rather than garbage. The second re-runs against the
+    /// same directory through a zero-TTL view of it, which is what "seven days
+    /// later" looks like without waiting seven days.
+    #[tokio::test]
+    async fn scavenger_aborts_a_stale_record_from_the_injected_store() {
+        use crate::transfer_dag::TransferCheckpointStore;
+        use std::time::Duration;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store_dir = dir.path().join("checkpoints");
+        let local = dir.path().join("source.bin");
+        std::fs::write(&local, b"0123456789abcdefghij").expect("write source");
+
+        // One cancelled multipart upload, purely to leave a real non-terminal
+        // record behind. Hand-writing the record would let the test drift from
+        // the shape production actually journals.
+        let seed_aborted = Arc::new(StdMutex::new(false));
+        let token = CancellationToken::new();
+        let seed = SlowMockProvider::new(
+            Arc::new(StdMutex::new(false)),
+            Arc::new(StdMutex::new(false)),
+        )
+        .with_multipart_state(
+            Arc::new(StdMutex::new(false)),
+            Arc::clone(&seed_aborted),
+            Arc::new(AtomicU64::new(0)),
+        )
+        .cancelling_during_part(token.clone());
+        let caps = TransferCapabilities {
+            multipart_upload: Capability::Supported,
+            preferred_chunk_size: Some(10),
+            multipart_threshold: 0,
+            max_chunk_slots: Some(1),
+            ..TransferCapabilities::default()
+        };
+        let built = TransferDagBuilder::shaped_file(TransferDirection::Upload, &caps, 20);
+        let observer: Arc<dyn DagObserver> = Arc::new(crate::transfer_dag::NoopDagObserver);
+
+        let seeded = execute_single_file_dag(
+            &built,
+            Arc::new(Mutex::new(Some(
+                Box::new(seed) as Box<dyn crate::providers::StorageProvider>
+            ))),
+            "/remote.bin".to_string(),
+            local.to_string_lossy().to_string(),
+            None,
+            None,
+            Arc::clone(&observer),
+            Arc::new(AtomicU64::new(20)),
+            20,
+            Some(token),
+            Some(TransferCheckpointStore::new(&store_dir).expect("seed store")),
+        )
+        .await;
+        assert!(seeded.is_err(), "the seeding upload is cancelled by design");
+        assert!(
+            !*seed_aborted.lock().unwrap(),
+            "the seeding run must leave the session intact, or there is nothing stale to find"
+        );
+
+        let default_view = TransferCheckpointStore::new(&store_dir).expect("default-TTL view");
+        assert_eq!(
+            default_view.stale_nonterminal().expect("list stale").len(),
+            0,
+            "a record written seconds ago is not stale under the 7-day TTL: \
+             the scavenger must leave a live resume candidate alone"
+        );
+        let expired_view = TransferCheckpointStore::with_ttl(&store_dir, Duration::from_secs(0))
+            .expect("zero-TTL view");
+        assert_eq!(
+            expired_view.stale_nonterminal().expect("list stale").len(),
+            1,
+            "the same record is stale once the TTL has passed"
+        );
+
+        // Second run, same directory seen through the expired view. The
+        // scavenger must now find the seeded record and abort its session.
+        let scavenged = Arc::new(StdMutex::new(false));
+        let second = SlowMockProvider::new(
+            Arc::new(StdMutex::new(false)),
+            Arc::new(StdMutex::new(false)),
+        )
+        .with_multipart_state(
+            Arc::new(StdMutex::new(false)),
+            Arc::clone(&scavenged),
+            Arc::new(AtomicU64::new(0)),
+        );
+        let _ = execute_single_file_dag(
+            &built,
+            Arc::new(Mutex::new(Some(
+                Box::new(second) as Box<dyn crate::providers::StorageProvider>
+            ))),
+            "/remote.bin".to_string(),
+            local.to_string_lossy().to_string(),
+            None,
+            None,
+            observer,
+            Arc::new(AtomicU64::new(20)),
+            20,
+            Some(CancellationToken::new()),
+            Some(TransferCheckpointStore::with_ttl(&store_dir, Duration::from_secs(0)).unwrap()),
+        )
+        .await;
+
+        assert!(
+            *scavenged.lock().unwrap(),
+            "the stale record's provider session must be aborted by the scavenger"
         );
     }
 
@@ -2506,6 +2676,7 @@ mod tests {
             report,
             20,
             Some(CancellationToken::new()),
+            test_checkpoint_store(dir.path()),
         )
         .await;
 
@@ -2570,6 +2741,7 @@ mod tests {
             report,
             20,
             Some(CancellationToken::new()),
+            test_checkpoint_store(dir.path()),
         )
         .await;
 
@@ -2632,6 +2804,7 @@ mod tests {
             report,
             13,
             Some(CancellationToken::new()),
+            test_checkpoint_store(dir.path()),
         )
         .await;
 
@@ -2680,6 +2853,7 @@ mod tests {
             report,
             30,
             Some(CancellationToken::new()),
+            test_checkpoint_store(dir.path()),
         )
         .await;
         assert!(res.is_ok(), "download completes: {res:?}");
@@ -2727,6 +2901,7 @@ mod tests {
             report,
             5,
             Some(CancellationToken::new()),
+            test_checkpoint_store(dir.path()),
         )
         .await;
         assert!(res.is_ok(), "upload completes: {res:?}");
@@ -2773,6 +2948,7 @@ mod tests {
             report,
             30,
             Some(token),
+            test_checkpoint_store(dir.path()),
         )
         .await;
 
@@ -2835,6 +3011,7 @@ mod tests {
             Arc::new(AtomicU64::new(20)),
             20,
             Some(CancellationToken::new()),
+            test_checkpoint_store(dir.path()),
         )
         .await;
         assert!(
@@ -2861,6 +3038,7 @@ mod tests {
             Arc::new(AtomicU64::new(20)),
             20,
             Some(CancellationToken::new()),
+            test_checkpoint_store(dir.path()),
         )
         .await;
         assert!(second.is_ok(), "the resumed run commits: {second:?}");
@@ -2914,6 +3092,7 @@ mod tests {
             report,
             20,
             Some(CancellationToken::new()),
+            test_checkpoint_store(dir.path()),
         )
         .await;
         assert!(res.is_ok(), "multipart upload commits: {res:?}");
@@ -3158,6 +3337,7 @@ mod tests {
             report,
             7,
             Some(CancellationToken::new()),
+            test_checkpoint_store(dir.path()),
         )
         .await;
         assert!(res.is_ok(), "fixture download completes: {res:?}");
@@ -3219,6 +3399,7 @@ mod tests {
             report,
             20,
             Some(CancellationToken::new()),
+            test_checkpoint_store(dir.path()),
         )
         .await;
         assert!(res.is_ok(), "multipart fixture upload commits: {res:?}");

--- a/src-tauri/tests/dag_b2_multipart.rs
+++ b/src-tauri/tests/dag_b2_multipart.rs
@@ -163,6 +163,7 @@ async fn gtc_dag_b2_multipart_byte_identical() {
 
     let report_size = Arc::new(AtomicU64::new(file_size));
     let observer: Arc<dyn DagObserver> = Arc::new(NoopDagObserver);
+    let checkpoint_dir = tempfile::tempdir().expect("checkpoint tempdir");
     execute_single_file_dag(
         &built,
         Arc::clone(&arc_provider),
@@ -174,6 +175,10 @@ async fn gtc_dag_b2_multipart_byte_identical() {
         report_size,
         file_size,
         None,
+        Some(
+            ftp_client_gui_lib::transfer_dag::TransferCheckpointStore::new(checkpoint_dir.path())
+                .expect("per-test checkpoint store"),
+        ),
     )
     .await
     .expect("shaped multipart upload must succeed");

--- a/src-tauri/tests/dag_s3_multipart.rs
+++ b/src-tauri/tests/dag_s3_multipart.rs
@@ -188,6 +188,7 @@ async fn gtc_dag_s3_multipart_byte_identical() {
 
     let report_size = Arc::new(AtomicU64::new(file_size));
     let observer: Arc<dyn DagObserver> = Arc::new(NoopDagObserver);
+    let checkpoint_dir = tempfile::tempdir().expect("checkpoint tempdir");
     execute_single_file_dag(
         &built,
         Arc::clone(&arc_provider),
@@ -199,6 +200,10 @@ async fn gtc_dag_s3_multipart_byte_identical() {
         report_size,
         file_size,
         None,
+        Some(
+            ftp_client_gui_lib::transfer_dag::TransferCheckpointStore::new(checkpoint_dir.path())
+                .expect("per-test checkpoint store"),
+        ),
     )
     .await
     .expect("shaped multipart upload must succeed");

--- a/src-tauri/tests/integration_gtc_wan_segmented.rs
+++ b/src-tauri/tests/integration_gtc_wan_segmented.rs
@@ -1050,6 +1050,7 @@ async fn dag_download_once(
     let built = TransferDagBuilder::shaped_file(TransferDirection::Download, &caps, 0);
     let report = Arc::new(AtomicU64::new(0));
     let observer: Arc<dyn DagObserver> = Arc::new(NoopDagObserver);
+    let checkpoint_dir = tempfile::tempdir().expect("checkpoint tempdir");
     let res = execute_single_file_dag(
         &built,
         Arc::clone(&arc),
@@ -1061,6 +1062,10 @@ async fn dag_download_once(
         report,
         0,
         None,
+        Some(
+            ftp_client_gui_lib::transfer_dag::TransferCheckpointStore::new(checkpoint_dir.path())
+                .expect("per-test checkpoint store"),
+        ),
     )
     .await
     .map_err(|e| e.to_string());


### PR DESCRIPTION
## The defect

`execute_single_file_dag` opened `TransferCheckpointStore::default_store()` itself, with no way to override it. The multipart path does not merely *write* there: it scavenges orphan records past the 7-day TTL whose endpoint matches this transfer, and calls `abort_multipart_upload` on each one.

Under `cargo test`, that store is the developer's real `~/.config/aeroftp-dev/transfer-checkpoints`. So every test that shaped a multipart upload read and wrote a real user's configuration, and inherited every previous run's leftovers. On this machine that directory held **325 records accumulated since 21 July**, all from mock endpoints, all written by the test suite.

## Why this matters beyond hygiene: it is the second cause of the #470 flake

`cancel_token_keeps_durable_multipart_session_for_resume` asserts `multipart_aborted == false`. Four `slow-mock` records written on 21 July crossed the TTL on the morning of 28 July; the scavenger aborted one, `SlowMockProvider::abort_multipart_upload` raised the shared flag, and the test failed on exactly the assertion it exists to defend.

The run that fails then `remove()`s the record, which is why the very next run passes. The observed fail/pass pair is the mechanism, not noise.

CI never saw any of it, because a fresh runner has no history. It reproduces only on a developer's machine — the worst place for a flake to live.

**Queued #30 is not retracted by this.** #470 closed a real timing race by construction, and there is indeed no load level at which *that* window returns. This is a different abort path that has nothing to do with when the cancel lands. The tracker row wants an addition, not a correction.

## The fix

The store is a parameter now.

| Caller | Passes |
|---|---|
| `provider_commands.rs` download + upload, `aeroftp_cli.rs` | `None` → the real per-user store, unchanged behaviour |
| 14 call sites in the unit test module | that test's own temp directory |
| 3 call sites in `tests/` (`dag_b2_multipart`, `dag_s3_multipart`, `integration_gtc_wan_segmented`) | same |

Explicit rather than defaulted, on purpose: a new test cannot reach the developer's configuration by forgetting an argument, because it will not compile without one. The three call sites under `tests/` were found by `clippy --all-targets`, not by grep — they were writing to the real store too.

## The pin

`scavenger_aborts_a_stale_record_from_the_injected_store` covers the mechanism that had nothing exercising it, in **both** directions, because "aborts too eagerly" and "never aborts" are both regressions and one assertion cannot tell them apart:

1. seeds a genuine non-terminal record by running a cancelled multipart upload, rather than hand-writing one that could drift from the shape production journals;
2. asserts that record is **not** stale under the default 7-day TTL, so a live resume candidate is left alone;
3. re-runs against the same directory through a zero-TTL view — which is what "seven days later" looks like without waiting seven days — and asserts the session is aborted.

## Gates

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --lib --all-targets -- -D warnings` | clean |
| `cargo test --lib transfer_dag_single_file` | **29 passed, 0 failed**, including the previously flaky test |

## Credit

Root cause independently identified by the triage tab; full evidence in `20260728T074500Z-E4-flaky-multipart-cancel-ROOTCAUSE.md`. The four `slow-mock` records that reproduce it have deliberately **not** been deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)