### PR TITLE
fix(security): stop leaking the STS token on redirect and landing peer-supplied setuid bits

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -798,23 +798,24 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-fips-sys"
-version = "0.13.14"
+version = "0.13.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d619165468401dec3caa3366ebffbcb83f2f31883e5b3932f8e2dec2ddc568"
+checksum = "37b00953a69b2cfb471d13d72538d2e66930832340b0f31deadd404b48c573c5"
 dependencies = [
  "bindgen",
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
  "regex",
 ]
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-fips-sys",
  "aws-lc-sys",
@@ -824,15 +825,16 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
  "bindgen",
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -2250,7 +2252,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.118",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3530,7 +3532,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
+ "windows-link 0.1.3",
  "windows-result 0.4.1",
 ]
 
@@ -8927,9 +8929,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "log",

--- a/src-tauri/src/aerorsync/delta_transport_impl.rs
+++ b/src-tauri/src/aerorsync/delta_transport_impl.rs
@@ -2361,7 +2361,14 @@ async fn write_atomic_chunked_core(
         #[cfg(unix)]
         if let Some(mode) = preserve_mode {
             use std::os::unix::fs::PermissionsExt;
-            let perms = std::fs::Permissions::from_mode(mode & 0o7777);
+            // Mask to the ordinary rwx bits. `preserve_mode` reaches us from
+            // the peer's file list, so the setuid/setgid/sticky bits in
+            // 0o7000 are attacker-supplied: a hostile sender could ask us to
+            // land a setuid binary. Harmless when we run as an ordinary user
+            // (the file is ours, so setuid grants nothing new), but a real
+            // escalation when aerorsync runs as root or a service account.
+            // rclone reached the same conclusion in GHSA-945v-v9p3-v5xw.
+            let perms = std::fs::Permissions::from_mode(mode & 0o0777);
             fs::set_permissions(&tmp_path, perms).await.map_err(|e| {
                 WriteAtomicError::PostOpen {
                     stage: "chmod",
@@ -4646,6 +4653,37 @@ PY"#
 
         let actual = fs::read(&target).await.unwrap();
         assert_eq!(actual, b"NEW_CONTENTS");
+    }
+
+    /// A hostile sender controls `preserve_mode` (it is read off the peer's
+    /// file list), so the setuid/setgid/sticky bits must never survive onto
+    /// the file we land. Before the mask was tightened from 0o7777 to 0o0777
+    /// this test failed with mode 0o4755 instead of 0o0755.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn write_atomic_strips_peer_supplied_setuid_setgid_sticky() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = fresh_tempdir();
+
+        for (peer_mode, expected) in [
+            (0o4755_u32, 0o0755_u32), // setuid
+            (0o2755, 0o0755),         // setgid
+            (0o1755, 0o0755),         // sticky
+            (0o7777, 0o0777),         // all three at once
+            (0o0644, 0o0644),         // ordinary bits pass through untouched
+        ] {
+            let target = dir.path().join(format!("mode-{peer_mode:o}.bin"));
+            write_atomic_chunked(&target, b"payload", 4096, None, Some(peer_mode), None)
+                .await
+                .expect("atomic write must succeed");
+
+            let actual = std::fs::metadata(&target).unwrap().permissions().mode() & 0o7777;
+            assert_eq!(
+                actual, expected,
+                "peer-supplied mode {peer_mode:o} must land as {expected:o}, got {actual:o}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/src-tauri/src/aerorsync/streaming_writer.rs
+++ b/src-tauri/src/aerorsync/streaming_writer.rs
@@ -237,7 +237,11 @@ async fn finalize_steps(
     #[cfg(unix)]
     if let Some(mode) = mode {
         use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(mode & 0o7777);
+        // Same masking rule as `write_atomic_chunked_core`: `mode` is the
+        // peer's, so the setuid/setgid/sticky bits in 0o7000 are
+        // attacker-supplied and must not survive onto the file we land.
+        // See the longer note there (rclone GHSA-945v-v9p3-v5xw).
+        let perms = std::fs::Permissions::from_mode(mode & 0o0777);
         fs::set_permissions(temp, perms)
             .await
             .map_err(|e| WriteAtomicError::PostOpen {
@@ -423,6 +427,42 @@ mod tests {
         let ft = filetime::FileTime::from_last_modification_time(&meta);
         assert_eq!(ft.unix_seconds(), mtime.0, "mtime seconds must match");
         assert_eq!(ft.nanoseconds(), mtime.1, "mtime nanoseconds must match");
+    }
+
+    /// The streaming path takes the same peer-supplied `preserve_mode` that
+    /// `write_atomic_chunked_core` does (see the `.finalize(preserve_mode, ..)`
+    /// call in `delta_transport_impl`), so it needs the same guarantee: the
+    /// setuid/setgid/sticky bits never survive onto the landed file. The
+    /// sibling test above masks with 0o777 and so cannot see these bits;
+    /// this one looks at all of 0o7777 on purpose.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn streaming_atomic_writer_strips_peer_supplied_setuid_setgid_sticky() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = fresh_tempdir();
+
+        for (peer_mode, expected) in [
+            (0o4755_u32, 0o0755_u32), // setuid
+            (0o2755, 0o0755),         // setgid
+            (0o1755, 0o0755),         // sticky
+            (0o7777, 0o0777),         // all three at once
+            (0o0640, 0o0640),         // ordinary bits pass through untouched
+        ] {
+            let target = dir.path().join(format!("mode-{peer_mode:o}.bin"));
+            let mut w = StreamingAtomicWriter::new(&target).await.expect("new");
+            w.write_all(b"data").await.expect("write");
+            w.finalize(Some(peer_mode), None, None, false)
+                .await
+                .expect("finalize");
+
+            let meta = tokio::fs::metadata(&target).await.expect("metadata");
+            let actual = meta.permissions().mode() & 0o7777;
+            assert_eq!(
+                actual, expected,
+                "peer-supplied mode {peer_mode:o} must land as {expected:o}, got {actual:o}"
+            );
+        }
     }
 
     /// Test 5: `bytes_written` accumulates accurately across N writes,

--- a/src-tauri/src/provider_commands.rs
+++ b/src-tauri/src/provider_commands.rs
@@ -12492,8 +12492,9 @@ mod tests {
         normalize_aerocrypt_remote_files_for_compare, normalize_rclone_remote_files_for_compare,
         normalize_remote_files_for_compare, rclone_decrypted_size, remote_matches_repo,
         resolve_compare_overlay_keys, run_cancellable_connect, run_cancellable_listing,
-        ConnectTokenGuard, ConnectionCancelRegistry, ListingCancelState, ProviderConnectionParams,
-        ProviderState, TransferOperationGuard, CONNECT_CANCELLED, LISTING_CANCELLED,
+        sanitize_remote_filename, verify_path_containment, ConnectTokenGuard,
+        ConnectionCancelRegistry, ListingCancelState, ProviderConnectionParams, ProviderState,
+        TransferOperationGuard, CONNECT_CANCELLED, LISTING_CANCELLED,
     };
     use crate::rclone_crypt::{
         derive_keys, derive_keys_with_tweak, encrypt_file_content, encrypt_name,
@@ -12504,6 +12505,79 @@ mod tests {
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
     use std::time::{Duration, Instant};
+
+    // The two guards that stop a hostile server from steering a download out of
+    // the chosen folder. They were unpinned until now: the protection was real
+    // but nothing failed if a refactor dropped it. WinSCP shipped exactly this
+    // bug in 6.6.2 (tracker #2450) because their sanitisation sat behind a
+    // user-togglable setting; ours is unconditional, and these tests keep it so.
+    #[test]
+    fn sanitize_remote_filename_keeps_only_the_leaf() {
+        // A plain name is returned untouched.
+        assert_eq!(
+            sanitize_remote_filename("report.pdf").unwrap(),
+            "report.pdf"
+        );
+        // Directory components are dropped, leaf survives.
+        assert_eq!(sanitize_remote_filename("a/b/c.txt").unwrap(), "c.txt");
+        // Windows separators count too, even on Unix.
+        assert_eq!(sanitize_remote_filename(r"a\b\c.txt").unwrap(), "c.txt");
+        // Mixed separators.
+        assert_eq!(sanitize_remote_filename(r"a/b\c.txt").unwrap(), "c.txt");
+    }
+
+    #[test]
+    fn sanitize_remote_filename_defuses_traversal_and_rejects_drive_letters() {
+        // The guarantee is "the result can never escape the base", not "any
+        // input containing .. is refused". A traversal collapses to its leaf,
+        // which then lands inside the download folder like any other file.
+        assert_eq!(
+            sanitize_remote_filename("../../etc/passwd").unwrap(),
+            "passwd"
+        );
+        assert_eq!(
+            sanitize_remote_filename(r"..\..\windows\system32").unwrap(),
+            "system32"
+        );
+        // Absolute paths lose their root the same way.
+        assert_eq!(sanitize_remote_filename("/etc/passwd").unwrap(), "passwd");
+        // A name made only of traversal has no leaf left, so it is refused
+        // rather than turned into something arbitrary.
+        assert!(sanitize_remote_filename("..").is_err());
+        assert!(sanitize_remote_filename("../..").is_err());
+        // Names that reduce to nothing are refused rather than silently coerced.
+        assert!(sanitize_remote_filename("").is_err());
+        assert!(sanitize_remote_filename("/").is_err());
+        assert!(sanitize_remote_filename("./././").is_err());
+        // A Windows drive letter would re-anchor the join.
+        assert!(sanitize_remote_filename("C:").is_err());
+        assert!(sanitize_remote_filename(r"foo\C:").is_err());
+        // Null bytes never reach a path API.
+        assert!(sanitize_remote_filename("evil\0.txt").is_err());
+    }
+
+    #[test]
+    fn verify_path_containment_rejects_escapes_and_accepts_children() {
+        let base = tempfile::tempdir().unwrap();
+        let base_path = base.path();
+
+        // A direct child is fine, whether or not it exists yet.
+        assert!(verify_path_containment(base_path, &base_path.join("ok.bin")).is_ok());
+        std::fs::create_dir_all(base_path.join("nested")).unwrap();
+        assert!(verify_path_containment(base_path, &base_path.join("nested/ok.bin")).is_ok());
+
+        // A sibling directory outside the base must be refused.
+        let outside = tempfile::tempdir().unwrap();
+        let err = verify_path_containment(base_path, &outside.path().join("stolen.bin"))
+            .expect_err("a path outside the base must be refused");
+        assert!(
+            err.contains("Path traversal detected"),
+            "unexpected error text: {err}"
+        );
+
+        // And so must a traversal that resolves out of the base.
+        assert!(verify_path_containment(base_path, &base_path.join("../escaped.bin")).is_err());
+    }
 
     // Connection-scoped overlay-key cache (instant re-arm after a view-only lock):
     // store keeps a re-armable copy, re-arm is non-consuming, a generation change

--- a/src-tauri/src/providers/s3.rs
+++ b/src-tauri/src/providers/s3.rs
@@ -321,6 +321,21 @@ impl S3Provider {
             .user_agent(crate::providers::AEROFTP_USER_AGENT)
             .connect_timeout(std::time::Duration::from_secs(30))
             .read_timeout(std::time::Duration::from_secs(1800))
+            // Never follow redirects on a SigV4-signed request. Two reasons,
+            // and the second is the one that bites:
+            //
+            //   1. The signature covers the request's host and path, so a
+            //      redirected request arrives unverifiable anyway. Following
+            //      one cannot succeed; it only turns a clear error into a
+            //      confusing one.
+            //   2. reqwest's `remove_sensitive_headers` strips exactly
+            //      Authorization, Cookie, cookie2, Proxy-Authorization and
+            //      WWW-Authenticate on a cross-origin hop. `x-amz-security-token`
+            //      is not on that list, so with the default `Policy::limited(10)`
+            //      an STS session token would be replayed to whatever host the
+            //      redirect names -- including a plaintext http:// one.
+            //      Same class as rclone GHSA-cf44-9pgv-m4xc / GHSA-gx4c-2hqx-cw2r.
+            .redirect(reqwest::redirect::Policy::none())
             .http1_only();
         if accept_invalid_certs {
             debug!("[S3] accepting invalid TLS certificates (self-signed / loopback)");
@@ -5367,6 +5382,107 @@ mod tests {
         assert!(!is_s3_directory_content_type("application/octet-stream"));
         assert!(!is_s3_directory_content_type("text/plain"));
         assert!(!is_s3_directory_content_type(""));
+    }
+
+    /// The S3 client must not follow redirects. reqwest's default
+    /// `Policy::limited(10)` would, and its `remove_sensitive_headers` only
+    /// strips Authorization / Cookie / cookie2 / Proxy-Authorization /
+    /// WWW-Authenticate -- `x-amz-security-token` is not on that list, so an
+    /// STS session token would be replayed to the redirect target, plaintext
+    /// http:// included. Same class as rclone GHSA-cf44-9pgv-m4xc.
+    ///
+    /// Before `.redirect(Policy::none())` was added this test failed: the sink
+    /// was reached and it saw the session token.
+    #[tokio::test]
+    async fn s3_client_does_not_follow_redirects_and_never_replays_the_session_token() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+
+        let sink_hit = Arc::new(AtomicBool::new(false));
+        let sink_saw_token = Arc::new(AtomicBool::new(false));
+
+        let app = {
+            let sink_hit = Arc::clone(&sink_hit);
+            let sink_saw_token = Arc::clone(&sink_saw_token);
+            axum::Router::new()
+                .route(
+                    "/bounce",
+                    axum::routing::get(|| async {
+                        // Same host, downgraded scheme + different path: the
+                        // shape that leaked the token in rclone's advisory.
+                        (
+                            axum::http::StatusCode::FOUND,
+                            [(axum::http::header::LOCATION, "/sink")],
+                        )
+                    }),
+                )
+                .route(
+                    "/sink",
+                    axum::routing::get(move |headers: axum::http::HeaderMap| {
+                        let sink_hit = Arc::clone(&sink_hit);
+                        let sink_saw_token = Arc::clone(&sink_saw_token);
+                        async move {
+                            sink_hit.store(true, Ordering::SeqCst);
+                            if headers.contains_key("x-amz-security-token") {
+                                sink_saw_token.store(true, Ordering::SeqCst);
+                            }
+                            "landed"
+                        }
+                    }),
+                )
+        };
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().unwrap();
+        let _server = tokio::spawn(async move {
+            axum::serve(listener, app).await.ok();
+        });
+
+        let provider = S3Provider::new(S3Config {
+            endpoint: Some(format!("http://{addr}")),
+            region: "us-east-1".to_string(),
+            access_key_id: "AKIAEXAMPLE".to_string(),
+            secret_access_key: secrecy::SecretString::from("secret".to_string()),
+            session_token: Some(secrecy::SecretString::from("STS-SESSION-TOKEN".to_string())),
+            role_arn: None,
+            role_external_id: None,
+            role_session_name: None,
+            role_duration_seconds: None,
+            role_mfa_serial: None,
+            role_mfa_token_code: None,
+            bucket: "test-bucket".to_string(),
+            prefix: None,
+            path_style: true,
+            storage_class: None,
+            sse_mode: None,
+            sse_kms_key_id: None,
+            verify_cert: true,
+        })
+        .expect("Failed to create S3Provider");
+
+        let response = provider
+            .client
+            .get(format!("http://{addr}/bounce"))
+            .header("x-amz-security-token", "STS-SESSION-TOKEN")
+            .send()
+            .await
+            .expect("request must complete");
+
+        assert_eq!(
+            response.status().as_u16(),
+            302,
+            "the redirect must be handed back to us, not followed"
+        );
+        assert!(
+            !sink_hit.load(Ordering::SeqCst),
+            "the client followed the redirect; it must not"
+        );
+        assert!(
+            !sink_saw_token.load(Ordering::SeqCst),
+            "the STS session token was replayed to the redirect target"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Three hardening fixes and two dependency bumps that came out of the 2026-07-30 pre-release ecosystem briefing. Each one was found by checking a rival's patched bug class against our own code, so each is a real finding rather than a speculative tightening.

## 1. The S3 client no longer follows redirects

`S3Provider::new` built its `reqwest::Client` without a redirect policy, so it inherited the default `Policy::limited(10)`. That is wrong for a SigV4-signed client in two ways, and the second one leaks a credential.

The signature covers the request's host and path, so a redirected request arrives unverifiable — following one cannot succeed, it only turns a clear error into a confusing one. More importantly, reqwest's `remove_sensitive_headers` strips exactly `Authorization`, `Cookie`, `cookie2`, `Proxy-Authorization` and `WWW-Authenticate` on a cross-origin hop. `x-amz-security-token` is not on that list, so an STS session token was replayed to whatever host the redirect named, including a plaintext `http://` one. This is the same class rclone closed in GHSA-cf44-9pgv-m4xc and GHSA-gx4c-2hqx-cw2r.

Worth noting for reviewers: reqwest 0.13's cross-origin check does compare scheme as well as host and port, so the narrower "scheme downgrade" half of the rclone advisory was already handled for `Authorization`. The gap was only ever the custom `x-amz-*` header.

Fixed with `.redirect(Policy::none())`. The new test spins a local server that 302s to a sink and asserts both that the redirect is handed back to us and that the sink never sees the token. It fails on the unfixed client.

## 2. aerorsync no longer applies peer-supplied setuid/setgid/sticky bits

`write_atomic_chunked_core` restored `preserve_mode` onto the temp file with `mode & 0o7777`, and `preserve_mode` is read off the peer's file list. `0o7777` keeps the setuid, setgid and sticky bits, so a hostile sender could ask us to land a setuid binary.

Being precise about the severity: the file we write is owned by the user running the transfer, so setuid-to-self grants nothing new on an ordinary desktop. It becomes a real escalation when aerorsync runs as root or as a service account. rclone reached the same conclusion and masked anyway (GHSA-945v-v9p3-v5xw).

**There were two sites, not one.** The chunked path in `delta_transport_impl.rs` was the obvious one; a sweep for `0o7777` across the crate turned up `streaming_writer.rs`, which receives the same peer-supplied `preserve_mode` through the `.finalize(preserve_mode, ..)` call in `delta_transport_impl.rs`. Its existing mode test masked with `& 0o777`, so the setuid bit was invisible to it by construction. Both are masked to `0o0777` now, each with a test that looks at all of `0o7777`.

Two nearby sites were deliberately left alone: `local_transport.rs` takes its mode from the user's own local source file, where preserving setuid is correct copy semantics, and `filesystem.rs` only reads a mode to display it.

## 3. The download path-traversal guards are now pinned by tests

`sanitize_remote_filename` and `verify_path_containment` already stopped a hostile server from steering a download out of the chosen folder, and they are called unconditionally on both download paths. Nothing tested them, so a refactor could have removed the protection without turning anything red.

This matters because it is exactly how the bug shipped elsewhere: WinSCP's 6.6.2 fix (tracker #2450) was needed because their sanitisation sat behind a user-togglable setting. Ours is unconditional; these tests keep it that way. Coverage: traversal, mixed `/` and `\` separators, absolute paths, names that reduce to nothing, Windows drive letters, null bytes, and containment rejection for a sibling directory.

No behaviour change in this item — it is pure test coverage over existing guards.

## 4. Dependency bumps

- **aws-lc-rs 1.16.2 -> 1.17.3.** 1.16.3 moved the key-length validation in `UnboundCipherKey::new()` from a `debug_assert` to a runtime check. The assertion is stripped in release builds, so the shipped binary was accepting key lengths it should have rejected. This crate is part of our TLS trust root.
- **rustls 0.23.42 -> 0.23.43.** Fixes a reachable panic in `Rfc5077Ticketer` when decrypting a session ticket of a particular length, plus two QUIC-client negotiation panics. Low severity for us — the panic needs `overflow-checks`, and our QUIC goes through iroh rather than rustls directly — but it is a trivial bump.

Both are lockfile-only; neither is a direct dependency in `Cargo.toml`.

## Not in this PR

The briefing also identified the root cause of the Google Photos limitation: we request the `photoslibrary.readonly` scope, which Google removed on 2025-04-01, so the library endpoints now return only app-created content. That is a feature-sized migration to the Picker API and the provider is not production-supported, so it is tracked separately rather than bundled here.
