### PR TITLE
chore(deps): add md4 to the RustCrypto digest 0.11 block it already belonged to

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,6 +57,15 @@ updates:
         versions: [">=0.11.0"]
       - dependency-name: "md-5"
         versions: [">=0.11.0"]
+      # md4 belongs to this block and was simply missing from it, which is
+      # why PR #477 (0.10.2 -> 0.11.0) reached CI and failed every target
+      # rather than never being opened: md4 0.11 requires digest 0.11 while
+      # sha1/sha2/md-5 are held at 0.10, so the `Digest` trait types stop
+      # unifying and the tree does not compile. We use it for the legacy
+      # rsync negotiated checksum (aerorsync Y-RSC.3), so it is
+      # protocol-visible as well as crypto-adjacent.
+      - dependency-name: "md4"
+        versions: [">=0.11.0"]
       - dependency-name: "ripemd"
         versions: [">=0.2.0"]
       - dependency-name: "hkdf"


### PR DESCRIPTION
The `RustCrypto digest 0.11 / hmac 0.13 migration block` in `dependabot.yml` already exists and is already motivated: sha1, sha2, md-5, ripemd, hkdf, pbkdf2 and hmac are held back because taking any one of them in isolation pulls `digest 0.11` into a graph still on `digest 0.10`, forks the trait crates and breaks the build.

**md4 was simply missing from that list.** This adds it.

## Why it matters, measured

The omission is not theoretical. #477 bumped md4 `0.10.2 → 0.11.0` and failed **every** target — Checks, all four `build-and-release` jobs, both SFTP fixture lanes, the Windows cross-OS build and `cargo-install-smoke`. Not a flake, and no rebase could have saved it: md4 0.11 requires `digest = "0.11"` (confirmed against the crate's manifest upstream) while `sha1`, `sha2` and `md-5` are pinned at 0.10 in `src-tauri/Cargo.toml`, so the `Digest` trait types stop unifying and the tree does not compile. It can only land as part of the coordinated wave the block is already waiting for.

md4 is also **protocol-visible**, not merely crypto-adjacent: it implements the legacy rsync negotiated checksum (aerorsync Y-RSC.3), reached whenever a peer negotiates md4 instead of the modern algorithms.

## Why not just close #477 and move on

Closing it alone fixes today and not next Monday: dependabot re-proposes the same unmergeable PR on every weekly scan. Recurring noise that has a known, permanent cause is exactly what this file exists to stop — which is the same reasoning as the four missing labels (`dependencies`, `rust`, `javascript`, `ci`) that were making **every** dependabot PR post a "labels could not be found" error comment, now created.

#477 is closed with a pointer here.

Validated: the file parses, and the cargo ecosystem's ignore list now covers the whole family — sha1, sha2, md-5, md4, ripemd, hkdf, pbkdf2, hmac.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update settings to temporarily defer updates for the `md4` Rust package alongside related RustCrypto dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->