### PR TITLE
fix(sync): stop the script exports dropping the preset's excludes

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13090,7 +13090,9 @@ fn export_sync_template_cmd(
     profile_id: String,
     local_path: String,
     remote_path: String,
-    exclude_patterns: Vec<String>,
+    // `None` (or an empty list) means "the preset's own", see
+    // `sync::resolve_exclude_patterns`.
+    exclude_patterns: Option<Vec<String>>,
 ) -> Result<String, String> {
     let profiles = sync::load_sync_profiles()?;
     let profile = profiles
@@ -13103,13 +13105,14 @@ fn export_sync_template_cmd(
     } else {
         None
     };
+    let excludes = sync::resolve_exclude_patterns(exclude_patterns, &profile.exclude_patterns);
     let template = sync::export_sync_template(
         &name,
         &description,
         profile,
         &local_path,
         &remote_path,
-        &exclude_patterns,
+        &excludes,
         schedule_opt,
     )?;
     serde_json::to_string_pretty(&template).map_err(|e| e.to_string())
@@ -13136,7 +13139,9 @@ struct SyncScriptExportArgs {
     template_description: String,
     local_path: String,
     remote_path: String,
-    exclude_patterns: Vec<String>,
+    // `None` (or an empty list) means "the preset's own", see
+    // `sync::resolve_exclude_patterns`.
+    exclude_patterns: Option<Vec<String>>,
     format: String,
 }
 
@@ -13149,6 +13154,7 @@ fn export_sync_script_cmd(args: SyncScriptExportArgs) -> Result<String, String> 
         .iter()
         .find(|p| p.id == args.profile_id)
         .ok_or_else(|| format!("Profile '{}' not found", args.profile_id))?;
+    let excludes = sync::resolve_exclude_patterns(args.exclude_patterns, &profile.exclude_patterns);
     sync::export_sync_script(sync::SyncScriptExportOptions {
         profile,
         profile_display_name: &args.profile_display_name,
@@ -13156,7 +13162,7 @@ fn export_sync_script_cmd(args: SyncScriptExportArgs) -> Result<String, String> 
         template_description: &args.template_description,
         local_path: &args.local_path,
         remote_path: &args.remote_path,
-        exclude_patterns: &args.exclude_patterns,
+        exclude_patterns: &excludes,
         format,
     })
 }

--- a/src-tauri/src/sync.rs
+++ b/src-tauri/src/sync.rs
@@ -3853,6 +3853,25 @@ pub struct SyncTemplateProfile {
     pub compression_mode: crate::transfer_pool::CompressionMode,
 }
 
+/// What an export should exclude: the caller's list when it has one, the
+/// preset's own otherwise.
+///
+/// An empty list from the UI means "the user added nothing", not "exclude
+/// nothing". Sending it verbatim is how the `.sh` and `.ps1` exports came out
+/// with no excludes at all while the same preset exported as
+/// `.aeroftp-script` carried `node_modules`, `.git` and the rest: that path
+/// already passed `None` and fell back here. A Mirror script that has lost its
+/// excludes does not fail, it uploads `.git`, so the two paths have to agree.
+pub fn resolve_exclude_patterns(
+    caller_patterns: Option<Vec<String>>,
+    preset_patterns: &[String],
+) -> Vec<String> {
+    match caller_patterns {
+        Some(patterns) if !patterns.is_empty() => patterns,
+        _ => preset_patterns.to_vec(),
+    }
+}
+
 /// Export current sync config as a template
 pub fn export_sync_template(
     name: &str,
@@ -4177,6 +4196,38 @@ pub fn import_sync_script(script: &str) -> Result<SyncScriptMeta, String> {
         }
     }
     Err("No AEROFTP-META marker found in script".to_string())
+}
+
+#[cfg(test)]
+mod exclude_pattern_tests {
+    use super::*;
+
+    fn preset() -> Vec<String> {
+        vec!["node_modules".to_string(), ".git".to_string()]
+    }
+
+    #[test]
+    fn empty_caller_list_falls_back_to_the_preset() {
+        // The `.sh` and `.ps1` exports send `[]` when the user typed no
+        // extra pattern. Taking that literally is what shipped scripts that
+        // walked straight into `.git`.
+        assert_eq!(resolve_exclude_patterns(Some(vec![]), &preset()), preset());
+        assert_eq!(resolve_exclude_patterns(None, &preset()), preset());
+    }
+
+    #[test]
+    fn a_real_caller_list_replaces_the_preset() {
+        let mine = vec!["*.tmp".to_string()];
+        assert_eq!(
+            resolve_exclude_patterns(Some(mine.clone()), &preset()),
+            mine
+        );
+    }
+
+    #[test]
+    fn a_preset_with_no_patterns_still_yields_none() {
+        assert!(resolve_exclude_patterns(None, &[]).is_empty());
+    }
 }
 
 #[cfg(test)]

--- a/src/components/Sync/SyncTemplateDialog.tsx
+++ b/src/components/Sync/SyncTemplateDialog.tsx
@@ -137,7 +137,10 @@ export const SyncTemplateDialog: React.FC<SyncTemplateDialogProps> = ({
             profileId: presetId,
             localPath,
             remotePath,
-            excludePatterns,
+            // Empty means "the preset's own", the same contract the
+            // `.aeroftp-script` path has always used. Sending `[]` verbatim
+            // exported a Mirror script with no excludes at all.
+            excludePatterns: excludePatterns.length > 0 ? excludePatterns : null,
         });
         await writeTextFile(filePath, jsonContent);
         setResult({ success: true, message: t('syncPanel.templateExported') });
@@ -214,7 +217,8 @@ export const SyncTemplateDialog: React.FC<SyncTemplateDialogProps> = ({
                 template_description: templateDesc,
                 local_path: localPath,
                 remote_path: remotePath,
-                exclude_patterns: excludePatterns,
+                exclude_patterns:
+                    excludePatterns.length > 0 ? excludePatterns : null,
                 format,
             },
         });


### PR DESCRIPTION
Found while verifying #514 in the running app, on the same preset, exported twice.

`.aeroftp-script` came out with `node_modules`, `.git`, `.DS_Store`, `Thumbs.db`, `__pycache__` and `target`. The same Mirror preset exported as bash came out with none.

## Why

The dialog's exclude list is empty whenever the user has not typed a pattern of their own. `export_sync_script_cmd` and `export_sync_template_cmd` took a plain `Vec<String>` and used it as given, so an empty list read as "exclude nothing" rather than "the user added nothing". `aerosync_export_script_cmd` never had the bug: it takes an override of `Option<Vec<String>>` and falls back to the preset when it is `None`.

This is not a cosmetic difference between formats. A Mirror script that has quietly lost its excludes does not fail, it walks straight into `.git` and `node_modules` and uploads them.

## The fix

One rule, in one place:

```rust
pub fn resolve_exclude_patterns(
    caller_patterns: Option<Vec<String>>,
    preset_patterns: &[String],
) -> Vec<String>
```

A non-empty caller list wins, anything else means the preset's own. All three export commands go through it, and the two that took `Vec<String>` now take `Option<Vec<String>>` so the frontend can express "nothing of mine" instead of "exclude nothing". The two call sites use the expression the `.aeroftp-script` path already used.

## Verified against the running backend

Both commands invoked directly through the WebKit inspector, on the Mirror preset:

| Call | bash script | `.aerosync` template |
|---|---|---|
| `exclude_patterns: null` | `--exclude 'node_modules'`, `'.git'`, `'.DS_Store'`, `'Thumbs.db'`, `'__pycache__'`, `'target'` | same six |
| `exclude_patterns: ['*.tmp']` | `*.tmp` only | `*.tmp` only |

Three unit tests pin the helper, including the case that caused this: `Some(vec![])` resolves to the preset, not to nothing.

## Gates

`cargo fmt`, `cargo clippy --all-features --tests` clean, `cargo test --lib` 3385 passed with 0 failed, `tsc --noEmit` clean, `vitest` 592/592.

Found while working #514.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sync template and script exports now automatically use the preset’s exclude patterns when no custom patterns are provided.
  * Empty exclude-pattern selections are handled consistently, while explicitly chosen patterns continue to override preset defaults.
  * Improved export behavior for presets without exclude patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->