### PR TITLE
aerorsync: two parity-matrix claims that nothing was checking

### DIFF
--- a/docs/PROTOCOL-RSYNC-COMPARE.md
+++ b/docs/PROTOCOL-RSYNC-COMPARE.md
@@ -39,7 +39,7 @@ Everything below expands this positioning into operational detail.
 | Dimension | rsync (upstream) | AeroRsync (AeroFTP module) | Notes |
 |---|---|---|---|
 | **Software type** | System binary + optional library | In-process Rust module inside AeroFTP (aerorsync 0.0.x crate = name only) | rsync is an executable; AeroRsync is code linked inside the app |
-| **Language** | C | Rust | No unsafe in the module, permissive dependencies only (russh, ssh2, zstd, xxhash-rust) |
+| **Language** | C | Rust | **13 `unsafe` blocks in the module**, all POSIX calls with no Rust equivalent and each carrying a `SAFETY` note: 10 in `xattr_fs.rs` (the `l*xattr` family) and 3 in `delta_transport_impl.rs` (`utimensat` for mtime, `getpwuid_r` and `getgrgid_r` to resolve the user and group names the file-list entry carries). No pointer arithmetic, no hand-rolled parsing in unsafe: every wire byte is decoded in safe Rust. This row used to read "no unsafe in the module", which was measurably wrong, and a memory-safety claim is the last place to round a number |
 | **License** | GPL-3.0-or-later | GPL-3.0-only (aligned with AeroFTP and aerovault) | Compatible without conditions |
 | **Code origin** | Tridgell et al., 1996 | Clean-room 2026, zero copy from rsync sources | Analogous precedent: openrsync (OpenBSD, 2019, BSD-licensed) |
 | **Maturity** | ~30 years, production standard | Pre-1.0, runtime toggle ON by default since v3.8.0 | aerorsync crate stays `0.0.x` until stock-rsync interop is green end-to-end on all targets |
@@ -121,7 +121,7 @@ Items that have already left this list: **symlinks** ship end-to-end on unix in 
 - Delta sync **without installing the rsync binary on the user system** (zero runtime dep)
 - Windows first-class without MSYS2/WSL/Cygwin
 - Direct linking inside a Tauri app (in-process, no fork+exec)
-- **Memory-safe** Rust implementation (no buffer-overflow class CVE from C)
+- **Memory-safe** Rust implementation: every wire byte is decoded in safe Rust, so the buffer-overflow class that comes with parsing untrusted input in C is absent by construction. The 13 `unsafe` blocks in the module are POSIX calls with no Rust equivalent (xattr, `utimensat`, user and group lookup), not parsing
 - Atomic writes with `StreamingAtomicWriter` kill-9-safe invariant designed for desktop UI
 - Native integration with AeroFTP's `DeltaTransport` trait (event sink, fallback policy, host key pinning as part of UI flow)
 

--- a/src-tauri/src/aerorsync/russh_session_transport.rs
+++ b/src-tauri/src/aerorsync/russh_session_transport.rs
@@ -1101,16 +1101,94 @@ mod tests {
         );
     }
 
-    #[test]
-    fn host_key_policy_accept_any_compiles() {
-        let _h = RusshHandler::new(SshHostKeyPolicy::AcceptAny);
+    /// Two distinct host keys, generated fresh so neither is a constant
+    /// anyone could have tuned the code to.
+    fn two_distinct_host_keys() -> (PublicKey, PublicKey) {
+        let a = keys::PrivateKey::random(&mut rand_010::rng(), Algorithm::Ed25519)
+            .expect("generate host key A");
+        let b = keys::PrivateKey::random(&mut rand_010::rng(), Algorithm::Ed25519)
+            .expect("generate host key B");
+        let (a, b) = (a.public_key().clone(), b.public_key().clone());
+        assert_ne!(
+            RusshHandler::fingerprint_sha256_hex(&a),
+            RusshHandler::fingerprint_sha256_hex(&b),
+            "two freshly generated keys must not share a fingerprint"
+        );
+        (a, b)
     }
 
-    #[test]
-    fn host_key_policy_pinned_compiles() {
-        let _h = RusshHandler::new(SshHostKeyPolicy::PinnedFingerprintSha256 {
-            sha256_hex: "deadbeef".into(),
+    /// The one that matters: a server presenting a key we did not pin is
+    /// rejected. This is the module's strongest security claim, mandatory
+    /// host-key pinning in the flow rather than delegated to `known_hosts`,
+    /// and until 2026-07-29 nothing exercised it. What existed proved that
+    /// a rejection, once it happens, is a hard error that never falls back
+    /// to the classic wrapper. Nothing proved a wrong key produced one.
+    ///
+    /// Note what this asserts and what it deliberately does not: the
+    /// property is that the comparison SEPARATES two keys, which holds
+    /// regardless of whether `fingerprint_sha256_hex` computes the digest
+    /// the way OpenSSH would. Pinning the expected value through the same
+    /// helper would make a wrong digest self-consistent and invisible; the
+    /// digest itself is pinned separately by `sha256_hex_of` in the libssh2
+    /// leg, against known SHA-256 vectors.
+    #[tokio::test]
+    async fn pinned_host_key_rejects_a_different_server_key() {
+        let (pinned, impostor) = two_distinct_host_keys();
+        let expected = RusshHandler::fingerprint_sha256_hex(&pinned).expect("fingerprint");
+
+        let mut h = RusshHandler::new(SshHostKeyPolicy::PinnedFingerprintSha256 {
+            sha256_hex: expected,
         });
+
+        assert!(
+            h.check_server_key(&pinned)
+                .await
+                .expect("no transport error"),
+            "the pinned key must be accepted"
+        );
+        assert!(
+            !h.check_server_key(&impostor)
+                .await
+                .expect("a mismatch is a rejection, not a transport error"),
+            "a server key we did not pin MUST be rejected: this is the man-in-the-middle case"
+        );
+    }
+
+    /// Fingerprints are hex, and hex has two spellings. A pin captured from
+    /// a tool that emits uppercase must not lock the user out of their own
+    /// server, which is a self-inflicted outage rather than a security win.
+    #[tokio::test]
+    async fn pinned_host_key_comparison_ignores_hex_case() {
+        let (pinned, _) = two_distinct_host_keys();
+        let expected = RusshHandler::fingerprint_sha256_hex(&pinned).expect("fingerprint");
+
+        let mut h = RusshHandler::new(SshHostKeyPolicy::PinnedFingerprintSha256 {
+            sha256_hex: expected.to_ascii_uppercase(),
+        });
+
+        assert!(
+            h.check_server_key(&pinned)
+                .await
+                .expect("no transport error"),
+            "an uppercase pin must match the same key"
+        );
+    }
+
+    /// `AcceptAny` is the documented bootstrap escape hatch, used when the
+    /// fingerprint has not been captured yet. Pinned here so that what it
+    /// does stays a deliberate decision: it accepts a key nobody vouched
+    /// for, and a change that quietly made it stricter or looser should
+    /// have to edit this test and say why.
+    #[tokio::test]
+    async fn accept_any_takes_a_key_nobody_pinned() {
+        let (_, unknown) = two_distinct_host_keys();
+        let mut h = RusshHandler::new(SshHostKeyPolicy::AcceptAny);
+        assert!(
+            h.check_server_key(&unknown)
+                .await
+                .expect("no transport error"),
+            "AcceptAny is the bootstrap hatch and accepts an unvouched key by design"
+        );
     }
 
     /// open_raw_channel without a connected handle returns the typed

--- a/src-tauri/src/aerorsync/ssh_transport.rs
+++ b/src-tauri/src/aerorsync/ssh_transport.rs
@@ -574,19 +574,30 @@ fn connect_and_auth(
     Ok((session, tcp_arc))
 }
 
-fn enforce_host_key_policy(
-    session: &Session,
+/// The host-key decision itself, taking the key as bytes instead of a
+/// live [`Session`].
+///
+/// Split out on 2026-07-29 for one reason: until then the decision could
+/// only run against a real server, so nothing tested it. What was tested
+/// was that a rejection, once produced, is a hard error that never falls
+/// back to the classic wrapper. Nothing tested that a wrong fingerprint
+/// produced one, which is the half that stops a man in the middle. This
+/// signature is what makes that testable, and
+/// [`enforce_host_key_policy`] stays a thin wrapper so the production
+/// path is unchanged.
+fn decide_host_key(
     policy: &SshHostKeyPolicy,
+    host_key: Option<&[u8]>,
 ) -> Result<(), AerorsyncError> {
     match policy {
         SshHostKeyPolicy::AcceptAny => Ok(()),
         SshHostKeyPolicy::PinnedFingerprintSha256 { sha256_hex } => {
-            let host_key = session.host_key().ok_or_else(|| {
-                AerorsyncError::host_key_rejected(
+            let Some(host_key) = host_key else {
+                return Err(AerorsyncError::host_key_rejected(
                     "remote did not expose a host key (unsupported cipher suite?)",
-                )
-            })?;
-            let actual = sha256_hex_of(host_key.0);
+                ));
+            };
+            let actual = sha256_hex_of(host_key);
             let expected = sha256_hex.to_ascii_lowercase();
             if actual != expected {
                 return Err(AerorsyncError::host_key_rejected(format!(
@@ -595,6 +606,20 @@ fn enforce_host_key_policy(
             }
             Ok(())
         }
+    }
+}
+
+fn enforce_host_key_policy(
+    session: &Session,
+    policy: &SshHostKeyPolicy,
+) -> Result<(), AerorsyncError> {
+    match policy {
+        // Kept as its own arm rather than falling through to
+        // `decide_host_key`, so `session.host_key()` is still not called
+        // when no pin is configured. Behaviour-preserving by construction
+        // instead of by assuming the getter is free.
+        SshHostKeyPolicy::AcceptAny => Ok(()),
+        pinned => decide_host_key(pinned, session.host_key().map(|(key, _kind)| key)),
     }
 }
 
@@ -1245,5 +1270,70 @@ mod tests {
             .snapshot_active()
             .expect("healthy mutex snapshots fine");
         assert!(snapshot.is_none(), "no session was ever stored");
+    }
+}
+
+#[cfg(test)]
+mod host_key_decision_tests {
+    use super::{decide_host_key, sha256_hex_of, SshHostKeyPolicy};
+    use crate::aerorsync::types::AerorsyncErrorKind;
+
+    const PINNED: &[u8] = b"ssh-ed25519 AAAA the key we trust";
+    const IMPOSTOR: &[u8] = b"ssh-ed25519 AAAA somebody else entirely";
+
+    fn pinned_to(key: &[u8]) -> SshHostKeyPolicy {
+        SshHostKeyPolicy::PinnedFingerprintSha256 {
+            sha256_hex: sha256_hex_of(key),
+        }
+    }
+
+    /// The libssh2 twin of
+    /// `pinned_host_key_rejects_a_different_server_key` on the russh leg.
+    /// Both legs can serve the same profile, so a gap on either one is a
+    /// gap in the claim, and this leg had no test at all because the
+    /// decision used to be reachable only through a live `Session`.
+    #[test]
+    fn pinned_policy_rejects_a_host_key_we_did_not_pin() {
+        assert!(
+            decide_host_key(&pinned_to(PINNED), Some(PINNED)).is_ok(),
+            "the pinned key must be accepted"
+        );
+
+        let err = decide_host_key(&pinned_to(PINNED), Some(IMPOSTOR))
+            .expect_err("a server key we did not pin MUST be rejected");
+        assert_eq!(
+            err.kind,
+            AerorsyncErrorKind::HostKeyRejected,
+            "the rejection must carry the kind the fallback policy treats as a hard error, \
+             otherwise a mismatch could be retried or silently downgraded"
+        );
+    }
+
+    /// A peer that exposes no host key at all must be refused rather than
+    /// waved through: "we could not check" is not "it checked out".
+    #[test]
+    fn pinned_policy_refuses_a_peer_that_exposes_no_host_key() {
+        let err = decide_host_key(&pinned_to(PINNED), None)
+            .expect_err("no host key with a pin configured must fail closed");
+        assert_eq!(err.kind, AerorsyncErrorKind::HostKeyRejected);
+    }
+
+    /// Hex has two spellings, and a pin copied from a tool that emits
+    /// uppercase must not lock the user out of their own server.
+    #[test]
+    fn pinned_policy_ignores_hex_case() {
+        let policy = SshHostKeyPolicy::PinnedFingerprintSha256 {
+            sha256_hex: sha256_hex_of(PINNED).to_ascii_uppercase(),
+        };
+        assert!(decide_host_key(&policy, Some(PINNED)).is_ok());
+    }
+
+    /// `AcceptAny` is the bootstrap hatch used before a fingerprint has
+    /// been captured. Pinned so that staying permissive is a decision
+    /// somebody has to edit this test to change.
+    #[test]
+    fn accept_any_passes_even_with_no_host_key() {
+        assert!(decide_host_key(&SshHostKeyPolicy::AcceptAny, None).is_ok());
+        assert!(decide_host_key(&SshHostKeyPolicy::AcceptAny, Some(IMPOSTOR)).is_ok());
     }
 }

--- a/src-tauri/src/aerorsync/tests.rs
+++ b/src-tauri/src/aerorsync/tests.rs
@@ -2790,3 +2790,88 @@ fn compress_zstd_literal_stream_round_trips_through_frozen_oracle_payloads() {
         "round-trip raw -> compress -> decompress drifted from original"
     );
 }
+
+/// The public parity docs state the module's `unsafe` surface as a number
+/// and say what each block is for. That claim used to read "no unsafe in
+/// the module", which was wrong by 13, and nothing contradicted it: a
+/// memory-safety claim with no mechanism behind it is the same shape as
+/// the `--mkpath` claim and the compressor list, both of which survived
+/// for months because reading them was the only check they ever got.
+///
+/// This is the mechanism. It counts production `unsafe` in the module and
+/// fails when the number moves, so adding one is a deliberate act that
+/// updates the documentation rather than a silent widening of the claim.
+/// Test code is excluded on purpose: `live_tests.rs` is a harness, and its
+/// `unsafe` is not part of what ships.
+///
+/// If this fails, do not adjust the constant on its own. Update
+/// `docs/PROTOCOL-RSYNC-COMPARE.md` (the Language row and the strengths
+/// bullet) and `docs.aeroftp.app/features/aerorsync.md` in the same
+/// commit, then move it.
+#[test]
+fn production_unsafe_surface_matches_the_documented_count() {
+    // (file, blocks) as documented. A file that is entirely test code is
+    // recognised by its own inner `#![cfg(test)]` rather than by a
+    // hardcoded exclusion list, so a new harness file is handled without
+    // editing this test, and a production file can never be excluded by
+    // being added to a list.
+    const DOCUMENTED: [(&str, usize); 2] = [("xattr_fs.rs", 10), ("delta_transport_impl.rs", 3)];
+
+    let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/aerorsync");
+    let mut found: Vec<(String, usize)> = Vec::new();
+
+    for entry in std::fs::read_dir(&dir).expect("aerorsync module directory must be readable") {
+        let path = entry.expect("readable dir entry").path();
+        if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+            continue;
+        }
+        let name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .expect("utf-8 file name")
+            .to_string();
+        let src = std::fs::read_to_string(&path).expect("readable source file");
+        // An inner `#![cfg(test)]` (or `#![cfg(all(test, ...))]`) means the
+        // whole file is test code, so it ships nothing.
+        if src
+            .lines()
+            .map(str::trim_start)
+            .any(|l| l.starts_with("#![cfg(") && l.contains("test"))
+        {
+            continue;
+        }
+        // Otherwise everything from the first `#[cfg(test)]` on is tests.
+        let production = match src.find("\n#[cfg(test)]") {
+            Some(i) => &src[..i],
+            None => &src[..],
+        };
+        let count = production
+            .lines()
+            .map(str::trim_start)
+            // Comments mentioning the word must not inflate the count, and
+            // `// SAFETY:` notes sit directly above the real blocks.
+            .filter(|l| !l.starts_with("//") && !l.starts_with("*"))
+            .filter(|l| l.contains("unsafe {") || l.contains("unsafe fn"))
+            .count();
+        if count > 0 {
+            found.push((name, count));
+        }
+    }
+
+    found.sort();
+    let mut expected: Vec<(String, usize)> = DOCUMENTED
+        .iter()
+        .map(|(f, n)| ((*f).to_string(), *n))
+        .collect();
+    expected.sort();
+
+    assert_eq!(
+        found, expected,
+        "the module's production `unsafe` surface moved. The parity docs state this \
+         count and what each block is for, so update them in the same commit instead \
+         of only moving the constant here"
+    );
+
+    let total: usize = found.iter().map(|(_, n)| n).sum();
+    assert_eq!(total, 13, "documented total in the parity docs is 13");
+}


### PR DESCRIPTION
Two findings from the same pass, both on rows the parity matrix marks 🟢, both of the same species: a claim nothing ever contradicted.

The pass is "every 🟢 in the matrix must name the test that proves it". 28 rows examined. **No row turned out to be entirely uncovered**, which is the good news. The work was the other category: tests nobody had ever seen fail.

## 1. The `unsafe` surface was documented as smaller than it is

`docs/PROTOCOL-RSYNC-COMPARE.md` said **"No unsafe in the module"**. There are **13** blocks in production code. The public page said "no unsafe beyond thin libc xattr wrappers", which is closer and still wrong: 10 are the xattr wrappers, 3 are not xattr at all.

| Where | Blocks | What |
|---|---|---|
| `xattr_fs.rs` | 10 | the `l*xattr` family |
| `delta_transport_impl.rs` | 3 | `utimensat` (mtime **on a symlink**, which needs `AT_SYMLINK_NOFOLLOW` and so cannot go through std), `getpwuid_r`, `getgrgid_r` |

**Not a code defect.** Every one is a POSIX call with no Rust equivalent, each carries a `SAFETY` note, buffer lengths are derived from the buffers rather than written as constants, and returned pointers are null-checked before being read. What was wrong was the claim, and a memory-safety claim is the last place to round a number down.

The strengths bullet now says where the value actually is: **every wire byte is decoded in safe Rust**, which is where a C implementation earns the buffer-overflow class of CVE from parsing untrusted input. The `unsafe` sits on the local filesystem side. The honest version is the stronger one.

`production_unsafe_surface_matches_the_documented_count` now counts production `unsafe` per file and fails when the number moves, telling the reader to update both documents in the same commit. Verified as a pin: a throwaway `unsafe` in `xattr_fs.rs` makes it fail with `11` against `10`.

Its own first version carried a hardcoded `HARNESS_ONLY = ["live_tests.rs"]`, which is the defect it exists to prevent, a list written **beside** the thing instead of derived from it. A file that is entirely test code is now recognised by its own inner `#![cfg(test)]`, so a production file cannot be excluded by ending up in a list.

## 2. Nothing proved that a host key we did not pin is rejected

Mandatory host-key pinning is the module's strongest security claim, the row where the matrix marks rsync 🔴 and us 🟢 because the check lives in the flow rather than in `known_hosts`.

What existed proved the **second** half: that a rejection, once produced, is a hard error that never falls back to the classic wrapper. Three tests, worth keeping. Nothing proved a wrong fingerprint **produces** one. Around it sat `sha256_hex_of` over `""` and `"abc"` (the hash helper, not the decision), `pinned_hex` lowercasing (a constructor), and two tests named `host_key_policy_*_compiles` that **assert nothing at all**: they construct a value and drop it. The live lane pins the *correct* fingerprint, so it only ever walked the happy path.

An empty test is worse than a missing one: it counts in an inventory and proves nothing, so it makes a row look covered. Both are replaced rather than joined.

**russh leg** — three tests over two freshly generated Ed25519 keys, so neither is a constant the code could have been tuned to: the pinned key is accepted, a different key is **rejected**, uppercase hex still matches (a pin copied from a tool that emits uppercase must not lock a user out of their own server), and `AcceptAny` is pinned as the deliberate bootstrap hatch it is.

Note what the mismatch test asserts and what it deliberately does not: the property is that the comparison **separates two keys**, which holds whether or not `fingerprint_sha256_hex` computes the digest OpenSSH would. Deriving the expected value through that same helper would make a wrong digest self-consistent and invisible; the digest is pinned separately against known SHA-256 vectors.

**libssh2 leg** — this needed a small production change, and it is precisely why the leg had no test. The decision lived inside `enforce_host_key_policy(&Session, ..)`, reachable only with a real server. It is now `decide_host_key(policy, Option<&[u8]>)` with the old function kept as a thin wrapper. The `AcceptAny` arm stays in the wrapper rather than falling through, so `session.host_key()` is still not called when no pin is configured: behaviour-preserving by construction rather than by assuming the getter is free.

Four tests there, including one that was not on the plan and matters most: **a peer exposing no host key at all is refused**. "We could not check" is not "it checked out".

All seven verified as pins by breaking the code and watching the right one fail. Disabling each leg's comparison drops exactly the mismatch test and leaves the others green, which is each test guarding its own property rather than all of them restating one.

## Gate

615 aerorsync tests (was 605 before this pass began), 0 failed. `cargo fmt` clean, `clippy --lib --features aerorsync --all-targets -D warnings` exit 0, `RUSTFLAGS='--cfg ci_lane3' check` exit 0.

Worth noting which gate caught the one mistake made here: an unused import survived `cargo test`, `cargo fmt` and the lane 3 check, and only `clippy --features aerorsync -D warnings` rejected it. That is the gate the local pre-push hook does not run.

## Still open, recorded in the appendix rather than fixed here

`set_symlink_times_best_effort` runs on the symlink path but the resulting mtime is never asserted, so mtime **on a symlink** is the one sub-case with no assertion behind it.
