### PR TITLE
fix(speedtest,portal): CodeRabbit Majors from #525 + wins_ref skip

### DIFF
--- a/src-tauri/src/speedtest.rs
+++ b/src-tauri/src/speedtest.rs
@@ -406,6 +406,10 @@ async fn run_speedtest_inner(
     {
         Ok(()) => {}
         Err(msg) if msg == "Test cancelled while creating scratch directory" => {
+            // connect() already succeeded at this point: drop the session
+            // before returning so a cancelled run never leaks a connected
+            // provider (every other post-connect error path disconnects).
+            let _ = provider.disconnect().await;
             return Err(msg);
         }
         Err(e) => {
@@ -796,27 +800,37 @@ fn validate_supported_protocol(protocol: &str) -> Result<(), String> {
 }
 
 /// True when `remote_dir` is a path commonly served as a public web document
-/// root. A multi-hundred-MB payload under such a tree can be fetched by anyone
-/// who knows the URL, even when nested in `.aeroftp-speedtest/`.
+/// root, or any descendant of one. A multi-hundred-MB payload under such a
+/// tree can be fetched by anyone who knows the URL, even when nested in
+/// `.aeroftp-speedtest/`.
 fn is_public_web_document_root(remote_dir: &str) -> bool {
     let trimmed = remote_dir.trim().trim_end_matches('/');
     let p = if trimmed.is_empty() { "/" } else { trimmed };
     let lower = p.to_ascii_lowercase();
-    matches!(
-        lower.as_str(),
-        "/var/www"
-            | "/var/www/html"
-            | "/var/www/htdocs"
-            | "/usr/share/nginx/html"
-            | "/usr/share/nginx"
-            | "/srv/www"
-            | "/srv/http"
-            | "/opt/homebrew/var/www"
-    ) || lower.ends_with("/public_html")
-        || lower.ends_with("/htdocs")
-        || lower.ends_with("/wwwroot")
-        // Trailing "/www" but not shorter false friends like "/www-data".
-        || lower.ends_with("/www")
+    const PUBLIC_ROOTS: &[&str] = &[
+        "/var/www",
+        "/var/www/html",
+        "/var/www/htdocs",
+        "/usr/share/nginx/html",
+        "/usr/share/nginx",
+        "/srv/www",
+        "/srv/http",
+        "/opt/homebrew/var/www",
+    ];
+    // Exact root or any descendant of it. The prefix check is on a full path
+    // component boundary (`root + "/"`), so "/var/www-data" is NOT rejected.
+    if PUBLIC_ROOTS
+        .iter()
+        .any(|root| lower == *root || lower.starts_with(&format!("{root}/")))
+    {
+        return true;
+    }
+    // Per-user document roots: any path component that is itself a known
+    // document-root name (public_html, htdocs, wwwroot, www) makes the whole
+    // subtree public, no matter where it is mounted.
+    lower
+        .split('/')
+        .any(|seg| matches!(seg, "public_html" | "htdocs" | "wwwroot" | "www"))
 }
 
 /// Refuse known public document roots before any network work. Account root
@@ -953,7 +967,8 @@ mod tests {
 
     /// Pin: known public document roots must be refused before any network work.
     /// Re-allowing `/var/www/html` would put a multi-hundred-MB file where a web
-    /// server can still serve it from `.aeroftp-speedtest/`.
+    /// server can still serve it from `.aeroftp-speedtest/`. Descendants of a
+    /// public root are equally servable, so they must be rejected too.
     #[test]
     fn public_web_document_roots_are_rejected() {
         for dir in [
@@ -967,13 +982,31 @@ mod tests {
             "/Users/bob/Sites/htdocs",
             "/inetpub/wwwroot",
             "/opt/site/www",
+            // Descendants of a public root: still web-servable, must reject.
+            "/var/www/html/uploads",
+            "/var/www/html/.aeroftp-speedtest",
+            "/home/alice/public_html/bench",
+            "/srv/http/site/assets",
+            "/opt/site/www/bench",
         ] {
             assert!(
                 validate_remote_dir_for_speedtest(dir).is_err(),
                 "expected rejection for public web root {dir}"
             );
         }
-        for dir in ["/", "", "/tmp", "/home/user", "/data/bench", "/account"] {
+        for dir in [
+            "/",
+            "",
+            "/tmp",
+            "/home/user",
+            "/data/bench",
+            "/account",
+            // False friends: contain a public-root-looking substring but are not
+            // document roots (component-boundary matching must not over-reject).
+            "/var/www-data",
+            "/srv/www-data/backups",
+            "/home/user/public_html_backup",
+        ] {
             assert!(
                 validate_remote_dir_for_speedtest(dir).is_ok(),
                 "expected allow for non-document-root {dir}"
@@ -1007,6 +1040,27 @@ mod tests {
         assert!(
             window.contains("run_cancelable"),
             "run_cancelable must wrap provider.mkdir(&scratch_dir)"
+        );
+    }
+
+    /// Pin: the scratch-mkdir cancel branch runs AFTER connect() succeeded, so
+    /// it must disconnect the provider before returning (every other
+    /// post-connect error path does). Removing the disconnect leaks a live
+    /// session on cancel.
+    #[test]
+    fn cancel_after_connect_disconnects_provider() {
+        let src = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/speedtest.rs"));
+        let branch_at = src
+            .find("Err(msg) if msg == \"Test cancelled while creating scratch directory\" => {")
+            .expect("cancel branch for scratch mkdir present");
+        let return_at = src[branch_at..]
+            .find("return Err(msg);")
+            .map(|i| branch_at + i)
+            .expect("cancel branch returns the cancel message");
+        let branch_body = &src[branch_at..return_at];
+        assert!(
+            branch_body.contains("provider.disconnect()"),
+            "cancel after connect must disconnect the provider before returning"
         );
     }
 

--- a/src-tauri/src/speedtest.rs
+++ b/src-tauri/src/speedtest.rs
@@ -799,13 +799,34 @@ fn validate_supported_protocol(protocol: &str) -> Result<(), String> {
     }
 }
 
+/// Lexically resolve `.` and `..` components (no filesystem access). Providers
+/// resolve these server-side, so `/tmp/../var/www/html` must be classified as
+/// the public root it escapes to, not as the innocent-looking raw string.
+fn normalize_remote_path(path: &str) -> String {
+    let mut out: Vec<&str> = Vec::new();
+    for seg in path.split('/') {
+        match seg {
+            "" | "." => {}
+            ".." => {
+                out.pop();
+            }
+            s => out.push(s),
+        }
+    }
+    format!("/{}", out.join("/"))
+}
+
 /// True when `remote_dir` is a path commonly served as a public web document
 /// root, or any descendant of one. A multi-hundred-MB payload under such a
 /// tree can be fetched by anyone who knows the URL, even when nested in
 /// `.aeroftp-speedtest/`.
 fn is_public_web_document_root(remote_dir: &str) -> bool {
-    let trimmed = remote_dir.trim().trim_end_matches('/');
-    let p = if trimmed.is_empty() { "/" } else { trimmed };
+    let trimmed = remote_dir.trim();
+    let p = if trimmed.is_empty() {
+        "/".to_string()
+    } else {
+        normalize_remote_path(trimmed)
+    };
     let lower = p.to_ascii_lowercase();
     const PUBLIC_ROOTS: &[&str] = &[
         "/var/www",
@@ -988,6 +1009,12 @@ mod tests {
             "/home/alice/public_html/bench",
             "/srv/http/site/assets",
             "/opt/site/www/bench",
+            // Dot and dot-dot components resolve server-side: the raw string
+            // looks innocent but lands in a public root after normalization.
+            "/tmp/../var/www/html",
+            "/user/./public_html/../../var/www/html",
+            "/var/www/./html/uploads",
+            "/home/alice/x/../public_html/bench",
         ] {
             assert!(
                 validate_remote_dir_for_speedtest(dir).is_err(),
@@ -1006,6 +1033,9 @@ mod tests {
             "/var/www-data",
             "/srv/www-data/backups",
             "/home/user/public_html_backup",
+            // Normalization that stays OUTSIDE public roots must stay allowed.
+            "/data/./bench",
+            "/data/x/../bench",
         ] {
             assert!(
                 validate_remote_dir_for_speedtest(dir).is_ok(),

--- a/tests/portal-chooser/portal-chooser-test.sh
+++ b/tests/portal-chooser/portal-chooser-test.sh
@@ -224,11 +224,19 @@ if session_ok noportal "$rc"; then
   # holding -- the remedy is a message rendered by the WebView, not a second window,
   # and the day a window does appear here somebody has reintroduced the in-process
   # chooser that corrupts the GLib heap. If this fails, read it before "fixing" it.
-  wins=$(count_lines "$WORK/noportal/windows-after.txt")
-  wins_ref=$(count_lines "$WORK/cancel/windows-after.txt")
-  [ "$wins" = "$wins_ref" ] &&
-    ok "no extra window appears without a portal (measured: no native fallback)" ||
-    bad "window count changed ($wins vs $wins_ref): the fallback behaviour is not what was pinned"
+  # The reference window count comes from case 1: if that session failed its
+  # precondition the file was never written and count_lines would quietly read
+  # it as 0, turning a missing baseline into a chooser-shaped FAIL. Missing
+  # baseline is a skip, not a verdict (same contract as the #521 cascade-stop).
+  if [ ! -f "$WORK/cancel/windows-after.txt" ]; then
+    skip "no extra window appears without a portal (case 1 reference missing)"
+  else
+    wins=$(count_lines "$WORK/noportal/windows-after.txt")
+    wins_ref=$(count_lines "$WORK/cancel/windows-after.txt")
+    [ "$wins" = "$wins_ref" ] &&
+      ok "no extra window appears without a portal (measured: no native fallback)" ||
+      bad "window count changed ($wins vs $wins_ref): the fallback behaviour is not what was pinned"
+  fi
 
   # The #510 assertion, and the one that made this case worth revisiting. Until the
   # fix, everything above could pass on an app that presented the user with nothing


### PR DESCRIPTION
Follow-up to #525 (merged as aabde6914), closing the 2 Major and 1 portal Minor CodeRabbit findings.

## Major: speedtest disconnect on cancel after connect
`speedtest.rs`: the cancel branch on scratch-dir creation returned without disconnecting, while `connect()` had already succeeded and every other post-connect error path disconnects. Now it disconnects before returning.
Pin: `cancel_after_connect_disconnects_provider` (structure pin, fails if the disconnect is removed).

## Major: reject descendants of public web document roots
`is_public_web_document_root` only matched exact roots and trailing suffixes, so `/var/www/html/uploads` or `/home/alice/public_html/bench` passed validation while being web-servable. Now: prefix match on a path-component boundary for the known roots, plus per-segment match for `public_html` / `htdocs` / `wwwroot` / `www`. False friends like `/var/www-data` stay allowed.
Pin: extended `public_web_document_roots_are_rejected` with descendant cases and false friends.

## Minor: portal wins_ref when case 1 failed
`tests/portal-chooser/portal-chooser-test.sh`: when the case 1 session fails its precondition, `windows-after.txt` is never written and `count_lines` read it as 0, turning a missing baseline into a chooser-shaped FAIL. Missing baseline is now a skip, same contract as the #521 cascade-stop.

## Gates
- `cargo test --lib speedtest::` 27/27
- `cargo clippy --lib -- -D warnings` clean, `cargo fmt --check` clean
- `tests/portal-chooser/selftest-precondition.sh` 6/6, `selftest-portal.sh` 14/14

The 14 i18n Minor findings from #525 are intentionally out of scope here (separate batch via the GLM method).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation cleanup to prevent lingering provider sessions.
  * Strengthened protection against using public document-root directories while avoiding false positives for similarly named paths.
  * Improved portal chooser test validation when reference data is unavailable.

* **Tests**
  * Added coverage for nested document-root paths, lookalike directories, and cancellation cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->