### PR TITLE
fix(titlebar): stop the #511 drag fillers collapsing to zero height

### DIFF
--- a/src/components/CustomTitlebar.tsx
+++ b/src/components/CustomTitlebar.tsx
@@ -448,8 +448,15 @@ export const CustomTitlebar: React.FC<TitlebarProps> = (props) => {
                 than a `gap-3` on this container: a gap is dead space the window
                 manager cannot see, so the bar was undraggable on its whole
                 right half (#511). Same reason the reserved slot below carries
-                a drag filler. */}
-            <div className="flex items-center">
+                a drag filler.
+                `h-full` on this container and `self-stretch` (never `h-full`) on
+                the fillers is what gives them a hit area at all: `height: 100%`
+                resolves against a parent whose own height is `auto`, so it
+                collapsed the fillers to 0px tall. They reserved their width,
+                the bar looked right, and the window manager still saw nothing
+                to grab. Only the titlebar itself has a definite height (`h-9`),
+                so the chain of `h-full` has to reach it unbroken. */}
+            <div className="flex items-center h-full">
                 {/* Cluster 1: Page Navigation.
                     min-w-[96px] reserves the slot so the utility cluster never
                     shifts when the button label/visibility changes (Connect vs
@@ -459,8 +466,8 @@ export const CustomTitlebar: React.FC<TitlebarProps> = (props) => {
                     neither button renders, so all 96px sat empty and inert
                     right next to AeroVault, which is exactly where #511 was
                     reported. */}
-                <div className="flex items-center justify-end min-w-[96px] gap-1">
-                    <div data-tauri-drag-region className="flex-1 h-full" />
+                <div className="flex items-center justify-end min-w-[96px] gap-1 h-full">
+                    <div data-tauri-drag-region className="flex-1 self-stretch" />
                     {!showConnectionScreen && (
                         <button
                             onClick={onShowConnectionScreen}
@@ -492,7 +499,7 @@ export const CustomTitlebar: React.FC<TitlebarProps> = (props) => {
                     ) : null}
                 </div>
 
-                <div data-tauri-drag-region className="w-3 h-full shrink-0" />
+                <div data-tauri-drag-region className="w-3 self-stretch shrink-0" />
 
                 {/* Cluster 2: Utility (Notifications, Security Tools, AeroVault, Users, Lock, Settings) */}
                 <div className="flex items-center gap-0.5">
@@ -551,7 +558,7 @@ export const CustomTitlebar: React.FC<TitlebarProps> = (props) => {
                     (top-left) provide minimize/maximize/close instead (#290). */}
                 {!isMac && (
                 <>
-                <div data-tauri-drag-region className="w-3 h-full shrink-0" />
+                <div data-tauri-drag-region className="w-3 self-stretch shrink-0" />
                 <div className="flex items-center gap-0.5">
                     <button
                         onClick={handleMinimize}

--- a/src/components/customTitlebarDragRegions.test.ts
+++ b/src/components/customTitlebarDragRegions.test.ts
@@ -33,6 +33,15 @@ describe('titlebar drag fillers (#511)', () => {
     const rightHandFillers = dragRegionClasses(SOURCE).filter((cls) => cls.includes('self-stretch'));
     // The reserved 96px slot filler plus the two 12px inter-cluster spacers.
     expect(rightHandFillers).toHaveLength(3);
+    // Counted by role, not in aggregate: three fillers that all stretch would
+    // also satisfy the total while the slot filler had lost its `flex-1` and
+    // stopped claiming the empty width, or a spacer had lost its `w-3` and
+    // become a zero-width region that is just as ungrabbable as a zero-height
+    // one.
+    expect(rightHandFillers.filter((cls) => cls.includes('flex-1'))).toHaveLength(1);
+    expect(
+      rightHandFillers.filter((cls) => cls.includes('w-3') && cls.includes('shrink-0')),
+    ).toHaveLength(2);
     for (const cls of rightHandFillers) {
       // `h-full` next to `self-stretch` wins and puts the height back to 0.
       expect(cls).not.toContain('h-full');

--- a/src/components/customTitlebarDragRegions.test.ts
+++ b/src/components/customTitlebarDragRegions.test.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+//
+// Guard for #511. The titlebar drag fillers are invisible by design, so a
+// broken one looks exactly like a working one: it still reserves its width and
+// the bar still renders correctly. The first fix for #511 shipped that way,
+// with all three fillers 0px tall, because `h-full` is `height: 100%` and a
+// percentage cannot resolve against a parent whose own height is `auto`.
+// Only the titlebar has a definite height (`h-9`), so a filler is safe when it
+// is a direct child of the bar, and otherwise needs `self-stretch` plus an
+// unbroken `h-full` chain on the containers above it.
+//
+// These assertions read the source rather than the rendered DOM on purpose:
+// vitest runs in `node` here, and jsdom has no layout engine, so a rendered
+// test would report height 0 for a correct filler and pass for a broken one.
+
+// The source arrives through Vite's `?raw` rather than `node:fs`: the app
+// tsconfig has no node types, so a filesystem read would fail `tsc --noEmit`.
+import { describe, expect, it } from 'vitest';
+import SOURCE from './CustomTitlebar.tsx?raw';
+
+/** className of every element that carries `data-tauri-drag-region`. */
+const dragRegionClasses = (src: string): string[] =>
+  [...src.matchAll(/data-tauri-drag-region[^>]*?className="([^"]*)"/gs)].map((m) => m[1]);
+
+describe('titlebar drag fillers (#511)', () => {
+  it('finds every drag region declared in the titlebar', () => {
+    // Left logo cluster, center spacer, reserved-slot filler, two inter-cluster spacers.
+    expect(dragRegionClasses(SOURCE)).toHaveLength(5);
+  });
+
+  it('gives the right-hand fillers a hit area instead of collapsing them', () => {
+    const rightHandFillers = dragRegionClasses(SOURCE).filter((cls) => cls.includes('self-stretch'));
+    // The reserved 96px slot filler plus the two 12px inter-cluster spacers.
+    expect(rightHandFillers).toHaveLength(3);
+    for (const cls of rightHandFillers) {
+      // `h-full` next to `self-stretch` wins and puts the height back to 0.
+      expect(cls).not.toContain('h-full');
+    }
+  });
+
+  it('keeps the height chain unbroken from the bar down to the fillers', () => {
+    // The bar is the only definite height in the chain.
+    expect(SOURCE).toContain('aero-titlebar flex items-center h-9');
+    // The 3-cluster container, parent of both inter-cluster spacers.
+    expect(SOURCE).toContain('<div className="flex items-center h-full">');
+    // The reserved page-nav slot, parent of the filler that sits next to AeroVault.
+    expect(SOURCE).toContain('min-w-[96px] gap-1 h-full');
+  });
+});


### PR DESCRIPTION
The fix for #511 shipped in #516 did not work, and it looked like it did.

The three drag fillers it added, the reserved 96px navigation slot and the two 12px inter-cluster spacers that replaced a `gap-3`, all used `h-full`. That is `height: 100%`, and a percentage height cannot resolve against a parent whose own height is `auto`, which is what both of their containers had. They rendered **0px tall**: they still reserved their width, the bar still looked right, and the window manager still had nothing to grab. Only the pre-existing centre spacer worked, because its parent is the bar itself, the one element in the chain with a definite height (`h-9`).

## Measured, not reasoned

Driven headlessly in the running app through the WebKit inspector, hit-testing every 2px across the titlebar with `document.elementFromPoint(x, y).closest('[data-tauri-drag-region]')`:

```
before   DRAG 480-1104    DEAD 1106-1212    DEAD 1432-1442
after    DRAG 480-1212                      DRAG 1432-1442
```

That dead span of 108px sits immediately left of the AeroVault shield, which is exactly where the report placed it. Filler heights over the same DOM go from `[35, 35, 0, 0, 0]` to `[35, 35, 35, 35, 35]`.

Checked in both states: on My Servers, where the reserved slot renders no button and the filler owns all 96px, and on a connected session, where Home and Disconnect fill the slot and the two spacers carry the affordance (`DRAG 1202-1212`, `DRAG 1432-1442`).

## The fix

`h-full` on the two containers, so the definite height reaches down from the bar unbroken, and `self-stretch` instead of `h-full` on the fillers themselves, because a definite height beats the stretch and would put them straight back to zero.

## The guard

`src/components/customTitlebarDragRegions.test.ts` reads the source rather than the rendered DOM, on purpose: vitest runs in the `node` environment here and jsdom has no layout engine, so a rendered assertion would report zero height for a correct filler and pass for a broken one. Verified by breaking it: restoring `h-full` on a filler, or dropping `h-full` from the 3-cluster container, turns it red.

## Gates

`tsc --noEmit` clean, `vitest` 595/595, `vite build` clean, `i18n:validate` 46/46 with 0 placeholders. No Rust touched.

Verified on Linux only. Confirmation on Windows 10 is what closes the report, so this does not close it.

#511


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the title bar’s right-side draggable regions to reliably maintain a vertical hit area and prevent collapse within the layout.
  * Kept consistent reserved spacing around the navigation, utility, and window-control sections.

* **Tests**
  * Added/extended automated checks to confirm the correct number and sizing behavior of `data-tauri-drag-region` elements in the title bar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->