### PR TITLE
fix(ui): restore titlebar dragging on the right, and unbreak AeroSync template export

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10766,6 +10766,7 @@ const App: React.FC = () => {
           initialSource: currentLocalPath || '',
           initialDestination: currentRemotePath || '',
           activeProfileId: activeUnifiedRemoteProfile?.id,
+          activeProfileName: activeUnifiedRemoteProfile?.name,
           isProvider: isProviderConn,
           excludePatterns: [],
           protocol: activeUnifiedRemoteProfile?.protocol,

--- a/src/components/AeroSync/AeroSyncDialog.tsx
+++ b/src/components/AeroSync/AeroSyncDialog.tsx
@@ -91,7 +91,7 @@ export const AeroSyncDialog: React.FC<AeroSyncDialogProps> = ({
         && !!context.activeProfileId;
     const localPath = context.initialSource || '';
     const remotePath = context.initialDestination || '';
-    const profileId = context.activeProfileId || '';
+    const serverProfileName = context.activeProfileName || '';
     const excludePatterns = context.excludePatterns || [];
     const isProvider = !!context.isProvider;
 
@@ -278,7 +278,7 @@ export const AeroSyncDialog: React.FC<AeroSyncDialogProps> = ({
                         onClose={() => setShowTemplates(false)}
                         localPath={localPath}
                         remotePath={remotePath}
-                        profileId={profileId}
+                        serverProfileName={serverProfileName}
                         excludePatterns={excludePatterns}
                     />
                     <MultiPathEditor

--- a/src/components/AeroSync/types.ts
+++ b/src/components/AeroSync/types.ts
@@ -94,6 +94,12 @@ export interface AeroSyncContext {
      * stay hidden.
      */
     activeProfileId?: string;
+    /**
+     * Display name of the same saved server. The Templates dialog writes it
+     * into the exported script's `CONNECT --profile`, which is resolved by
+     * name against the vault, so an id would not do (#514).
+     */
+    activeProfileName?: string;
     isProvider?: boolean;
     excludePatterns?: string[];
     /**

--- a/src/components/BreadcrumbBar.tsx
+++ b/src/components/BreadcrumbBar.tsx
@@ -398,6 +398,8 @@ export const BreadcrumbBar: React.FC<BreadcrumbBarProps> = ({
             : idx + 1;
           const isLast = realIndex === segments.length - 1;
 
+          const isSeparatorOpen = chevronDropdown?.segmentIndex === realIndex - 1;
+
           return (
             <React.Fragment key={seg.fullPath}>
               {/* Chevron separator */}
@@ -406,15 +408,21 @@ export const BreadcrumbBar: React.FC<BreadcrumbBarProps> = ({
                   onClick={(e) => handleChevronClick(e, realIndex - 1)}
                   className="flex items-center p-0.5 rounded hover:bg-gray-100 dark:hover:bg-gray-700/30 transition-colors group"
                   title={t('breadcrumb.browseSiblings') || 'Browse sibling directories'}
+                  aria-haspopup="menu"
+                  aria-expanded={isSeparatorOpen}
                 >
+                  {/* Points down while its menu is open, the way a
+                      File Explorer path bar does (wishlist #347). */}
                   <ChevronRight
                     size={14}
-                    className="w-3.5 h-3.5 text-gray-500 flex-shrink-0 group-hover:text-blue-400 transition-colors"
+                    className={`w-3.5 h-3.5 text-gray-500 flex-shrink-0 group-hover:text-blue-400 transition ${
+                      isSeparatorOpen ? 'rotate-90' : ''
+                    }`}
                   />
                 </button>
 
                 {/* Chevron dropdown */}
-                {chevronDropdown?.segmentIndex === realIndex - 1 && (
+                {isSeparatorOpen && (
                   <div
                     ref={chevronDropdownRef}
                     style={{ top: chevronDropdown.anchor.top, left: chevronDropdown.anchor.left }}
@@ -489,7 +497,9 @@ export const BreadcrumbBar: React.FC<BreadcrumbBarProps> = ({
               >
                 <ChevronRight
                   size={14}
-                  className="w-3.5 h-3.5 text-gray-400 flex-shrink-0 group-hover:text-blue-400 transition-colors"
+                  className={`w-3.5 h-3.5 text-gray-400 flex-shrink-0 group-hover:text-blue-400 transition ${
+                    isOpen ? 'rotate-90' : ''
+                  }`}
                 />
               </button>
 

--- a/src/components/BreadcrumbBar.tsx
+++ b/src/components/BreadcrumbBar.tsx
@@ -408,7 +408,10 @@ export const BreadcrumbBar: React.FC<BreadcrumbBarProps> = ({
                   onClick={(e) => handleChevronClick(e, realIndex - 1)}
                   className="flex items-center p-0.5 rounded hover:bg-gray-100 dark:hover:bg-gray-700/30 transition-colors group"
                   title={t('breadcrumb.browseSiblings') || 'Browse sibling directories'}
-                  aria-haspopup="menu"
+                  // No aria-haspopup: the dropdown is a plain list of buttons,
+                  // not a role="menu" with arrow-key navigation, so declaring
+                  // one would promise keyboard behaviour that does not exist.
+                  // aria-expanded alone is accurate on a disclosure button.
                   aria-expanded={isSeparatorOpen}
                 >
                   {/* Points down while its menu is open, the way a
@@ -492,7 +495,6 @@ export const BreadcrumbBar: React.FC<BreadcrumbBarProps> = ({
                 onClick={(e) => handleChevronClick(e, trailingIndex)}
                 className="flex items-center p-0.5 rounded hover:bg-gray-100 dark:hover:bg-gray-700/30 transition-colors group"
                 title={t('breadcrumb.browseChildren') || 'Browse subdirectories'}
-                aria-haspopup="menu"
                 aria-expanded={isOpen}
               >
                 <ChevronRight

--- a/src/components/CustomTitlebar.tsx
+++ b/src/components/CustomTitlebar.tsx
@@ -444,14 +444,23 @@ export const CustomTitlebar: React.FC<TitlebarProps> = (props) => {
             <div data-tauri-drag-region className="flex-1 h-full" />
 
             {/* Right: 3-cluster layout (page-nav / utility / window controls).
-                gap-3 between clusters replaces ad-hoc vertical separators. */}
-            <div className="flex items-center gap-3">
+                The 12px inter-cluster spacers are explicit drag regions rather
+                than a `gap-3` on this container: a gap is dead space the window
+                manager cannot see, so the bar was undraggable on its whole
+                right half (#511). Same reason the reserved slot below carries
+                a drag filler. */}
+            <div className="flex items-center">
                 {/* Cluster 1: Page Navigation.
                     min-w-[96px] reserves the slot so the utility cluster never
                     shifts when the button label/visibility changes (Connect vs
                     Disconnect have different widths, and on the connection
-                    screen neither button renders). */}
+                    screen neither button renders). The filler makes that
+                    reserved width draggable: on My Servers and Add Service
+                    neither button renders, so all 96px sat empty and inert
+                    right next to AeroVault, which is exactly where #511 was
+                    reported. */}
                 <div className="flex items-center justify-end min-w-[96px] gap-1">
+                    <div data-tauri-drag-region className="flex-1 h-full" />
                     {!showConnectionScreen && (
                         <button
                             onClick={onShowConnectionScreen}
@@ -482,6 +491,8 @@ export const CustomTitlebar: React.FC<TitlebarProps> = (props) => {
                         </button>
                     ) : null}
                 </div>
+
+                <div data-tauri-drag-region className="w-3 h-full shrink-0" />
 
                 {/* Cluster 2: Utility (Notifications, Security Tools, AeroVault, Users, Lock, Settings) */}
                 <div className="flex items-center gap-0.5">
@@ -539,6 +550,8 @@ export const CustomTitlebar: React.FC<TitlebarProps> = (props) => {
                     Hidden on macOS, where the native Overlay traffic lights
                     (top-left) provide minimize/maximize/close instead (#290). */}
                 {!isMac && (
+                <>
+                <div data-tauri-drag-region className="w-3 h-full shrink-0" />
                 <div className="flex items-center gap-0.5">
                     <button
                         onClick={handleMinimize}
@@ -566,6 +579,7 @@ export const CustomTitlebar: React.FC<TitlebarProps> = (props) => {
                         <X size={15} className="text-[var(--color-text-secondary)] group-hover:text-white" />
                     </button>
                 </div>
+                </>
                 )}
             </div>
         </div>

--- a/src/components/Sync/SyncTemplateDialog.tsx
+++ b/src/components/Sync/SyncTemplateDialog.tsx
@@ -99,14 +99,17 @@ export const SyncTemplateDialog: React.FC<SyncTemplateDialogProps> = ({
     useEffect(() => {
         if (!isOpen) return;
         let cancelled = false;
+        // Cleared up front, not just on success: a stale id surviving a failed
+        // reload would keep Export enabled and reach the backend, which is the
+        // very "not found" this dialog was fixed to stop producing.
+        setSyncProfiles([]);
+        setPresetId('');
         void (async () => {
             try {
                 const profiles = await invoke<SyncProfile[]>('load_sync_profiles_cmd');
                 if (cancelled) return;
                 setSyncProfiles(profiles);
-                setPresetId(prev =>
-                    profiles.some(p => p.id === prev) ? prev : profiles[0]?.id || '',
-                );
+                setPresetId(profiles[0]?.id || '');
             } catch {
                 // Leave the picker empty: Export stays disabled rather than
                 // reaching a backend lookup that cannot succeed.
@@ -496,10 +499,14 @@ export const SyncTemplateDialog: React.FC<SyncTemplateDialogProps> = ({
                                 onChange={e => setTemplateDesc(e.target.value)}
                             />
                             <div className="space-y-1">
-                                <div className="text-[11px] uppercase tracking-wide text-gray-500">
+                                <label
+                                    htmlFor="sync-template-preset"
+                                    className="block text-[11px] uppercase tracking-wide text-gray-500"
+                                >
                                     {t('syncPresets.title')}
-                                </div>
+                                </label>
                                 <select
+                                    id="sync-template-preset"
                                     className="w-full text-xs bg-transparent border border-gray-300 dark:border-gray-600 rounded px-2 py-1.5 dark:bg-gray-800"
                                     value={presetId}
                                     onChange={e => setPresetId(e.target.value)}

--- a/src/components/Sync/SyncTemplateDialog.tsx
+++ b/src/components/Sync/SyncTemplateDialog.tsx
@@ -30,7 +30,13 @@ interface SyncTemplateDialogProps {
     onClose: () => void;
     localPath: string;
     remotePath: string;
-    profileId: string;
+    /**
+     * Name of the connected saved server. It is what the exported script
+     * connects with (`CONNECT --profile <name>`), and it is deliberately not
+     * the sync preset: the two are separate objects and conflating them was
+     * what broke every export path (#514).
+     */
+    serverProfileName: string;
     excludePatterns: string[];
 }
 
@@ -49,7 +55,7 @@ export const SyncTemplateDialog: React.FC<SyncTemplateDialogProps> = ({
     onClose,
     localPath,
     remotePath,
-    profileId,
+    serverProfileName,
     excludePatterns,
 }) => {
     const t = useTranslation();
@@ -67,6 +73,11 @@ export const SyncTemplateDialog: React.FC<SyncTemplateDialogProps> = ({
     const [templateDesc, setTemplateDesc] = useState('');
     const [exportFormat, setExportFormat] = useState<ExportFormat>('aeroftp-script');
     const [alsoGenerateWrapper, setAlsoGenerateWrapper] = useState(true);
+    // The sync preset the export describes (direction, comparison keys,
+    // retry policy). Every export command resolves this id against the
+    // sync-preset store, which is why it must not be a saved-server id.
+    const [syncProfiles, setSyncProfiles] = useState<SyncProfile[]>([]);
+    const [presetId, setPresetId] = useState('');
 
     const defaultScriptFormat = useMemo(detectDefaultScriptFormat, []);
 
@@ -80,6 +91,28 @@ export const SyncTemplateDialog: React.FC<SyncTemplateDialogProps> = ({
             setExportFormat('aeroftp-script');
             setAlsoGenerateWrapper(true);
         }
+    }, [isOpen]);
+
+    // Builtins first (Mirror, Two-way, Backup, Pull, Remote Backup), then any
+    // custom preset saved from an imported script. Reloaded on each open so a
+    // preset applied from the Import tab shows up without a remount.
+    useEffect(() => {
+        if (!isOpen) return;
+        let cancelled = false;
+        void (async () => {
+            try {
+                const profiles = await invoke<SyncProfile[]>('load_sync_profiles_cmd');
+                if (cancelled) return;
+                setSyncProfiles(profiles);
+                setPresetId(prev =>
+                    profiles.some(p => p.id === prev) ? prev : profiles[0]?.id || '',
+                );
+            } catch {
+                // Leave the picker empty: Export stays disabled rather than
+                // reaching a backend lookup that cannot succeed.
+            }
+        })();
+        return () => { cancelled = true; };
     }, [isOpen]);
 
     useEffect(() => {
@@ -98,7 +131,7 @@ export const SyncTemplateDialog: React.FC<SyncTemplateDialogProps> = ({
         const jsonContent = await invoke<string>('export_sync_template_cmd', {
             name: templateName || 'Sync Template',
             description: templateDesc,
-            profileId,
+            profileId: presetId,
             localPath,
             remotePath,
             excludePatterns,
@@ -128,11 +161,14 @@ export const SyncTemplateDialog: React.FC<SyncTemplateDialogProps> = ({
             'aerosync_export_script_cmd',
             {
                 args: {
-                    profile_id: profileId,
-                    profile_display_name: templateName || null,
+                    profile_id: presetId,
+                    // The script's own label is the template name when the
+                    // user typed one; what it CONNECTs with is always the
+                    // saved server, resolved by name against the vault.
+                    profile_display_name: templateName || serverProfileName || null,
                     local_path: localPath,
                     remote_path: remotePath,
-                    connect_profile: templateName || null,
+                    connect_profile: serverProfileName || null,
                     exclude_patterns_override:
                         excludePatterns.length > 0 ? excludePatterns : null,
                     dry_run: false,
@@ -169,8 +205,8 @@ export const SyncTemplateDialog: React.FC<SyncTemplateDialogProps> = ({
         if (!filePath) return false;
         const scriptContent = await invoke<string>('export_sync_script_cmd', {
             args: {
-                profile_id: profileId,
-                profile_display_name: templateName || 'AeroFTP Server',
+                profile_id: presetId,
+                profile_display_name: serverProfileName || templateName || 'AeroFTP Server',
                 template_name: templateName,
                 template_description: templateDesc,
                 local_path: localPath,
@@ -461,6 +497,20 @@ export const SyncTemplateDialog: React.FC<SyncTemplateDialogProps> = ({
                             />
                             <div className="space-y-1">
                                 <div className="text-[11px] uppercase tracking-wide text-gray-500">
+                                    {t('syncPresets.title')}
+                                </div>
+                                <select
+                                    className="w-full text-xs bg-transparent border border-gray-300 dark:border-gray-600 rounded px-2 py-1.5 dark:bg-gray-800"
+                                    value={presetId}
+                                    onChange={e => setPresetId(e.target.value)}
+                                >
+                                    {syncProfiles.map(p => (
+                                        <option key={p.id} value={p.id}>{p.name}</option>
+                                    ))}
+                                </select>
+                            </div>
+                            <div className="space-y-1">
+                                <div className="text-[11px] uppercase tracking-wide text-gray-500">
                                     {t('syncPanel.templateFormat') || 'Format'}
                                 </div>
                                 <div className="space-y-1">
@@ -496,7 +546,7 @@ export const SyncTemplateDialog: React.FC<SyncTemplateDialogProps> = ({
                                 <button
                                     className="px-6 py-2 rounded-lg bg-purple-500 text-white text-xs font-medium hover:bg-purple-600 disabled:opacity-50"
                                     onClick={handleExport}
-                                    disabled={exporting}
+                                    disabled={exporting || !presetId}
                                 >
                                     {exporting ? '...' : exportButtonLabel}
                                 </button>


### PR DESCRIPTION
Three reports from Ehud Kirsh, one commit: two window-level defects in the titlebar and the AeroSync template export, plus the path-bar chevron from the wishlist.

## The titlebar could not be dragged from its right half (#511)

The outer titlebar container deliberately carries no `data-tauri-drag-region`: on Windows the runtime intercepts the mousedown geometrically over a drag region before the DOM event is dispatched, which used to swallow clicks on modal close buttons falling inside the bar's 36px. The affordance was left to two explicit children, and everything to the right of the AeroShare button was neither.

Two dead zones, both now filled with drag regions that contain no interactive children, so the Windows behaviour above cannot come back:

- the reserved 96px navigation slot. It exists so the utility cluster does not shift when Connect and Disconnect swap, and on My Servers and Add Service it renders no button at all: 96 inert pixels immediately left of AeroVault, which is exactly the spot in the report.
- the two 12px inter-cluster gaps, previously a `gap-3` on the flex container. A gap is dead space the window manager cannot see, so they are now explicit spacers of the same width.

This also restores double-click to maximise and restore on that side, which follows the drag region rather than a handler of ours.

## AeroSync template export failed in all four formats (#514)

Export returned `Profile '<id>' not found` for `.aeroftp-script`, `.aerosync`, bash and PowerShell alike. Two objects in this codebase are called a profile, and the dialog was handed the wrong one: the connected **saved server**, while all three export commands resolve the id against the **sync preset** store (Mirror, Two-way, Backup, Pull, Remote Backup). The lookup could never match, so no format could ever have worked.

The dialog now has a preset picker, which is the object the export actually describes (direction, comparison keys, retry policy), and the saved server travels separately as what the generated script connects with.

That second half was a defect on its own, latent behind the first. The export wrote `CONNECT --profile` with the **template name the user typed** into the dialog, and the bash and PowerShell wrappers put the same value in `aeroftp-cli sync --profile`. Since the CLI resolves that name against the vault, even a script that had exported successfully would not have connected. The string in the error message is the saved-server id, not a credential.

## The path-bar chevron now points down while its menu is open (discussion #347)

Pure CSS, `rotate-90` on the open state, matching what File Explorer does. One component covers every surface Ehud named: `BreadcrumbBar` is shared by AeroFile, the local panel and the remote panel. The separator chevrons also gained the `aria-haspopup` and `aria-expanded` the trailing one already had.

## Verification

`tsc` (TS 7.0.2) clean, `npm run build` ok, `vitest` 531/531, `cargo clippy --all-features --tests` exit 0, `i18n:validate` 46/46 clean with 0 placeholders. No new i18n key: the preset picker reuses `syncPresets.title`, which is already translated in all 47 locales, so this PR does not touch the locale files and cannot conflict with the i18n chain.

Frontend only. Branched off `main` at `64efc8f5`, after TypeScript 7.

## Merge order

This is outside the agreed `#502 -> #506 -> #509` chain and blocks nobody, but it shares one file with #506 (`src/App.tsx`, one added line in a different block), so it should land after it.

Reported in #511 and #514, and in discussion #347.

Not marked as closing either issue: they stay open until Ehud confirms on Windows 10.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sync preset selection when exporting synchronization templates and scripts.
  * Exports now use the selected preset and active server profile name for connection details.
  * Export actions remain unavailable until a preset is selected.

* **Bug Fixes**
  * Improved breadcrumb dropdown indicators with clearer open states, rotation, and accessibility attributes.
  * Improved custom titlebar dragging between control areas for more reliable window movement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->