### PR TITLE
fix(sync): name the export action, and stop shipping a raw i18n key

### DIFF
--- a/src/components/Sync/SyncTemplateDialog.tsx
+++ b/src/components/Sync/SyncTemplateDialog.tsx
@@ -392,14 +392,14 @@ export const SyncTemplateDialog: React.FC<SyncTemplateDialogProps> = ({
 
     if (!isOpen) return null;
 
+    // The button names the action, never the format. Labelling it
+    // `templateFormatBash` put a second control reading `Bash script (.sh)`
+    // next to the radio of the same name, so the only button that does
+    // anything read as one more format to choose from.
     const exportButtonLabel =
         exportFormat === 'aerosync'
             ? t('syncPanel.templateExport')
-            : exportFormat === 'aeroftp-script'
-                ? t('syncPanel.aerosyncScriptExportButton') || 'Export script'
-                : exportFormat === 'bash'
-                    ? t('syncPanel.templateFormatBash')
-                    : t('syncPanel.templateFormatPwsh');
+            : t('syncPanel.aerosyncScriptExportButton');
 
     const formatRadio = (value: ExportFormat, label: string, hint?: string) => {
         const active = exportFormat === value;
@@ -428,7 +428,11 @@ export const SyncTemplateDialog: React.FC<SyncTemplateDialogProps> = ({
                     ) : null}
                     {isDefault ? (
                         <span className="ml-1 text-[10px] uppercase tracking-wide text-purple-400">
-                            ({t('common.default') || 'default'})
+                            {/* No `|| 'default'` guard: `t()` returns the key
+                                itself on a miss, which is truthy, so the guard
+                                could never fire and the raw `common.default`
+                                reached the user. The key exists now. */}
+                            ({t('common.default')})
                         </span>
                     ) : null}
                 </span>

--- a/src/i18n/locales/bg.json
+++ b/src/i18n/locales/bg.json
@@ -70,7 +70,8 @@
             "duplicate": "Дублиране",
             "current": "текущ",
             "goToActiveSession": "Към активната сесия",
-            "password": "Парола"
+            "password": "Парола",
+            "default": "По подразбиране"
         },
         "connection": {
             "title": "Свързване със сървър",

--- a/src/i18n/locales/bn.json
+++ b/src/i18n/locales/bn.json
@@ -70,7 +70,8 @@
             "duplicate": "ডুপ্লিকেট",
             "current": "বর্তমান",
             "goToActiveSession": "সক্রিয় সেশনে যান",
-            "password": "পাসওয়ার্ড"
+            "password": "পাসওয়ার্ড",
+            "default": "ডিফল্ট"
         },
         "connection": {
             "title": "সার্ভারে সংযোগ করুন",

--- a/src/i18n/locales/ca.json
+++ b/src/i18n/locales/ca.json
@@ -70,7 +70,8 @@
             "duplicate": "Duplicar",
             "current": "actual",
             "goToActiveSession": "Vés a la sessió activa",
-            "password": "Contrasenya"
+            "password": "Contrasenya",
+            "default": "Predeterminat"
         },
         "connection": {
             "title": "Connectar al Servidor",

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -70,7 +70,8 @@
             "duplicate": "Duplikovat",
             "current": "aktuální",
             "goToActiveSession": "Přejít na aktivní relaci",
-            "password": "Heslo"
+            "password": "Heslo",
+            "default": "Výchozí"
         },
         "connection": {
             "title": "Připojení k serveru",

--- a/src/i18n/locales/cy.json
+++ b/src/i18n/locales/cy.json
@@ -70,7 +70,8 @@
             "duplicate": "Dyblygu",
             "current": "cyfredol",
             "goToActiveSession": "Mynd i'r sesiwn weithredol",
-            "password": "Cyfrinair"
+            "password": "Cyfrinair",
+            "default": "Rhagosodedig"
         },
         "connection": {
             "title": "Cysylltu a'r Gweinydd",

--- a/src/i18n/locales/da.json
+++ b/src/i18n/locales/da.json
@@ -70,7 +70,8 @@
             "duplicate": "Dupliker",
             "current": "aktuel",
             "goToActiveSession": "Gå til aktiv session",
-            "password": "Adgangskode"
+            "password": "Adgangskode",
+            "default": "Standard"
         },
         "connection": {
             "title": "Forbind til server",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -70,7 +70,8 @@
             "duplicate": "Duplizieren",
             "current": "aktuell",
             "goToActiveSession": "Zur aktiven Sitzung",
-            "password": "Passwort"
+            "password": "Passwort",
+            "default": "Standard"
         },
         "connection": {
             "title": "Mit Server verbinden",

--- a/src/i18n/locales/el.json
+++ b/src/i18n/locales/el.json
@@ -70,7 +70,8 @@
             "duplicate": "Αντίγραφο",
             "current": "τρέχον",
             "goToActiveSession": "Μετάβαση στην ενεργή συνεδρία",
-            "password": "Κωδικός"
+            "password": "Κωδικός",
+            "default": "Προεπιλογή"
         },
         "connection": {
             "title": "Σύνδεση σε διακομιστή",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1121,7 +1121,8 @@
             "warning": "Warning",
             "yes": "Yes",
             "goToActiveSession": "Go to active session",
-            "password": "Password"
+            "password": "Password",
+            "default": "Default"
         },
         "compare": {
             "title": "Compare panels",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -70,7 +70,8 @@
             "duplicate": "Duplicar",
             "current": "actual",
             "goToActiveSession": "Ir a la sesión activa",
-            "password": "Contraseña"
+            "password": "Contraseña",
+            "default": "Predeterminado"
         },
         "connection": {
             "title": "Conectar al Servidor",

--- a/src/i18n/locales/et.json
+++ b/src/i18n/locales/et.json
@@ -70,7 +70,8 @@
             "duplicate": "Dubleeri",
             "current": "praegune",
             "goToActiveSession": "Ava aktiivne seanss",
-            "password": "Parool"
+            "password": "Parool",
+            "default": "Vaikimisi"
         },
         "connection": {
             "title": "Ühenda serveriga",

--- a/src/i18n/locales/eu.json
+++ b/src/i18n/locales/eu.json
@@ -70,7 +70,8 @@
             "duplicate": "Bikoiztu",
             "current": "uneko",
             "goToActiveSession": "Joan saio aktibora",
-            "password": "Pasahitza"
+            "password": "Pasahitza",
+            "default": "Lehenetsia"
         },
         "connection": {
             "title": "Zerbitzarira Konektatu",

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -70,7 +70,8 @@
             "duplicate": "Kopioi",
             "current": "nykyinen",
             "goToActiveSession": "Siirry aktiiviseen istuntoon",
-            "password": "Salasana"
+            "password": "Salasana",
+            "default": "Oletus"
         },
         "connection": {
             "title": "Yhdistä palvelimeen",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -70,7 +70,8 @@
             "duplicate": "Dupliquer",
             "current": "actuel",
             "goToActiveSession": "Aller à la session active",
-            "password": "Mot de passe"
+            "password": "Mot de passe",
+            "default": "Par défaut"
         },
         "connection": {
             "title": "Connexion au Serveur",

--- a/src/i18n/locales/gl.json
+++ b/src/i18n/locales/gl.json
@@ -70,7 +70,8 @@
             "duplicate": "Duplicar",
             "current": "actual",
             "goToActiveSession": "Ir á sesión activa",
-            "password": "Contrasinal"
+            "password": "Contrasinal",
+            "default": "Predeterminado"
         },
         "connection": {
             "title": "Conectar ao Servidor",

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -70,7 +70,8 @@
             "duplicate": "डुप्लिकेट",
             "current": "वर्तमान",
             "goToActiveSession": "सक्रिय सत्र पर जाएं",
-            "password": "पासवर्ड"
+            "password": "पासवर्ड",
+            "default": "डिफ़ॉल्ट"
         },
         "connection": {
             "title": "सर्वर से कनेक्ट करें",

--- a/src/i18n/locales/hr.json
+++ b/src/i18n/locales/hr.json
@@ -70,7 +70,8 @@
             "duplicate": "Dupliciraj",
             "current": "trenutno",
             "goToActiveSession": "Idi na aktivnu sesiju",
-            "password": "Lozinka"
+            "password": "Lozinka",
+            "default": "Zadano"
         },
         "connection": {
             "title": "Poveži se na poslužitelj",

--- a/src/i18n/locales/hu.json
+++ b/src/i18n/locales/hu.json
@@ -70,7 +70,8 @@
             "duplicate": "Másolat",
             "current": "jelenlegi",
             "goToActiveSession": "Ugrás az aktív munkamenethez",
-            "password": "Jelszó"
+            "password": "Jelszó",
+            "default": "Alapértelmezett"
         },
         "connection": {
             "title": "Csatlakozás szerverhez",

--- a/src/i18n/locales/hy.json
+++ b/src/i18n/locales/hy.json
@@ -70,7 +70,8 @@
             "duplicate": "Կրկնակ",
             "current": "ընթացիկ",
             "goToActiveSession": "Անցնել ակտիվ նիստին",
-            "password": "Գաղտնաբառ"
+            "password": "Գաղտնաբառ",
+            "default": "Կանխադրված"
         },
         "connection": {
             "title": "Կապվել սերվերուհն",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -70,7 +70,8 @@
             "duplicate": "Duplikat",
             "current": "saat ini",
             "goToActiveSession": "Buka sesi aktif",
-            "password": "Kata sandi"
+            "password": "Kata sandi",
+            "default": "Bawaan"
         },
         "connection": {
             "title": "Hubungkan ke Server",

--- a/src/i18n/locales/is.json
+++ b/src/i18n/locales/is.json
@@ -70,7 +70,8 @@
             "duplicate": "Afrita",
             "current": "núverandi",
             "goToActiveSession": "Fara í virka lotu",
-            "password": "Lykilorð"
+            "password": "Lykilorð",
+            "default": "Sjálfgefið"
         },
         "connection": {
             "title": "Tengjast þjóni",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -70,7 +70,8 @@
             "required": "obbligatorio",
             "duplicate": "Duplica",
             "goToActiveSession": "Vai alla sessione attiva",
-            "password": "Password"
+            "password": "Password",
+            "default": "Predefinito"
         },
         "accountLock": {
             "title": "Scegli un account",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -70,7 +70,8 @@
             "duplicate": "複製",
             "current": "現在",
             "goToActiveSession": "アクティブなセッションへ移動",
-            "password": "パスワード"
+            "password": "パスワード",
+            "default": "デフォルト"
         },
         "connection": {
             "title": "サーバーに接続",

--- a/src/i18n/locales/ka.json
+++ b/src/i18n/locales/ka.json
@@ -70,7 +70,8 @@
             "duplicate": "დუბლირება",
             "current": "მიმდინარე",
             "goToActiveSession": "აქტიურ სესიაზე გადასვლა",
-            "password": "პაროლი"
+            "password": "პაროლი",
+            "default": "ნაგულისხმევი"
         },
         "connection": {
             "title": "სერვერთან დაკავშირება",

--- a/src/i18n/locales/km.json
+++ b/src/i18n/locales/km.json
@@ -70,7 +70,8 @@
             "duplicate": "ចម្លងទម្រង់",
             "current": "បច្ចុប្បន្ន",
             "goToActiveSession": "ទៅកាន់វគ្គសកម្ម",
-            "password": "ពាក្យសម្ងាត់"
+            "password": "ពាក្យសម្ងាត់",
+            "default": "លំនាំដើម"
         },
         "connection": {
             "title": "តភ្ជាប់ទៅម៉ាស៊ីនបម្រើ",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -70,7 +70,8 @@
             "duplicate": "복제",
             "current": "현재",
             "goToActiveSession": "활성 세션으로 이동",
-            "password": "비밀번호"
+            "password": "비밀번호",
+            "default": "기본값"
         },
         "connection": {
             "title": "서버에 연결",

--- a/src/i18n/locales/lt.json
+++ b/src/i18n/locales/lt.json
@@ -70,7 +70,8 @@
             "duplicate": "Dubliuoti",
             "current": "dabartinis",
             "goToActiveSession": "Eiti į aktyvią sesiją",
-            "password": "Slaptažodis"
+            "password": "Slaptažodis",
+            "default": "Numatytasis"
         },
         "connection": {
             "title": "Prisijungti prie serverio",

--- a/src/i18n/locales/lv.json
+++ b/src/i18n/locales/lv.json
@@ -70,7 +70,8 @@
             "duplicate": "Dublēt",
             "current": "pašreizējais",
             "goToActiveSession": "Pāriet uz aktīvo sesiju",
-            "password": "Parole"
+            "password": "Parole",
+            "default": "Noklusējums"
         },
         "connection": {
             "title": "Savienoties ar serveri",

--- a/src/i18n/locales/mk.json
+++ b/src/i18n/locales/mk.json
@@ -70,7 +70,8 @@
             "duplicate": "Дуплирај",
             "current": "тековно",
             "goToActiveSession": "Кон активната сесија",
-            "password": "Лозинка"
+            "password": "Лозинка",
+            "default": "Стандардно"
         },
         "connection": {
             "title": "Поврзи се на сервер",

--- a/src/i18n/locales/ms.json
+++ b/src/i18n/locales/ms.json
@@ -70,7 +70,8 @@
             "duplicate": "Gandakan",
             "current": "semasa",
             "goToActiveSession": "Pergi ke sesi aktif",
-            "password": "Kata laluan"
+            "password": "Kata laluan",
+            "default": "Lalai"
         },
         "connection": {
             "title": "Sambung ke Pelayan",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -70,7 +70,8 @@
             "duplicate": "Dupliceren",
             "current": "huidig",
             "goToActiveSession": "Naar actieve sessie",
-            "password": "Wachtwoord"
+            "password": "Wachtwoord",
+            "default": "Standaard"
         },
         "connection": {
             "title": "Verbinden met Server",

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -70,7 +70,8 @@
             "duplicate": "Dupliser",
             "current": "gjeldende",
             "goToActiveSession": "Gå til aktiv økt",
-            "password": "Passord"
+            "password": "Passord",
+            "default": "Standard"
         },
         "connection": {
             "title": "Koble til server",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -70,7 +70,8 @@
             "duplicate": "Duplikuj",
             "current": "bieżący",
             "goToActiveSession": "Przejdź do aktywnej sesji",
-            "password": "Hasło"
+            "password": "Hasło",
+            "default": "Domyślny"
         },
         "connection": {
             "title": "Połącz z serwerem",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -70,7 +70,8 @@
             "duplicate": "Duplicar",
             "current": "atual",
             "goToActiveSession": "Ir para a sessão ativa",
-            "password": "Palavra-passe"
+            "password": "Palavra-passe",
+            "default": "Padrão"
         },
         "connection": {
             "title": "Conectar ao Servidor",

--- a/src/i18n/locales/ro.json
+++ b/src/i18n/locales/ro.json
@@ -70,7 +70,8 @@
             "duplicate": "Duplică",
             "current": "curent",
             "goToActiveSession": "Mergi la sesiunea activă",
-            "password": "Parolă"
+            "password": "Parolă",
+            "default": "Implicit"
         },
         "connection": {
             "title": "Conectare la server",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -70,7 +70,8 @@
             "duplicate": "Дублировать",
             "current": "текущий",
             "goToActiveSession": "Перейти к активной сессии",
-            "password": "Пароль"
+            "password": "Пароль",
+            "default": "По умолчанию"
         },
         "connection": {
             "title": "Подключение к серверу",

--- a/src/i18n/locales/sk.json
+++ b/src/i18n/locales/sk.json
@@ -70,7 +70,8 @@
             "duplicate": "Duplikovať",
             "current": "aktuálny",
             "goToActiveSession": "Prejsť na aktívnu reláciu",
-            "password": "Heslo"
+            "password": "Heslo",
+            "default": "Predvolené"
         },
         "connection": {
             "title": "Pripojenie k serveru",

--- a/src/i18n/locales/sl.json
+++ b/src/i18n/locales/sl.json
@@ -70,7 +70,8 @@
             "duplicate": "Podvoji",
             "current": "trenutno",
             "goToActiveSession": "Pojdi na aktivno sejo",
-            "password": "Geslo"
+            "password": "Geslo",
+            "default": "Privzeto"
         },
         "connection": {
             "title": "Poveži se s strežnikom",

--- a/src/i18n/locales/sr.json
+++ b/src/i18n/locales/sr.json
@@ -70,7 +70,8 @@
             "duplicate": "Дуплирај",
             "current": "тренутно",
             "goToActiveSession": "Иди на активну сесију",
-            "password": "Лозинка"
+            "password": "Лозинка",
+            "default": "Подразумевано"
         },
         "connection": {
             "title": "Повежи се на сервер",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -70,7 +70,8 @@
             "duplicate": "Duplicera",
             "current": "aktuell",
             "goToActiveSession": "Gå till aktiv session",
-            "password": "Lösenord"
+            "password": "Lösenord",
+            "default": "Standard"
         },
         "connection": {
             "title": "Anslut till server",

--- a/src/i18n/locales/sw.json
+++ b/src/i18n/locales/sw.json
@@ -70,7 +70,8 @@
             "duplicate": "Nakili",
             "current": "ya sasa",
             "goToActiveSession": "Nenda kwenye kipindi kinachoendelea",
-            "password": "Nywila"
+            "password": "Nywila",
+            "default": "Chaguo-msingi"
         },
         "connection": {
             "title": "Unganisha na Seva",

--- a/src/i18n/locales/th.json
+++ b/src/i18n/locales/th.json
@@ -70,7 +70,8 @@
             "duplicate": "ทำซ้ำ",
             "current": "ปัจจุบัน",
             "goToActiveSession": "ไปยังเซสชันที่ใช้งานอยู่",
-            "password": "รหัสผ่าน"
+            "password": "รหัสผ่าน",
+            "default": "ค่าเริ่มต้น"
         },
         "connection": {
             "title": "เชื่อมต่อเซิร์ฟเวอร์",

--- a/src/i18n/locales/tl.json
+++ b/src/i18n/locales/tl.json
@@ -70,7 +70,8 @@
             "duplicate": "Doblehin",
             "current": "kasalukuyan",
             "goToActiveSession": "Pumunta sa aktibong session",
-            "password": "Password"
+            "password": "Password",
+            "default": "Default"
         },
         "connection": {
             "title": "Kumonekta sa Server",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -70,7 +70,8 @@
             "duplicate": "Çoğalt",
             "current": "geçerli",
             "goToActiveSession": "Etkin oturuma git",
-            "password": "Parola"
+            "password": "Parola",
+            "default": "Varsayılan"
         },
         "connection": {
             "title": "Sunucuya Bağlan",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -70,7 +70,8 @@
             "duplicate": "Дублювати",
             "current": "поточний",
             "goToActiveSession": "Перейти до активної сесії",
-            "password": "Пароль"
+            "password": "Пароль",
+            "default": "За замовчуванням"
         },
         "connection": {
             "title": "Підключення до сервера",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -70,7 +70,8 @@
             "duplicate": "Nhân bản",
             "current": "hiện tại",
             "goToActiveSession": "Đến phiên đang hoạt động",
-            "password": "Mật khẩu"
+            "password": "Mật khẩu",
+            "default": "Mặc định"
         },
         "connection": {
             "title": "Kết nối đến máy chủ",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -70,7 +70,8 @@
             "duplicate": "复制",
             "current": "当前",
             "goToActiveSession": "前往活动会话",
-            "password": "密码"
+            "password": "密码",
+            "default": "默认"
         },
         "connection": {
             "title": "连接到服务器",


### PR DESCRIPTION
Two defects in the AeroSync Templates dialog, both on screen, both found while verifying #514 in the running app rather than by reading the code.

## The raw key

The Bash format radio shipped as `Bash script (.sh)(common.default)`.

`common.default` was never a key in `en.json`, and the call site's guard could not save it:

```tsx
({t('common.default') || 'default'})
```

`t()` returns the key itself when it misses, and a non-empty string is truthy, so the `||` branch was unreachable by construction. The app logged `[i18n] Missing translation: common.default` on every render of the dialog while the user read the key on screen.

The key is added and translated across all 46 non-English locales, and the dead guard is removed rather than left in place implying a safety it never provided.

## The button that named a format instead of an action

`exportButtonLabel` fell back to `syncPanel.templateFormatBash` and `syncPanel.templateFormatPwsh` for the two script formats. Those are the exact strings used by the format radios, so the dialog presented two identical `Bash script (.sh)` controls, and the only one that did anything read as one more format to pick.

It now reads `Export script` for the three script formats and `Export Template` for `.aerosync`. Both are keys that already existed and are already translated, so this adds no new string beyond `common.default`.

## Verified in the app

Driven headlessly through the WebKit inspector against a connected SFTP remote, reading the labels back from the live DOM:

| Format selected | Action button |
|---|---|
| `.aeroftp-script` | `Export script` |
| `.aerosync` | `Export Template` |
| Bash | `Export script` |
| PowerShell | `Export script` |

and the Bash radio now reads `Bash script (.sh)(Default)`.

## Gates

`tsc --noEmit` clean, `vitest` 592/592, `vite build` clean, `i18n:validate` 47/47 with 0 placeholders and 0 orphan keys. No Rust touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Export actions now display the correct label based on the selected format.
  * Format options consistently show the localized “Default” hint.

* **Localization**
  * Added localized “Default” labels across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->