### PR TITLE
fix(sync): crypt Compare stops reporting "no differences" over a folder that is not

### DIFF
--- a/src-tauri/src/provider_commands.rs
+++ b/src-tauri/src/provider_commands.rs
@@ -6338,33 +6338,78 @@ impl crate::transfer_dag::DagObserver for ScanProgressEmitter {
     }
 }
 
-async fn decrypt_remote_file_map_for_compare(
+/// Resolve the keys a crypt-aware compare must normalize the RAW remote listing
+/// with, from whichever unlock path armed this session.
+///
+/// There are two, and only one of them ever populated the standalone vault maps:
+///
+/// * the **provider overlay** (`provider_apply_crypt_overlay`), which is what the
+///   Overlays Path and every saved crypt profile use. It derives the keys into
+///   the live decorator and into this connection's key cache, and the vault id
+///   the frontend then reports is a synthetic sentinel
+///   (`provider-overlay:<kind>:<owner>`), never a map key;
+/// * the **standalone vault** commands (`rclone_crypt_unlock` /
+///   `aerocrypt_unlock`), used by the vault browser, which do insert under the
+///   UUID they hand back.
+///
+/// Looking only in the maps therefore failed for every provider-overlay session,
+/// which is the whole of the Overlays Path (#347). The cache is consulted first
+/// because it is the same key material the file panel is displaying with, so
+/// Compare and the panel cannot disagree; the maps stay as the fallback so the
+/// vault-browser path keeps working unchanged.
+async fn resolve_compare_overlay_keys(
     kind: Option<&str>,
     vault_id: &str,
+    state: &ProviderState,
     rclone_state: &crate::rclone_crypt::RcloneCryptState,
     aerocrypt_state: &crate::aerocrypt_provider::AeroCryptState,
-    entries: HashMap<String, crate::sync::FileInfo>,
-) -> Result<HashMap<String, crate::sync::FileInfo>, String> {
+) -> Result<crate::crypt_overlay_provider::OverlayKeys, String> {
+    use crate::crypt_overlay_provider::OverlayKeys;
+
+    // 1. This connection's armed overlay, if its kind is the one asked for. A
+    //    kind mismatch falls through rather than decrypting with the wrong
+    //    scheme, which would drop every row and read as "no differences".
+    if let Some((keys, _scope, cached_kind)) = state.cached_overlay_for_rearm() {
+        if Some(cached_kind.as_str()) == kind {
+            return Ok(keys);
+        }
+    }
+
+    // 2. A standalone unlocked vault, keyed by the UUID that unlock returned.
     match kind {
         Some("rclone-crypt") => {
             let vaults = rclone_state.vaults.lock().await;
-            let keys = vaults
+            vaults
                 .get(vault_id)
-                .ok_or_else(|| "Crypt vault is not unlocked".to_string())?;
-            Ok(normalize_rclone_remote_files_for_compare(keys, entries))
+                .map(|keys| OverlayKeys::Rclone(keys.clone()))
+                .ok_or_else(|| "Crypt vault is not unlocked".to_string())
         }
         Some("aerocrypt") => {
             let vaults = aerocrypt_state.vaults.lock().await;
-            let keys = vaults
+            vaults
                 .get(vault_id)
-                .ok_or_else(|| "Crypt vault is not unlocked".to_string())?;
-            Ok(normalize_aerocrypt_remote_files_for_compare(
-                &keys.master_key,
-                entries,
-            ))
+                .map(|keys| OverlayKeys::AeroCrypt {
+                    master_key: keys.master_key,
+                    config: keys.config.clone(),
+                })
+                .ok_or_else(|| "Crypt vault is not unlocked".to_string())
         }
         Some(_) => Err("Unsupported crypt overlay kind for compare".to_string()),
         None => Err("Missing crypt overlay kind for compare".to_string()),
+    }
+}
+
+fn normalize_remote_files_for_compare(
+    keys: &crate::crypt_overlay_provider::OverlayKeys,
+    entries: HashMap<String, crate::sync::FileInfo>,
+) -> HashMap<String, crate::sync::FileInfo> {
+    match keys {
+        crate::crypt_overlay_provider::OverlayKeys::Rclone(k) => {
+            normalize_rclone_remote_files_for_compare(k, entries)
+        }
+        crate::crypt_overlay_provider::OverlayKeys::AeroCrypt { master_key, .. } => {
+            normalize_aerocrypt_remote_files_for_compare(master_key, entries)
+        }
     }
 }
 
@@ -6718,25 +6763,68 @@ pub async fn provider_compare_directories(
         }
     }
 
+    // The remote scan above ran through `state.provider`, which IS the crypt
+    // decorator whenever the overlay is armed and in scope. In that case the
+    // listing already came back as plaintext names and plaintext sizes, and
+    // normalizing it a second time would try to decrypt cleartext, drop every
+    // row on the failed-decrypt `continue`, and hand Compare an empty remote:
+    // "no differences" over a folder that is not in sync. Normalization exists
+    // for the OTHER case, a compare launched while the box is unwrapped (badge
+    // locked, or a scope that never applied the overlay slot), where the
+    // listing really is encrypted.
     if let Some(vault_id) = crypt_vault_id.as_deref() {
-        let raw_len = remote_files.len();
-        remote_files = decrypt_remote_file_map_for_compare(
-            crypt_kind.as_deref(),
-            vault_id,
-            &rclone_state,
-            &aerocrypt_state,
-            remote_files,
-        )
-        .await?;
-        // rclone-crypt has no config MAC: a wrong overlay password derives
-        // valid-shaped keys that decrypt nothing, so a non-empty remote that
-        // normalizes to zero rows is a wrong-key signal. Fail closed rather
-        // than re-flag the whole tree as missing (the #364 symptom).
-        if crypt_kind.as_deref() == Some("rclone-crypt") && raw_len > 0 && remote_files.is_empty() {
-            return Err(
-                "Crypt overlay decrypted no remote entries: wrong overlay password or non-crypt remote."
-                    .to_string(),
+        if state.overlay_wrapped.load(Ordering::SeqCst) {
+            // An overlay that cannot map the ciphertext length back to the
+            // plaintext one (legacy AeroCrypt v1/v2) reports the on-wire size,
+            // so comparing it against the local plaintext size flags every
+            // single file as different and proposes re-uploading the whole
+            // tree. `cloud_service` already drops size comparison on that
+            // signal; this path did not, so it does now, and says so in the log
+            // rather than quietly producing a full-tree diff.
+            let exact_size = {
+                let guard = state.provider.lock().await;
+                guard
+                    .as_ref()
+                    .map(|p| p.reports_exact_size())
+                    .unwrap_or(true)
+            };
+            if !exact_size && options.compare_size {
+                options.compare_size = false;
+                info!(
+                    "Crypt compare: overlay does not map ciphertext size to plaintext size, \
+                     size comparison disabled for this run (kind: {})",
+                    crypt_kind.as_deref().unwrap_or("unknown")
+                );
+            }
+            info!(
+                "Crypt compare: live provider is overlay-wrapped, remote listing is already \
+                 plaintext (kind: {})",
+                crypt_kind.as_deref().unwrap_or("unknown")
             );
+        } else {
+            let keys = resolve_compare_overlay_keys(
+                crypt_kind.as_deref(),
+                vault_id,
+                &state,
+                &rclone_state,
+                &aerocrypt_state,
+            )
+            .await?;
+            let raw_len = remote_files.len();
+            remote_files = normalize_remote_files_for_compare(&keys, remote_files);
+            // rclone-crypt has no config MAC: a wrong overlay password derives
+            // valid-shaped keys that decrypt nothing, so a non-empty remote that
+            // normalizes to zero rows is a wrong-key signal. Fail closed rather
+            // than re-flag the whole tree as missing (the #364 symptom).
+            if crypt_kind.as_deref() == Some("rclone-crypt")
+                && raw_len > 0
+                && remote_files.is_empty()
+            {
+                return Err(
+                    "Crypt overlay decrypted no remote entries: wrong overlay password or non-crypt remote."
+                        .to_string(),
+                );
+            }
         }
     }
 
@@ -12299,10 +12387,10 @@ mod tests {
     use super::{
         decrypt_rel_aerocrypt, decrypt_rel_rclone, drain_in_flight_transfers,
         normalize_aerocrypt_remote_files_for_compare, normalize_rclone_remote_files_for_compare,
-        rclone_decrypted_size, remote_matches_repo, run_cancellable_connect,
-        run_cancellable_listing, ConnectTokenGuard, ConnectionCancelRegistry, ListingCancelState,
-        ProviderConnectionParams, ProviderState, TransferOperationGuard, CONNECT_CANCELLED,
-        LISTING_CANCELLED,
+        normalize_remote_files_for_compare, rclone_decrypted_size, remote_matches_repo,
+        resolve_compare_overlay_keys, run_cancellable_connect, run_cancellable_listing,
+        ConnectTokenGuard, ConnectionCancelRegistry, ListingCancelState, ProviderConnectionParams,
+        ProviderState, TransferOperationGuard, CONNECT_CANCELLED, LISTING_CANCELLED,
     };
     use crate::rclone_crypt::{
         derive_keys, derive_keys_with_tweak, encrypt_file_content, encrypt_name,
@@ -12364,6 +12452,187 @@ mod tests {
         assert!(state.cached_overlay_for_rearm().is_some());
         state.invalidate_overlay_key_cache();
         assert!(state.cached_overlay_for_rearm().is_none());
+    }
+
+    // ── Crypt-aware Compare key resolution (#347) ─────────────────────────────
+    //
+    // The regression these pin: a crypt Compare reported "no differences" over a
+    // folder that was not in sync, on BOTH overlay kinds, because the vault id
+    // the frontend passes for a provider overlay is a synthetic sentinel and the
+    // resolver only looked in the standalone vault maps, which that unlock path
+    // never populates. Reported against v4.1.6.
+
+    fn compare_test_keys() -> crate::crypt_overlay_provider::OverlayKeys {
+        let (name_key, data_key, name_tweak) =
+            derive_keys_with_tweak("compare-pass", "compare-salt").unwrap();
+        crate::crypt_overlay_provider::OverlayKeys::Rclone(RcloneCryptKeys {
+            name_key,
+            data_key,
+            name_tweak,
+            filename_encryption: FilenameEncryption::Standard,
+            off_suffix: String::new(),
+            directory_name_encryption: true,
+        })
+    }
+
+    fn compare_file_entry(rel: &str) -> (String, crate::sync::FileInfo) {
+        (
+            rel.to_string(),
+            crate::sync::FileInfo {
+                name: rel.rsplit('/').next().unwrap_or(rel).to_string(),
+                path: rel.to_string(),
+                size: 1024,
+                modified: None,
+                is_dir: false,
+                checksum: None,
+                checksum_alg: None,
+            },
+        )
+    }
+
+    /// The sentinel the GUI reports for a provider overlay resolves to the keys
+    /// this connection actually armed. Before the fix this fell through to the
+    /// vault maps, which a provider overlay never writes to, and the compare
+    /// died with "Crypt vault is not unlocked".
+    #[tokio::test]
+    async fn compare_resolves_provider_overlay_keys_from_the_connection_cache() {
+        let state = ProviderState::new();
+        let rclone_state = crate::rclone_crypt::RcloneCryptState::default();
+        let aerocrypt_state = crate::aerocrypt_provider::AeroCryptState::default();
+        state.store_overlay_key_cache(
+            compare_test_keys(),
+            "/Vault".to_string(),
+            "rclone-crypt".to_string(),
+        );
+
+        let resolved = resolve_compare_overlay_keys(
+            Some("rclone-crypt"),
+            // Exactly the shape App.tsx builds: `provider-overlay:<kind>:<owner>`,
+            // which is not, and never was, a key in either vault map.
+            "provider-overlay:rclone-crypt:saved-server-1",
+            &state,
+            &rclone_state,
+            &aerocrypt_state,
+        )
+        .await
+        .expect("a provider-overlay session must resolve its own armed keys");
+        assert_eq!(resolved.kind_str(), "rclone-crypt");
+    }
+
+    /// A cached overlay of the OTHER kind must not answer: decrypting with the
+    /// wrong scheme drops every row, which reads as "no differences" rather than
+    /// as the error it is.
+    #[tokio::test]
+    async fn compare_does_not_answer_with_a_different_overlay_kind() {
+        let state = ProviderState::new();
+        let rclone_state = crate::rclone_crypt::RcloneCryptState::default();
+        let aerocrypt_state = crate::aerocrypt_provider::AeroCryptState::default();
+        state.store_overlay_key_cache(
+            compare_test_keys(),
+            "/Vault".to_string(),
+            "rclone-crypt".to_string(),
+        );
+
+        // `OverlayKeys` has no `Debug` on purpose (it holds key material), so the
+        // assertion matches rather than unwrapping.
+        match resolve_compare_overlay_keys(
+            Some("aerocrypt"),
+            "provider-overlay:aerocrypt:saved-server-1",
+            &state,
+            &rclone_state,
+            &aerocrypt_state,
+        )
+        .await
+        {
+            Ok(_) => panic!("a kind mismatch must not silently decrypt with the wrong scheme"),
+            Err(err) => assert!(err.contains("not unlocked"), "unexpected error: {err}"),
+        }
+    }
+
+    /// A stale cache (the connection moved on) must not answer either, for the
+    /// same reason it can never re-arm: those keys belong to another server.
+    #[tokio::test]
+    async fn compare_ignores_a_cache_from_a_previous_connection() {
+        let state = ProviderState::new();
+        let rclone_state = crate::rclone_crypt::RcloneCryptState::default();
+        let aerocrypt_state = crate::aerocrypt_provider::AeroCryptState::default();
+        state.store_overlay_key_cache(
+            compare_test_keys(),
+            "/Vault".to_string(),
+            "rclone-crypt".to_string(),
+        );
+        state.connection_generation.fetch_add(1, Ordering::SeqCst);
+
+        assert!(
+            resolve_compare_overlay_keys(
+                Some("rclone-crypt"),
+                "provider-overlay:rclone-crypt:saved-server-1",
+                &state,
+                &rclone_state,
+                &aerocrypt_state,
+            )
+            .await
+            .is_err(),
+            "keys cached for a previous connection must never answer a compare"
+        );
+    }
+
+    /// The standalone vault-browser path keeps working: its unlock really does
+    /// insert under the UUID it hands back, and that is still resolvable.
+    #[tokio::test]
+    async fn compare_still_resolves_a_standalone_unlocked_vault_by_uuid() {
+        let state = ProviderState::new();
+        let rclone_state = crate::rclone_crypt::RcloneCryptState::default();
+        let aerocrypt_state = crate::aerocrypt_provider::AeroCryptState::default();
+        let (name_key, data_key, name_tweak) =
+            derive_keys_with_tweak("compare-pass", "compare-salt").unwrap();
+        rclone_state.vaults.lock().await.insert(
+            "11111111-2222-3333-4444-555555555555".to_string(),
+            RcloneCryptKeys {
+                name_key,
+                data_key,
+                name_tweak,
+                filename_encryption: FilenameEncryption::Standard,
+                off_suffix: String::new(),
+                directory_name_encryption: true,
+            },
+        );
+
+        let resolved = resolve_compare_overlay_keys(
+            Some("rclone-crypt"),
+            "11111111-2222-3333-4444-555555555555",
+            &state,
+            &rclone_state,
+            &aerocrypt_state,
+        )
+        .await
+        .expect("the vault-browser unlock path must keep resolving");
+        assert_eq!(resolved.kind_str(), "rclone-crypt");
+    }
+
+    /// Why the wrapped branch must skip normalization entirely: the compare scan
+    /// runs through `state.provider`, which IS the decorator when the overlay is
+    /// armed, so the listing is already plaintext. Normalizing it again decrypts
+    /// cleartext, every row fails and is dropped, and the remote arrives EMPTY,
+    /// which Compare renders as "no differences" over a folder that is not in
+    /// sync. This asserts the emptying, so the guard around it cannot be removed
+    /// as redundant.
+    #[test]
+    fn normalizing_an_already_plaintext_listing_would_empty_the_remote() {
+        let keys = compare_test_keys();
+        let plaintext: HashMap<String, crate::sync::FileInfo> = [
+            compare_file_entry("notes.txt"),
+            compare_file_entry("photos/holiday.jpg"),
+        ]
+        .into_iter()
+        .collect();
+
+        let normalized = normalize_remote_files_for_compare(&keys, plaintext);
+        assert!(
+            normalized.is_empty(),
+            "plaintext names are not valid ciphertext, so every row drops: this is \
+             exactly the 'no differences' the wrapped-provider guard prevents"
+        );
     }
 
     fn s3_params(path_style: Option<bool>) -> ProviderConnectionParams {

--- a/src-tauri/src/providers/filen/mod.rs
+++ b/src-tauri/src/providers/filen/mod.rs
@@ -55,6 +55,14 @@ struct FilenMultipartMeta {
     total: u64,
     part: u64,
     total_chunks: u64,
+    /// Source mtime in epoch ms, captured when the session opened. The commit
+    /// happens long after the local file was read, so the mtime has to travel
+    /// with the handle: without it the multipart path re-dated large files to
+    /// their upload time while the single-shot path preserved them, and the two
+    /// disagreed on the same folder (#347). `None` for handles created before
+    /// this field existed, which then fall back to the commit time.
+    #[serde(default)]
+    last_modified_ms: Option<i64>,
 }
 
 impl FilenMultipartMeta {
@@ -658,6 +666,39 @@ impl FilenProvider {
         }
         // Fall back to raw string (our older format or simple names)
         Some(decrypted)
+    }
+
+    /// The `lastModified` a write must carry, in the epoch milliseconds Filen
+    /// stores in the encrypted file metadata.
+    ///
+    /// It is the SOURCE file's modification time, not the moment of the write.
+    /// Filen's `lastModified` is the only mtime the account holds, so stamping
+    /// the upload instant re-dates every file to when it was transferred: a
+    /// folder uploaded through AeroFTP then compares as entirely out of sync
+    /// against the very local folder it came from, and stays that way, because
+    /// each re-upload stamps a new "now" (#347). The same wrong value is what
+    /// the Filen desktop bridge then serves over WebDAV, which is why the
+    /// symptom shows on both transports.
+    ///
+    /// Falls back to the current time only when the source has no readable
+    /// mtime, which is the best a write can do and is still better than
+    /// nothing for a file that never had one.
+    fn source_last_modified_ms(source: Option<&std::fs::Metadata>) -> i64 {
+        source
+            .and_then(|m| m.modified().ok())
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| d.as_millis() as i64)
+            .unwrap_or_else(|| chrono::Utc::now().timestamp_millis())
+    }
+
+    /// Epoch milliseconds for an existing entry's timestamp, so a metadata-only
+    /// write (a rename) can carry the mtime the file already had instead of
+    /// re-dating it. `None` when the entry never had one.
+    fn entry_last_modified_ms(modified: Option<&str>) -> Option<i64> {
+        let raw = modified?;
+        chrono::DateTime::parse_from_rfc3339(raw)
+            .ok()
+            .map(|dt| dt.timestamp_millis())
     }
 
     /// Hash file/folder name for Filen API: SHA-1(SHA-512(name.toLowerCase()).hex()).hex()
@@ -1879,13 +1920,13 @@ impl StorageProvider for FilenProvider {
 
         // Encrypt metadata using the file size in plaintext bytes (matches
         // what the official SDK and the existing download path expect).
-        let now = chrono::Utc::now().timestamp_millis();
+        let last_modified = Self::source_last_modified_ms(Some(&file_metadata));
         let metadata = serde_json::json!({
             "name": file_name,
             "size": file_size,
             "mime": mime_type,
             "key": file_key,
-            "lastModified": now,
+            "lastModified": last_modified,
         });
         let encrypted_metadata = self.encrypt_metadata(&metadata.to_string())?;
         let encrypted_name = self.encrypt_metadata(file_name)?;
@@ -2212,17 +2253,18 @@ impl StorageProvider for FilenProvider {
                 .mime_type
                 .clone()
                 .unwrap_or_else(|| "application/octet-stream".to_string());
-            let now = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_millis() as u64;
+            // A rename changes the name, not the contents: carry the mtime the
+            // file already had. Stamping "now" here re-dated every renamed file
+            // and put it out of sync with its unchanged local twin.
+            let last_modified = Self::entry_last_modified_ms(entry.modified.as_deref())
+                .unwrap_or_else(|| chrono::Utc::now().timestamp_millis());
 
             let meta_json = serde_json::json!({
                 "name": new_name,
                 "size": entry.size,
                 "mime": mime,
                 "key": file_key,
-                "lastModified": now,
+                "lastModified": last_modified,
             });
             let encrypted_metadata = self.encrypt_metadata(&meta_json.to_string())?;
 
@@ -2801,7 +2843,7 @@ impl StorageProvider for FilenProvider {
         remote_path: &str,
         total_size: u64,
         _content_type: Option<&str>,
-        _local_source_path: Option<&str>,
+        local_source_path: Option<&str>,
     ) -> Result<MultipartHandle, ProviderError> {
         if !self.connected {
             return Err(ProviderError::NotConnected);
@@ -2846,6 +2888,19 @@ impl StorageProvider for FilenProvider {
         let part = filen_runner_part_size(total_size);
         let total_chunks = total_size.div_ceil(part);
 
+        // Capture the source mtime now, while the local file is still the one
+        // being read: the commit runs after every part has landed and has no
+        // access to it. The runner does not always know the source path (a
+        // stream with no file behind it), in which case the commit stamps its
+        // own time, which is the only thing left to stamp.
+        let last_modified_ms = match local_source_path {
+            Some(p) => tokio::fs::metadata(p)
+                .await
+                .ok()
+                .map(|m| Self::source_last_modified_ms(Some(&m))),
+            None => None,
+        };
+
         let meta = FilenMultipartMeta {
             file_uuid,
             parent_uuid,
@@ -2856,6 +2911,7 @@ impl StorageProvider for FilenProvider {
             total: total_size,
             part,
             total_chunks,
+            last_modified_ms,
         };
         Ok(MultipartHandle {
             upload_id: meta.encode(),
@@ -2941,14 +2997,17 @@ impl StorageProvider for FilenProvider {
         }
 
         // Build the same /v3/upload/done envelope as the legacy upload()
-        // path so the file metadata and the file table stay byte-compatible.
-        let now = chrono::Utc::now().timestamp_millis();
+        // path so the file metadata and the file table stay byte-compatible,
+        // including the source mtime the handle carried from the session start.
+        let last_modified = meta
+            .last_modified_ms
+            .unwrap_or_else(|| chrono::Utc::now().timestamp_millis());
         let metadata = serde_json::json!({
             "name": meta.file_name,
             "size": meta.total,
             "mime": meta.mime,
             "key": meta.file_key,
-            "lastModified": now,
+            "lastModified": last_modified,
         });
         let encrypted_metadata = self.encrypt_metadata(&metadata.to_string())?;
         let encrypted_name = self.encrypt_metadata(&meta.file_name)?;
@@ -3354,6 +3413,7 @@ mod tests {
             total: 16 * 1024 * 1024,
             part: 1024 * 1024,
             total_chunks: 16,
+            last_modified_ms: None,
         };
         let encoded = meta.encode();
         let decoded = FilenMultipartMeta::decode(&encoded).expect("decode roundtrip");
@@ -3700,6 +3760,7 @@ mod tests {
             total: 4096,
             part: 1024,
             total_chunks: 4,
+            last_modified_ms: None,
         };
         let handle = MultipartHandle {
             upload_id: meta.encode(),
@@ -3897,6 +3958,7 @@ mod tests {
             total: (4 * part_plain) as u64,
             part: part_plain as u64,
             total_chunks: 4,
+            last_modified_ms: None,
         };
         let handle = MultipartHandle {
             upload_id: meta.encode(),
@@ -4045,6 +4107,7 @@ mod tests {
             total: 4096,
             part: 1024,
             total_chunks: 4,
+            last_modified_ms: None,
         };
         let handle = MultipartHandle {
             upload_id: meta.encode(),
@@ -4136,6 +4199,7 @@ mod tests {
             total: 2048,
             part: 1024,
             total_chunks: 2,
+            last_modified_ms: None,
         };
         let handle = MultipartHandle {
             upload_id: meta.encode(),
@@ -4183,6 +4247,7 @@ mod tests {
             total: 64,
             part: 64,
             total_chunks: 1,
+            last_modified_ms: None,
         };
         let handle = MultipartHandle {
             upload_id: meta.encode(),
@@ -4209,5 +4274,92 @@ mod tests {
             !s.contains("uploadKey=cafe") && !s.contains(&format!("uploadKey={upload_key}")),
             "raw uploadKey query must be redacted: {s}"
         );
+    }
+
+    // ── lastModified is the SOURCE mtime, never the moment of the write ──────
+    //
+    // Filen's `lastModified` is the only mtime the account holds. Stamping the
+    // write instant re-dated every file to when it was transferred, so a folder
+    // uploaded through AeroFTP compared as entirely out of sync against the
+    // local folder it came from, on every subsequent compare, and the Filen
+    // desktop bridge served the same wrong value over WebDAV (#347).
+
+    #[test]
+    fn upload_metadata_carries_the_source_mtime_not_the_upload_time() {
+        let dir = std::env::temp_dir().join(format!("filen_mtime_{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("report.txt");
+        std::fs::write(&path, b"contents").unwrap();
+
+        // Backdate the source well outside any comparison tolerance.
+        let long_ago =
+            std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_000_000_000);
+        filetime::set_file_mtime(&path, filetime::FileTime::from_system_time(long_ago)).unwrap();
+
+        let meta = std::fs::metadata(&path).unwrap();
+        let stamped = FilenProvider::source_last_modified_ms(Some(&meta));
+        assert_eq!(
+            stamped, 1_000_000_000_000,
+            "the upload must record the file's own mtime"
+        );
+
+        let now = chrono::Utc::now().timestamp_millis();
+        assert!(
+            (now - stamped) > 60_000,
+            "a source mtime that lands within a minute of now means the write is              stamping its own time again"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// No readable source mtime is the one case where the write has nothing
+    /// better than its own clock.
+    #[test]
+    fn upload_metadata_falls_back_to_now_without_a_source() {
+        let before = chrono::Utc::now().timestamp_millis();
+        let stamped = FilenProvider::source_last_modified_ms(None);
+        assert!(stamped >= before, "fallback must be the current time");
+    }
+
+    /// A rename changes the name, not the contents, so it carries the mtime the
+    /// file already had rather than re-dating it.
+    #[test]
+    fn rename_preserves_the_existing_mtime() {
+        assert_eq!(
+            FilenProvider::entry_last_modified_ms(Some("2020-05-17T10:30:00Z")),
+            Some(1_589_711_400_000),
+        );
+        // An entry that never had a timestamp, and a malformed one, both decline
+        // rather than inventing a value; the caller then falls back to now.
+        assert_eq!(FilenProvider::entry_last_modified_ms(None), None);
+        assert_eq!(
+            FilenProvider::entry_last_modified_ms(Some("not a date")),
+            None
+        );
+    }
+
+    /// The commit runs long after the local file was read, so the mtime travels
+    /// inside the handle. A handle written before the field existed decodes with
+    /// `None` instead of failing, and the commit then stamps its own time.
+    #[test]
+    fn multipart_handle_carries_the_mtime_and_tolerates_older_handles() {
+        let meta = FilenMultipartMeta {
+            file_uuid: "u".into(),
+            parent_uuid: "p".into(),
+            file_key: "k".into(),
+            upload_key: "uk".into(),
+            file_name: "big.bin".into(),
+            mime: "application/octet-stream".into(),
+            total: 1024,
+            part: 512,
+            total_chunks: 2,
+            last_modified_ms: Some(1_589_711_400_000),
+        };
+        let decoded = FilenMultipartMeta::decode(&meta.encode()).unwrap();
+        assert_eq!(decoded.last_modified_ms, Some(1_589_711_400_000));
+
+        let legacy = r#"{"file_uuid":"u","parent_uuid":"p","file_key":"k","upload_key":"uk","file_name":"big.bin","mime":"application/octet-stream","total":1024,"part":512,"total_chunks":2}"#;
+        let decoded_legacy = FilenMultipartMeta::decode(legacy)
+            .expect("a handle from before this field must still decode");
+        assert_eq!(decoded_legacy.last_modified_ms, None);
     }
 }


### PR DESCRIPTION
Two independent regressions reported against v4.1.6 in [discussioncomment-17791442](https://github.com/axpdev-lab/aeroftp/discussions/347#discussioncomment-17791442) by @EhudKirsh.

> In 4.1.6, I'm getting this error for both Rclone Crypt and AeroCrypt: `INFO - AeroSync: Crypt vault is not unlocked`. AeroSync Compare shows no differences in both between the source and destination.
> I get a similar, yet different problem with Filen, where AeroSync Compare measures the entire folder size as being out of sync. This is both via API and WebDAV.

Both made Compare **lie rather than fail**, which is why they matter more than their size: one reports a folder as in sync when it is not, the other reports it as entirely out of sync when it is not.

## 1. The vault binding could never resolve (both crypt kinds)

The v4.1.6 fix made the GUI pass a vault binding to `provider_compare_directories`. That binding is a **synthetic sentinel** the frontend builds, `provider-overlay:<kind>:<owner>`. The backend looked it up in `RcloneCryptState.vaults` / `AeroCryptState.vaults`, which only `rclone_crypt_unlock` / `aerocrypt_unlock` ever write to, keyed by the UUID they return.

The provider overlay is a **different unlock path**: `provider_apply_crypt_overlay` derives the keys into the live decorator and into the connection's key cache, and never touches those maps. So for the whole of the Overlays Path, on both kinds, the lookup could not succeed — the command failed with "Crypt vault is not unlocked" and the frontend's fail-closed arm rendered an empty diff, which reads as "everything is in sync".

Compare now resolves keys from the connection's **armed overlay** first (the same key material the file panel is displaying with, so the two cannot disagree), falling back to the vault maps so the vault-browser path is unchanged. A cached overlay of the wrong kind, or from a previous connection generation, is refused rather than used.

## 2. The normalization ran on an already-plaintext listing

The compare scan lists through `state.provider`, which **is** the decorator whenever the overlay is armed, so names and sizes come back plaintext. Normalizing them again decrypts cleartext, every row fails and is dropped, and the remote arrives empty: the same "no differences" by a second route — and the one that would have surfaced the moment the binding started resolving.

Normalization now runs only when the box is unwrapped (badge locked, or a scope that never applied the overlay slot), which is the case it was written for. A test asserts that normalizing plaintext empties the map, so the guard cannot later be dropped as redundant.

**Also on that path:** `cloud_service` drops size comparison when the overlay cannot map ciphertext length back to plaintext length (legacy AeroCrypt v1/v2); this path did not, so a legacy vault would have flagged every file as a size mismatch and proposed re-uploading the tree. It honours the same signal now.

## 3. Filen stamped its own clock as every file's mtime

The upload built `"lastModified": now` while holding the source's `fs::metadata`, using only its length. Filen's `lastModified` is the **only** mtime the account has, so an uploaded folder came back dated at transfer time and compared as entirely out of sync against the local folder it came from — permanently, since each re-upload stamps a new "now". That also explains the WebDAV half of the report: the Filen desktop bridge serves the same stored value.

Fixed on all three writes:
| Write | Before | After |
| --- | --- | --- |
| `upload()` | `now` | the source file's mtime (already in hand) |
| `begin_multipart_upload()` → commit | `now` at commit | captured while the local file is still in hand, carried in the handle (`#[serde(default)]`, so older handles decode rather than fail) |
| `rename()` | `now` | the mtime the file already had — a name change is not a content change |

## Verification
- `cargo fmt --all -- --check` clean
- `cargo clippy --all-targets -- -D warnings` and with `--features aerorsync` clean
- `cargo test --lib` — **3359 passed**, 0 failed, including 9 new tests: 5 pinning the crypt key resolution (sentinel resolves, wrong kind refused, stale generation refused, standalone UUID still works, plaintext normalization empties the map) and 4 pinning the Filen mtime contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved encrypted directory comparisons for provider-overlay connections, including safer handling of keys, plaintext listings, and file-size comparisons.
  * Added safeguards to detect incorrect passwords or incompatible encrypted sources instead of silently reporting empty results.
  * Improved compatibility for existing vault-browser unlock workflows.
  * File modification dates are now preserved during Filen uploads, multipart uploads, and renames, rather than being replaced with the current time.
  * Improved compatibility with older multipart upload records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->