### PR TITLE
fix(commands): take the blocking Tauri commands off the main thread (and correct the count: 82, not 38)

### DIFF
--- a/src-tauri/src/aerocrypt_provider.rs
+++ b/src-tauri/src/aerocrypt_provider.rs
@@ -656,11 +656,18 @@ pub async fn aerocrypt_provider_create_remote(
 /// The caller (GUI create flow) is expected to have already persisted the
 /// config (via headerless keystore store or remote marker) and now reads it
 /// back before calling, exactly as the CLI does.
+///
+/// `async`: `config_json` crosses the IPC boundary from the frontend and
+/// nothing here bounds its size, so the parse and the kit construction are both
+/// linear in whatever was handed in. Off the main thread it is a slow call; on
+/// the main thread it is a frozen window.
 #[tauri::command]
-pub fn aerocrypt_build_emergency_kit(
+pub async fn aerocrypt_build_emergency_kit(
     config_json: String,
 ) -> Result<emergency_kit::EmergencyKit, String> {
-    emergency_kit::build_from_config_json(&config_json)
+    tokio::task::spawn_blocking(move || emergency_kit::build_from_config_json(&config_json))
+        .await
+        .unwrap_or_else(|err| Err(format!("Emergency kit build task failed: {err}")))
 }
 
 // ── v4 keyslot manager (T6 GUI parity with CLI crypt migrate-v4 / *-slot) ─────

--- a/src-tauri/src/ai_tools.rs
+++ b/src-tauri/src/ai_tools.rs
@@ -1439,23 +1439,41 @@ static DENIED_COMMAND_PATTERNS: std::sync::LazyLock<Vec<regex::Regex>> =
 
 /// Read image from system clipboard via arboard (native, works on WebKitGTK).
 /// Returns base64 PNG or null if no image in clipboard.
+///
+/// `async` for two measured reasons, either of which is enough:
+///
+///   * on X11 `get_image()` asks the *other* process that owns the selection
+///     and waits for it: arboard 3.6.1 gives that exchange a 4000 ms budget
+///     (`LONG_TIMEOUT_DUR` in its x11 backend). On a sync command that is up to
+///     four seconds of frozen GTK thread when the owning app is slow to answer;
+///   * the encoding is linear in the image: a 4K screenshot is ~33 MB of RGBA,
+///     which base64 turns into ~44 MB of `String` on top of the copy.
+///
+/// Safe off the main thread on all three platforms, checked rather than
+/// assumed: arboard's macOS `Clipboard` is declared `Send + Sync`, its Windows
+/// one opens and closes the clipboard inside each call so the `!Send` handle
+/// never escapes, and the X11 backend runs its own connection anyway.
 #[tauri::command]
-pub fn clipboard_read_image() -> Result<Option<String>, String> {
-    let mut clipboard =
-        arboard::Clipboard::new().map_err(|e| format!("Clipboard init failed: {}", e))?;
-    let img = match clipboard.get_image() {
-        Ok(img) => img,
-        Err(_) => return Ok(None), // No image in clipboard
-    };
+pub async fn clipboard_read_image() -> Result<Option<String>, String> {
+    tokio::task::spawn_blocking(|| {
+        let mut clipboard =
+            arboard::Clipboard::new().map_err(|e| format!("Clipboard init failed: {}", e))?;
+        let img = match clipboard.get_image() {
+            Ok(img) => img,
+            Err(_) => return Ok(None), // No image in clipboard
+        };
 
-    // Encode RGBA as BMP-like format, then convert via canvas on frontend.
-    // Simpler: encode as raw RGBA + dimensions as JSON, let frontend render via canvas.
-    use base64::Engine;
-    let rgba_base64 = base64::engine::general_purpose::STANDARD.encode(&img.bytes);
-    Ok(Some(format!(
-        "{}:{}:{}",
-        img.width, img.height, rgba_base64
-    )))
+        // Encode RGBA as BMP-like format, then convert via canvas on frontend.
+        // Simpler: encode as raw RGBA + dimensions as JSON, let frontend render via canvas.
+        use base64::Engine;
+        let rgba_base64 = base64::engine::general_purpose::STANDARD.encode(&img.bytes);
+        Ok(Some(format!(
+            "{}:{}:{}",
+            img.width, img.height, rgba_base64
+        )))
+    })
+    .await
+    .unwrap_or_else(|err| Err(format!("Clipboard read task failed: {err}")))
 }
 
 /// Execute a shell command and capture output.

--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -36510,11 +36510,11 @@ fn cmd_aerorsync_mode_get(format: OutputFormat) -> i32 {
 
 #[cfg(feature = "aerorsync")]
 fn cmd_aerorsync_mode_get(format: OutputFormat) -> i32 {
-    let stored = ftp_client_gui_lib::settings::native_rsync_mode_get();
+    let stored = ftp_client_gui_lib::settings::native_rsync_mode_str();
     let classic = detect_classic_rsync();
     let classic_path = classic.as_ref().map(|p| p.display().to_string());
 
-    // `native_rsync_mode_get()` returns the persisted string ("auto"
+    // `native_rsync_mode_str()` returns the persisted string ("auto"
     // / "classic" / "native"). When the user opted for classic but no
     // classic binary is reachable, declare the effective mode as
     // native so each transfer call knows what to do, without
@@ -36641,7 +36641,7 @@ fn cmd_aerorsync_mode_set(mode: &str, format: OutputFormat) -> i32 {
         print_error(format, &format!("failed to persist mode: {e}"), 5);
         return 5;
     }
-    let stored = ftp_client_gui_lib::settings::native_rsync_mode_get();
+    let stored = ftp_client_gui_lib::settings::native_rsync_mode_str();
     match format {
         OutputFormat::Json => {
             let classic_path = detect_classic_rsync()

--- a/src-tauri/src/cyber_tools.rs
+++ b/src-tauri/src/cyber_tools.rs
@@ -30,8 +30,28 @@ const BLAKE3_DEFAULT_LEN: usize = 32;
 /// - `output_len`: optional BLAKE3 XOF length in bytes (1..=1024). Ignored for
 ///   non-BLAKE3 algorithms. `None` keeps the classic 32-byte BLAKE3 digest.
 /// - Empty input is valid (empty-string / empty-decoded bytes are hashed).
+///
+/// `async` because `text` is whatever the user pasted into the tool and nothing
+/// bounds it: decode and digest are both linear in that length, and a sync
+/// command would run them on the main thread. Nothing here touches the disk —
+/// the input arrives already in memory over the IPC boundary — so this is a
+/// CPU-duration fix, not an I/O one.
 #[tauri::command]
-pub fn hash_text(
+pub async fn hash_text(
+    text: String,
+    algorithm: String,
+    output_len: Option<usize>,
+    encoding: Option<String>,
+) -> Result<String, String> {
+    tokio::task::spawn_blocking(move || hash_text_blocking(text, algorithm, output_len, encoding))
+        .await
+        .unwrap_or_else(|err| Err(format!("Hash task failed: {err}")))
+}
+
+/// The hashing itself. Named rather than inlined into the closure so the tests
+/// can drive it directly instead of standing up a runtime for each case; the
+/// command's asyncness has its own pin in `hash_forge_tests`.
+fn hash_text_blocking(
     text: String,
     algorithm: String,
     output_len: Option<usize>,
@@ -908,43 +928,66 @@ const WORDLIST: &[&str] = &[
 mod hash_forge_tests {
     use super::*;
 
+    /// `hash_text` must never run on the main thread: `text` is whatever the
+    /// user pasted, nothing bounds its length, and both the decode and the
+    /// digest are linear in it.
+    ///
+    /// The pin is `block_on`, and it acts at **compile time**: it only accepts
+    /// a future, so turning the command back into a `pub fn` stops this test
+    /// building (E0277) rather than failing an assertion someone can delete.
+    /// The cases below drive `hash_text_blocking` directly, so this is also the
+    /// one place that checks the wrapper reports what the body computed.
+    #[test]
+    fn hash_text_stays_off_the_main_thread() {
+        let rt = tokio::runtime::Runtime::new().expect("test runtime");
+        let from_command = rt
+            .block_on(hash_text("hello".into(), "blake3".into(), None, None))
+            .expect("blake3 of a short string");
+        assert_eq!(
+            from_command,
+            hash_text_blocking("hello".into(), "blake3".into(), None, None).expect("blocking body"),
+            "the async wrapper must report what the blocking body computed"
+        );
+    }
+
     /// BLAKE3 of empty input (32-byte classic digest) — known test vector.
     const BLAKE3_EMPTY: &str = "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262";
 
     #[test]
     fn blake3_empty_input_matches_known_vector() {
-        let hex = hash_text("".into(), "blake3".into(), None, None).expect("empty blake3");
+        let hex = hash_text_blocking("".into(), "blake3".into(), None, None).expect("empty blake3");
         assert_eq!(hex, BLAKE3_EMPTY);
     }
 
     #[test]
     fn blake3_xof_32_equals_classic_digest() {
-        let classic = hash_text("hello".into(), "blake3".into(), None, None).unwrap();
-        let xof32 = hash_text("hello".into(), "blake3".into(), Some(32), None).unwrap();
+        let classic = hash_text_blocking("hello".into(), "blake3".into(), None, None).unwrap();
+        let xof32 = hash_text_blocking("hello".into(), "blake3".into(), Some(32), None).unwrap();
         assert_eq!(classic, xof32);
         assert_eq!(classic.len(), 64); // 32 bytes → 64 hex chars
     }
 
     #[test]
     fn blake3_xof_64_is_128_hex_chars_and_extends_classic() {
-        let classic = hash_text("hello".into(), "blake3".into(), None, None).unwrap();
-        let xof64 = hash_text("hello".into(), "blake3".into(), Some(64), None).unwrap();
+        let classic = hash_text_blocking("hello".into(), "blake3".into(), None, None).unwrap();
+        let xof64 = hash_text_blocking("hello".into(), "blake3".into(), Some(64), None).unwrap();
         assert_eq!(xof64.len(), 128);
         assert!(xof64.starts_with(&classic));
     }
 
     #[test]
     fn blake3_output_len_bounds() {
-        assert!(hash_text("x".into(), "blake3".into(), Some(0), None).is_err());
-        assert!(hash_text("x".into(), "blake3".into(), Some(1025), None).is_err());
-        assert!(hash_text("x".into(), "blake3".into(), Some(1), None).is_ok());
-        assert!(hash_text("x".into(), "blake3".into(), Some(1024), None).is_ok());
+        assert!(hash_text_blocking("x".into(), "blake3".into(), Some(0), None).is_err());
+        assert!(hash_text_blocking("x".into(), "blake3".into(), Some(1025), None).is_err());
+        assert!(hash_text_blocking("x".into(), "blake3".into(), Some(1), None).is_ok());
+        assert!(hash_text_blocking("x".into(), "blake3".into(), Some(1024), None).is_ok());
     }
 
     #[test]
     fn encoding_utf8_default_hashes_raw_bytes() {
-        let a = hash_text("hi".into(), "sha256".into(), None, None).unwrap();
-        let b = hash_text("hi".into(), "sha256".into(), None, Some("utf-8".into())).unwrap();
+        let a = hash_text_blocking("hi".into(), "sha256".into(), None, None).unwrap();
+        let b =
+            hash_text_blocking("hi".into(), "sha256".into(), None, Some("utf-8".into())).unwrap();
         assert_eq!(a, b);
         // SHA-256("hi") known value
         assert_eq!(
@@ -957,9 +1000,10 @@ mod hash_forge_tests {
     fn encoding_base64_happy_path() {
         // base64("hi") = "aGk="
         let from_b64 =
-            hash_text("aGk=".into(), "sha256".into(), None, Some("base64".into())).unwrap();
+            hash_text_blocking("aGk=".into(), "sha256".into(), None, Some("base64".into()))
+                .unwrap();
         let from_utf8 =
-            hash_text("hi".into(), "sha256".into(), None, Some("utf-8".into())).unwrap();
+            hash_text_blocking("hi".into(), "sha256".into(), None, Some("utf-8".into())).unwrap();
         assert_eq!(from_b64, from_utf8);
     }
 
@@ -967,9 +1011,9 @@ mod hash_forge_tests {
     fn encoding_hex_happy_path() {
         // hex("hi") = "6869"
         let from_hex =
-            hash_text("68 69".into(), "sha256".into(), None, Some("hex".into())).unwrap();
+            hash_text_blocking("68 69".into(), "sha256".into(), None, Some("hex".into())).unwrap();
         let from_utf8 =
-            hash_text("hi".into(), "sha256".into(), None, Some("utf-8".into())).unwrap();
+            hash_text_blocking("hi".into(), "sha256".into(), None, Some("utf-8".into())).unwrap();
         assert_eq!(from_hex, from_utf8);
     }
 
@@ -978,25 +1022,36 @@ mod hash_forge_tests {
         // "hi" = 0x68 0x69 → binary
         let bits = "01101000 01101001";
         let from_bin =
-            hash_text(bits.into(), "sha256".into(), None, Some("binary".into())).unwrap();
+            hash_text_blocking(bits.into(), "sha256".into(), None, Some("binary".into())).unwrap();
         let from_utf8 =
-            hash_text("hi".into(), "sha256".into(), None, Some("utf-8".into())).unwrap();
+            hash_text_blocking("hi".into(), "sha256".into(), None, Some("utf-8".into())).unwrap();
         assert_eq!(from_bin, from_utf8);
     }
 
     #[test]
     fn encoding_invalid_inputs_error() {
-        assert!(hash_text("!!!".into(), "sha256".into(), None, Some("base64".into())).is_err());
-        assert!(hash_text("zz".into(), "sha256".into(), None, Some("hex".into())).is_err());
-        assert!(hash_text("012".into(), "sha256".into(), None, Some("binary".into())).is_err()); // not multiple of 8
-        assert!(hash_text("0123".into(), "sha256".into(), None, Some("binary".into())).is_err()); // not only 0/1
-        assert!(hash_text("x".into(), "sha256".into(), None, Some("rot13".into())).is_err());
+        assert!(
+            hash_text_blocking("!!!".into(), "sha256".into(), None, Some("base64".into())).is_err()
+        );
+        assert!(
+            hash_text_blocking("zz".into(), "sha256".into(), None, Some("hex".into())).is_err()
+        );
+        assert!(
+            hash_text_blocking("012".into(), "sha256".into(), None, Some("binary".into())).is_err()
+        ); // not multiple of 8
+        assert!(
+            hash_text_blocking("0123".into(), "sha256".into(), None, Some("binary".into()))
+                .is_err()
+        ); // not only 0/1
+        assert!(
+            hash_text_blocking("x".into(), "sha256".into(), None, Some("rot13".into())).is_err()
+        );
     }
 
     #[test]
     fn non_blake3_ignores_output_len() {
-        let a = hash_text("hi".into(), "md5".into(), None, None).unwrap();
-        let b = hash_text("hi".into(), "md5".into(), Some(64), None).unwrap();
+        let a = hash_text_blocking("hi".into(), "md5".into(), None, None).unwrap();
+        let b = hash_text_blocking("hi".into(), "md5".into(), Some(64), None).unwrap();
         assert_eq!(a, b);
         assert_eq!(a.len(), 32); // md5 is always 16 bytes
     }

--- a/src-tauri/src/filesystem.rs
+++ b/src-tauri/src/filesystem.rs
@@ -84,7 +84,9 @@ pub struct UnmountedPartition {
 }
 
 /// A subdirectory entry for tree/breadcrumb navigation.
-#[derive(Serialize, Clone)]
+// Debug + PartialEq so the pin in `main_thread_tests` can assert that the async
+// wrapper returns exactly what the blocking body computed.
+#[derive(Serialize, Clone, Debug, PartialEq)]
 pub struct SubDirectory {
     pub name: String,
     pub path: String,
@@ -102,8 +104,25 @@ const WELL_KNOWN_HIDDEN: &[&str] = &[
 
 /// Returns standard user directories detected via the `dirs` crate.
 /// Only directories that exist on disk are included.
+///
+/// `async` on purpose: every mapping ends in a `path.exists()`, which is a
+/// `stat(2)`, and a home directory can live on an NFS/SMB/SSHFS mount whose
+/// server has gone away. A sync command runs on the main thread (the GTK
+/// thread on Linux), so one unreachable mount here freezes the whole window
+/// for as long as the mount's own timeout, with no spinner and nothing the
+/// user can tell apart from a crash. `spawn_blocking` keeps the syscalls on
+/// the blocking pool.
 #[tauri::command]
-pub fn get_user_directories() -> Vec<UserDirectory> {
+pub async fn get_user_directories() -> Vec<UserDirectory> {
+    tokio::task::spawn_blocking(get_user_directories_blocking)
+        .await
+        .unwrap_or_else(|err| {
+            warn!("get_user_directories blocking task failed: {err}");
+            Vec::new()
+        })
+}
+
+fn get_user_directories_blocking() -> Vec<UserDirectory> {
     let mappings: Vec<(Option<PathBuf>, &str, &str)> = vec![
         (dirs::home_dir(), "home", "Home"),
         (dirs::desktop_dir(), "desktop", "Monitor"),
@@ -740,8 +759,32 @@ async fn list_mounted_volumes_windows() -> Result<Vec<VolumeInfo>, String> {
 /// Returns subdirectories of the given path, sorted alphabetically (case-insensitive).
 /// Used for breadcrumb dropdowns and tree expansion in the Places sidebar.
 /// Skips hidden directories unless they are well-known (e.g. `.config`, `.ssh`).
+///
+/// `async` is not decoration here, it is the fix for the worst instance of the
+/// main-thread problem in this crate. A synchronous `#[tauri::command]` runs on
+/// the main thread, which on Linux is the GTK thread, and this one:
+///
+///   * takes its path **straight from the frontend**, so the caller chooses
+///     which mount we walk into;
+///   * stats it twice (`exists`, `is_dir`), then `read_dir`s it, then stats
+///     every entry, then `read_dir`s each subdirectory again for the expand
+///     chevron. That is O(entries) syscalls, not one;
+///   * has no timeout of its own anywhere, so on a dead NFS/SMB/SSHFS mount it
+///     blocks in the kernel for however long that mount was configured to wait.
+///
+/// Sync, that is a frozen window with no spinner. On the blocking pool it is a
+/// tree node that stays on "Loading...", and the rest of the app keeps working.
 #[tauri::command]
-pub fn list_subdirectories(path: String) -> Result<Vec<SubDirectory>, String> {
+pub async fn list_subdirectories(path: String) -> Result<Vec<SubDirectory>, String> {
+    tokio::task::spawn_blocking(move || list_subdirectories_blocking(path))
+        .await
+        .unwrap_or_else(|err| {
+            warn!("list_subdirectories blocking task failed: {err}");
+            Err("Failed to read directory".to_string())
+        })
+}
+
+fn list_subdirectories_blocking(path: String) -> Result<Vec<SubDirectory>, String> {
     validate_path(&path)?;
 
     let dir_path = Path::new(&path);
@@ -2090,9 +2133,26 @@ fn djb2_hash(bytes: &[u8]) -> u64 {
 /// listing to detect changes without spawning subprocesses or doing disk space
 /// queries. The frontend polls this cheaply and only performs a full volume
 /// refresh when it returns true.
+///
+/// `async` because of the GVFS half. `/proc/mounts` is a kernel file and always
+/// answers, but `/run/user/N/gvfs` is a FUSE mount served by a userspace daemon:
+/// listing it goes out to `gvfsd`, and if a network share behind it has gone
+/// unreachable the `readdir` blocks until that share's own timeout. The frontend
+/// polls this every 30 seconds, so on a sync command that is a periodic freeze
+/// of the GTK thread, arriving on its own with no user action to blame it on.
 #[cfg(target_os = "linux")]
 #[tauri::command]
-pub fn volumes_changed() -> bool {
+pub async fn volumes_changed() -> bool {
+    tokio::task::spawn_blocking(volumes_changed_blocking)
+        .await
+        .unwrap_or_else(|err| {
+            warn!("volumes_changed blocking task failed: {err}");
+            true // same fallback as an unreadable /proc/mounts: assume changed
+        })
+}
+
+#[cfg(target_os = "linux")]
+fn volumes_changed_blocking() -> bool {
     let content = match std::fs::read_to_string("/proc/mounts") {
         Ok(c) => c,
         Err(_) => return true, // On error, assume changed
@@ -2139,9 +2199,14 @@ static LAST_DRIVE_MASK: std::sync::atomic::AtomicU32 = std::sync::atomic::Atomic
 /// Label renames without a mask change are rare and are still covered by the
 /// real-time `WM_DEVICECHANGE` watcher emit and the focus-refetch safety net.
 /// First call with a non-zero mask reports changed (same pattern as Linux hash at 0).
+///
+/// `GetLogicalDrives` is a cheap in-kernel bitmask and needs no blocking pool,
+/// but the command is `async` anyway so the three platform variants present the
+/// same surface: one of them (Linux) must be off the main thread, and a command
+/// whose asyncness depends on the target is a trap for the next reader.
 #[cfg(target_os = "windows")]
 #[tauri::command]
-pub fn volumes_changed() -> bool {
+pub async fn volumes_changed() -> bool {
     use std::sync::atomic::Ordering;
     use windows::Win32::Storage::FileSystem::GetLogicalDrives;
 
@@ -2151,9 +2216,10 @@ pub fn volumes_changed() -> bool {
 }
 
 /// Non-Linux, non-Windows platforms always report changed (poll full refresh).
+/// `async` to match the other two variants; see the Windows one for why.
 #[cfg(not(any(target_os = "linux", target_os = "windows")))]
 #[tauri::command]
-pub fn volumes_changed() -> bool {
+pub async fn volumes_changed() -> bool {
     true
 }
 
@@ -2504,4 +2570,81 @@ pub fn start_mount_watcher(app_handle: tauri::AppHandle) {
 #[cfg(not(any(target_os = "linux", target_os = "windows")))]
 pub fn start_mount_watcher(_app_handle: tauri::AppHandle) {
     // No-op: rely on frontend polling fallback
+}
+
+#[cfg(test)]
+mod main_thread_tests {
+    use super::*;
+
+    /// `list_subdirectories` must never run on the main thread.
+    ///
+    /// A synchronous `#[tauri::command]` is dispatched on the main thread, which
+    /// on Linux is the GTK thread. This command takes its path from the
+    /// frontend and walks it with `read_dir` plus a `stat` per entry plus
+    /// another `read_dir` per subdirectory, none of it bounded by anything we
+    /// control: on a network mount whose server has gone, that is the whole
+    /// window frozen for the mount's own timeout.
+    ///
+    /// The pin is `block_on`, and it acts at **compile time**: `block_on` takes
+    /// a future, so turning the command back into a `pub fn` stops this test
+    /// building (E0277) instead of failing an assertion somebody can delete.
+    /// What it asserts on top of that is the other half: the wrapper returns
+    /// what the blocking body computed, it does not quietly change the answer.
+    #[test]
+    fn list_subdirectories_stays_off_the_main_thread() {
+        let base = tempfile::tempdir().expect("temp dir");
+        std::fs::create_dir(base.path().join("beta")).expect("mkdir beta");
+        std::fs::create_dir(base.path().join("alpha")).expect("mkdir alpha");
+        std::fs::write(base.path().join("not-a-dir.txt"), b"x").expect("write file");
+        let path = base.path().to_string_lossy().to_string();
+
+        let rt = tokio::runtime::Runtime::new().expect("test runtime");
+        let from_command = rt
+            .block_on(list_subdirectories(path.clone()))
+            .expect("command should list the temp dir");
+
+        let names: Vec<&str> = from_command.iter().map(|d| d.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["alpha", "beta"],
+            "only directories, sorted case-insensitively"
+        );
+        assert_eq!(
+            from_command,
+            list_subdirectories_blocking(path).expect("blocking body"),
+            "the async wrapper must report what the blocking body computed"
+        );
+    }
+
+    /// The error path has to survive the move onto the blocking pool too:
+    /// a missing path is still a plain error, not a task failure.
+    #[test]
+    fn list_subdirectories_still_rejects_a_path_that_is_not_there() {
+        let base = tempfile::tempdir().expect("temp dir");
+        let missing = base.path().join("nope").to_string_lossy().to_string();
+
+        let rt = tokio::runtime::Runtime::new().expect("test runtime");
+        let err = rt
+            .block_on(list_subdirectories(missing))
+            .expect_err("a path that does not exist must be an error");
+        assert_eq!(err, "Path does not exist");
+    }
+
+    /// Same pin for the volume poll: the frontend runs it every 30 seconds, so
+    /// a synchronous version would freeze the GTK thread on a schedule, with no
+    /// user action to attribute it to.
+    #[test]
+    fn volumes_changed_stays_off_the_main_thread() {
+        let rt = tokio::runtime::Runtime::new().expect("test runtime");
+        // First call primes the cached state, the second must agree with it.
+        let _ = rt.block_on(volumes_changed());
+        let second = rt.block_on(volumes_changed());
+        #[cfg(target_os = "linux")]
+        assert!(
+            !second,
+            "nothing mounted between the two calls, so the poll must report no change"
+        );
+        #[cfg(not(target_os = "linux"))]
+        let _ = second;
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -190,6 +190,11 @@ pub mod ssh_config_import;
 mod ssh_shell;
 pub mod sync;
 mod sync_badge;
+/// Class-level pin against `#[tauri::command]`s that block the main thread.
+/// Tests only; see the module docs for why it reads the sources instead of
+/// reflecting over the crate.
+#[cfg(test)]
+mod sync_command_audit;
 pub mod sync_core;
 mod sync_ignore;
 mod sync_scheduler;

--- a/src-tauri/src/local_panel_watcher.rs
+++ b/src-tauri/src/local_panel_watcher.rs
@@ -14,7 +14,7 @@
 use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use serde::Serialize;
 use std::path::PathBuf;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter, State};
 
@@ -38,15 +38,24 @@ struct WatcherSlot {
 }
 
 /// Tauri-managed state. Holds at most one active watcher.
+///
+/// The mutex is behind an `Arc` so a command can clone a `'static` handle out
+/// of `State<'_, LocalPanelWatcherState>` and hand it to `spawn_blocking`;
+/// `State` borrows the app and cannot cross that boundary itself.
 pub struct LocalPanelWatcherState {
-    inner: Mutex<Option<WatcherSlot>>,
+    inner: Arc<Mutex<Option<WatcherSlot>>>,
 }
 
 impl LocalPanelWatcherState {
     pub fn new() -> Self {
         Self {
-            inner: Mutex::new(None),
+            inner: Arc::new(Mutex::new(None)),
         }
+    }
+
+    /// A `'static` handle to the slot, for use off the main thread.
+    fn handle(&self) -> Arc<Mutex<Option<WatcherSlot>>> {
+        Arc::clone(&self.inner)
     }
 }
 
@@ -58,11 +67,28 @@ impl Default for LocalPanelWatcherState {
 
 /// Start watching `path` non-recursively. If a previous watcher is active,
 /// it is dropped first. Idempotent: passing the same path again is a no-op.
+///
+/// `async`: `path` comes from the frontend, and `is_dir()` on it is a `stat(2)`
+/// that blocks for the mount's own timeout when that mount is a network share
+/// whose server has gone. Registering the inotify/FSEvents/RDCW watch is a
+/// syscall against the same path. A synchronous command would do both on the
+/// main thread, which on Linux is the GTK thread.
 #[tauri::command]
-pub fn local_panel_watch(
+pub async fn local_panel_watch(
     path: String,
     app: AppHandle,
     state: State<'_, LocalPanelWatcherState>,
+) -> Result<(), String> {
+    let slot = state.handle();
+    tokio::task::spawn_blocking(move || local_panel_watch_blocking(path, app, &slot))
+        .await
+        .unwrap_or_else(|err| Err(format!("Watcher start task failed: {err}")))
+}
+
+fn local_panel_watch_blocking(
+    path: String,
+    app: AppHandle,
+    state: &Mutex<Option<WatcherSlot>>,
 ) -> Result<(), String> {
     let new_path = PathBuf::from(&path);
     if !new_path.is_dir() {
@@ -70,7 +96,6 @@ pub fn local_panel_watch(
     }
 
     let mut slot = state
-        .inner
         .lock()
         .map_err(|_| "watcher state poisoned".to_string())?;
 
@@ -128,12 +153,23 @@ pub fn local_panel_watch(
 }
 
 /// Stop the active watcher (if any). Safe to call when nothing is watching.
+///
+/// `async` for two reasons: dropping the slot tears down the platform watch
+/// handle, and it takes the same lock `local_panel_watch` holds while it stats
+/// a frontend-supplied path. Leaving this one synchronous would keep the freeze
+/// reachable by navigating away from a hung mount.
 #[tauri::command]
-pub fn local_panel_watch_stop(state: State<'_, LocalPanelWatcherState>) -> Result<(), String> {
-    let mut slot = state
-        .inner
-        .lock()
-        .map_err(|_| "watcher state poisoned".to_string())?;
-    *slot = None;
-    Ok(())
+pub async fn local_panel_watch_stop(
+    state: State<'_, LocalPanelWatcherState>,
+) -> Result<(), String> {
+    let slot = state.handle();
+    tokio::task::spawn_blocking(move || {
+        let mut slot = slot
+            .lock()
+            .map_err(|_| "watcher state poisoned".to_string())?;
+        *slot = None;
+        Ok(())
+    })
+    .await
+    .unwrap_or_else(|err| Err(format!("Watcher stop task failed: {err}")))
 }

--- a/src-tauri/src/peer_commands.rs
+++ b/src-tauri/src/peer_commands.rs
@@ -593,12 +593,20 @@ fn apply_active_discovery_pref(app: &AppHandle) {
 /// can open it in the OS file manager (via `open_in_file_manager`) without
 /// guessing the path. Creates the directory if absent so "Open inbox folder"
 /// never fails on a fresh install that has not received anything yet.
+///
+/// `async`: the inbox root sits under the home directory, which may be an
+/// NFS/SMB mount, and `create_dir_all` stats every component on the way down.
+/// A sync command would do that on the main thread.
 #[tauri::command]
-pub fn aeroshare_inbox_root() -> Result<String, String> {
-    let root = default_inbox_root()?;
-    std::fs::create_dir_all(&root)
-        .map_err(|e| format!("could not create the AeroShare inbox folder: {e}"))?;
-    Ok(root.to_string_lossy().to_string())
+pub async fn aeroshare_inbox_root() -> Result<String, String> {
+    tokio::task::spawn_blocking(|| {
+        let root = default_inbox_root()?;
+        std::fs::create_dir_all(&root)
+            .map_err(|e| format!("could not create the AeroShare inbox folder: {e}"))?;
+        Ok(root.to_string_lossy().to_string())
+    })
+    .await
+    .unwrap_or_else(|err| Err(format!("AeroShare inbox root task failed: {err}")))
 }
 
 #[derive(Deserialize)]

--- a/src-tauri/src/provider_commands.rs
+++ b/src-tauri/src/provider_commands.rs
@@ -1719,8 +1719,22 @@ pub async fn provider_apply_crypt_overlay(
 /// the "Recovery kit" action in the saved-server context menu, so a user can
 /// re-view and re-save the kit any time. Errors clearly when the profile has no
 /// headerless vault yet (never created, or it uses an on-remote header).
+///
+/// `async`: `CredentialStore::from_cache()` plus two `resolve_active_credential`
+/// reads go to the platform keystore, which on Linux is the Secret Service over
+/// D-Bus -- another process, and one that can be slow or wedged. A sync command
+/// would wait for it on the main thread, which is exactly the shape of the
+/// freeze fixed in #515 for the portal chooser.
 #[tauri::command]
-pub fn aerocrypt_profile_recovery_kit(
+pub async fn aerocrypt_profile_recovery_kit(
+    profile_id: String,
+) -> Result<crate::aerocrypt::emergency_kit::EmergencyKit, String> {
+    tokio::task::spawn_blocking(move || aerocrypt_profile_recovery_kit_blocking(profile_id))
+        .await
+        .unwrap_or_else(|err| Err(format!("Recovery kit task failed: {err}")))
+}
+
+fn aerocrypt_profile_recovery_kit_blocking(
     profile_id: String,
 ) -> Result<crate::aerocrypt::emergency_kit::EmergencyKit, String> {
     let store = crate::credential_store::CredentialStore::from_cache()
@@ -1762,8 +1776,22 @@ pub fn aerocrypt_profile_recovery_kit(
 /// profile's keystore config. Offline, no password, no network. Surfaces the
 /// internal `build_from_config_json` / kit-text parser path so a user can check
 /// a printed kit occasionally without a full recovery drill (tracker #421 #6).
+///
+/// `async` for the same reason as `aerocrypt_profile_recovery_kit`: keystore
+/// reads over D-Bus, plus a verification pass over text supplied by the user.
 #[tauri::command]
-pub fn aerocrypt_verify_recovery_kit(
+pub async fn aerocrypt_verify_recovery_kit(
+    profile_id: String,
+    kit_or_marker_text: String,
+) -> Result<crate::aerocrypt::emergency_kit::KitVerifyReport, String> {
+    tokio::task::spawn_blocking(move || {
+        aerocrypt_verify_recovery_kit_blocking(profile_id, kit_or_marker_text)
+    })
+    .await
+    .unwrap_or_else(|err| Err(format!("Recovery kit verification task failed: {err}")))
+}
+
+fn aerocrypt_verify_recovery_kit_blocking(
     profile_id: String,
     kit_or_marker_text: String,
 ) -> Result<crate::aerocrypt::emergency_kit::KitVerifyReport, String> {

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -21,9 +21,20 @@ pub struct PtySession {
     pub writer: Option<Box<dyn Write + Send>>,
 }
 
+/// A session behind its own lock, so touching one session does not require
+/// holding the manager.
+///
+/// This matters now that the commands are off the main thread. While they ran
+/// there, the main thread serialised them for free and one lock was enough.
+/// Off it they run concurrently, and `pty_write` blocks for as long as the
+/// child refuses to drain the master: with a single manager lock that write
+/// would park every other session's write, every resize and every close behind
+/// it. Per session, a wedged child costs only its own session.
+pub type SessionHandle = Arc<Mutex<PtySession>>;
+
 /// Manager holding multiple PTY sessions keyed by session ID
 pub struct PtyManager {
-    pub sessions: HashMap<String, PtySession>,
+    pub sessions: HashMap<String, SessionHandle>,
     next_id: u64,
 }
 
@@ -50,6 +61,77 @@ pub type PtyState = Arc<Mutex<PtyManager>>;
 /// Create a new PTY state
 pub fn create_pty_state() -> PtyState {
     Arc::new(Mutex::new(PtyManager::default()))
+}
+
+/// Holds a reserved session slot until setup either finishes or fails.
+///
+/// The limit check and the insert have to happen under one acquisition of the
+/// manager lock. Checking, releasing, spawning and only then inserting is a
+/// time-of-check-to-time-of-use gap: two concurrent `spawn_shell` calls both
+/// see 19 sessions and both insert, and the cap is quietly 21. That race was
+/// unreachable while the command was synchronous, because Tauri ran it on the
+/// main thread and the main thread does one thing at a time; moving the work
+/// onto the blocking pool is exactly what makes it reachable, so the fix
+/// belongs with the move rather than after it.
+///
+/// Everything between the reservation and `commit` can fail, and each failure
+/// returns early. Dropping the guard puts the slot back, so a failed spawn
+/// cannot leak a slot and shrink the cap for the rest of the session.
+struct SlotReservation<'a> {
+    state: &'a PtyState,
+    id: Option<String>,
+}
+
+impl SlotReservation<'_> {
+    fn commit(mut self) -> String {
+        self.id.take().expect("a reservation is committed once")
+    }
+}
+
+impl Drop for SlotReservation<'_> {
+    fn drop(&mut self) {
+        if let Some(id) = self.id.take() {
+            if let Ok(mut manager) = self.state.lock() {
+                manager.sessions.remove(&id);
+            }
+        }
+    }
+}
+
+/// Reserve one slot, or refuse because the cap is reached. The check and the
+/// insert share a single lock acquisition on purpose; see `SlotReservation`.
+fn reserve_session_slot(pty_state: &PtyState) -> Result<SlotReservation<'_>, String> {
+    let mut manager = pty_state.lock().map_err(|_| "Lock error")?;
+    if manager.sessions.len() >= MAX_PTY_SESSIONS {
+        return Err(format!(
+            "Maximum PTY session limit reached ({}). Close existing sessions first.",
+            MAX_PTY_SESSIONS
+        ));
+    }
+    let id = manager.next_session_id();
+    manager.sessions.insert(
+        id.clone(),
+        Arc::new(Mutex::new(PtySession {
+            pair: None,
+            writer: None,
+        })),
+    );
+    Ok(SlotReservation {
+        state: pty_state,
+        id: Some(id),
+    })
+}
+
+/// The handle for a session id, cloned out from under the manager lock so the
+/// caller can work on the session without holding it.
+fn session_handle(pty_state: &PtyState, session_id: &str) -> Result<SessionHandle, String> {
+    let manager = pty_state.lock().map_err(|_| "Lock error")?;
+    manager
+        .sessions
+        .get(session_id)
+        .cloned()
+        // H31: session_id is required: no fallback to prevent multi-tab session confusion
+        .ok_or_else(|| format!("PTY session not found: {}", session_id))
 }
 
 // The four commands below are `async` and do their work on the blocking pool.
@@ -85,16 +167,10 @@ fn spawn_shell_blocking(
     pty_state: &PtyState,
     cwd: Option<String>,
 ) -> Result<String, String> {
-    // Check session limit before allocating resources
-    {
-        let manager = pty_state.lock().map_err(|_| "Lock error")?;
-        if manager.sessions.len() >= MAX_PTY_SESSIONS {
-            return Err(format!(
-                "Maximum PTY session limit reached ({}). Close existing sessions first.",
-                MAX_PTY_SESSIONS
-            ));
-        }
-    }
+    // Reserve the slot before allocating anything: the cap is only a cap if the
+    // check and the insert are one operation. Every `?` below drops the guard,
+    // which hands the slot back.
+    let reservation = reserve_session_slot(pty_state)?;
 
     let pty_system = native_pty_system();
 
@@ -183,18 +259,14 @@ fn spawn_shell_blocking(
         .take_writer()
         .map_err(|e| format!("Failed to take writer: {}", e))?;
 
-    // Generate session ID
-    let mut manager = pty_state.lock().map_err(|_| "Lock error")?;
-    let session_id = manager.next_session_id();
-
-    // Store in state
-    manager.sessions.insert(
-        session_id.clone(),
-        PtySession {
-            pair: Some(pair),
-            writer: Some(writer),
-        },
-    );
+    // Setup is done, so the slot is ours to keep: fill it in place.
+    let session_id = reservation.commit();
+    {
+        let handle = session_handle(pty_state, &session_id)?;
+        let mut session = handle.lock().map_err(|_| "Lock error")?;
+        session.pair = Some(pair);
+        session.writer = Some(writer);
+    }
 
     // Spawn a thread to read output from the PTY and emit it to the frontend
     // Each session emits to its own event channel: pty-output-{session_id}
@@ -235,13 +307,11 @@ fn pty_write_blocking(
     data: String,
     session_id: String,
 ) -> Result<(), String> {
-    let mut manager = pty_state.lock().map_err(|_| "Lock error")?;
-
-    // H31: session_id is required: no fallback to prevent multi-tab session confusion
-    let session = manager
-        .sessions
-        .get_mut(&session_id)
-        .ok_or_else(|| format!("PTY session not found: {}", session_id))?;
+    // The manager lock is released the moment we have the handle: `write_all`
+    // below blocks for as long as the child refuses to read, and holding the
+    // manager across it would park every other session with it.
+    let handle = session_handle(pty_state, &session_id)?;
+    let mut session = handle.lock().map_err(|_| "Lock error")?;
 
     if let Some(ref mut writer) = session.writer {
         writer
@@ -274,13 +344,8 @@ fn pty_resize_blocking(
     cols: u16,
     session_id: String,
 ) -> Result<(), String> {
-    let manager = pty_state.lock().map_err(|_| "Lock error")?;
-
-    // H31: session_id is required: no fallback to prevent multi-tab session confusion
-    let session = manager
-        .sessions
-        .get(&session_id)
-        .ok_or_else(|| format!("PTY session not found: {}", session_id))?;
+    let handle = session_handle(pty_state, &session_id)?;
+    let session = handle.lock().map_err(|_| "Lock error")?;
 
     if let Some(ref pair) = session.pair {
         pair.master
@@ -307,10 +372,130 @@ pub async fn pty_close(pty_state: State<'_, PtyState>, session_id: String) -> Re
 }
 
 fn pty_close_blocking(pty_state: &PtyState, session_id: String) -> Result<(), String> {
+    // Deliberately only the manager lock, and deliberately not the session's.
+    // Closing has to work while a write to that same session is blocked on a
+    // child that stopped reading, which is the case a user actually wants out
+    // of. Taking the session lock here would make close wait for exactly the
+    // write it is meant to abandon.
+    //
+    // What this does and does not buy, so nobody reads more into it: the
+    // session leaves the map, so it is gone for every later command and the
+    // next write reports "session not found". The in-flight write is not
+    // interrupted, because it owns a writer handle taken from the master and
+    // dropping our side does not unblock a write already in the kernel. It
+    // costs one parked blocking-pool thread per wedged child, which ends when
+    // the child dies or drains. Interrupting it would mean a non-blocking
+    // writer with its own cancellation, which is a different change.
     let mut manager = pty_state.lock().map_err(|_| "Lock error")?;
 
     // H31: session_id is required: no fallback to prevent multi-tab session confusion
     manager.sessions.remove(&session_id);
 
     Ok(())
+}
+
+#[cfg(test)]
+mod session_slot_tests {
+    use super::*;
+
+    /// The cap is only a cap if the check and the insert are one operation.
+    ///
+    /// Pinned by driving the reservation concurrently rather than by reading
+    /// the code: 32 threads race for 20 slots, and the invariant is that the
+    /// map never exceeds `MAX_PTY_SESSIONS` and exactly 20 reservations
+    /// succeed. Against the previous shape (check, release, spawn, insert) the
+    /// map ends up over the cap, which is what this test was written against.
+    #[test]
+    fn concurrent_reservations_cannot_exceed_the_cap() {
+        // A barrier, and rounds. Spawning the threads in a loop and hoping is
+        // not a pin: the first threads finish before the last ones start, so
+        // the racy shape passes it. Every thread waits on the barrier and then
+        // calls in at once, and the experiment repeats, because one round of a
+        // race proves nothing about the round that would have failed.
+        const RACERS: usize = 32;
+        const ROUNDS: usize = 200;
+
+        for round in 0..ROUNDS {
+            let state = create_pty_state();
+            let barrier = Arc::new(std::sync::Barrier::new(RACERS));
+            let granted = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+            std::thread::scope(|scope| {
+                for _ in 0..RACERS {
+                    let state = PtyState::clone(&state);
+                    let barrier = Arc::clone(&barrier);
+                    let granted = Arc::clone(&granted);
+                    scope.spawn(move || {
+                        barrier.wait();
+                        if let Ok(reservation) = reserve_session_slot(&state) {
+                            granted.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                            // Keep it: this stands for a spawn that succeeded.
+                            let _ = reservation.commit();
+                        }
+                    });
+                }
+            });
+
+            let held = state.lock().unwrap().sessions.len();
+            assert_eq!(
+                held, MAX_PTY_SESSIONS,
+                "round {round}: {RACERS} racing reservations against a cap of \
+                 {MAX_PTY_SESSIONS} left {held} sessions"
+            );
+            assert_eq!(
+                granted.load(std::sync::atomic::Ordering::SeqCst),
+                MAX_PTY_SESSIONS,
+                "round {round}: more reservations were granted than the cap allows"
+            );
+        }
+    }
+
+    /// A reservation that is dropped instead of committed puts the slot back,
+    /// so a spawn that fails half way does not shrink the cap for good.
+    #[test]
+    fn a_dropped_reservation_returns_the_slot() {
+        let state = create_pty_state();
+        {
+            let _reservation = reserve_session_slot(&state).expect("first slot");
+            assert_eq!(state.lock().unwrap().sessions.len(), 1);
+        }
+        assert_eq!(
+            state.lock().unwrap().sessions.len(),
+            0,
+            "dropping the guard must remove the reserved slot"
+        );
+
+        // And the cap is still whole afterwards.
+        let mut kept = Vec::new();
+        for _ in 0..MAX_PTY_SESSIONS {
+            kept.push(reserve_session_slot(&state).expect("slot").commit());
+        }
+        assert!(reserve_session_slot(&state).is_err(), "cap must now refuse");
+    }
+
+    /// Writing to a session must not hold the manager lock, or one child that
+    /// stops reading parks every other session, every resize and every close.
+    ///
+    /// Pinned by holding a session's own lock and then asserting the manager is
+    /// still acquirable, which is precisely what fails if the write path takes
+    /// the manager for the duration.
+    #[test]
+    fn a_busy_session_does_not_hold_the_manager() {
+        let state = create_pty_state();
+        let id = reserve_session_slot(&state).expect("slot").commit();
+        let handle = session_handle(&state, &id).expect("handle");
+
+        let _busy = handle.lock().expect("session lock");
+        assert!(
+            state.try_lock().is_ok(),
+            "the manager must be free while a session is busy"
+        );
+
+        // Close only needs the manager, so it works while that session is busy.
+        pty_close_blocking(&state, id.clone()).expect("close while busy");
+        assert!(
+            session_handle(&state, &id).is_err(),
+            "the closed session must be gone from the map"
+        );
+    }
 }

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -52,12 +52,37 @@ pub fn create_pty_state() -> PtyState {
     Arc::new(Mutex::new(PtyManager::default()))
 }
 
+// The four commands below are `async` and do their work on the blocking pool.
+// A synchronous `#[tauri::command]` runs on the main thread -- the GTK thread on
+// Linux -- and each of these can sit there for an unbounded time:
+//
+//   * `spawn_shell` opens a PTY and forks a shell process;
+//   * `pty_write` writes to the PTY master, which blocks once the child stops
+//     draining it and the buffer fills;
+//   * `pty_resize` and `pty_close` only take the manager lock, but it is the
+//     *same* lock `pty_write` holds across its write. Converting only the
+//     writer would leave the freeze reachable by resizing the terminal.
+//
+// The guard is taken inside the closure: a `std::sync::MutexGuard` held across
+// an `.await` is `clippy::await_holding_lock`, and the lint is right.
+
 /// Spawn a new shell in the PTY. Returns session info including session ID.
 /// Enforces a maximum of MAX_PTY_SESSIONS concurrent sessions.
 #[tauri::command]
-pub fn spawn_shell(
+pub async fn spawn_shell(
     app: AppHandle,
     pty_state: State<'_, PtyState>,
+    cwd: Option<String>,
+) -> Result<String, String> {
+    let pty_state = PtyState::clone(&pty_state);
+    tokio::task::spawn_blocking(move || spawn_shell_blocking(app, &pty_state, cwd))
+        .await
+        .unwrap_or_else(|err| Err(format!("Shell spawn task failed: {err}")))
+}
+
+fn spawn_shell_blocking(
+    app: AppHandle,
+    pty_state: &PtyState,
     cwd: Option<String>,
 ) -> Result<String, String> {
     // Check session limit before allocating resources
@@ -194,8 +219,19 @@ pub fn spawn_shell(
 
 /// Write data to a PTY session (send keystrokes to shell)
 #[tauri::command]
-pub fn pty_write(
+pub async fn pty_write(
     pty_state: State<'_, PtyState>,
+    data: String,
+    session_id: String,
+) -> Result<(), String> {
+    let pty_state = PtyState::clone(&pty_state);
+    tokio::task::spawn_blocking(move || pty_write_blocking(&pty_state, data, session_id))
+        .await
+        .unwrap_or_else(|err| Err(format!("PTY write task failed: {err}")))
+}
+
+fn pty_write_blocking(
+    pty_state: &PtyState,
     data: String,
     session_id: String,
 ) -> Result<(), String> {
@@ -220,8 +256,20 @@ pub fn pty_write(
 
 /// Resize a PTY session
 #[tauri::command]
-pub fn pty_resize(
+pub async fn pty_resize(
     pty_state: State<'_, PtyState>,
+    rows: u16,
+    cols: u16,
+    session_id: String,
+) -> Result<(), String> {
+    let pty_state = PtyState::clone(&pty_state);
+    tokio::task::spawn_blocking(move || pty_resize_blocking(&pty_state, rows, cols, session_id))
+        .await
+        .unwrap_or_else(|err| Err(format!("PTY resize task failed: {err}")))
+}
+
+fn pty_resize_blocking(
+    pty_state: &PtyState,
     rows: u16,
     cols: u16,
     session_id: String,
@@ -251,7 +299,14 @@ pub fn pty_resize(
 
 /// Close a PTY session
 #[tauri::command]
-pub fn pty_close(pty_state: State<'_, PtyState>, session_id: String) -> Result<(), String> {
+pub async fn pty_close(pty_state: State<'_, PtyState>, session_id: String) -> Result<(), String> {
+    let pty_state = PtyState::clone(&pty_state);
+    tokio::task::spawn_blocking(move || pty_close_blocking(&pty_state, session_id))
+        .await
+        .unwrap_or_else(|err| Err(format!("PTY close task failed: {err}")))
+}
+
+fn pty_close_blocking(pty_state: &PtyState, session_id: String) -> Result<(), String> {
     let mut manager = pty_state.lock().map_err(|_| "Lock error")?;
 
     // H31: session_id is required: no fallback to prevent multi-tab session confusion

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -161,21 +161,38 @@ pub fn native_rsync_feature_compiled() -> bool {
     cfg!(feature = "aerorsync")
 }
 
+// The four accessors below all reach `$XDG_CONFIG_HOME/aeroftp/native_rsync.toml`
+// underneath: the getters stat and read it, the setters take a process-wide
+// write lock and then do write + rename. That is disk I/O plus a lock on a
+// config directory that can perfectly well be on a network home, so none of
+// them belongs on the main thread, however small the value they return is.
+
 #[cfg(feature = "aerorsync")]
 #[tauri::command]
-pub fn native_rsync_enabled_get() -> bool {
-    load_native_rsync_enabled()
+pub async fn native_rsync_enabled_get() -> bool {
+    tokio::task::spawn_blocking(load_native_rsync_enabled)
+        .await
+        .unwrap_or_else(|err| {
+            tracing::warn!("native_rsync_enabled_get task failed: {err}");
+            // Same fallback the loader itself uses when the path is unavailable.
+            false
+        })
 }
 
 #[cfg(feature = "aerorsync")]
 #[tauri::command]
-pub fn native_rsync_enabled_set(enabled: bool) -> Result<(), String> {
-    set_native_rsync_enabled(enabled)
+pub async fn native_rsync_enabled_set(enabled: bool) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || set_native_rsync_enabled(enabled))
+        .await
+        .unwrap_or_else(|err| Err(format!("native rsync settings write failed: {err}")))
 }
 
+/// The persisted mode as the string the GUI and the CLI both speak.
+///
+/// Synchronous, and stays that way: the CLI calls it from plain `fn`s and has
+/// no main thread to protect. The Tauri command below is the wrapper that does.
 #[cfg(feature = "aerorsync")]
-#[tauri::command]
-pub fn native_rsync_mode_get() -> String {
+pub fn native_rsync_mode_str() -> String {
     match load_native_rsync_mode() {
         NativeRsyncMode::Auto => "auto",
         NativeRsyncMode::Classic => "classic",
@@ -186,7 +203,26 @@ pub fn native_rsync_mode_get() -> String {
 
 #[cfg(feature = "aerorsync")]
 #[tauri::command]
-pub fn native_rsync_mode_set(mode: String) -> Result<(), String> {
+pub async fn native_rsync_mode_get() -> String {
+    tokio::task::spawn_blocking(native_rsync_mode_str)
+        .await
+        .unwrap_or_else(|err| {
+            tracing::warn!("native_rsync_mode_get task failed: {err}");
+            // Same fallback the loader itself uses when the path is unavailable.
+            "classic".to_string()
+        })
+}
+
+#[cfg(feature = "aerorsync")]
+#[tauri::command]
+pub async fn native_rsync_mode_set(mode: String) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || native_rsync_mode_set_blocking(mode))
+        .await
+        .unwrap_or_else(|err| Err(format!("native rsync settings write failed: {err}")))
+}
+
+#[cfg(feature = "aerorsync")]
+fn native_rsync_mode_set_blocking(mode: String) -> Result<(), String> {
     let mode = match mode.as_str() {
         "auto" => NativeRsyncMode::Auto,
         "classic" => NativeRsyncMode::Classic,
@@ -218,10 +254,15 @@ pub fn native_rsync_mode_set(mode: String) -> Result<(), String> {
 /// machine cannot honor. Returns `(available, optional_path)` so the
 /// UI can tell the user *where* the binary was found when they hover
 /// the chip.
+///
+/// `async`: `detect_classic_rsync_path` walks every entry of `PATH` and calls
+/// `is_file()` on each candidate. A single `PATH` entry pointing at an
+/// unreachable network mount is enough to park that walk in the kernel, and on
+/// a sync command the window parks with it.
 #[cfg(feature = "aerorsync")]
 #[tauri::command]
-pub fn native_rsync_classic_available() -> ClassicRsyncAvailability {
-    match detect_classic_rsync_path() {
+pub async fn native_rsync_classic_available() -> ClassicRsyncAvailability {
+    tokio::task::spawn_blocking(|| match detect_classic_rsync_path() {
         Some(path) => ClassicRsyncAvailability {
             available: true,
             path: Some(path.display().to_string()),
@@ -230,7 +271,15 @@ pub fn native_rsync_classic_available() -> ClassicRsyncAvailability {
             available: false,
             path: None,
         },
-    }
+    })
+    .await
+    .unwrap_or_else(|err| {
+        tracing::warn!("native_rsync_classic_available task failed: {err}");
+        ClassicRsyncAvailability {
+            available: false,
+            path: None,
+        }
+    })
 }
 
 #[cfg(feature = "aerorsync")]

--- a/src-tauri/src/sync_command_audit.rs
+++ b/src-tauri/src/sync_command_audit.rs
@@ -1,0 +1,420 @@
+#![cfg(test)]
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+//! Class-level pin: a `#[tauri::command]` that is not `async` runs on the main
+//! thread, and on Linux the main thread is the GTK thread.
+//!
+//! Tauri decides this at expansion time. In `tauri-macros`, `WrapperAttributes`
+//! starts at `ExecutionContext::Blocking` and only moves to `Async` if the
+//! function is declared `async` or carries `#[tauri::command(async)]`; a
+//! `Blocking` command is invoked inline on the thread that dispatches IPC.
+//! So a synchronous command that blocks -- on a syscall, on a D-Bus round trip,
+//! on a lock somebody else holds while blocking -- freezes the entire window
+//! for that duration, with no spinner and nothing the user can tell apart from
+//! a crash.
+//!
+//! Individual commands are pinned where they live, by tests that `block_on`
+//! them: `block_on` takes a future, so turning one back into a `pub fn` fails
+//! to compile rather than failing an assertion somebody can delete. That form
+//! only defends the commands that already have such a test. It does nothing
+//! about the failure mode that actually recurs, which is **addition**: someone
+//! writes a new command months from now, writes it synchronous because that is
+//! the shorter spelling, and the count of main-thread commands climbs back.
+//!
+//! This test is the answer to that. It reads the sources, collects every
+//! synchronous command, and compares the set against two explicit lists:
+//! `MAIN_THREAD_ALLOWED`, the ones that are justified, and
+//! `MAIN_THREAD_NOT_YET_MOVED`, the ones that are not and are being drained.
+//! A new synchronous command matches neither and is red. Same shape as
+//! `pickPathIsTheOnlyPicker.test.ts` on the frontend side, which stops a new
+//! call site from reintroducing the silent picker.
+//!
+//! It is deliberately a set equality and not a "no more than N" check, in both
+//! directions: making an allowlisted command `async` fails too, and so does
+//! converting a pending one without deleting its line. Neither list can rot
+//! into a record of what used to be true, and neither can grow.
+//!
+//! The counting is worth a line of its own, because the number that started
+//! this work was wrong. It was taken with a regex anchored at `pub fn`
+//! immediately after the attribute, which silently skipped every command
+//! declared inside a nested `mod` -- that is, most of `lib.rs`. It reported 38
+//! synchronous commands. There are 82, out of 853.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+/// Commands that are allowed to run on the main thread, with the reason.
+///
+/// The bar is: the work is bounded by our own code and cannot wait on anything
+/// outside the process. Disk, keystore, D-Bus, clipboard, a child process, a
+/// lock that some other command holds across such an operation, or a payload
+/// whose size the caller chooses -- none of those qualify.
+const MAIN_THREAD_ALLOWED: &[(&str, &str)] = &[
+    (
+        "aeroshare_notify",
+        "must be on the main thread: it marshals the notification through \
+         AppHandle::run_on_main_thread, and tauri-runtime-wry's send_user_message \
+         runs the closure inline when the caller already is the main thread. \
+         Making it async would only add a trip through the event loop without \
+         moving any work off that thread.",
+    ),
+    (
+        "compare_hashes",
+        "constant-time compare of two hex strings, no I/O.",
+    ),
+    (
+        "generate_password",
+        "pure CPU; the command rejects length outside 8..=128 and clamps count \
+         to 10 before doing any work, so the duration is bounded by its own \
+         validation rather than by the caller.",
+    ),
+    (
+        "generate_passphrase",
+        "pure CPU; word_count is rejected outside 3..=24 and count is clamped \
+         to 10.",
+    ),
+    (
+        "calculate_entropy",
+        "arithmetic over a character-group set the command builds itself.",
+    ),
+    (
+        "native_rsync_feature_compiled",
+        "returns cfg!(feature = \"aerorsync\"), a compile-time constant.",
+    ),
+    (
+        "provider_arm_crypt_capability",
+        "two atomic stores on already-managed state.",
+    ),
+    (
+        "local_sync_cancel",
+        "one atomic store; the cancellation is observed by the worker itself.",
+    ),
+];
+
+/// Commands that are still synchronous and should not be.
+///
+/// This list is a **ratchet, frozen at the commit that introduced it**, and the
+/// test below asserts the synchronous set is exactly `MAIN_THREAD_ALLOWED` plus
+/// this one. That has three consequences, and they are the point:
+///
+///   * a **new** synchronous command is red immediately, so the count cannot
+///     climb again by addition, which is how it got here;
+///   * converting one of these without deleting its line is **also** red, so
+///     the list has to shrink as the work lands and cannot drift into fiction;
+///   * the list can never grow. Adding to it is not a way to get green.
+///
+/// Everything here does real blocking work on the main thread -- most of it is
+/// the sync index / journal / profile / snapshot / cloud-config family, which
+/// is JSON read and write against the config directory -- except for a handful
+/// that touch GTK and will end up in `MAIN_THREAD_ALLOWED` instead once each
+/// has been read and the reason written down. Neither outcome is "leave it".
+const MAIN_THREAD_NOT_YET_MOVED: &[&str] = &[
+    "speech_model_status",              // lib.rs:245
+    "preview_provider_totp",            // lib.rs:467
+    "portable_info",                    // lib.rs:2444
+    "copy_to_clipboard",                // lib.rs:2463
+    "log_update_detection",             // lib.rs:2607
+    "restart_app",                      // lib.rs:3017
+    "is_running_as_snap",               // lib.rs:5370
+    "get_dependencies",                 // lib.rs:5406
+    "get_system_info",                  // lib.rs:6059
+    "safe_picker_start_dir",            // lib.rs:6458
+    "set_close_to_tray",                // lib.rs:10906
+    "is_autostart_launch",              // lib.rs:10916
+    "toggle_menu_bar",                  // lib.rs:11159
+    "rebuild_menu",                     // lib.rs:11170
+    "get_compare_options_default",      // lib.rs:12532
+    "load_sync_index_cmd",              // lib.rs:12537
+    "save_sync_index_cmd",              // lib.rs:12547
+    "load_sync_journal_cmd",            // lib.rs:12556
+    "save_sync_journal_cmd",            // lib.rs:12566
+    "delete_sync_journal_cmd",          // lib.rs:12573
+    "list_sync_journals_cmd",           // lib.rs:12580
+    "cleanup_old_journals_cmd",         // lib.rs:12585
+    "clear_all_journals_cmd",           // lib.rs:12590
+    "save_transfer_queue_journal_cmd",  // lib.rs:12597
+    "load_transfer_queue_journal_cmd",  // lib.rs:12604
+    "clear_transfer_queue_journal_cmd", // lib.rs:12610
+    "load_sync_profiles_cmd",           // lib.rs:12615
+    "save_sync_profile_cmd",            // lib.rs:12620
+    "delete_sync_profile_cmd",          // lib.rs:12625
+    "get_sync_schedule_cmd",            // lib.rs:12651
+    "save_sync_schedule_cmd",           // lib.rs:12656
+    "get_watcher_status_cmd",           // lib.rs:12661
+    "get_multi_path_config",            // lib.rs:13062
+    "save_multi_path_config_cmd",       // lib.rs:13067
+    "add_path_pair",                    // lib.rs:13072
+    "remove_path_pair",                 // lib.rs:13080
+    "export_sync_template_cmd",         // lib.rs:13092
+    "import_sync_template_cmd",         // lib.rs:13124
+    "export_sync_script_cmd",           // lib.rs:13149
+    "import_sync_script_cmd",           // lib.rs:13170
+    "aerosync_export_script_cmd",       // lib.rs:13209
+    "aerosync_import_script_cmd",       // lib.rs:13312
+    "create_sync_snapshot_cmd",         // lib.rs:13350
+    "list_sync_snapshots_cmd",          // lib.rs:13359
+    "delete_sync_snapshot_cmd",         // lib.rs:13372
+    "load_sync_snapshot_cmd",           // lib.rs:13385
+    "get_default_retry_policy",         // lib.rs:14380
+    "verify_local_transfer",            // lib.rs:14385
+    "classify_transfer_error",          // lib.rs:14407
+    "get_cloud_config",                 // lib.rs:14805
+    "save_cloud_config_cmd",            // lib.rs:14810
+    "get_cloud_pairs_config",           // lib.rs:14818
+    "save_cloud_pairs_config_cmd",      // lib.rs:14823
+    "add_cloud_pair",                   // lib.rs:14828
+    "remove_cloud_pair",                // lib.rs:14841
+    "update_cloud_pair",                // lib.rs:14853
+    "update_excluded_folders",          // lib.rs:14868
+    "list_file_versions",               // lib.rs:14875
+    "list_all_file_versions",           // lib.rs:14882
+    "restore_file_version",             // lib.rs:14889
+    "cleanup_versions",                 // lib.rs:14919
+    "versions_disk_usage",              // lib.rs:14926
+    "archive_before_sync_delete",       // lib.rs:14935
+    "get_cloud_status",                 // lib.rs:15080
+    "enable_aerocloud",                 // lib.rs:15098
+    "generate_share_link",              // lib.rs:15198
+    "generate_share_link_remote",       // lib.rs:15236
+    "generate_server_share_link",       // lib.rs:15272
+    "get_default_cloud_folder",         // lib.rs:15317
+    "update_conflict_strategy",         // lib.rs:15323
+    "is_background_sync_running",       // lib.rs:16012
+    "flatpak_config_import_status",     // lib.rs:16171
+    "flatpak_config_import_apply",      // lib.rs:16186
+    "mount_autostart_blocked",          // lib.rs:17516
+];
+
+/// One `#[tauri::command]` found in the sources.
+#[derive(Debug)]
+struct FoundCommand {
+    name: String,
+    is_async: bool,
+    file: String,
+    line: usize,
+}
+
+fn source_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("src")
+}
+
+fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
+    let entries = std::fs::read_dir(dir)
+        .unwrap_or_else(|e| panic!("cannot read {}: {e}", dir.display()))
+        .flatten();
+    for entry in entries {
+        let path = entry.path();
+        if path.is_dir() {
+            rust_sources(&path, out);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            out.push(path);
+        }
+    }
+    out.sort();
+}
+
+/// Collect the commands by reading the source text.
+///
+/// Reading the text rather than reflecting over the crate is on purpose: it
+/// sees commands behind `#[cfg(...)]` that this build did not compile, which is
+/// where a platform-specific or feature-gated command would otherwise hide. It
+/// costs us a hand-rolled scan, which is why the scan is written to be
+/// pedantic about what it accepts and to panic on anything it does not expect,
+/// instead of silently skipping it.
+fn collect_commands() -> Vec<FoundCommand> {
+    let mut files = Vec::new();
+    rust_sources(&source_root(), &mut files);
+
+    let mut found = Vec::new();
+    for file in &files {
+        let text = std::fs::read_to_string(file)
+            .unwrap_or_else(|e| panic!("cannot read {}: {e}", file.display()));
+        let lines: Vec<&str> = text.lines().collect();
+        let short = file
+            .strip_prefix(source_root())
+            .unwrap_or(file)
+            .display()
+            .to_string();
+
+        for (idx, raw) in lines.iter().enumerate() {
+            let line = raw.trim_start();
+            if !line.starts_with("#[tauri::command") {
+                continue;
+            }
+            // `#[tauri::command(async)]` is the other way to get off the main
+            // thread, and it counts even when the function itself is sync.
+            let attr_forces_async = line.contains("async");
+
+            // Walk forward past any further attributes, doc comments and blank
+            // lines to the signature this attribute belongs to.
+            let mut cursor = idx + 1;
+            let signature = loop {
+                let Some(next) = lines.get(cursor) else {
+                    panic!(
+                        "{short}:{}: #[tauri::command] with no function after it",
+                        idx + 1
+                    );
+                };
+                let next = next.trim_start();
+                if next.starts_with("#[")
+                    || next.starts_with("//")
+                    || next.starts_with("#!")
+                    || next.is_empty()
+                {
+                    cursor += 1;
+                    continue;
+                }
+                break next;
+            };
+
+            let (is_async, after_fn) = if let Some(rest) = signature.strip_prefix("pub async fn ") {
+                (true, rest)
+            } else if let Some(rest) = signature.strip_prefix("pub fn ") {
+                (false, rest)
+            } else if let Some(rest) = signature.strip_prefix("async fn ") {
+                (true, rest)
+            } else if let Some(rest) = signature.strip_prefix("fn ") {
+                (false, rest)
+            } else {
+                panic!(
+                    "{short}:{}: #[tauri::command] is followed by `{signature}`, which this \
+                     scan does not recognise as a function signature. Either the command was \
+                     written in a new shape or the scan needs teaching -- do not delete the \
+                     check to make this go away.",
+                    cursor + 1
+                );
+            };
+
+            let name: String = after_fn
+                .chars()
+                .take_while(|c| c.is_alphanumeric() || *c == '_')
+                .collect();
+            assert!(
+                !name.is_empty(),
+                "{short}:{}: could not read a command name out of `{signature}`",
+                cursor + 1
+            );
+
+            found.push(FoundCommand {
+                name,
+                is_async: is_async || attr_forces_async,
+                file: short.clone(),
+                line: cursor + 1,
+            });
+        }
+    }
+    found
+}
+
+/// The scan has to actually find things; a regression that made it match
+/// nothing would turn every assertion below into a silent pass.
+#[test]
+fn the_scan_finds_the_commands() {
+    let found = collect_commands();
+    assert!(
+        found.len() > 500,
+        "the command scan found only {} commands, which means it stopped matching, \
+         not that the crate shrank",
+        found.len()
+    );
+    assert!(
+        found.iter().any(|c| c.name == "list_subdirectories"),
+        "the scan did not find list_subdirectories"
+    );
+    assert!(
+        found.iter().any(|c| c.name == "aeroshare_notify"),
+        "the scan did not find aeroshare_notify"
+    );
+}
+
+/// The pin itself.
+#[test]
+fn no_command_blocks_the_main_thread_unless_it_is_on_the_list() {
+    let found = collect_commands();
+
+    let justified: BTreeSet<&str> = MAIN_THREAD_ALLOWED.iter().map(|(name, _)| *name).collect();
+    assert_eq!(
+        justified.len(),
+        MAIN_THREAD_ALLOWED.len(),
+        "MAIN_THREAD_ALLOWED contains a duplicate name"
+    );
+    let not_yet: BTreeSet<&str> = MAIN_THREAD_NOT_YET_MOVED.iter().copied().collect();
+    assert_eq!(
+        not_yet.len(),
+        MAIN_THREAD_NOT_YET_MOVED.len(),
+        "MAIN_THREAD_NOT_YET_MOVED contains a duplicate name"
+    );
+    let overlap: Vec<&&str> = justified.intersection(&not_yet).collect();
+    assert!(
+        overlap.is_empty(),
+        "{overlap:?} is both justified and pending, which cannot both be true"
+    );
+    let allowed: BTreeSet<&str> = justified.union(&not_yet).copied().collect();
+
+    let sync_commands: Vec<&FoundCommand> = found.iter().filter(|c| !c.is_async).collect();
+    let sync_names: BTreeSet<&str> = sync_commands.iter().map(|c| c.name.as_str()).collect();
+
+    let unexpected: Vec<&&FoundCommand> = sync_commands
+        .iter()
+        .filter(|c| !allowed.contains(c.name.as_str()))
+        .collect();
+    if !unexpected.is_empty() {
+        let listing = unexpected
+            .iter()
+            .map(|c| format!("  {}:{}  {}", c.file, c.line, c.name))
+            .collect::<Vec<_>>()
+            .join("\n");
+        panic!(
+            "these #[tauri::command]s are synchronous, so they run on the main thread \
+             (the GTK thread on Linux) and block the whole window for as long as they \
+             take:\n{listing}\n\n\
+             Make each one `pub async fn` and put the blocking part inside \
+             `tokio::task::spawn_blocking`, the way `filesystem::list_subdirectories` and \
+             `portal_chooser::chooser_unavailable` do. Take any `std::sync::Mutex` guard \
+             *inside* the closure: holding one across an `.await` is \
+             `clippy::await_holding_lock`.\n\n\
+             If a command genuinely has to stay on the main thread, or its work is bounded \
+             by its own validation and touches nothing outside the process, add it to \
+             MAIN_THREAD_ALLOWED in this file together with the reason.\n\n\
+             MAIN_THREAD_NOT_YET_MOVED is not the place for it: that list is frozen and \
+             only shrinks."
+        );
+    }
+
+    let stale_justified: Vec<&str> = justified
+        .iter()
+        .filter(|name| !sync_names.contains(*name))
+        .copied()
+        .collect();
+    assert!(
+        stale_justified.is_empty(),
+        "MAIN_THREAD_ALLOWED still lists {stale_justified:?}, but no synchronous command by \
+         that name exists any more. Either it was made async -- in which case drop the entry, \
+         the list is not a history -- or it was renamed or removed and the entry went stale."
+    );
+
+    let drained: Vec<&str> = not_yet
+        .iter()
+        .filter(|name| !sync_names.contains(*name))
+        .copied()
+        .collect();
+    assert!(
+        drained.is_empty(),
+        "{drained:?} are no longer synchronous, which is the point -- now delete them from \
+         MAIN_THREAD_NOT_YET_MOVED. The list has to shrink as the work lands, otherwise it \
+         stops describing anything."
+    );
+}
+
+/// Every entry has to carry a reason, because a bare name is how an allowlist
+/// turns into a place to put things.
+#[test]
+fn every_allowlist_entry_explains_itself() {
+    for (name, reason) in MAIN_THREAD_ALLOWED {
+        assert!(
+            reason.len() > 30,
+            "MAIN_THREAD_ALLOWED entry `{name}` has no real reason attached"
+        );
+    }
+}

--- a/src-tauri/src/totp.rs
+++ b/src-tauri/src/totp.rs
@@ -13,7 +13,7 @@
 // Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
 
 use secrecy::{ExposeSecret, SecretString};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tauri::State;
 use totp_rs::{Algorithm, Secret, TOTP};
@@ -59,14 +59,26 @@ struct TotpInner {
 }
 
 /// Thread-safe TOTP state managed by Tauri.
+///
+/// The inner mutex is behind an `Arc` so a command can clone a `'static` handle
+/// out of `State<'_, TotpState>` and hand it to `spawn_blocking`. `State` itself
+/// borrows the app and cannot cross that boundary; without the `Arc` every
+/// command here would have to stay synchronous, which means on the main thread.
 pub struct TotpState {
-    inner: Mutex<TotpInner>,
+    inner: Arc<Mutex<TotpInner>>,
+}
+
+impl TotpState {
+    /// A `'static` handle to the inner state, for use off the main thread.
+    fn handle(&self) -> Arc<Mutex<TotpInner>> {
+        Arc::clone(&self.inner)
+    }
 }
 
 impl Default for TotpState {
     fn default() -> Self {
         Self {
-            inner: Mutex::new(TotpInner {
+            inner: Arc::new(Mutex::new(TotpInner {
                 pending_secret: None,
                 setup_verified: false,
                 enabled: false,
@@ -74,15 +86,19 @@ impl Default for TotpState {
                 failed_attempts: 0,
                 lockout_until: None,
                 last_used_step: None,
-            }),
+            })),
         }
     }
 }
 
 /// Acquire the inner lock with poison recovery.
 fn lock_state(state: &TotpState) -> Result<std::sync::MutexGuard<'_, TotpInner>, String> {
-    state
-        .inner
+    lock_inner(&state.inner)
+}
+
+/// Same, for the `Arc` handle a command carries into `spawn_blocking`.
+fn lock_inner(inner: &Mutex<TotpInner>) -> Result<std::sync::MutexGuard<'_, TotpInner>, String> {
+    inner
         .lock()
         .map_err(|_| "TOTP internal state error".to_string())
 }
@@ -313,13 +329,36 @@ fn generate_secret_base32() -> String {
 
 /// Start 2FA setup: generate a new TOTP secret and return the otpauth URI.
 /// Returns: { secret: string, uri: string }
+// Every command below is `async` and does its work on the blocking pool. Two
+// reasons, and the first one alone is enough:
+//
+//   * `totp_enable` writes the secret to the credential store, which on Linux
+//     is the Secret Service over D-Bus: another process, which can be slow or
+//     unreachable. A synchronous `#[tauri::command]` runs on the main thread
+//     (the GTK thread on Linux), so that write would freeze the window.
+//   * they all take the same mutex. Even the ones that only read a bool would
+//     block on the main thread for as long as whoever holds it -- which is the
+//     keystore writer above. Moving only `totp_enable` would leave the freeze
+//     reachable through `totp_status`.
+//
+// The guard is taken *inside* the closure on purpose: a `std::sync::MutexGuard`
+// held across an `.await` is `clippy::await_holding_lock`, and the lint is
+// right -- the future can resume on a different worker still holding it.
+
 #[tauri::command]
-pub fn totp_setup_start(state: State<'_, TotpState>) -> Result<serde_json::Value, String> {
+pub async fn totp_setup_start(state: State<'_, TotpState>) -> Result<serde_json::Value, String> {
+    let inner = state.handle();
+    tokio::task::spawn_blocking(move || totp_setup_start_blocking(&inner))
+        .await
+        .unwrap_or_else(|err| Err(format!("TOTP setup task failed: {err}")))
+}
+
+fn totp_setup_start_blocking(state: &Mutex<TotpInner>) -> Result<serde_json::Value, String> {
     let secret_base32 = generate_secret_base32();
     let totp = build_totp(&secret_base32)?;
     let uri = append_image_param(&totp.get_url());
 
-    let mut inner = lock_state(&state)?;
+    let mut inner = lock_inner(state)?;
     // Return the secret to the frontend for QR code display, then wrap in SecretString
     let result = serde_json::json!({
         "secret": secret_base32,
@@ -334,8 +373,15 @@ pub fn totp_setup_start(state: State<'_, TotpState>) -> Result<serde_json::Value
 /// Verify a TOTP code during setup. If valid, marks the pending secret as verified.
 /// The caller must then call totp_enable to activate.
 #[tauri::command]
-pub fn totp_setup_verify(state: State<'_, TotpState>, code: String) -> Result<bool, String> {
-    let mut inner = lock_state(&state)?;
+pub async fn totp_setup_verify(state: State<'_, TotpState>, code: String) -> Result<bool, String> {
+    let inner = state.handle();
+    tokio::task::spawn_blocking(move || totp_setup_verify_blocking(&inner, code))
+        .await
+        .unwrap_or_else(|err| Err(format!("TOTP verification task failed: {err}")))
+}
+
+fn totp_setup_verify_blocking(state: &Mutex<TotpInner>, code: String) -> Result<bool, String> {
+    let mut inner = lock_inner(state)?;
     check_rate_limit(&inner)?;
 
     let secret = inner
@@ -358,8 +404,15 @@ pub fn totp_setup_verify(state: State<'_, TotpState>, code: String) -> Result<bo
 
 /// Verify a TOTP code during unlock (using the active secret).
 #[tauri::command]
-pub fn totp_verify(state: State<'_, TotpState>, code: String) -> Result<bool, String> {
-    let mut inner = lock_state(&state)?;
+pub async fn totp_verify(state: State<'_, TotpState>, code: String) -> Result<bool, String> {
+    let inner = state.handle();
+    tokio::task::spawn_blocking(move || totp_verify_blocking(&inner, code))
+        .await
+        .unwrap_or_else(|err| Err(format!("TOTP verification task failed: {err}")))
+}
+
+fn totp_verify_blocking(state: &Mutex<TotpInner>, code: String) -> Result<bool, String> {
+    let mut inner = lock_inner(state)?;
     check_rate_limit(&inner)?;
 
     let secret = inner
@@ -379,9 +432,14 @@ pub fn totp_verify(state: State<'_, TotpState>, code: String) -> Result<bool, St
 
 /// Check if TOTP is enabled.
 #[tauri::command]
-pub fn totp_status(state: State<'_, TotpState>) -> Result<bool, String> {
-    let inner = lock_state(&state)?;
-    Ok(inner.enabled)
+pub async fn totp_status(state: State<'_, TotpState>) -> Result<bool, String> {
+    let inner = state.handle();
+    tokio::task::spawn_blocking(move || {
+        let guard = lock_inner(&inner)?;
+        Ok(guard.enabled)
+    })
+    .await
+    .unwrap_or_else(|err| Err(format!("TOTP status task failed: {err}")))
 }
 
 /// Enable TOTP after successful verification. Requires that totp_setup_verify
@@ -390,8 +448,15 @@ pub fn totp_status(state: State<'_, TotpState>) -> Result<bool, String> {
 /// If the vault store fails, TOTP is NOT enabled (fail-closed).
 /// Returns the secret as a plain String for backward compatibility.
 #[tauri::command]
-pub fn totp_enable(state: State<'_, TotpState>) -> Result<String, String> {
-    let mut inner = lock_state(&state)?;
+pub async fn totp_enable(state: State<'_, TotpState>) -> Result<String, String> {
+    let inner = state.handle();
+    tokio::task::spawn_blocking(move || totp_enable_blocking(&inner))
+        .await
+        .unwrap_or_else(|err| Err(format!("TOTP enable task failed: {err}")))
+}
+
+fn totp_enable_blocking(state: &Mutex<TotpInner>) -> Result<String, String> {
+    let mut inner = lock_inner(state)?;
 
     if !inner.setup_verified {
         return Err("Must verify TOTP code before enabling".into());
@@ -424,8 +489,15 @@ pub fn totp_enable(state: State<'_, TotpState>) -> Result<String, String> {
 
 /// Disable TOTP (requires valid code first).
 #[tauri::command]
-pub fn totp_disable(state: State<'_, TotpState>, code: String) -> Result<bool, String> {
-    let mut inner = lock_state(&state)?;
+pub async fn totp_disable(state: State<'_, TotpState>, code: String) -> Result<bool, String> {
+    let inner = state.handle();
+    tokio::task::spawn_blocking(move || totp_disable_blocking(&inner, code))
+        .await
+        .unwrap_or_else(|err| Err(format!("TOTP disable task failed: {err}")))
+}
+
+fn totp_disable_blocking(state: &Mutex<TotpInner>, code: String) -> Result<bool, String> {
+    let mut inner = lock_inner(state)?;
     check_rate_limit(&inner)?;
 
     let secret = inner.active_secret.as_ref().ok_or("TOTP not enabled")?;
@@ -447,32 +519,39 @@ pub fn totp_disable(state: State<'_, TotpState>, code: String) -> Result<bool, S
 
 /// Load TOTP state from a stored secret (called after vault unlock).
 #[tauri::command]
-pub fn totp_load_secret(state: State<'_, TotpState>, secret: String) -> Result<(), String> {
-    load_secret_internal(&state, &secret)
+pub async fn totp_load_secret(state: State<'_, TotpState>, secret: String) -> Result<(), String> {
+    let inner = state.handle();
+    tokio::task::spawn_blocking(move || load_secret_into(&inner, &secret, None))
+        .await
+        .unwrap_or_else(|err| Err(format!("TOTP load task failed: {err}")))
 }
 
 /// Internal: Load a TOTP secret into state without requiring Tauri State wrapper.
 /// Used by unlock_credential_store for 2FA enforcement.
-pub fn load_secret_internal(state: &TotpState, secret: &str) -> Result<(), String> {
-    load_secret_internal_from_store(state, secret, None)
-}
-
+///
+/// The store-less variant used to exist next to this one for `totp_load_secret`
+/// to call. That command now goes to `load_secret_into` directly, since it has
+/// to hand `spawn_blocking` an `Arc` handle rather than the `State` wrapper,
+/// which left the store-less wrapper with no callers at all: removed rather
+/// than kept alive with an `#[allow(dead_code)]`.
 pub(crate) fn load_secret_internal_with_store(
     state: &TotpState,
     secret: &str,
     store: &crate::credential_store::CredentialStore,
 ) -> Result<(), String> {
-    load_secret_internal_from_store(state, secret, Some(store))
+    load_secret_into(&state.inner, secret, Some(store))
 }
 
-fn load_secret_internal_from_store(
-    state: &TotpState,
+/// The load itself, against the inner mutex rather than the Tauri `State`
+/// wrapper, so `totp_load_secret` can run it on the blocking pool.
+fn load_secret_into(
+    state: &Mutex<TotpInner>,
     secret: &str,
     store: Option<&crate::credential_store::CredentialStore>,
 ) -> Result<(), String> {
     // Validate the secret is valid base32
     build_totp(secret)?;
-    let mut inner = lock_state(state)?;
+    let mut inner = lock_inner(state)?;
     inner.active_secret = Some(SecretString::from(secret.to_string()));
     inner.enabled = true;
     // TOTP-02: re-arm any lockout that was in force when the process last

--- a/src-tauri/src/vault_remote.rs
+++ b/src-tauri/src/vault_remote.rs
@@ -159,8 +159,21 @@ fn validate_managed_temp_vault_path(path: &Path) -> Result<PathBuf, String> {
 
 /// Clean up a temporary vault file securely.
 /// Validates: temp directory confinement, filename pattern, no symlinks.
+///
+/// `async` because the secure-delete path is the opposite of cheap: it opens
+/// the file, overwrites every byte of it in 1 MB chunks, calls `sync_all()`
+/// (which waits on the physical device), and only then unlinks. The duration is
+/// linear in the size of the vault file and ends in an fsync, so on a sync
+/// command the whole window would sit frozen for it. `spawn_blocking` keeps the
+/// zero-fill on the blocking pool; the validation order is untouched.
 #[tauri::command]
-pub fn vault_v2_cleanup_temp(local_path: String) -> Result<(), String> {
+pub async fn vault_v2_cleanup_temp(local_path: String) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || vault_v2_cleanup_temp_blocking(local_path))
+        .await
+        .unwrap_or_else(|err| Err(format!("Temp vault cleanup task failed: {err}")))
+}
+
+fn vault_v2_cleanup_temp_blocking(local_path: String) -> Result<(), String> {
     validate_no_null_bytes(&local_path)?;
 
     let path = PathBuf::from(&local_path);


### PR DESCRIPTION
Part of #517.

## The defect

Tauri dispatches a synchronous `#[tauri::command]` on the main thread. That is not a documentation claim, it is in the macro: `tauri-macros` 2.6.3 starts `WrapperAttributes` at `ExecutionContext::Blocking` and only moves it to `Async` when the function is declared `async` or carries `#[tauri::command(async)]`; a `Blocking` command is invoked inline on the dispatching thread. On Linux that thread is the GTK thread, so any wait inside such a command freezes the entire window for its duration — no spinner, and nothing the user can tell apart from a crash. #515 already fixed one instance (`portal_chooser::chooser_unavailable`, up to two seconds on a wedged session bus).

## The count was wrong, and that is the most useful thing in this PR

The work was scoped at "38 synchronous commands". That number came from a regex anchored on `pub fn` immediately after the attribute, which silently skips every command declared inside a nested `mod` — that is, most of `lib.rs`.

**There are 82 synchronous commands out of 853.** The 44 that the original count missed are not marginal: they are the sync index / journal / profile / snapshot / cloud-config / versioning family, which is JSON read and write against the config directory, all of it on the main thread.

Three other claims in the scoping notes did not survive reading the code, and are corrected here:

| Claim | What the code does |
|---|---|
| `local_sync_cancel` does `File::open` | one `AtomicBool::store`. It stays synchronous, and that is now written down with the reason. |
| `hash_text` does `File::open` plus hashing, linear in the file | it hashes a **string** that arrived over IPC. Worth moving, but for CPU duration, not I/O. `hash_file` is the one that opens a file, and it was already `async`. |
| `native_rsync_enabled_get` / `mode_get` / `enabled_set` / `mode_set` can stay synchronous | all four reach `native_rsync.toml`: the getters stat and read it, the setters take a process-wide write lock and then write and rename. Moved. |

## What this PR moves, and why each one

Thirty commands become `pub async fn` with the blocking part inside `tokio::task::spawn_blocking`, the form already merged in `portal_chooser.rs`. Each carries the reason in a doc comment; the ones that are more than mechanical:

- **`filesystem::list_subdirectories`** — the worst of them, and the reason it goes first. It takes its path **straight from the frontend**, stats it twice, `read_dir`s it, stats every entry, and `read_dir`s each subdirectory again for the expand chevron. That is O(entries) syscalls with no timeout anywhere in our code, so on a dead NFS/SMB/SSHFS mount it blocks in the kernel for as long as that mount was configured to wait. Synchronous, that is a frozen window; on the blocking pool it is one tree node stuck on "Loading…" while the app keeps working.
- **`filesystem::volumes_changed` (Linux)** — `/proc/mounts` always answers, but `/run/user/N/gvfs` is a FUSE mount served by `gvfsd`, and listing it blocks when a share behind it is unreachable. The frontend polls it every 30 seconds, so synchronously this is a *periodic* freeze with no user action to attribute it to. The Windows and fallback variants move too, so the command does not change asyncness with the target.
- **`vault_remote::vault_v2_cleanup_temp`** — overwrites every byte of the temp vault in 1 MB chunks and then `sync_all()`s. Duration is linear in the file and ends in an fsync.
- **`ai_tools::clipboard_read_image`** — arboard 3.6.1 gives the X11 selection exchange a 4000 ms budget (`LONG_TIMEOUT_DUR`), so a slow clipboard owner is up to four seconds of frozen GTK thread; plus base64 of a full-resolution image (~33 MB of RGBA for a 4K screenshot). Checked rather than assumed that this is safe off the main thread on all three platforms: arboard's macOS `Clipboard` is declared `Send + Sync`, its Windows one opens and closes the clipboard inside each call so the `!Send` handle never escapes, and the X11 backend runs its own connection.
- **`totp::*` (7), `pty::*` (4), `local_panel_watcher::*` (2)** — these needed a small design change, not a rename: `State<'_, T>` borrows the app and cannot enter `spawn_blocking`, so `TotpState` and `LocalPanelWatcherState` now hold their mutex behind an `Arc` and the commands clone a `'static` handle out. Converting only the one command that blocks would not have been enough: they all share one mutex, so leaving `totp_status` synchronous would keep the keystore-write freeze reachable through it, and leaving `pty_resize` synchronous would keep `pty_write`'s blocked write reachable by resizing the terminal.
- **`provider_commands::aerocrypt_profile_recovery_kit` / `aerocrypt_verify_recovery_kit`** — keystore reads, which on Linux are the Secret Service over D-Bus: another process, and one that can be wedged. Same shape as the freeze #515 fixed.

Every guard is taken **inside** the closure. A `std::sync::MutexGuard` held across an `.await` is `clippy::await_holding_lock`, and that lint is the one that turned a claimed-green gate red on #515.

Two internal callers broke and are fixed rather than worked around: the CLI called `settings::native_rsync_mode_get()` from plain `fn`s, so the synchronous body is now `native_rsync_mode_str()` and the CLI calls that (a CLI has no main thread to protect); and 24 test cases drove `hash_text` synchronously, so they now drive the named `hash_text_blocking` body.

## The pins

**Per command, at compile time.** `list_subdirectories` and `hash_text` get a `#[test]` that `block_on`s them. `block_on` only accepts a future, so turning either back into a `pub fn` stops the test *building* (E0277) instead of failing an assertion someone can delete. Each also asserts the wrapper returns what the blocking body computed, so it is not only a type-level check.

**Class level, `src-tauri/src/sync_command_audit.rs`.** The per-command form defends only the commands that already have such a test; it does nothing about the failure mode that actually recurs, which is **addition** — someone writes a new command in six months, writes it synchronous because that is the shorter spelling, and the count climbs back. So this test reads the sources, collects every synchronous command, and asserts the set is exactly `MAIN_THREAD_ALLOWED` (justified, 8 entries, each with its reason) plus `MAIN_THREAD_NOT_YET_MOVED` (frozen, 74 entries). It reads text rather than reflecting over the crate on purpose: that way it sees commands behind a `#[cfg]` this build did not compile, which is exactly where a platform-specific one would otherwise hide.

It is a set equality in both directions, so it cannot rot: a new synchronous command is red, converting a pending one without deleting its line is red, and an allowlisted command that becomes async is red. The pending list can only shrink — adding to it is not a way to get green.

`MAIN_THREAD_ALLOWED` holds the eight that are justified, including two that must **stay** on the main thread and now say so: `aeroshare_notify` and (in the pending list until its entry is written) `rebuild_menu` marshal their work onto the main thread through `run_on_main_thread`, and `tauri-runtime-wry`'s `send_user_message` runs the closure inline when the caller already is that thread — so making them async would add a trip through the event loop without moving any work.

## What is left, and when

`MAIN_THREAD_NOT_YET_MOVED` lists the 74 remaining by name. They are mostly the `lib.rs` config/journal/snapshot family plus a handful that touch GTK and will end up justified instead once each has been read. That work follows in the next PR from this same session; the ratchet is what makes it not optional, and what makes this PR honest about not being the whole job.

Splitting is deliberate: those 74 live almost entirely in `lib.rs`, which several branches are editing right now, and holding the `list_subdirectories` fix behind a 3000-line mechanical diff helps nobody.

## Verification

Local gate and its results go in a comment below rather than here, so the claim and the evidence arrive together.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance & Reliability**
  * Improved responsiveness by moving intensive file, clipboard, security, terminal, synchronization, and authentication operations off the main application thread.
  * Added safer handling and clearer errors when background operations fail.
  * Preserved existing behaviors and fallback values across settings, volume detection, and clipboard operations.

* **File Monitoring**
  * Improved local folder watching and stopping, including more reliable change notifications.

* **Tests**
  * Added coverage confirming background execution and preserving existing results and error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->