### PR TITLE
fix(ci): the n0-mainline watcher could not tell "still blocked" from "I broke"

### DIFF
--- a/.github/scripts/check-n0-mainline-patch.sh
+++ b/.github/scripts/check-n0-mainline-patch.sh
@@ -41,9 +41,14 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR/src-tauri"
 
-if ! git diff --quiet -- Cargo.toml Cargo.lock; then
-  echo "refusing to run: src-tauri/Cargo.toml or Cargo.lock has uncommitted changes" >&2
-  echo "this check rewrites both and restores them from git; commit or stash first" >&2
+# Both halves matter. `git diff` compares the worktree with the INDEX, so a
+# staged edit to either file slips past it, and the restore below is
+# `git checkout HEAD --`, which would then throw that staged work away. Checking
+# --cached as well means the script refuses instead of destroying it.
+if ! git diff --quiet -- Cargo.toml Cargo.lock ||
+   ! git diff --cached --quiet -- Cargo.toml Cargo.lock; then
+  echo "refusing to run: src-tauri/Cargo.toml or Cargo.lock has uncommitted or staged changes" >&2
+  echo "this check rewrites both and restores them from HEAD; commit or stash first" >&2
   exit 2
 fi
 
@@ -62,7 +67,12 @@ echo
 # Restore unconditionally: this rewrites both files in place, and a failed
 # resolution must not leave the tree carrying a manifest nobody asked for.
 restore() {
-  git -C "$ROOT_DIR" checkout -- src-tauri/Cargo.toml src-tauri/Cargo.lock
+  # From HEAD, not from the index: `git checkout -- <path>` restores the STAGED
+  # content, so on a tree with staged manifest edits it would silently reinstate
+  # those instead of the committed state. The guard above already refuses that
+  # case; this makes the restore correct on its own terms rather than relying on
+  # the guard never being weakened.
+  git -C "$ROOT_DIR" checkout HEAD -- src-tauri/Cargo.toml src-tauri/Cargo.lock
 }
 trap restore EXIT
 
@@ -117,10 +127,25 @@ EOF
   exit 0
 fi
 
-if grep -q 'ed25519-dalek' <<<"$output"; then
-  echo "STILL NEEDED - same ed25519-dalek conflict, nothing to do."
+# Match the resolver-conflict SIGNATURE, not the crate name. Any failure that
+# merely mentions ed25519-dalek - a registry timeout, a network blip, a yanked
+# release - would otherwise be classified as "still blocked" and exit 1, which
+# this workflow treats as the quiet normal state. That is precisely the
+# confusion the exit-2 path exists to prevent: a watcher that cannot tell "still
+# blocked" from "I no longer work" is worse than none.
+#
+# Three markers together, and no version literals, so the check survives
+# upstream moving to another release candidate: cargo only prints
+# "previously selected package" when it really failed to reconcile two
+# requirements, which a transport error never does.
+if grep -q 'failed to select a version for' <<<"$output" &&
+   grep -q 'ed25519-dalek' <<<"$output" &&
+   grep -q 'previously selected package' <<<"$output"; then
+  echo "STILL NEEDED - same ed25519-dalek resolver conflict, nothing to do."
   exit 1
 fi
 
-echo "FAILED FOR ANOTHER REASON - the output above is not the ed25519-dalek conflict." >&2
+echo "FAILED FOR ANOTHER REASON - the output above is not the ed25519-dalek resolver conflict." >&2
+echo "Do not read this as 'still blocked': it is either a transport/registry failure or a" >&2
+echo "conflict of a different shape, and both need a human to look at the output." >&2
 exit 2

--- a/.github/workflows/n0-mainline-patch-watch.yml
+++ b/.github/workflows/n0-mainline-patch-watch.yml
@@ -97,11 +97,24 @@ jobs:
           # Idempotent: the schedule fires every week and the condition stays
           # true once it flips, so without this guard it would open one issue a
           # week until someone acts.
-          existing="$(gh issue list --state open --search "$TITLE in:title" \
-            --json number,title --jq "map(select(.title == env.TITLE)) | .[0].number // empty")"
+          #
+          # --state all, not open: a chore closed while the patch section is
+          # still in the tree would otherwise be invisible here, and the next
+          # Monday would file a duplicate. Closed-but-still-true is reopened
+          # instead, which is the honest state - the work was not done.
+          existing="$(gh issue list --state all --search "$TITLE in:title" \
+            --json number,title,state \
+            --jq "map(select(.title == env.TITLE)) | .[0] | if . == null then empty else \"\(.number) \(.state)\" end")"
 
           if [ -n "$existing" ]; then
-            echo "already tracked in #$existing, not filing again"
+            number="${existing%% *}"
+            state="${existing##* }"
+            if [ "$state" = "CLOSED" ]; then
+              echo "#$number was closed but the patch section is still here; reopening"
+              gh issue reopen "$number" --comment "Reopened automatically: the weekly check still resolves without \`[patch.crates-io]\`, so this chore is not done."
+            else
+              echo "already tracked in #$number, not filing again"
+            fi
             exit 0
           fi
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -371,6 +371,11 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 # by `rev` on purpose: a branch would let the patched source move under us
 # without the lockfile saying so.
 #
+# Read the resolved version before acting on a green: an OLDER n0-mainline also
+# makes the conflict disappear, because the exact pin is what an older release
+# does not carry yet. The checker prints the version it settled on for exactly
+# this reason. A downgrade is not the exit condition, it is a different problem.
+#
 # That condition is WATCHED, not merely written here:
 # `.github/workflows/n0-mainline-patch-watch.yml` runs
 # `.github/scripts/check-n0-mainline-patch.sh` every Monday, which strips this


### PR DESCRIPTION
Three findings from CodeRabbit's review on #499, all valid. I merged that PR before reading them — this closes the loop.

## The one that mattered: the watcher could not tell "still blocked" from "I broke"

`check-n0-mainline-patch.sh` classified the failure with `grep -q 'ed25519-dalek'`, so **any** failure mentioning that crate — a registry timeout, a transport error, a yanked release — was reported as the expected block and exited 1. That is the quiet state the workflow deliberately stays silent on, so a permanently broken check would have reported nothing, every Monday, forever. The PR that introduced it said in as many words that "a watcher that cannot tell *still blocked* from *I no longer work* is worse than none", and then shipped exactly that.

It now requires the resolver-conflict signature — `failed to select a version for` + the crate + `previously selected package` — with no version literals, so an upstream move to another release candidate still matches instead of becoming noise. Cargo prints `previously selected package` only when it genuinely failed to reconcile two requirements; a transport error never does.

| Case | Before | After |
|---|---|---|
| real tree, genuine conflict | exit 1 | exit 1 ✔ |
| `failed to download .../ed25519-dalek/3.0.0/download` + `Timeout was reached` | **exit 1 (silent)** | **exit 2, job fails** ✔ |

Proven against the defect, not by watching it pass: the canned transport error contains the crate name twice, so the old predicate matched it beyond doubt.

## A staged manifest slipped past the guard, and the restore would have eaten it

`git diff --quiet` compares the worktree with the **index**, so a staged edit to `Cargo.toml`/`Cargo.lock` passed the cleanliness check. Worse, the restore was `git checkout -- <path>`, which restores the **staged** content — so the script could run against staged work and silently reinstate it later.

Fixed on both sides rather than one: the guard also checks `--cached`, and the restore is `git checkout HEAD --`, correct on its own terms instead of depending on the guard never being weakened. Verified incidentally — editing `Cargo.toml` for this very commit made the script refuse to run.

## A closed chore would have been refiled every week

The duplicate guard searched `--state open`, so a chore closed while the patch section was still in the tree was invisible and the next Monday would file a second one. It now searches all states and **reopens** the closed issue with a comment, which is the honest reading: closed-but-still-true means the work was not done.

## And the comment beside the patch section

It said any successful resolution means the section can go, while the checker warns that an **older** n0-mainline resolves too — the exact pin is what an older release does not carry yet. The downgrade guard is now stated where someone deleting the section would actually read it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency conflict detection to distinguish genuine resolution issues from unrelated failures such as network or registry errors.
  * Prevented temporary checks from leaving staged changes behind.
  * Strengthened safeguards around modified dependency files.

* **Chores**
  * Weekly maintenance automation now reopens matching closed issues instead of creating duplicates.

* **Documentation**
  * Clarified the dependency patch-check workflow and its version-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->