### PR TITLE
fix(aerotools): close B9 audit findings

### DIFF
--- a/src-tauri/src/aws_credentials_import.rs
+++ b/src-tauri/src/aws_credentials_import.rs
@@ -107,6 +107,17 @@ pub fn import_aws_credentials(cred_path: &Path) -> Result<AwsImportResult, Strin
     import_aws_credentials_with_config(cred_path, config_path.as_deref())
 }
 
+/// True when `path` is a regular file within the shared import size cap.
+///
+/// The secondary config file is opened by us, not by the caller, so it bypasses
+/// the checks `import_bridge_config` / the CLI run on the primary path.
+fn is_readable_regular_file(path: &Path) -> bool {
+    match std::fs::metadata(path) {
+        Ok(m) => m.is_file() && crate::bridge_shared::ensure_import_file_size_ok(path).is_ok(),
+        Err(_) => false,
+    }
+}
+
 /// Import with an explicit (optional) config path. Kept separate for
 /// testability: `import_aws_credentials` resolves the sibling/env config,
 /// while tests inject a known config path or `None`.
@@ -119,14 +130,20 @@ pub fn import_aws_credentials_with_config(
     let mut sections = crate::bridge_shared::parse_ini_sections(&cred);
 
     if let Some(cp) = config_path {
-        if let Ok(cfg) = std::fs::read_to_string(cp) {
-            // `[profile x]` collapses to `x` inside parse_ini_sections, so
-            // config keys land in the matching credentials section. Config
-            // augments credentials: it never replaces an existing key.
-            for (name, kv) in crate::bridge_shared::parse_ini_sections(&cfg) {
-                let dest = sections.entry(name).or_default();
-                for (k, v) in kv {
-                    dest.entry(k).or_insert(v);
+        // The sibling config (or whatever AWS_CONFIG_FILE points at) never went
+        // through the caller's regular-file + 10 MB checks, so apply them here:
+        // reading a character device such as /dev/zero would grow the buffer
+        // until the process is OOM-killed.
+        if is_readable_regular_file(cp) {
+            if let Ok(cfg) = std::fs::read_to_string(cp) {
+                // `[profile x]` collapses to `x` inside parse_ini_sections, so
+                // config keys land in the matching credentials section. Config
+                // augments credentials: it never replaces an existing key.
+                for (name, kv) in crate::bridge_shared::parse_ini_sections(&cfg) {
+                    let dest = sections.entry(name).or_default();
+                    for (k, v) in kv {
+                        dest.entry(k).or_insert(v);
+                    }
                 }
             }
         }

--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -38388,8 +38388,20 @@ async fn cmd_df(url: &str, scan: bool, full: bool, cli: &Cli, format: OutputForm
                     0.0
                 };
                 let scope = if full { "account-root" } else { "initial-path" };
+                // Only a complete walk may be recorded as the profile's used
+                // figure. A cancelled, capped or partly-unreadable scan is a
+                // lower bound, and persisting it would leave the GUI showing it
+                // as an authoritative total for the rest of the profile's life.
+                let partial = s.cancelled || s.truncated || s.hit_cap || s.unreadable_dirs > 0;
                 if cli.profile.is_some() {
-                    persist_scanned_quota_to_profile(cli, used, eff_total, total_source);
+                    if partial {
+                        eprintln!(
+                            "Note: incomplete scan (not saved to the profile){}",
+                            if s.cancelled { ", cancelled" } else { "" }
+                        );
+                    } else {
+                        persist_scanned_quota_to_profile(cli, used, eff_total, total_source);
+                    }
                 }
                 match format {
                     OutputFormat::Text => {

--- a/src-tauri/src/bridge_commands.rs
+++ b/src-tauri/src/bridge_commands.rs
@@ -346,13 +346,29 @@ pub async fn import_bridge_config(source: String, file_path: String) -> Result<V
 
     // Upgrade recovered secrets into the vault (server_<id> key, same as
     // the connect path and the legacy importers).
+    //
+    // Hard cap on the number of vault writes one import may trigger: each
+    // `store_active_credential_dual` is a read-modify-rewrite of the whole
+    // vault, so an import of N credentials costs O(N^2) bytes written. The
+    // per-format parsers cap themselves too; this is the backstop that holds
+    // for every source, including ones added later.
+    const MAX_IMPORTED_CREDENTIALS: usize = 10_000;
+
     let mut cred_errors: Vec<String> = Vec::new();
+    let mut stored = 0usize;
     match CredentialStore::from_cache() {
         Some(store) => {
             for s in &servers {
+                if stored >= MAX_IMPORTED_CREDENTIALS {
+                    cred_errors.push(format!(
+                        "stopped after {MAX_IMPORTED_CREDENTIALS} credentials (import too large)"
+                    ));
+                    break;
+                }
                 let id = s.get("id").and_then(|v| v.as_str()).unwrap_or("");
                 let cred = s.get("credential").and_then(|v| v.as_str()).unwrap_or("");
                 if !id.is_empty() && !cred.is_empty() {
+                    stored += 1;
                     // MUV-3: dual-write into vault + active user's partition.
                     if let Err(e) = crate::user_partitions::store_active_credential_dual(
                         &store,

--- a/src-tauri/src/bridge_shared.rs
+++ b/src-tauri/src/bridge_shared.rs
@@ -245,6 +245,13 @@ pub fn ensure_import_file_size_ok(path: &Path) -> Result<(), String> {
 
 // ============ INI parser (aws, s3cmd, ...) ============
 
+/// Maximum number of sections an imported INI may yield.
+///
+/// Same cap and same reason as the per-format importers: within the 10 MB file
+/// limit a config can still declare hundreds of thousands of profiles, and each
+/// one that carries a credential costs a full vault read-modify-write.
+const MAX_IMPORT_SECTIONS: usize = 10_000;
+
 /// Section-keyed INI parser. Mirrors the exact shape of
 /// `rclone_import::parse_rclone_conf`: `[section]` headers, `key = value`
 /// pairs, `#`/`;` comments, keys lowercased. An `[profile foo]` header
@@ -266,6 +273,10 @@ pub(crate) fn parse_ini_sections(content: &str) -> HashMap<String, HashMap<Strin
                 .trim()
                 .to_string();
             if !name.is_empty() {
+                if !out.contains_key(&name) && out.len() >= MAX_IMPORT_SECTIONS {
+                    log::warn!("ini import: stopped at the {MAX_IMPORT_SECTIONS}-section cap");
+                    break;
+                }
                 out.entry(name.clone()).or_default();
                 cur = Some(name);
             }
@@ -282,6 +293,16 @@ pub(crate) fn parse_ini_sections(content: &str) -> HashMap<String, HashMap<Strin
 
 // ============ XML scanner (cyberduck .duck, dreamweaver .ste) ============
 
+/// Longest entity body we accept, `&` and `;` excluded.
+///
+/// The longest thing that can decode is a numeric character reference
+/// (`#x10FFFF` / `#1114111`, 8 characters); named entities top out at 4
+/// (`apos`). Bounding the lookahead keeps `html_unescape` linear: searching the
+/// whole remainder for `;` on every `&` made a field of N ampersands with no
+/// semicolon cost O(N^2), and a 10 MB `.duck`/`.ste` value could hold ten
+/// million of them.
+const MAX_ENTITY_BODY: usize = 8;
+
 /// Decode the small set of XML/HTML entities these config files use.
 pub(crate) fn html_unescape(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
@@ -292,7 +313,10 @@ pub(crate) fn html_unescape(s: &str) -> String {
             continue;
         }
         let rest = &s[i..];
-        let Some(semi) = rest.find(';') else {
+        // `;` is ASCII, so a byte search cannot land inside a multi-byte
+        // character and every index it yields is a valid char boundary.
+        let window = rest.len().min(MAX_ENTITY_BODY + 2);
+        let Some(semi) = rest.as_bytes()[..window].iter().position(|b| *b == b';') else {
             out.push(c);
             continue;
         };
@@ -683,9 +707,38 @@ mod tests {
         assert_eq!(s.get("bar").unwrap().get("k").unwrap(), "v");
     }
 
+    /// CLAUDE-AV-B9-04: the entity lookahead used to scan the whole remaining
+    /// string for `;` on every `&`, so a field of N ampersands with no
+    /// semicolon cost O(N^2). A 1 MB run has to finish immediately, and the
+    /// ampersands must be preserved verbatim.
+    #[test]
+    fn html_unescape_is_linear_on_a_field_of_bare_ampersands() {
+        let hostile = "&".repeat(1_000_000);
+        let started = std::time::Instant::now();
+        let out = html_unescape(&hostile);
+        assert_eq!(out.len(), hostile.len());
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(2),
+            "html_unescape went quadratic: {:?}",
+            started.elapsed()
+        );
+    }
+
+    /// An over-long `&...;` run is not an entity and must be left alone rather
+    /// than scanned to the end of the input.
+    #[test]
+    fn html_unescape_leaves_an_overlong_entity_untouched() {
+        let s = format!("&{};", "a".repeat(64));
+        assert_eq!(html_unescape(&s), s);
+    }
+
     #[test]
     fn xml_helpers() {
         assert_eq!(html_unescape("a&amp;b&lt;c&#65;"), "a&b<cA");
+        // Longest forms that must still decode with the bounded lookahead.
+        assert_eq!(html_unescape("&#x10FFFF;"), "\u{10FFFF}");
+        assert_eq!(html_unescape("&#1114111;"), "\u{10FFFF}");
+        assert_eq!(html_unescape("&apos;"), "'");
         let duck = "<key>Hostname</key><string>ftp.example.com</string><key>Port</key><integer>21</integer><key>Secure</key><true/>";
         assert_eq!(
             plist_field(duck, "Hostname").as_deref(),

--- a/src-tauri/src/cyber_tools.rs
+++ b/src-tauri/src/cyber_tools.rs
@@ -163,6 +163,17 @@ pub async fn stage_hash_drop(name: String, data_base64: String) -> Result<String
     tokio::fs::create_dir_all(&dir)
         .await
         .map_err(|e| format!("Failed to create drop stage dir: {e}"))?;
+    // The staged copy is the file's plaintext: keep the directory owner-only.
+    // create_dir_all leaves 0777&!umask (0755 on a default umask), which would
+    // let every local account read a dropped key or vault file.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = tokio::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700)).await;
+    }
+    // Sweep stale drops from earlier sessions: a staged file is consumed by the
+    // very next hash_file call, so anything older than an hour is a leftover.
+    sweep_stale_hash_drops(&dir).await;
 
     let safe: String = std::path::Path::new(&name)
         .file_name()
@@ -187,6 +198,19 @@ pub async fn stage_hash_drop(name: String, data_base64: String) -> Result<String
     tokio::fs::write(&path, &data)
         .await
         .map_err(|e| format!("Failed to stage dropped file: {e}"))?;
+    // Same reason as the directory: 0666&!umask (0644) would publish the
+    // plaintext of whatever the user dropped to every local account.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Err(e) =
+            tokio::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).await
+        {
+            // Cannot restrict it: do not leave a world-readable copy behind.
+            let _ = tokio::fs::remove_file(&path).await;
+            return Err(format!("Failed to secure staged file: {e}"));
+        }
+    }
 
     log::info!(
         "[HASHDROP] staged {} bytes as {}",
@@ -194,6 +218,57 @@ pub async fn stage_hash_drop(name: String, data_base64: String) -> Result<String
         path.display()
     );
     Ok(path.to_string_lossy().into_owned())
+}
+
+/// Remove staged drops left by earlier runs.
+///
+/// A staged file exists only to be handed straight back to `hash_file`, so it
+/// has no reason to outlive the operation. Nothing used to delete them and they
+/// accumulated in the shared temp directory as plaintext copies of whatever the
+/// user had hashed.
+async fn sweep_stale_hash_drops(dir: &std::path::Path) {
+    const STALE_AFTER: std::time::Duration = std::time::Duration::from_secs(3600);
+
+    let mut entries = match tokio::fs::read_dir(dir).await {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    let now = std::time::SystemTime::now();
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        let stale = match entry.metadata().await {
+            Ok(m) if m.is_file() => m
+                .modified()
+                .ok()
+                .and_then(|t| now.duration_since(t).ok())
+                .map(|age| age >= STALE_AFTER)
+                .unwrap_or(false),
+            _ => false,
+        };
+        if stale {
+            let _ = tokio::fs::remove_file(entry.path()).await;
+        }
+    }
+}
+
+/// Delete a file staged by `stage_hash_drop`.
+///
+/// The frontend calls this once the hash has been computed (or when the drop is
+/// abandoned) so the plaintext copy does not linger in the temp directory.
+/// Restricted to our own staging directory so it can never be turned into an
+/// arbitrary-delete primitive.
+#[tauri::command]
+pub async fn discard_hash_drop(path: String) -> Result<(), String> {
+    let dir = std::env::temp_dir().join("aeroftp-hash-drops");
+    let target = std::path::PathBuf::from(&path);
+    if target.parent() != Some(dir.as_path()) {
+        return Err("Not a staged drop path".to_string());
+    }
+    match tokio::fs::remove_file(&target).await {
+        Ok(()) => Ok(()),
+        // Already gone (swept, or never created): nothing to do.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(format!("Failed to discard staged file: {e}")),
+    }
 }
 
 /// Constant-time hash comparison to prevent timing attacks.

--- a/src-tauri/src/filezilla_import.rs
+++ b/src-tauri/src/filezilla_import.rs
@@ -30,160 +30,172 @@ const MAX_FILE_SIZE: u64 = 10 * 1024 * 1024;
 
 /// Parse FileZilla sitemanager.xml and extract server entries.
 /// Handles nested <Folder> elements for hierarchical names.
+///
+/// Event-driven (quick-xml) rather than line-oriented: FileZilla itself writes
+/// one tag per line, but a sitemanager.xml that went through a minifier or was
+/// written by another tool is still valid XML, and a line parser silently
+/// imported nothing from it.
 fn parse_sitemanager_xml(content: &str) -> Vec<FileZillaServer> {
-    let mut servers = Vec::new();
-    let mut folder_stack: Vec<String> = Vec::new();
+    use quick_xml::events::Event;
+    use quick_xml::Reader;
+
+    let mut servers: Vec<FileZillaServer> = Vec::new();
+    // (folder name, index of the first server pushed inside it). FileZilla
+    // writes a folder's name as a text node AFTER its children, so the name is
+    // not known yet when the servers inside it are pushed: the path is stamped
+    // onto them when the folder closes, innermost folder first.
+    let mut folder_stack: Vec<(String, usize)> = Vec::new();
     let mut in_server = false;
     let mut current_fields: HashMap<String, String> = HashMap::new();
     let mut current_name = String::new();
     let mut current_tag = String::new();
     let mut current_text = String::new();
     let mut pass_encoding = String::new();
+    let mut capped = false;
 
-    for line in content.lines() {
-        let trimmed = line.trim();
+    let mut reader = Reader::from_str(content);
+    reader.config_mut().trim_text(true);
+    let mut buf = Vec::new();
 
-        // Folder open: <Folder expanded="1">
-        if trimmed.starts_with("<Folder") && !trimmed.starts_with("</Folder") {
-            // Next text content before </Folder> is the folder name,
-            // but FileZilla puts folder name as text AFTER child elements.
-            // We'll handle it via a stack approach.
-            folder_stack.push(String::new());
-            continue;
-        }
-
-        // Folder close: </Folder>
-        if trimmed == "</Folder>" {
-            folder_stack.pop();
-            continue;
-        }
-
-        // Folder name (text between <Folder> children and </Folder>)
-        // FileZilla puts folder name as the last text node before </Folder>
-        // We detect it as a bare text line when we're not in a server
-        if !in_server && !trimmed.is_empty() && !trimmed.starts_with('<') {
-            if let Some(last) = folder_stack.last_mut() {
-                if last.is_empty() {
-                    *last = xml_unescape(trimmed);
-                }
-            }
-            continue;
-        }
-
-        // Server open
-        if trimmed == "<Server>" {
-            if servers.len() >= MAX_SERVERS {
-                break;
-            }
-            in_server = true;
-            current_fields.clear();
-            current_name.clear();
-            pass_encoding.clear();
-            continue;
-        }
-
-        // Server close
-        if trimmed == "</Server>" {
-            if in_server {
-                // Build hierarchical name from folder stack
-                let folder_path: Vec<&str> = folder_stack
-                    .iter()
-                    .filter(|f| !f.is_empty())
-                    .map(|f| f.as_str())
-                    .collect();
-                let display_name = if current_name.is_empty() {
-                    current_fields
-                        .get("Host")
-                        .cloned()
-                        .unwrap_or_else(|| "unnamed".to_string())
-                } else {
-                    current_name.clone()
-                };
-                // Store folder path for reference
-                if !folder_path.is_empty() {
-                    current_fields.insert("_folder".to_string(), folder_path.join("/"));
-                }
-                servers.push(FileZillaServer {
-                    fields: current_fields.clone(),
-                    name: display_name,
-                });
-            }
-            in_server = false;
-            continue;
-        }
-
-        if !in_server {
-            continue;
-        }
-
-        // Parse tag open with optional attributes: <Pass encoding="base64">
-        if trimmed.starts_with('<') && !trimmed.starts_with("</") {
-            if let Some(tag_end) = trimmed.find('>') {
-                let tag_content = &trimmed[1..tag_end];
-                let (tag_name, attrs) = match tag_content.find(' ') {
-                    Some(i) => (&tag_content[..i], &tag_content[i..]),
-                    None => (tag_content, ""),
-                };
-                current_tag = tag_name.to_string();
-                current_text.clear();
-
-                // Check for encoding attribute on Pass
-                if tag_name == "Pass" {
-                    pass_encoding = if attrs.contains("base64") {
-                        "base64".to_string()
-                    } else {
-                        String::new()
-                    };
-                }
-
-                // Inline text: <Host>example.com</Host>
-                let after_open = &trimmed[tag_end + 1..];
-                if let Some(close_start) = after_open.find("</") {
-                    let text = &after_open[..close_start];
-                    let value = xml_unescape(text);
-
-                    if current_tag == "Name" {
-                        current_name = value;
-                    } else {
-                        current_fields.insert(current_tag.clone(), value);
+    // Malformed XML ends iteration while preserving every server parsed
+    // cleanly before the error.
+    while let Ok(event) = reader.read_event_into(&mut buf) {
+        match event {
+            Event::Eof => break,
+            Event::Start(e) => {
+                let tag = String::from_utf8_lossy(e.name().as_ref()).to_string();
+                match tag.as_str() {
+                    "Folder" if !in_server => {
+                        folder_stack.push((String::new(), servers.len()));
                     }
-                    // Store pass encoding info
+                    "Server" if !in_server => {
+                        if servers.len() >= MAX_SERVERS {
+                            capped = true;
+                            break;
+                        }
+                        in_server = true;
+                        current_fields.clear();
+                        current_name.clear();
+                        pass_encoding.clear();
+                        current_tag.clear();
+                        current_text.clear();
+                    }
+                    _ if in_server => {
+                        if tag == "Pass" {
+                            pass_encoding = e
+                                .try_get_attribute("encoding")
+                                .ok()
+                                .flatten()
+                                .map(|a| String::from_utf8_lossy(&a.value).to_string())
+                                .unwrap_or_default();
+                        }
+                        current_tag = tag;
+                        current_text.clear();
+                    }
+                    _ => {}
+                }
+            }
+            // Self-closing element, e.g. <Name/>: an empty value.
+            Event::Empty(e) => {
+                if !in_server {
+                    continue;
+                }
+                let tag = String::from_utf8_lossy(e.name().as_ref()).to_string();
+                if tag == "Pass" {
+                    let enc = e
+                        .try_get_attribute("encoding")
+                        .ok()
+                        .flatten()
+                        .map(|a| String::from_utf8_lossy(&a.value).to_string())
+                        .unwrap_or_default();
+                    current_fields.insert("_pass_encoding".to_string(), enc);
+                }
+                if tag == "Name" {
+                    current_name.clear();
+                } else {
+                    current_fields.insert(tag, String::new());
+                }
+            }
+            Event::Text(e) => {
+                let text = e
+                    .xml_content(quick_xml::XmlVersion::Implicit1_0)
+                    .map(|c| c.to_string())
+                    .unwrap_or_else(|_| {
+                        xml_unescape(&String::from_utf8_lossy(e.into_inner().as_ref()))
+                    });
+                if text.is_empty() {
+                    continue;
+                }
+                if in_server {
+                    if current_tag.is_empty() {
+                        continue;
+                    }
+                    if !current_text.is_empty() {
+                        current_text.push(' ');
+                    }
+                    current_text.push_str(&text);
+                } else if let Some((name, _)) = folder_stack.last_mut() {
+                    // FileZilla writes the folder name as a text node after the
+                    // folder's children; the first one wins.
+                    if name.is_empty() {
+                        *name = text;
+                    }
+                }
+            }
+            Event::End(e) => {
+                let tag = String::from_utf8_lossy(e.name().as_ref()).to_string();
+                if in_server && tag == "Server" {
+                    let display_name = if current_name.is_empty() {
+                        current_fields
+                            .get("Host")
+                            .cloned()
+                            .unwrap_or_else(|| "unnamed".to_string())
+                    } else {
+                        current_name.clone()
+                    };
+                    servers.push(FileZillaServer {
+                        fields: current_fields.clone(),
+                        name: display_name,
+                    });
+                    in_server = false;
+                    current_tag.clear();
+                    current_text.clear();
+                } else if !in_server && tag == "Folder" {
+                    // The name is known only now: stamp it on every server this
+                    // folder contains. Inner folders closed first, so prepending
+                    // builds the path outermost-last.
+                    if let Some((name, first_server)) = folder_stack.pop() {
+                        if !name.is_empty() {
+                            for server in servers.iter_mut().skip(first_server) {
+                                let path = match server.fields.get("_folder") {
+                                    Some(inner) => format!("{name}/{inner}"),
+                                    None => name.clone(),
+                                };
+                                server.fields.insert("_folder".to_string(), path);
+                            }
+                        }
+                    }
+                } else if in_server && tag == current_tag {
+                    if current_tag == "Name" {
+                        current_name = current_text.clone();
+                    } else {
+                        current_fields.insert(current_tag.clone(), current_text.clone());
+                    }
                     if current_tag == "Pass" {
                         current_fields.insert("_pass_encoding".to_string(), pass_encoding.clone());
                     }
                     current_tag.clear();
+                    current_text.clear();
                 }
             }
-            continue;
+            _ => {}
         }
-
-        // Close tag
-        if trimmed.starts_with("</") {
-            if !current_tag.is_empty() && !current_text.is_empty() {
-                let value = xml_unescape(&current_text);
-                if current_tag == "Name" {
-                    current_name = value;
-                } else {
-                    current_fields.insert(current_tag.clone(), value);
-                }
-                if current_tag == "Pass" {
-                    current_fields.insert("_pass_encoding".to_string(), pass_encoding.clone());
-                }
-            }
-            current_tag.clear();
-            current_text.clear();
-            continue;
-        }
-
-        // Text content between tags
-        if !current_tag.is_empty() {
-            if !current_text.is_empty() {
-                current_text.push(' ');
-            }
-            current_text.push_str(trimmed);
-        }
+        buf.clear();
     }
 
+    if capped {
+        log::warn!("filezilla import: stopped at the {MAX_SERVERS}-server cap");
+    }
     servers
 }
 
@@ -774,5 +786,94 @@ mod tests {
         assert_eq!(servers.len(), 2);
         assert_eq!(servers[0].name, "Server 1");
         assert_eq!(servers[1].name, "Server 2");
+    }
+
+    /// CLAUDE-AV-B9-01: the parser used to be line-oriented, so a well-formed
+    /// sitemanager.xml whose tags were not one-per-line (an XML minifier, a
+    /// third-party writer, a hand edit) imported ZERO sites and reported
+    /// success, with no skip reason. Same document, no newlines.
+    #[test]
+    fn parses_sitemanager_written_on_a_single_line() {
+        let xml = concat!(
+            r#"<?xml version="1.0"?><FileZilla3><Servers>"#,
+            r#"<Server><Host>h1</Host><Port>21</Port><Protocol>0</Protocol>"#,
+            r#"<User>u</User><Pass encoding="base64">QUJD</Pass>"#,
+            r#"<Name>one-liner</Name></Server>"#,
+            r#"</Servers></FileZilla3>"#,
+        );
+        let servers = parse_sitemanager_xml(xml);
+        assert_eq!(servers.len(), 1, "single-line XML must still import");
+        assert_eq!(servers[0].name, "one-liner");
+        assert_eq!(
+            servers[0].fields.get("Host").map(String::as_str),
+            Some("h1")
+        );
+        assert_eq!(
+            servers[0].fields.get("_pass_encoding").map(String::as_str),
+            Some("base64"),
+            "the Pass encoding attribute must survive the event parser"
+        );
+        assert_eq!(
+            decode_filezilla_password("QUJD", "base64").as_deref(),
+            Some("ABC")
+        );
+    }
+
+    /// FileZilla writes a folder's name as a text node AFTER its children, so
+    /// the name is not yet known when the servers inside it are parsed. The
+    /// path is stamped on when the folder closes; before this it always came
+    /// out empty.
+    #[test]
+    fn stamps_the_folder_path_on_the_servers_it_contains() {
+        let xml = concat!(
+            r#"<?xml version="1.0"?><FileZilla3><Servers>"#,
+            r#"<Folder expanded="1"><Server><Host>h1</Host><Name>inner</Name></Server>"#,
+            r#"Clients</Folder>"#,
+            r#"<Server><Host>h2</Host><Name>outside</Name></Server>"#,
+            r#"</Servers></FileZilla3>"#,
+        );
+        let servers = parse_sitemanager_xml(xml);
+        assert_eq!(servers.len(), 2);
+        assert_eq!(servers[0].name, "inner");
+        assert_eq!(
+            servers[0].fields.get("_folder").map(String::as_str),
+            Some("Clients")
+        );
+        assert_eq!(
+            servers[1].fields.get("_folder"),
+            None,
+            "a server outside the folder must not inherit its path"
+        );
+    }
+
+    /// Nested folders compose outermost-first.
+    #[test]
+    fn nested_folder_paths_compose_in_order() {
+        let xml = concat!(
+            r#"<?xml version="1.0"?><FileZilla3><Servers>"#,
+            r#"<Folder><Folder><Server><Host>h1</Host><Name>deep</Name></Server>"#,
+            r#"Inner</Folder>Outer</Folder>"#,
+            r#"</Servers></FileZilla3>"#,
+        );
+        let servers = parse_sitemanager_xml(xml);
+        assert_eq!(servers.len(), 1);
+        assert_eq!(
+            servers[0].fields.get("_folder").map(String::as_str),
+            Some("Outer/Inner")
+        );
+    }
+
+    /// A truncated document must keep the servers that parsed cleanly instead
+    /// of discarding the whole file.
+    #[test]
+    fn keeps_servers_parsed_before_a_malformed_tail() {
+        let xml = concat!(
+            r#"<?xml version="1.0"?><FileZilla3><Servers>"#,
+            r#"<Server><Host>h1</Host><Name>good</Name></Server>"#,
+            r#"<Server><Host>h2</Host><Name>trunc"#,
+        );
+        let servers = parse_sitemanager_xml(xml);
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].name, "good");
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -19646,6 +19646,7 @@ pub fn run() {
             cyber_tools::hash_text,
             cyber_tools::hash_file,
             cyber_tools::stage_hash_drop,
+            cyber_tools::discard_hash_drop,
             cyber_tools::compare_hashes,
             cyber_tools::crypto_encrypt_text,
             cyber_tools::crypto_decrypt_text,

--- a/src-tauri/src/rclone_import.rs
+++ b/src-tauri/src/rclone_import.rs
@@ -80,6 +80,14 @@ fn obscure_password(plaintext: &str) -> Result<String, String> {
 /// A parsed rclone remote: section name → key/value pairs.
 type RcloneRemote = HashMap<String, String>;
 
+/// Maximum number of remotes to parse.
+///
+/// A 10 MB config (the caller's cap) holds hundreds of thousands of minimal
+/// `[name]\ntype=ftp\npass=x` sections, and each imported credential costs a
+/// full read-modify-rewrite of the vault, so an uncapped parse turns one file
+/// into a quadratic write storm. Matches the cap the other importers use.
+const MAX_REMOTES: usize = 10_000;
+
 /// Parse rclone.conf INI format into named sections.
 fn parse_rclone_conf(content: &str) -> HashMap<String, RcloneRemote> {
     let mut sections: HashMap<String, RcloneRemote> = HashMap::new();
@@ -97,6 +105,10 @@ fn parse_rclone_conf(content: &str) -> HashMap<String, RcloneRemote> {
         if line.starts_with('[') && line.ends_with(']') {
             let name = line[1..line.len() - 1].trim().to_string();
             if !name.is_empty() {
+                if !sections.contains_key(&name) && sections.len() >= MAX_REMOTES {
+                    log::warn!("rclone import: stopped at the {MAX_REMOTES}-remote cap");
+                    break;
+                }
                 sections.entry(name.clone()).or_default();
                 current_section = Some(name);
             }
@@ -1857,33 +1869,12 @@ pub fn export_rclone(
         exported += 1;
     }
 
-    // Atomic write + secure permissions. Create the temp file 0600 *before*
-    // writing so the OAuth refresh blob / obscured passwords are never world-
-    // readable, not even in the window between write and the post-rename chmod.
-    let tmp_path = file_path.with_extension("tmp");
-    #[cfg(unix)]
-    {
-        use std::io::Write;
-        use std::os::unix::fs::OpenOptionsExt;
-        let mut f = std::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .mode(0o600)
-            .open(&tmp_path)
-            .map_err(|e| format!("Write rclone.conf: {}", e))?;
-        f.write_all(output.as_bytes())
-            .map_err(|e| format!("Write rclone.conf: {}", e))?;
-    }
-    #[cfg(not(unix))]
-    std::fs::write(&tmp_path, output.as_bytes())
+    // Atomic write + secure permissions, through the same helper the other
+    // bridge exporters use: its temp file is O_EXCL/0600 (so a symlink planted
+    // at a predictable sibling path cannot capture the secrets) and it unlinks
+    // itself on any early return instead of leaving a partial cleartext file.
+    crate::bridge_shared::atomic_write_600(file_path, output.as_bytes())
         .map_err(|e| format!("Write rclone.conf: {}", e))?;
-    std::fs::rename(&tmp_path, file_path).map_err(|e| format!("Rename temp file: {}", e))?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = std::fs::set_permissions(file_path, std::fs::Permissions::from_mode(0o600));
-    }
 
     Ok(exported)
 }
@@ -1897,6 +1888,27 @@ mod tests {
         let path = std::env::temp_dir().join(name);
         std::fs::write(&path, conf).expect("write temp conf");
         path
+    }
+
+    /// CLAUDE-AV-B9-02: an uncapped parse let a single 10 MB config declare
+    /// hundreds of thousands of remotes, each costing a whole-vault rewrite.
+    #[test]
+    fn parse_rclone_conf_stops_at_the_remote_cap() {
+        let mut conf = String::new();
+        for i in 0..(MAX_REMOTES + 500) {
+            conf.push_str(&format!("[r{i}]\ntype = ftp\nhost = h\n"));
+        }
+        let sections = parse_rclone_conf(&conf);
+        assert_eq!(sections.len(), MAX_REMOTES);
+    }
+
+    /// The cap must not disturb an ordinary config.
+    #[test]
+    fn parse_rclone_conf_keeps_every_remote_below_the_cap() {
+        let conf = "[a]\ntype = ftp\nhost = h1\n\n[b]\ntype = sftp\nhost = h2\n";
+        let sections = parse_rclone_conf(conf);
+        assert_eq!(sections.len(), 2);
+        assert_eq!(sections["b"]["host"], "h2");
     }
 
     #[test]

--- a/src-tauri/src/server_health.rs
+++ b/src-tauri/src/server_health.rs
@@ -57,6 +57,14 @@ fn cloud_provider_info(protocol: &str) -> Option<CloudProviderInfo> {
             host: "www.googleapis.com",
             probe_url: "https://www.googleapis.com/discovery/v1/apis/drive/v3/rest",
         }),
+        // The frontend classifies googlephotos as a cloud provider and sends
+        // the bare protocol name as the host, so without this arm a working
+        // profile is DNS-resolved as the literal "googlephotos" and always
+        // scores 0 / unreachable.
+        "googlephotos" => Some(CloudProviderInfo {
+            host: "photoslibrary.googleapis.com",
+            probe_url: "https://photoslibrary.googleapis.com/$discovery/rest?version=v1",
+        }),
         "dropbox" => Some(CloudProviderInfo {
             host: "api.dropboxapi.com",
             probe_url: "https://api.dropboxapi.com/2/check/user",
@@ -337,7 +345,7 @@ fn is_reachable_status(status: reqwest::StatusCode) -> bool {
 
 /// Probe HTTP endpoint. Tries HEAD first, falls back to GET if HEAD fails/times out.
 /// Some APIs (MEGA, Jottacloud) don't respond to HEAD at all.
-async fn check_http(url: &str, is_cloud: bool) -> CheckDetail {
+async fn check_http(url: &str) -> CheckDetail {
     let start = Instant::now();
 
     let client = match reqwest::Client::builder()
@@ -369,10 +377,14 @@ async fn check_http(url: &str, is_cloud: bool) -> CheckDetail {
                     details: Some(format!("HTTP {}", status.as_u16())),
                 };
             }
-            // HEAD returned unexpected status: still reachable, just report it
+            // Not a reachable status: by `is_reachable_status`'s contract that
+            // leaves transport errors and 5xx, i.e. the server is up but
+            // erroring. That is a failure for a cloud API exactly as it is for
+            // a self-hosted one: a provider in a 503 outage must not score as
+            // healthy. The GET fallback below already treats it this way.
             return CheckDetail {
                 name: "http_response".into(),
-                status: if is_cloud { "pass" } else { "fail" }.into(),
+                status: "fail".into(),
                 latency_ms: Some(elapsed.as_secs_f64() * 1000.0),
                 details: Some(format!("HTTP {}", status.as_u16())),
             };
@@ -565,7 +577,6 @@ async fn run_health_check(req: &HealthCheckRequest) -> HealthCheckResult {
     // 4. HTTP Response (for HTTP-based protocols and cloud APIs)
     // Use provider-specific probe URLs when available for accurate results
     if matches!(req.protocol.as_str(), "webdav" | "s3") || is_cloud {
-        let is_cloud_like = is_cloud || req.protocol == "s3";
         let url = if let Some(probe) = cloud_probe_url(&req.protocol) {
             // Provider-specific lightweight health endpoint
             probe.to_string()
@@ -588,7 +599,7 @@ async fn run_health_check(req: &HealthCheckRequest) -> HealthCheckResult {
             };
             format!("{}://{}:{}/", scheme, effective_host, effective_port)
         };
-        let http = check_http(&url, is_cloud_like).await;
+        let http = check_http(&url).await;
         checks.push(http);
     }
 

--- a/src-tauri/src/speedtest.rs
+++ b/src-tauri/src/speedtest.rs
@@ -24,7 +24,7 @@ use tauri::{AppHandle, Emitter, State};
 use tempfile::NamedTempFile;
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 const ONE_MB: u64 = 1024 * 1024;
@@ -36,6 +36,9 @@ const EXPERT_CONFIRM_THRESHOLD: u64 = 100 * ONE_MB;
 /// Hard ceiling for any speed test, expert mode included.
 const MAX_TEST_SIZE: u64 = ONE_GB;
 const EVENT_NAME: &str = "speedtest-progress";
+/// Scratch subdirectory the benchmark payload is written into, so a test never
+/// drops a multi-hundred-MB file straight into the user's data directory.
+const SCRATCH_DIR_NAME: &str = ".aeroftp-speedtest";
 const COMPARE_DEFAULT_PARALLEL: u8 = 2;
 const COMPARE_MAX_PARALLEL: u8 = 4;
 /// Hard cap on compare-mode test count. Prevents accidental N-server
@@ -381,8 +384,19 @@ async fn run_speedtest_inner(
     )
     .await?;
 
+    // House rule: a benchmark never writes into the server's live data
+    // directory. Everything goes into a dedicated scratch subdirectory that the
+    // test creates and removes, so a 1 GB payload can never land in (and be
+    // served from) a web root or the account root.
+    let scratch_dir = join_remote_path(&request.remote_dir, SCRATCH_DIR_NAME);
     let temp_file_name = format!(".aeroftp-speedtest-{}.bin", Uuid::new_v4());
-    let remote_path = join_remote_path(&request.remote_dir, &temp_file_name);
+    let remote_path = join_remote_path(&scratch_dir, &temp_file_name);
+
+    // Pre-existing scratch dir is fine (a previous run, or a provider that
+    // creates parents implicitly); only a hard failure is worth reporting.
+    if let Err(e) = provider.mkdir(&scratch_dir).await {
+        debug!("speedtest: scratch dir {} not created: {}", scratch_dir, e);
+    }
 
     info!(
         "speedtest: {} {} bytes -> {} (test_id={})",
@@ -474,7 +488,7 @@ async fn run_speedtest_inner(
     }
 
     if token.is_cancelled() {
-        let _ = cleanup_remote(
+        let (cleaned, cleanup_error) = cleanup_remote(
             &app,
             provider.as_mut(),
             &remote_path,
@@ -484,7 +498,19 @@ async fn run_speedtest_inner(
         )
         .await;
         let _ = provider.disconnect().await;
-        return Err("Test cancelled".to_string());
+        if cleaned {
+            return Err("Test cancelled".to_string());
+        }
+        // The upload had already completed, so a full-size payload is still on
+        // the server: say so, and say where, instead of a bare "cancelled".
+        return Err(format!(
+            "Test cancelled. The test file could not be removed and is still on the server at {}{}",
+            remote_path,
+            cleanup_error
+                .as_ref()
+                .map(|e| format!(": {}", e))
+                .unwrap_or_default()
+        ));
     }
 
     // ---------------------- DOWNLOAD (streaming) ----------------------
@@ -706,7 +732,17 @@ async fn cleanup_remote(
     }
     emit_progress(app, test_id, server_name, "cleaning_up", 0, 0, None);
     match provider.delete(remote_path).await {
-        Ok(()) => (true, None),
+        Ok(()) => {
+            // Take the scratch directory with it when it is now empty, so a
+            // completed test leaves nothing at all behind. Best effort: a
+            // concurrent test in the same directory keeps it alive.
+            if let Some(dir) = remote_path.rsplit_once('/').map(|(d, _)| d) {
+                if dir.ends_with(SCRATCH_DIR_NAME) {
+                    let _ = provider.rmdir(dir).await;
+                }
+            }
+            (true, None)
+        }
         Err(err) => {
             let msg = err.to_string();
             warn!("speedtest: cleanup failed for {}: {}", remote_path, msg);
@@ -836,6 +872,26 @@ fn emit_progress(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// CLAUDE-AV-B9-03: the benchmark payload used to be written straight into
+    /// the profile's own directory, so a 1 GB test could land in a live web
+    /// root. It must always sit under the scratch subdirectory.
+    #[test]
+    fn payload_path_is_confined_to_the_scratch_dir() {
+        for dir in ["/", "", "/var/www/html", "/var/www/html/"] {
+            let scratch = join_remote_path(dir, SCRATCH_DIR_NAME);
+            let path = join_remote_path(&scratch, ".aeroftp-speedtest-x.bin");
+            assert!(
+                path.starts_with(&scratch),
+                "payload {path} escaped scratch {scratch}"
+            );
+            assert!(
+                path.contains(SCRATCH_DIR_NAME),
+                "payload {path} is not under a scratch dir"
+            );
+            assert_ne!(path, "/.aeroftp-speedtest-x.bin", "payload landed in root");
+        }
+    }
 
     #[test]
     fn join_remote_path_handles_root() {

--- a/src-tauri/src/ssh_config_import.rs
+++ b/src-tauri/src/ssh_config_import.rs
@@ -95,6 +95,11 @@ fn split_directive(line: &str) -> Option<(String, String)> {
     Some((k.to_lowercase(), value))
 }
 
+/// Maximum number of `Host` blocks to parse, matching the other importers:
+/// each imported profile with a credential costs a whole-vault rewrite, so an
+/// uncapped parse of a large config is a self-inflicted write storm.
+const MAX_HOSTS: usize = 10_000;
+
 /// Parse the ssh config into ordered `Host` blocks. Comments (`#`) and blank
 /// lines are ignored. Directives before the first `Host` (rare global block)
 /// are discarded since they cannot produce a concrete profile.
@@ -115,6 +120,10 @@ fn parse_ssh_config(content: &str) -> Vec<HostBlock> {
         if key == "host" {
             if let Some(block) = current.take() {
                 blocks.push(block);
+            }
+            if blocks.len() >= MAX_HOSTS {
+                log::warn!("ssh config import: stopped at the {MAX_HOSTS}-host cap");
+                return blocks;
             }
             let aliases: Vec<String> = value
                 .split_whitespace()

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3523,13 +3523,18 @@ const App: React.FC = () => {
             files: res.file_count,
           });
         }
-        await persistQuotaToProfile(profileId, {
-          used: res.used,
-          total: 0,
-          usedSource: 'scan',
-          used_at: new Date().toISOString(),
-          fileCount: res.file_count,
-        });
+        // A truncated walk is a lower bound, not a total. Persisting it would
+        // pin that figure to the profile card as an authoritative "used" across
+        // sessions, so it is shown for this run and deliberately not saved.
+        if (!res.truncated) {
+          await persistQuotaToProfile(profileId, {
+            used: res.used,
+            total: 0,
+            usedSource: 'scan',
+            used_at: new Date().toISOString(),
+            fileCount: res.file_count,
+          });
+        }
         const doneDetail = t('statusBar.usedScanDoneDetail', {
           used: formatBytes(res.used),
           files: String(res.file_count),

--- a/src/components/CyberToolsModal.tsx
+++ b/src/components/CyberToolsModal.tsx
@@ -313,13 +313,32 @@ const HashForgeTab: React.FC = () => {
         };
     }, [mode, input, filePath, algorithm, encoding, outputLen, isBlake3]);
 
+    // A staged drop is a plaintext copy of the dropped file in the temp dir.
+    // Track it so it is removed as soon as it is replaced or the panel goes
+    // away, instead of lingering until the OS clears /tmp.
+    const stagedPathRef = useRef<string | null>(null);
+    const discardStaged = useCallback(() => {
+        const staged = stagedPathRef.current;
+        if (!staged) return;
+        stagedPathRef.current = null;
+        void invoke('discard_hash_drop', { path: staged }).catch(() => {});
+    }, []);
+
+    useEffect(() => discardStaged, [discardStaged]);
+
+    const applyDroppedPath = useCallback((path: string) => {
+        // Replacing the current selection: the previous staged copy is dead.
+        if (stagedPathRef.current !== path) discardStaged();
+        setMode('file');
+        setFilePath(path);
+    }, [discardStaged]);
+
     const selectFile = useCallback(async () => {
         const selected = await open({ multiple: false, directory: false });
         if (selected) {
-            setMode('file');
-            setFilePath(selected as string);
+            applyDroppedPath(selected as string);
         }
-    }, []);
+    }, [applyDroppedPath]);
 
     // Primary drop path on Linux/macOS: Tauri native onDragDropEvent (GTK/WebKit
     // file URIs). Windows keeps disable_drag_drop_handler so HTML5 handleHtmlDrop
@@ -340,8 +359,7 @@ const HashForgeTab: React.FC = () => {
                     } else if (event.payload.type === 'drop' && event.payload.paths.length > 0) {
                         setDragActive(false);
                         dragDepthRef.current = 0;
-                        setMode('file');
-                        setFilePath(event.payload.paths[0]);
+                        applyDroppedPath(event.payload.paths[0]);
                     }
                 });
                 if (cancelled) un();
@@ -365,11 +383,6 @@ const HashForgeTab: React.FC = () => {
             setMatch(null);
         }
     }, [expected, result]);
-
-    const applyDroppedPath = useCallback((path: string) => {
-        setMode('file');
-        setFilePath(path);
-    }, []);
 
     const handleHtmlDrop = useCallback(async (e: ReactDragEvent) => {
         e.preventDefault();
@@ -440,6 +453,7 @@ const HashForgeTab: React.FC = () => {
                 dataBase64,
             });
             applyDroppedPath(staged);
+            stagedPathRef.current = staged;
         } catch (err) {
             setResult(`Error: ${err}`);
             setLoading(false);


### PR DESCRIPTION
## Summary
- replace fragile FileZilla parsing and cap hostile config expansion
- harden secret-bearing exports and hash-drop staging
- isolate speedtest scratch, correct health scoring, and avoid persisting partial scans

## Verification
- `npm run ci:pre-push` green on `4722a447` after rebase onto `53ebb641`
- rebuilt-CLI hostile fixtures: no panic/hang; minified FileZilla import fixed
- real 100 MiB SFTP speedtest on development profile `SSH MyCloud HD`: integrity verified, scratch created and removed

Audit report: `docs/dev/roadmap/[PENDING-8]-APPENDIX-AUDIT-BUNDLES/AUDIT-04-B9-AEROTOOLS-REPORT.md` (local roadmap corpus).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Google Photos connectivity checks.
  - Improved FileZilla imports, including nested folders and partially readable files.
  - Speed tests now use a dedicated temporary location and clean up after completion.

- **Bug Fixes**
  - Prevented incomplete scans from saving inaccurate quota estimates.
  - Improved handling of AWS, rclone, and SSH configuration imports.
  - Hash Forge now securely removes staged files when no longer needed.

- **Security & Reliability**
  - Added safeguards against oversized or excessively complex imports.
  - Improved protection for temporary files and clearer cleanup errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->