### PR TITLE
fix(providers): stop trim_text from corrupting listed names around XML entities (LIVE-1)

### DIFF
--- a/src-tauri/src/providers/azure.rs
+++ b/src-tauri/src/providers/azure.rs
@@ -68,7 +68,9 @@ fn azure_retry_config() -> HttpRetryConfig {
 /// Falls back to sanitize_api_error if XML parsing fails.
 fn parse_azure_xml_error(body: &str) -> String {
     let mut reader = Reader::from_str(body);
-    reader.config_mut().trim_text(true);
+    // No trim_text: fragments around XML entities must survive intact;
+    // code/message are trimmed once at output below.
+    reader.config_mut().trim_text(false);
     let mut code = String::new();
     let mut message = String::new();
     let mut current_tag = String::new();
@@ -79,6 +81,9 @@ fn parse_azure_xml_error(body: &str) -> String {
             }
             Ok(Event::Text(ref e)) => {
                 let text = String::from_utf8_lossy(e.as_ref()).into_owned();
+                if text.trim().is_empty() {
+                    continue;
+                }
                 match current_tag.as_str() {
                     "Code" => code.push_str(&text),
                     "Message" if message.lines().count() <= 1 => {
@@ -102,6 +107,8 @@ fn parse_azure_xml_error(body: &str) -> String {
             _ => {}
         }
     }
+    let code = code.trim().to_string();
+    let message = message.trim().to_string();
     if !code.is_empty() {
         if message.is_empty() {
             code
@@ -448,7 +455,9 @@ impl AzureProvider {
         let mut next_marker: Option<String> = None;
 
         let mut reader = Reader::from_str(xml);
-        reader.config_mut().trim_text(true);
+        // No trim_text: blob-name fragments around XML entities must
+        // survive intact (entity-adjacent spaces are part of the name).
+        reader.config_mut().trim_text(false);
 
         // State machine for XML parsing
         #[derive(PartialEq)]
@@ -509,6 +518,10 @@ impl AzureProvider {
                 },
                 Ok(Event::Text(ref e)) => {
                     let text = String::from_utf8_lossy(e.as_ref()).into_owned();
+                    if text.trim().is_empty() {
+                        buf.clear();
+                        continue;
+                    }
                     match state {
                         ParseState::BlobPrefixName => {
                             current_name.push_str(&text);
@@ -519,12 +532,12 @@ impl AzureProvider {
                         ParseState::BlobContentLength => {
                             current_size = text.trim().parse().unwrap_or(current_size);
                         }
-                        ParseState::BlobLastModified if !text.is_empty() => {
+                        ParseState::BlobLastModified => {
                             current_modified
                                 .get_or_insert_with(String::new)
                                 .push_str(&text);
                         }
-                        ParseState::NextMarker if !text.is_empty() => {
+                        ParseState::NextMarker => {
                             next_marker.get_or_insert_with(String::new).push_str(&text);
                         }
                         _ => {}
@@ -575,7 +588,9 @@ impl AzureProvider {
                             items.push(BlobItem {
                                 name: relative.to_string(),
                                 size: current_size,
-                                last_modified: current_modified.clone(),
+                                last_modified: current_modified
+                                    .as_ref()
+                                    .map(|m| m.trim().to_string()),
                                 is_prefix: false,
                             });
                         }
@@ -611,7 +626,7 @@ impl AzureProvider {
             buf.clear();
         }
 
-        (items, next_marker)
+        (items, next_marker.map(|m| m.trim().to_string()))
     }
 
     fn resolve_blob_path(&self, path: &str) -> String {
@@ -2239,7 +2254,9 @@ impl AzureProvider {
 
             let mut next_marker: Option<String> = None;
             let mut reader = quick_xml::Reader::from_str(&body);
-            reader.config_mut().trim_text(true);
+            // No trim_text: blob-name fragments around XML entities must
+            // survive intact (entity-adjacent spaces are part of the name).
+            reader.config_mut().trim_text(false);
             let mut buf = Vec::new();
             let mut in_blob = false;
             let mut blob_name = String::new();
@@ -2263,6 +2280,10 @@ impl AzureProvider {
                     }
                     Ok(quick_xml::events::Event::Text(ref e)) => {
                         let text = String::from_utf8_lossy(e.as_ref()).into_owned();
+                        if text.trim().is_empty() {
+                            buf.clear();
+                            continue;
+                        }
                         if in_blob {
                             match tag_name.as_str() {
                                 "Name" => blob_name.push_str(&text),
@@ -2277,7 +2298,7 @@ impl AzureProvider {
                                 }
                                 _ => {}
                             }
-                        } else if tag_name == "NextMarker" && !text.is_empty() {
+                        } else if tag_name == "NextMarker" {
                             next_marker.get_or_insert_with(String::new).push_str(&text);
                         }
                     }
@@ -2311,7 +2332,7 @@ impl AzureProvider {
                                 path: blob_name.clone(),
                                 is_dir: false,
                                 size: blob_size,
-                                modified: blob_modified.clone(),
+                                modified: blob_modified.as_ref().map(|m| m.trim().to_string()),
                                 permissions: None,
                                 owner: None,
                                 group: None,
@@ -2331,7 +2352,7 @@ impl AzureProvider {
             }
 
             if next_marker.is_some() {
-                marker = next_marker;
+                marker = next_marker.map(|m| m.trim().to_string());
             } else {
                 break;
             }

--- a/src-tauri/src/providers/azure.rs
+++ b/src-tauri/src/providers/azure.rs
@@ -518,7 +518,12 @@ impl AzureProvider {
                 },
                 Ok(Event::Text(ref e)) => {
                     let text = String::from_utf8_lossy(e.as_ref()).into_owned();
-                    if text.trim().is_empty() {
+                    // Skip indentation-only fragments, but preserve
+                    // whitespace while a blob/prefix <Name> is open: there
+                    // it is payload (e.g. `a&amp; &amp;b.txt`).
+                    if text.trim().is_empty()
+                        && !matches!(state, ParseState::BlobName | ParseState::BlobPrefixName)
+                    {
                         buf.clear();
                         continue;
                     }
@@ -2280,7 +2285,10 @@ impl AzureProvider {
                     }
                     Ok(quick_xml::events::Event::Text(ref e)) => {
                         let text = String::from_utf8_lossy(e.as_ref()).into_owned();
-                        if text.trim().is_empty() {
+                        // Skip indentation-only fragments, but preserve
+                        // whitespace inside <Name>: there it is payload
+                        // (e.g. `a&amp; &amp;b.txt`).
+                        if text.trim().is_empty() && !(in_blob && tag_name == "Name") {
                             buf.clear();
                             continue;
                         }
@@ -2849,5 +2857,39 @@ Time:2026-01-01</Message>
         let (items, marker) = p.parse_blob_list("not xml at all <<<");
         assert!(items.is_empty());
         assert_eq!(marker, None);
+    }
+
+    /// CR-536 regression: a whitespace-ONLY Text fragment is indentation
+    /// only when no <Name> element is open. Between two entity refs
+    /// (`a&amp; &amp;b.txt`) or at an element edge (` &amp;x.txt`) it is
+    /// part of the blob name and must survive; pretty-print indentation
+    /// between elements must still be ignored.
+    #[test]
+    fn parse_blob_list_preserves_whitespace_only_fragments_around_entities() {
+        let p = test_provider();
+        let xml = r#"<?xml version="1.0" encoding="utf-8"?>
+<EnumerationResults>
+  <Blobs>
+    <Blob>
+      <Name>a&amp; &amp;b.txt</Name>
+      <Properties>
+        <Content-Length>3</Content-Length>
+      </Properties>
+    </Blob>
+    <Blob>
+      <Name> &amp;x.txt</Name>
+      <Properties>
+        <Content-Length>4</Content-Length>
+      </Properties>
+    </Blob>
+  </Blobs>
+</EnumerationResults>"#;
+
+        let (items, marker) = p.parse_blob_list(xml);
+        assert_eq!(marker, None);
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].name, "a& &b.txt");
+        assert_eq!(items[0].size, 3);
+        assert_eq!(items[1].name, " &x.txt");
     }
 }

--- a/src-tauri/src/providers/jottacloud.rs
+++ b/src-tauri/src/providers/jottacloud.rs
@@ -609,11 +609,14 @@ impl JottacloudProvider {
 
         let mut names = Vec::new();
         let mut reader = Reader::from_str(xml);
-        reader.config_mut().trim_text(true);
+        // No trim_text: name fragments around XML entities must survive
+        // intact; the name accumulates and is trimmed once at element end.
+        reader.config_mut().trim_text(false);
         let mut buf = Vec::new();
         let mut in_devices = false;
         let mut in_device = false;
         let mut in_name = false;
+        let mut current_name = String::new();
 
         loop {
             match reader.read_event_into(&mut buf) {
@@ -622,7 +625,10 @@ impl JottacloudProvider {
                     match tag.as_str() {
                         "devices" => in_devices = true,
                         "device" if in_devices => in_device = true,
-                        "name" if in_device => in_name = true,
+                        "name" if in_device => {
+                            in_name = true;
+                            current_name.clear();
+                        }
                         _ => {}
                     }
                 }
@@ -634,14 +640,22 @@ impl JottacloudProvider {
                             in_device = false;
                         }
                         "device" => in_device = false,
-                        "name" => in_name = false,
+                        "name" => {
+                            in_name = false;
+                            let trimmed = current_name.trim().to_string();
+                            if !trimmed.is_empty() {
+                                names.push(trimmed);
+                            }
+                        }
                         _ => {}
                     }
                 }
                 Ok(Event::Text(ref e)) if in_name => {
-                    let text = String::from_utf8_lossy(e.as_ref()).trim().to_string();
-                    if !text.is_empty() {
-                        names.push(text);
+                    current_name.push_str(&String::from_utf8_lossy(e.as_ref()));
+                }
+                Ok(Event::GeneralRef(ref e)) if in_name => {
+                    if let Some(ch) = super::xml_text::xml_entity_to_str(e.as_ref()) {
+                        current_name.push_str(&ch);
                     }
                 }
                 Ok(Event::Eof) => break,
@@ -661,7 +675,9 @@ impl JottacloudProvider {
 
         let mut names = Vec::new();
         let mut reader = Reader::from_str(xml);
-        reader.config_mut().trim_text(true);
+        // No trim_text: name fragments around XML entities must survive
+        // intact; the name accumulates and is trimmed once at element end.
+        reader.config_mut().trim_text(false);
         let mut buf = Vec::new();
         // JFS nests the name as a child element:
         //   <mountPoints><mountPoint><name>Archive</name>...
@@ -670,6 +686,7 @@ impl JottacloudProvider {
         // mountpoint (#397). Both shapes are accepted now.
         let mut in_mount_point = false;
         let mut in_name = false;
+        let mut current_name = String::new();
 
         loop {
             match reader.read_event_into(&mut buf) {
@@ -689,12 +706,15 @@ impl JottacloudProvider {
                         }
                     } else if tag == "name" && in_mount_point {
                         in_name = true;
+                        current_name.clear();
                     }
                 }
                 Ok(Event::Text(ref e)) if in_name => {
-                    let name = String::from_utf8_lossy(e.as_ref()).trim().to_string();
-                    if !name.is_empty() && !names.contains(&name) {
-                        names.push(name);
+                    current_name.push_str(&String::from_utf8_lossy(e.as_ref()));
+                }
+                Ok(Event::GeneralRef(ref e)) if in_name => {
+                    if let Some(ch) = super::xml_text::xml_entity_to_str(e.as_ref()) {
+                        current_name.push_str(&ch);
                     }
                 }
                 Ok(Event::End(ref e)) => {
@@ -703,6 +723,10 @@ impl JottacloudProvider {
                         in_mount_point = false;
                     } else if tag == "name" {
                         in_name = false;
+                        let trimmed = current_name.trim().to_string();
+                        if !trimmed.is_empty() && !names.contains(&trimmed) {
+                            names.push(trimmed);
+                        }
                     }
                 }
                 Ok(Event::Eof) => break,
@@ -794,6 +818,8 @@ impl JottacloudProvider {
 
         let mut entries = Vec::new();
         let mut reader = Reader::from_str(xml);
+        // trim_text(true) is SAFE here: entry names arrive as attributes
+        // (xml_text::attr_value), never as Text events; only scalars do.
         reader.config_mut().trim_text(true);
         let mut buf = Vec::new();
 
@@ -1932,6 +1958,8 @@ impl JottacloudProvider {
 
         let mut entries = Vec::new();
         let mut reader = Reader::from_str(xml);
+        // trim_text(true) is SAFE here: entry names arrive as attributes
+        // (xml_text::attr_value), never as Text events; only scalars do.
         reader.config_mut().trim_text(true);
         let mut buf = Vec::new();
 
@@ -2256,6 +2284,31 @@ mod tests {
             </user>"#;
         let names = JottacloudProvider::parse_device_names(xml);
         assert_eq!(names, vec!["Jotta", "LAPTOP-01", "iPhone"]);
+    }
+
+    /// LIVE-1 regression: a device/mountpoint name whose XML text is split
+    /// around an entity must come back whole, not as trimmed fragments
+    /// ("a &amp; b" must not become two names "a" and "b").
+    #[test]
+    fn parse_names_preserve_entity_adjacent_whitespace() {
+        let xml = r#"<?xml version="1.0"?>
+            <user>
+              <devices>
+                <device><name>Mum &amp; Dad</name></device>
+              </devices>
+            </user>"#;
+        assert_eq!(
+            JottacloudProvider::parse_device_names(xml),
+            vec!["Mum & Dad"]
+        );
+
+        let xml_mp = r#"<device>
+            <mountPoints><mountPoint><name>Tom &amp; Jerry</name></mountPoint></mountPoints>
+        </device>"#;
+        assert_eq!(
+            JottacloudProvider::parse_mountpoint_names(xml_mp),
+            vec!["Tom & Jerry"]
+        );
     }
 
     #[test]

--- a/src-tauri/src/providers/s3.rs
+++ b/src-tauri/src/providers/s3.rs
@@ -1180,10 +1180,20 @@ impl S3Provider {
                     // and trimming each piece is fine, but blindly assigning
                     // the last fragment overwrites the preceding "a": which
                     // is exactly how `a&b.txt` was being shown as `b.txt`.
-                    // Whitespace-ONLY fragments (pretty-print indentation)
-                    // carry no payload and are skipped.
+                    // Whitespace-ONLY fragments are pretty-print indentation
+                    // ONLY when no payload-bearing element is open: between
+                    // two entity refs (`a&amp; &amp;b.txt`) or at an element
+                    // edge (` &amp;x`) the space is part of the value and
+                    // must be preserved.
                     let raw = String::from_utf8_lossy(e.as_ref()).to_string();
-                    if raw.trim().is_empty() {
+                    let payload_open = in_next_token
+                        || (matches!(context, Context::CommonPrefixes) && current_tag == "Prefix")
+                        || (matches!(context, Context::Contents)
+                            && matches!(
+                                current_tag.as_str(),
+                                "Key" | "Size" | "LastModified" | "ETag" | "StorageClass"
+                            ));
+                    if raw.trim().is_empty() && !payload_open {
                         buf.clear();
                         continue;
                     }
@@ -1366,6 +1376,10 @@ impl S3Provider {
         reader.config_mut().trim_text(false);
         let mut buf = Vec::new();
         let mut inside_target = false;
+        // Nesting depth below the target element: text is collected only
+        // from the target's immediate content (depth 0), so a container tag
+        // like <Error> no longer concatenates its descendants' text ("XY").
+        let mut depth: u32 = 0;
         let mut acc = String::new();
 
         loop {
@@ -1373,15 +1387,18 @@ impl S3Provider {
                 Ok(Event::Start(ref e)) => {
                     let name = e.name();
                     let tag_name = String::from_utf8_lossy(name.as_ref());
-                    if tag_name == tag {
+                    if inside_target {
+                        depth += 1;
+                    } else if tag_name == tag {
                         inside_target = true;
+                        depth = 0;
                         acc.clear();
                     }
                 }
-                Ok(Event::Text(ref e)) if inside_target => {
+                Ok(Event::Text(ref e)) if inside_target && depth == 0 => {
                     acc.push_str(&String::from_utf8_lossy(e.as_ref()));
                 }
-                Ok(Event::GeneralRef(ref e)) if inside_target => {
+                Ok(Event::GeneralRef(ref e)) if inside_target && depth == 0 => {
                     if let Some(ch) = super::xml_text::xml_entity_to_str(e.as_ref()) {
                         acc.push_str(&ch);
                     }
@@ -1389,12 +1406,16 @@ impl S3Provider {
                 Ok(Event::End(ref e)) => {
                     let name = e.name();
                     let tag_name = String::from_utf8_lossy(name.as_ref());
-                    if tag_name == tag {
-                        let trimmed = acc.trim().to_string();
-                        if !trimmed.is_empty() {
-                            return Some(trimmed);
+                    if inside_target {
+                        if depth > 0 {
+                            depth -= 1;
+                        } else if tag_name == tag {
+                            let trimmed = acc.trim().to_string();
+                            inside_target = false;
+                            if !trimmed.is_empty() {
+                                return Some(trimmed);
+                            }
                         }
-                        inside_target = false;
                     }
                 }
                 Ok(Event::Eof) => break,
@@ -2329,7 +2350,10 @@ impl S3Provider {
                     }
                     Ok(Event::Text(ref e)) => {
                         let text = String::from_utf8_lossy(e.as_ref());
-                        if text.trim().is_empty() {
+                        // Skip indentation-only fragments, but preserve
+                        // whitespace while a Key/token element is open: there
+                        // it is payload (e.g. `a&amp; &amp;b.txt`).
+                        if text.trim().is_empty() && !inside_key && !inside_next_token {
                             buf.clear();
                             continue;
                         }
@@ -3764,9 +3788,14 @@ impl StorageProvider for S3Provider {
                     Ok(Event::Text(ref e)) => {
                         // Accumulate raw fragments (entity-adjacent whitespace
                         // inside a Key is significant); skip indentation-only
-                        // fragments; scalars are trimmed at consumption.
+                        // fragments only when no payload element (Key inside
+                        // Contents, or the continuation token) is open;
+                        // scalars are trimmed at consumption.
                         let t = String::from_utf8_lossy(e.as_ref());
-                        if t.trim().is_empty() {
+                        if t.trim().is_empty()
+                            && !in_next_tok
+                            && !(in_contents && find_tag == "Key")
+                        {
                             find_buf.clear();
                             continue;
                         }
@@ -4217,7 +4246,15 @@ impl StorageProvider for S3Provider {
                     }
                     Ok(Event::Text(ref e)) => {
                         let text = String::from_utf8_lossy(e.as_ref());
-                        if text.trim().is_empty() {
+                        // Skip indentation-only fragments, but preserve
+                        // whitespace while a Key inside <Version> or a
+                        // pagination marker element is open: there it is
+                        // payload (e.g. `a&amp; &amp;b.txt`).
+                        if text.trim().is_empty()
+                            && !in_next_key_marker
+                            && !in_next_version_id_marker
+                            && !(in_version && current_tag == "Key")
+                        {
                             buf.clear();
                             continue;
                         }
@@ -4911,7 +4948,10 @@ impl S3Provider {
                 },
                 Ok(Event::Text(ref e)) => {
                     let text = String::from_utf8_lossy(e.as_ref());
-                    if text.trim().is_empty() {
+                    // Skip indentation-only fragments, but preserve
+                    // whitespace while a <Key>/<Value> element is open:
+                    // there it is payload (e.g. `a&amp; &amp;b`).
+                    if text.trim().is_empty() && !in_key && !in_value {
                         buf.clear();
                         continue;
                     }
@@ -5306,7 +5346,9 @@ fn parse_batch_delete_errors(xml_str: &str) -> Vec<(String, String)> {
                     continue;
                 }
                 let text = String::from_utf8_lossy(e.as_ref());
-                if text.trim().is_empty() {
+                // Skip indentation-only fragments, except inside <Key> where
+                // whitespace is payload (e.g. `a&amp; &amp;b.txt`).
+                if text.trim().is_empty() && current_tag != "Key" {
                     buf.clear();
                     continue;
                 }
@@ -5474,7 +5516,14 @@ fn parse_object_versions_page(xml_str: &str) -> Result<VersionsPage, ProviderErr
             }
             Ok(Event::Text(ref e)) => {
                 let text = String::from_utf8_lossy(e.as_ref());
-                if text.trim().is_empty() {
+                // Skip indentation-only fragments, but preserve whitespace
+                // while a Key inside <Version>/<DeleteMarker> or a pagination
+                // marker element is open: there it is payload.
+                if text.trim().is_empty()
+                    && !in_next_key_marker
+                    && !in_next_version_id_marker
+                    && !(elem != Elem::None && current_tag == "Key")
+                {
                     buf.clear();
                     continue;
                 }
@@ -5653,6 +5702,125 @@ mod tests {
         assert_eq!(
             errors,
             vec![("a & b.txt".to_string(), "AccessDenied".to_string())]
+        );
+    }
+
+    fn trim_text_test_provider() -> S3Provider {
+        S3Provider::new(S3Config {
+            endpoint: Some("http://localhost:9000".to_string()),
+            region: "us-east-1".to_string(),
+            access_key_id: "key".to_string(),
+            secret_access_key: secrecy::SecretString::from("secret".to_string()),
+            session_token: None,
+            role_arn: None,
+            role_external_id: None,
+            role_session_name: None,
+            role_duration_seconds: None,
+            role_mfa_serial: None,
+            role_mfa_token_code: None,
+            bucket: "test-bucket".to_string(),
+            prefix: None,
+            path_style: true,
+            storage_class: None,
+            sse_mode: None,
+            sse_kms_key_id: None,
+            verify_cert: true,
+        })
+        .expect("Failed to create S3Provider")
+    }
+
+    /// CR-536 regression: a whitespace-ONLY Text fragment is indentation
+    /// only when no payload element is open. Between two entity refs
+    /// (`a&amp; &amp;b.txt`) or at an element edge (` &amp;x.txt`) it is
+    /// part of the key and must survive. Pretty-print indentation between
+    /// elements must still be ignored.
+    #[test]
+    fn parse_list_response_preserves_whitespace_only_fragments_around_entities() {
+        let provider = trim_text_test_provider();
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Name>test-bucket</Name>
+  <Prefix></Prefix>
+  <Contents>
+    <Key>a&amp; &amp;b.txt</Key>
+    <LastModified>2026-07-30T12:00:00.000Z</LastModified>
+    <ETag>"abc"</ETag>
+    <Size>3</Size>
+    <StorageClass>STANDARD</StorageClass>
+  </Contents>
+  <Contents>
+    <Key> &amp;x.txt</Key>
+    <LastModified>2026-07-30T12:00:00.000Z</LastModified>
+    <ETag>"def"</ETag>
+    <Size>4</Size>
+    <StorageClass>STANDARD</StorageClass>
+  </Contents>
+</ListBucketResult>"#;
+        let (entries, next_token) = provider.parse_list_response(xml).expect("parse");
+        assert_eq!(next_token, None);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].name, "a& &b.txt");
+        assert_eq!(entries[0].size, 3);
+        assert_eq!(entries[1].name, " &x.txt");
+    }
+
+    /// Same regression for the ListObjectVersions trash parser.
+    #[test]
+    fn parse_object_versions_page_preserves_whitespace_only_fragments() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<ListVersionsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Version>
+    <Key>a&amp; &amp;b.txt</Key>
+    <VersionId>v1</VersionId>
+    <IsLatest>false</IsLatest>
+    <LastModified>2026-07-30T12:00:00.000Z</LastModified>
+    <Size>10</Size>
+  </Version>
+  <DeleteMarker>
+    <Key> &amp;x.txt</Key>
+    <VersionId>d1</VersionId>
+    <IsLatest>true</IsLatest>
+    <LastModified>2026-07-30T13:00:00.000Z</LastModified>
+  </DeleteMarker>
+</ListVersionsResult>"#;
+        let (entries, truncated, _, _) = parse_object_versions_page(xml).expect("parse");
+        assert!(!truncated);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].key, "a& &b.txt");
+        assert_eq!(entries[1].key, " &x.txt");
+        assert!(entries[1].is_delete_marker);
+    }
+
+    /// Same regression for batch-delete error keys.
+    #[test]
+    fn parse_batch_delete_errors_preserves_whitespace_only_fragments() {
+        let xml = "<DeleteResult>\n  <Error>\n    <Key>a&amp; &amp;b.txt</Key>\n    <Code>AccessDenied</Code>\n  </Error>\n</DeleteResult>";
+        let errors = parse_batch_delete_errors(xml);
+        assert_eq!(
+            errors,
+            vec![("a& &b.txt".to_string(), "AccessDenied".to_string())]
+        );
+    }
+
+    /// CR-536 nitpick: extract_xml_tag must collect only the target
+    /// element's immediate content, not the concatenated text of nested
+    /// descendants. Leaf-tag callers (UploadId, ETag, Code, Message) keep
+    /// their trimmed, entity-decoded behavior.
+    #[test]
+    fn extract_xml_tag_reads_only_immediate_content() {
+        let provider = trim_text_test_provider();
+        // Leaf tag: trimmed, entities decoded.
+        assert_eq!(
+            provider.extract_xml_tag(
+                "<Error><Code>Access&amp;Denied</Code><Message>m</Message></Error>",
+                "Code"
+            ),
+            Some("Access&Denied".to_string())
+        );
+        // Container tag: descendant text must NOT be concatenated ("XY").
+        assert_eq!(
+            provider.extract_xml_tag("<Error><Code>X</Code><Message>Y</Message></Error>", "Error"),
+            None
         );
     }
 

--- a/src-tauri/src/providers/s3.rs
+++ b/src-tauri/src/providers/s3.rs
@@ -3771,19 +3771,15 @@ impl StorageProvider for S3Provider {
                             continue;
                         }
                         if in_next_tok {
-                            next_tok_val
-                                .get_or_insert_with(String::new)
-                                .push_str(&t);
+                            next_tok_val.get_or_insert_with(String::new).push_str(&t);
                         }
                         if in_contents {
                             match find_tag.as_str() {
                                 "Key" => find_key.get_or_insert_with(String::new).push_str(&t),
-                                "Size" => find_size
-                                    .get_or_insert_with(String::new)
-                                    .push_str(&t),
-                                "LastModified" => find_modified
-                                    .get_or_insert_with(String::new)
-                                    .push_str(&t),
+                                "Size" => find_size.get_or_insert_with(String::new).push_str(&t),
+                                "LastModified" => {
+                                    find_modified.get_or_insert_with(String::new).push_str(&t)
+                                }
                                 _ => {}
                             }
                         }
@@ -3795,15 +3791,13 @@ impl StorageProvider for S3Provider {
                             }
                             if in_contents {
                                 match find_tag.as_str() {
-                                    "Key" => find_key
-                                        .get_or_insert_with(String::new)
-                                        .push_str(&ch),
-                                    "Size" => find_size
-                                        .get_or_insert_with(String::new)
-                                        .push_str(&ch),
-                                    "LastModified" => find_modified
-                                        .get_or_insert_with(String::new)
-                                        .push_str(&ch),
+                                    "Key" => find_key.get_or_insert_with(String::new).push_str(&ch),
+                                    "Size" => {
+                                        find_size.get_or_insert_with(String::new).push_str(&ch)
+                                    }
+                                    "LastModified" => {
+                                        find_modified.get_or_insert_with(String::new).push_str(&ch)
+                                    }
                                     _ => {}
                                 }
                             }
@@ -4245,12 +4239,12 @@ impl StorageProvider for S3Provider {
                         if in_version {
                             match current_tag.as_str() {
                                 "Key" => v_key.get_or_insert_with(String::new).push_str(&text),
-                                "VersionId" => v_version_id
-                                    .get_or_insert_with(String::new)
-                                    .push_str(&text),
-                                "IsLatest" => v_is_latest
-                                    .get_or_insert_with(String::new)
-                                    .push_str(&text),
+                                "VersionId" => {
+                                    v_version_id.get_or_insert_with(String::new).push_str(&text)
+                                }
+                                "IsLatest" => {
+                                    v_is_latest.get_or_insert_with(String::new).push_str(&text)
+                                }
                                 "LastModified" => v_last_modified
                                     .get_or_insert_with(String::new)
                                     .push_str(&text),
@@ -4262,7 +4256,9 @@ impl StorageProvider for S3Provider {
                     Ok(Event::GeneralRef(ref e)) => {
                         if let Some(ch) = super::xml_text::xml_entity_to_str(e.as_ref()) {
                             if in_next_key_marker {
-                                next_key_marker.get_or_insert_with(String::new).push_str(&ch);
+                                next_key_marker
+                                    .get_or_insert_with(String::new)
+                                    .push_str(&ch);
                             }
                             if in_next_version_id_marker {
                                 next_version_id_marker
@@ -4272,18 +4268,16 @@ impl StorageProvider for S3Provider {
                             if in_version {
                                 match current_tag.as_str() {
                                     "Key" => v_key.get_or_insert_with(String::new).push_str(&ch),
-                                    "VersionId" => v_version_id
-                                        .get_or_insert_with(String::new)
-                                        .push_str(&ch),
-                                    "IsLatest" => v_is_latest
-                                        .get_or_insert_with(String::new)
-                                        .push_str(&ch),
+                                    "VersionId" => {
+                                        v_version_id.get_or_insert_with(String::new).push_str(&ch)
+                                    }
+                                    "IsLatest" => {
+                                        v_is_latest.get_or_insert_with(String::new).push_str(&ch)
+                                    }
                                     "LastModified" => v_last_modified
                                         .get_or_insert_with(String::new)
                                         .push_str(&ch),
-                                    "Size" => v_size
-                                        .get_or_insert_with(String::new)
-                                        .push_str(&ch),
+                                    "Size" => v_size.get_or_insert_with(String::new).push_str(&ch),
                                     _ => {}
                                 }
                             }
@@ -5319,9 +5313,7 @@ fn parse_batch_delete_errors(xml_str: &str) -> Vec<(String, String)> {
                 match current_tag.as_str() {
                     "Key" => e_key.get_or_insert_with(String::new).push_str(&text),
                     "Code" => e_code.get_or_insert_with(String::new).push_str(&text),
-                    "Message" => e_message
-                        .get_or_insert_with(String::new)
-                        .push_str(&text),
+                    "Message" => e_message.get_or_insert_with(String::new).push_str(&text),
                     _ => {}
                 }
             }
@@ -5334,9 +5326,7 @@ fn parse_batch_delete_errors(xml_str: &str) -> Vec<(String, String)> {
                     match current_tag.as_str() {
                         "Key" => e_key.get_or_insert_with(String::new).push_str(&ch),
                         "Code" => e_code.get_or_insert_with(String::new).push_str(&ch),
-                        "Message" => e_message
-                            .get_or_insert_with(String::new)
-                            .push_str(&ch),
+                        "Message" => e_message.get_or_insert_with(String::new).push_str(&ch),
                         _ => {}
                     }
                 }
@@ -5506,12 +5496,8 @@ fn parse_object_versions_page(xml_str: &str) -> Result<VersionsPage, ProviderErr
                 if elem != Elem::None {
                     match current_tag.as_str() {
                         "Key" => e_key.get_or_insert_with(String::new).push_str(&text),
-                        "VersionId" => e_version_id
-                            .get_or_insert_with(String::new)
-                            .push_str(&text),
-                        "IsLatest" => e_is_latest
-                            .get_or_insert_with(String::new)
-                            .push_str(&text),
+                        "VersionId" => e_version_id.get_or_insert_with(String::new).push_str(&text),
+                        "IsLatest" => e_is_latest.get_or_insert_with(String::new).push_str(&text),
                         "LastModified" => e_last_modified
                             .get_or_insert_with(String::new)
                             .push_str(&text),
@@ -5523,7 +5509,9 @@ fn parse_object_versions_page(xml_str: &str) -> Result<VersionsPage, ProviderErr
             Ok(Event::GeneralRef(ref e)) => {
                 if let Some(ch) = super::xml_text::xml_entity_to_str(e.as_ref()) {
                     if in_next_key_marker {
-                        next_key_marker.get_or_insert_with(String::new).push_str(&ch);
+                        next_key_marker
+                            .get_or_insert_with(String::new)
+                            .push_str(&ch);
                     }
                     if in_next_version_id_marker {
                         next_version_id_marker
@@ -5533,12 +5521,10 @@ fn parse_object_versions_page(xml_str: &str) -> Result<VersionsPage, ProviderErr
                     if elem != Elem::None {
                         match current_tag.as_str() {
                             "Key" => e_key.get_or_insert_with(String::new).push_str(&ch),
-                            "VersionId" => e_version_id
-                                .get_or_insert_with(String::new)
-                                .push_str(&ch),
-                            "IsLatest" => e_is_latest
-                                .get_or_insert_with(String::new)
-                                .push_str(&ch),
+                            "VersionId" => {
+                                e_version_id.get_or_insert_with(String::new).push_str(&ch)
+                            }
+                            "IsLatest" => e_is_latest.get_or_insert_with(String::new).push_str(&ch),
                             "LastModified" => e_last_modified
                                 .get_or_insert_with(String::new)
                                 .push_str(&ch),
@@ -5621,6 +5607,53 @@ mod tests {
         assert!(!is_s3_directory_content_type("application/octet-stream"));
         assert!(!is_s3_directory_content_type("text/plain"));
         assert!(!is_s3_directory_content_type(""));
+    }
+
+    /// LIVE-1 regression: with trim_text(true), quick-xml trimmed every Text
+    /// fragment, so `<Key>sp ace &amp; ünïcodé.txt</Key>` listed as
+    /// `sp ace&ünïcodé.txt` (entity-adjacent spaces deleted): the real object
+    /// became unreachable via the listed name, and a sync with delete planned
+    /// `delete_local` on the user's real file. Names must round-trip exactly.
+    #[test]
+    fn parse_object_versions_page_preserves_entity_adjacent_whitespace() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<ListVersionsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Version>
+    <Key>sp ace &amp; ünïcodé.txt</Key>
+    <VersionId>v1</VersionId>
+    <IsLatest>false</IsLatest>
+    <LastModified>2026-07-30T12:00:00.000Z</LastModified>
+    <Size>65536</Size>
+  </Version>
+  <DeleteMarker>
+    <Key>a &amp; b.txt</Key>
+    <VersionId>d1</VersionId>
+    <IsLatest>true</IsLatest>
+    <LastModified>2026-07-30T13:00:00.000Z</LastModified>
+  </DeleteMarker>
+</ListVersionsResult>"#;
+        let (entries, truncated, _, _) = parse_object_versions_page(xml).expect("parse");
+        assert!(!truncated);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].key, "sp ace & ünïcodé.txt");
+        assert_eq!(entries[0].size, 65536);
+        assert!(!entries[0].is_latest);
+        assert_eq!(entries[1].key, "a & b.txt");
+        assert!(entries[1].is_delete_marker);
+        assert!(entries[1].is_latest);
+        assert_eq!(entries[1].version_id, "d1");
+    }
+
+    /// LIVE-1 regression: batch-delete error keys must keep entity-adjacent
+    /// whitespace, and pretty-print indentation must not pollute scalars.
+    #[test]
+    fn parse_batch_delete_errors_preserves_entity_adjacent_whitespace() {
+        let xml = "<DeleteResult>\n  <Error>\n    <Key>a &amp; b.txt</Key>\n    <Code>AccessDenied</Code>\n    <Message>denied</Message>\n  </Error>\n</DeleteResult>";
+        let errors = parse_batch_delete_errors(xml);
+        assert_eq!(
+            errors,
+            vec![("a & b.txt".to_string(), "AccessDenied".to_string())]
+        );
     }
 
     /// The S3 client must not follow redirects. reqwest's default

--- a/src-tauri/src/providers/s3.rs
+++ b/src-tauri/src/providers/s3.rs
@@ -1115,7 +1115,12 @@ impl S3Provider {
         let filen_decode = self.is_filen_s3_endpoint();
 
         let mut reader = Reader::from_str(xml_str);
-        reader.config_mut().trim_text(true);
+        // Do NOT enable trim_text: it trims every Event::Text fragment, and
+        // for a key like "a & b.txt" (Text("a ") + GeneralRef("amp") +
+        // Text(" b.txt")) that silently deletes the entity-adjacent spaces.
+        // Whitespace-only indentation fragments are skipped in the Text
+        // branch instead, and scalar fields are trimmed at consumption.
+        reader.config_mut().trim_text(false);
         let mut buf = Vec::new();
 
         // State machine for tracking current element context
@@ -1175,8 +1180,10 @@ impl S3Provider {
                     // and trimming each piece is fine, but blindly assigning
                     // the last fragment overwrites the preceding "a": which
                     // is exactly how `a&b.txt` was being shown as `b.txt`.
+                    // Whitespace-ONLY fragments (pretty-print indentation)
+                    // carry no payload and are skipped.
                     let raw = String::from_utf8_lossy(e.as_ref()).to_string();
-                    if raw.is_empty() {
+                    if raw.trim().is_empty() {
                         buf.clear();
                         continue;
                     }
@@ -1291,12 +1298,13 @@ impl S3Provider {
                                         if !name.is_empty() {
                                             let size: u64 = c_size
                                                 .as_ref()
-                                                .and_then(|s| s.parse().ok())
+                                                .and_then(|s| s.trim().parse().ok())
                                                 .unwrap_or(0);
 
                                             let mut metadata = HashMap::new();
                                             if let Some(raw_etag) = c_etag.as_ref() {
-                                                let etag = raw_etag.trim_matches('"').to_string();
+                                                let etag =
+                                                    raw_etag.trim().trim_matches('"').to_string();
                                                 if let Some(md5) = etag_to_md5(&etag) {
                                                     metadata.insert("md5".to_string(), md5);
                                                 }
@@ -1305,7 +1313,7 @@ impl S3Provider {
                                             if let Some(ref sc) = c_storage_class {
                                                 metadata.insert(
                                                     "storage_class".to_string(),
-                                                    sc.clone(),
+                                                    sc.trim().to_string(),
                                                 );
                                             }
 
@@ -1314,7 +1322,9 @@ impl S3Provider {
                                                 path: format!("/{}", key),
                                                 is_dir: false,
                                                 size,
-                                                modified: c_modified.clone(),
+                                                modified: c_modified
+                                                    .as_ref()
+                                                    .map(|m| m.trim().to_string()),
                                                 permissions: None,
                                                 owner: None,
                                                 group: None,
@@ -1345,15 +1355,18 @@ impl S3Provider {
             buf.clear();
         }
 
-        Ok((entries, top_next_token))
+        Ok((entries, top_next_token.map(|t| t.trim().to_string())))
     }
 
     /// Extract content from an XML tag using quick-xml (M-11/M-12)
     fn extract_xml_tag(&self, xml_str: &str, tag: &str) -> Option<String> {
         let mut reader = Reader::from_str(xml_str);
-        reader.config_mut().trim_text(true);
+        // No trim_text: fragments around XML entities must survive intact
+        // (they are reassembled below and trimmed once, at the element end).
+        reader.config_mut().trim_text(false);
         let mut buf = Vec::new();
         let mut inside_target = false;
+        let mut acc = String::new();
 
         loop {
             match reader.read_event_into(&mut buf) {
@@ -1362,18 +1375,25 @@ impl S3Provider {
                     let tag_name = String::from_utf8_lossy(name.as_ref());
                     if tag_name == tag {
                         inside_target = true;
+                        acc.clear();
                     }
                 }
                 Ok(Event::Text(ref e)) if inside_target => {
-                    let trimmed = String::from_utf8_lossy(e.as_ref()).trim().to_string();
-                    if !trimmed.is_empty() {
-                        return Some(trimmed);
+                    acc.push_str(&String::from_utf8_lossy(e.as_ref()));
+                }
+                Ok(Event::GeneralRef(ref e)) if inside_target => {
+                    if let Some(ch) = super::xml_text::xml_entity_to_str(e.as_ref()) {
+                        acc.push_str(&ch);
                     }
                 }
                 Ok(Event::End(ref e)) => {
                     let name = e.name();
                     let tag_name = String::from_utf8_lossy(name.as_ref());
                     if tag_name == tag {
+                        let trimmed = acc.trim().to_string();
+                        if !trimmed.is_empty() {
+                            return Some(trimmed);
+                        }
                         inside_target = false;
                     }
                 }
@@ -2279,11 +2299,16 @@ impl S3Provider {
 
             // Parse keys and next token using quick-xml
             let mut reader = Reader::from_str(&xml_str);
-            reader.config_mut().trim_text(true);
+            // No trim_text: key fragments around XML entities must survive
+            // (a `trim()` per fragment used to split "a & b.txt" into the
+            // two bogus keys "a" and "b.txt").
+            reader.config_mut().trim_text(false);
             let mut buf = Vec::new();
             let mut inside_key = false;
             let mut inside_next_token = false;
             let mut next_token: Option<String> = None;
+            let mut current_key = String::new();
+            let mut current_token = String::new();
 
             loop {
                 match reader.read_event_into(&mut buf) {
@@ -2291,20 +2316,35 @@ impl S3Provider {
                         let name = e.name();
                         let tag = String::from_utf8_lossy(name.as_ref());
                         match tag.as_ref() {
-                            "Key" => inside_key = true,
-                            "NextContinuationToken" => inside_next_token = true,
+                            "Key" => {
+                                inside_key = true;
+                                current_key.clear();
+                            }
+                            "NextContinuationToken" => {
+                                inside_next_token = true;
+                                current_token.clear();
+                            }
                             _ => {}
                         }
                     }
                     Ok(Event::Text(ref e)) => {
-                        let text = String::from_utf8_lossy(e.as_ref()).trim().to_string();
-                        if !text.is_empty() {
+                        let text = String::from_utf8_lossy(e.as_ref());
+                        if text.trim().is_empty() {
+                            buf.clear();
+                            continue;
+                        }
+                        if inside_key {
+                            current_key.push_str(&text);
+                        } else if inside_next_token {
+                            current_token.push_str(&text);
+                        }
+                    }
+                    Ok(Event::GeneralRef(ref e)) => {
+                        if let Some(ch) = super::xml_text::xml_entity_to_str(e.as_ref()) {
                             if inside_key {
-                                // #368: decode Filen-encoded keys so the single
-                                // downstream encode_s3_key_path() encodes once.
-                                all_keys.push(filen_decode_listed_key(text, filen_decode));
+                                current_key.push_str(&ch);
                             } else if inside_next_token {
-                                next_token = Some(text);
+                                current_token.push_str(&ch);
                             }
                         }
                     }
@@ -2312,8 +2352,24 @@ impl S3Provider {
                         let name = e.name();
                         let tag = String::from_utf8_lossy(name.as_ref());
                         match tag.as_ref() {
-                            "Key" => inside_key = false,
-                            "NextContinuationToken" => inside_next_token = false,
+                            "Key" => {
+                                inside_key = false;
+                                if !current_key.is_empty() {
+                                    // #368: decode Filen-encoded keys so the single
+                                    // downstream encode_s3_key_path() encodes once.
+                                    all_keys.push(filen_decode_listed_key(
+                                        std::mem::take(&mut current_key),
+                                        filen_decode,
+                                    ));
+                                }
+                            }
+                            "NextContinuationToken" => {
+                                inside_next_token = false;
+                                let token = current_token.trim().to_string();
+                                if !token.is_empty() {
+                                    next_token = Some(token);
+                                }
+                            }
                             _ => {}
                         }
                     }
@@ -3680,7 +3736,7 @@ impl StorageProvider for S3Provider {
 
             // Parse keys, sizes, and filter by pattern using quick-xml
             let mut find_reader = Reader::from_str(&xml_str);
-            find_reader.config_mut().trim_text(true);
+            find_reader.config_mut().trim_text(false);
             let mut find_buf = Vec::new();
             let mut in_contents = false;
             let mut in_next_tok = false;
@@ -3706,16 +3762,48 @@ impl StorageProvider for S3Provider {
                         }
                     }
                     Ok(Event::Text(ref e)) => {
-                        let t = String::from_utf8_lossy(e.as_ref()).trim().to_string();
-                        if !t.is_empty() {
+                        // Accumulate raw fragments (entity-adjacent whitespace
+                        // inside a Key is significant); skip indentation-only
+                        // fragments; scalars are trimmed at consumption.
+                        let t = String::from_utf8_lossy(e.as_ref());
+                        if t.trim().is_empty() {
+                            find_buf.clear();
+                            continue;
+                        }
+                        if in_next_tok {
+                            next_tok_val
+                                .get_or_insert_with(String::new)
+                                .push_str(&t);
+                        }
+                        if in_contents {
+                            match find_tag.as_str() {
+                                "Key" => find_key.get_or_insert_with(String::new).push_str(&t),
+                                "Size" => find_size
+                                    .get_or_insert_with(String::new)
+                                    .push_str(&t),
+                                "LastModified" => find_modified
+                                    .get_or_insert_with(String::new)
+                                    .push_str(&t),
+                                _ => {}
+                            }
+                        }
+                    }
+                    Ok(Event::GeneralRef(ref e)) => {
+                        if let Some(ch) = super::xml_text::xml_entity_to_str(e.as_ref()) {
                             if in_next_tok {
-                                next_tok_val = Some(t.clone());
+                                next_tok_val.get_or_insert_with(String::new).push_str(&ch);
                             }
                             if in_contents {
                                 match find_tag.as_str() {
-                                    "Key" => find_key = Some(t),
-                                    "Size" => find_size = Some(t),
-                                    "LastModified" => find_modified = Some(t),
+                                    "Key" => find_key
+                                        .get_or_insert_with(String::new)
+                                        .push_str(&ch),
+                                    "Size" => find_size
+                                        .get_or_insert_with(String::new)
+                                        .push_str(&ch),
+                                    "LastModified" => find_modified
+                                        .get_or_insert_with(String::new)
+                                        .push_str(&ch),
                                     _ => {}
                                 }
                             }
@@ -3731,14 +3819,16 @@ impl StorageProvider for S3Provider {
                                         if super::matches_find_pattern(name, pattern) {
                                             let size: u64 = find_size
                                                 .as_ref()
-                                                .and_then(|s| s.parse().ok())
+                                                .and_then(|s| s.trim().parse().ok())
                                                 .unwrap_or(0);
                                             all_entries.push(RemoteEntry {
                                                 name: name.to_string(),
                                                 path: format!("/{}", key),
                                                 is_dir: false,
                                                 size,
-                                                modified: find_modified.clone(),
+                                                modified: find_modified
+                                                    .as_ref()
+                                                    .map(|m| m.trim().to_string()),
                                                 permissions: None,
                                                 owner: None,
                                                 group: None,
@@ -3776,7 +3866,7 @@ impl StorageProvider for S3Provider {
             }
 
             match next_tok_val {
-                Some(token) => continuation_token = Some(token),
+                Some(token) => continuation_token = Some(token.trim().to_string()),
                 None => break,
             }
         }
@@ -4083,7 +4173,9 @@ impl StorageProvider for S3Provider {
 
             // Parse ListVersionsResult XML using quick-xml
             let mut reader = Reader::from_str(&xml_str);
-            reader.config_mut().trim_text(true);
+            // No trim_text: Key fragments around XML entities must survive
+            // (whitespace next to an entity is part of the key).
+            reader.config_mut().trim_text(false);
             let mut buf = Vec::new();
 
             let mut in_version = false;
@@ -4130,30 +4222,70 @@ impl StorageProvider for S3Provider {
                         }
                     }
                     Ok(Event::Text(ref e)) => {
-                        let text = String::from_utf8_lossy(e.as_ref()).trim().to_string();
-                        if text.is_empty() {
+                        let text = String::from_utf8_lossy(e.as_ref());
+                        if text.trim().is_empty() {
                             buf.clear();
                             continue;
                         }
 
                         if in_is_truncated {
-                            is_truncated = text == "true";
+                            is_truncated = text.trim() == "true";
                         }
                         if in_next_key_marker {
-                            next_key_marker = Some(text.clone());
+                            next_key_marker
+                                .get_or_insert_with(String::new)
+                                .push_str(&text);
                         }
                         if in_next_version_id_marker {
-                            next_version_id_marker = Some(text.clone());
+                            next_version_id_marker
+                                .get_or_insert_with(String::new)
+                                .push_str(&text);
                         }
 
                         if in_version {
                             match current_tag.as_str() {
-                                "Key" => v_key = Some(text),
-                                "VersionId" => v_version_id = Some(text),
-                                "IsLatest" => v_is_latest = Some(text),
-                                "LastModified" => v_last_modified = Some(text),
-                                "Size" => v_size = Some(text),
+                                "Key" => v_key.get_or_insert_with(String::new).push_str(&text),
+                                "VersionId" => v_version_id
+                                    .get_or_insert_with(String::new)
+                                    .push_str(&text),
+                                "IsLatest" => v_is_latest
+                                    .get_or_insert_with(String::new)
+                                    .push_str(&text),
+                                "LastModified" => v_last_modified
+                                    .get_or_insert_with(String::new)
+                                    .push_str(&text),
+                                "Size" => v_size.get_or_insert_with(String::new).push_str(&text),
                                 _ => {}
+                            }
+                        }
+                    }
+                    Ok(Event::GeneralRef(ref e)) => {
+                        if let Some(ch) = super::xml_text::xml_entity_to_str(e.as_ref()) {
+                            if in_next_key_marker {
+                                next_key_marker.get_or_insert_with(String::new).push_str(&ch);
+                            }
+                            if in_next_version_id_marker {
+                                next_version_id_marker
+                                    .get_or_insert_with(String::new)
+                                    .push_str(&ch);
+                            }
+                            if in_version {
+                                match current_tag.as_str() {
+                                    "Key" => v_key.get_or_insert_with(String::new).push_str(&ch),
+                                    "VersionId" => v_version_id
+                                        .get_or_insert_with(String::new)
+                                        .push_str(&ch),
+                                    "IsLatest" => v_is_latest
+                                        .get_or_insert_with(String::new)
+                                        .push_str(&ch),
+                                    "LastModified" => v_last_modified
+                                        .get_or_insert_with(String::new)
+                                        .push_str(&ch),
+                                    "Size" => v_size
+                                        .get_or_insert_with(String::new)
+                                        .push_str(&ch),
+                                    _ => {}
+                                }
                             }
                         }
                     }
@@ -4164,11 +4296,15 @@ impl StorageProvider for S3Provider {
                                 // Only include versions whose key exactly matches
                                 if let Some(ref vk) = v_key {
                                     if vk == key {
-                                        let version_id = v_version_id.clone().unwrap_or_default();
-                                        let is_latest = v_is_latest.as_deref() == Some("true");
+                                        let version_id = v_version_id
+                                            .as_ref()
+                                            .map(|v| v.trim().to_string())
+                                            .unwrap_or_default();
+                                        let is_latest =
+                                            v_is_latest.as_deref().map(str::trim) == Some("true");
                                         let size: u64 = v_size
                                             .as_ref()
-                                            .and_then(|s| s.parse().ok())
+                                            .and_then(|s| s.trim().parse().ok())
                                             .unwrap_or(0);
 
                                         let mut modified_by_str = None;
@@ -4178,7 +4314,9 @@ impl StorageProvider for S3Provider {
 
                                         all_versions.push(FileVersion {
                                             id: version_id,
-                                            modified: v_last_modified.clone(),
+                                            modified: v_last_modified
+                                                .as_ref()
+                                                .map(|m| m.trim().to_string()),
                                             size,
                                             modified_by: modified_by_str,
                                         });
@@ -4206,8 +4344,8 @@ impl StorageProvider for S3Provider {
             }
 
             if is_truncated {
-                key_marker = next_key_marker;
-                version_id_marker = next_version_id_marker;
+                key_marker = next_key_marker.map(|m| m.trim().to_string());
+                version_id_marker = next_version_id_marker.map(|m| m.trim().to_string());
             } else {
                 break;
             }
@@ -4754,7 +4892,10 @@ impl S3Provider {
         // Parse <Tagging><TagSet><Tag><Key>k</Key><Value>v</Value></Tag>...</TagSet></Tagging>
         let mut tags = HashMap::new();
         let mut reader = Reader::from_str(&body);
-        reader.config_mut().trim_text(true);
+        // No trim_text: tag keys/values may contain XML entities whose
+        // surrounding whitespace is significant; fragments accumulate and
+        // are trimmed once at element end.
+        reader.config_mut().trim_text(false);
         let mut buf = Vec::new();
         let mut current_key: Option<String> = None;
         let mut current_value: Option<String> = None;
@@ -4764,17 +4905,45 @@ impl S3Provider {
         loop {
             match reader.read_event_into(&mut buf) {
                 Ok(Event::Start(ref e)) => match e.name().as_ref() {
-                    b"Key" => in_key = true,
-                    b"Value" => in_value = true,
+                    b"Key" => {
+                        in_key = true;
+                        current_key = Some(String::new());
+                    }
+                    b"Value" => {
+                        in_value = true;
+                        current_value = Some(String::new());
+                    }
                     _ => {}
                 },
                 Ok(Event::Text(ref e)) => {
-                    let text = String::from_utf8_lossy(e.as_ref()).into_owned();
+                    let text = String::from_utf8_lossy(e.as_ref());
+                    if text.trim().is_empty() {
+                        buf.clear();
+                        continue;
+                    }
                     if in_key {
-                        current_key = Some(text.clone());
+                        if let Some(ref mut k) = current_key {
+                            k.push_str(&text);
+                        }
                     }
                     if in_value {
-                        current_value = Some(text);
+                        if let Some(ref mut v) = current_value {
+                            v.push_str(&text);
+                        }
+                    }
+                }
+                Ok(Event::GeneralRef(ref e)) => {
+                    if let Some(ch) = super::xml_text::xml_entity_to_str(e.as_ref()) {
+                        if in_key {
+                            if let Some(ref mut k) = current_key {
+                                k.push_str(&ch);
+                            }
+                        }
+                        if in_value {
+                            if let Some(ref mut v) = current_value {
+                                v.push_str(&ch);
+                            }
+                        }
                     }
                 }
                 Ok(Event::End(ref e)) => match e.name().as_ref() {
@@ -4782,7 +4951,7 @@ impl S3Provider {
                     b"Value" => in_value = false,
                     b"Tag" => {
                         if let (Some(k), Some(v)) = (current_key.take(), current_value.take()) {
-                            tags.insert(k, v);
+                            tags.insert(k.trim().to_string(), v.trim().to_string());
                         }
                     }
                     _ => {}
@@ -5103,7 +5272,9 @@ fn build_batch_delete_xml(chunk: &[(String, Option<String>)]) -> Vec<u8> {
 /// elements (present only in a non-quiet response) are ignored.
 fn parse_batch_delete_errors(xml_str: &str) -> Vec<(String, String)> {
     let mut reader = Reader::from_str(xml_str);
-    reader.config_mut().trim_text(true);
+    // No trim_text: failed keys may contain XML entities whose adjacent
+    // whitespace is significant; fragments accumulate per element.
+    reader.config_mut().trim_text(false);
     let mut buf = Vec::new();
 
     let mut errors: Vec<(String, String)> = Vec::new();
@@ -5140,16 +5311,34 @@ fn parse_batch_delete_errors(xml_str: &str) -> Vec<(String, String)> {
                     buf.clear();
                     continue;
                 }
-                let text = String::from_utf8_lossy(e.as_ref()).trim().to_string();
-                if text.is_empty() {
+                let text = String::from_utf8_lossy(e.as_ref());
+                if text.trim().is_empty() {
                     buf.clear();
                     continue;
                 }
                 match current_tag.as_str() {
-                    "Key" => e_key = Some(text),
-                    "Code" => e_code = Some(text),
-                    "Message" => e_message = Some(text),
+                    "Key" => e_key.get_or_insert_with(String::new).push_str(&text),
+                    "Code" => e_code.get_or_insert_with(String::new).push_str(&text),
+                    "Message" => e_message
+                        .get_or_insert_with(String::new)
+                        .push_str(&text),
                     _ => {}
+                }
+            }
+            Ok(Event::GeneralRef(ref e)) => {
+                if !in_error {
+                    buf.clear();
+                    continue;
+                }
+                if let Some(ch) = super::xml_text::xml_entity_to_str(e.as_ref()) {
+                    match current_tag.as_str() {
+                        "Key" => e_key.get_or_insert_with(String::new).push_str(&ch),
+                        "Code" => e_code.get_or_insert_with(String::new).push_str(&ch),
+                        "Message" => e_message
+                            .get_or_insert_with(String::new)
+                            .push_str(&ch),
+                        _ => {}
+                    }
                 }
             }
             Ok(Event::End(ref e)) => {
@@ -5162,6 +5351,7 @@ fn parse_batch_delete_errors(xml_str: &str) -> Vec<(String, String)> {
                     let reason = e_code
                         .take()
                         .or_else(|| e_message.take())
+                        .map(|r| r.trim().to_string())
                         .unwrap_or_else(|| "unknown".to_string());
                     errors.push((key, reason));
                     in_error = false;
@@ -5242,7 +5432,10 @@ fn parse_object_versions_page(xml_str: &str) -> Result<VersionsPage, ProviderErr
     }
 
     let mut reader = Reader::from_str(xml_str);
-    reader.config_mut().trim_text(true);
+    // No trim_text: Key fragments around XML entities must survive
+    // (whitespace next to an entity is part of the key); scalars are
+    // trimmed at consumption.
+    reader.config_mut().trim_text(false);
     let mut buf = Vec::new();
 
     let mut entries: Vec<TrashEntry> = Vec::new();
@@ -5290,30 +5483,68 @@ fn parse_object_versions_page(xml_str: &str) -> Result<VersionsPage, ProviderErr
                 }
             }
             Ok(Event::Text(ref e)) => {
-                let text = String::from_utf8_lossy(e.as_ref()).trim().to_string();
-                if text.is_empty() {
+                let text = String::from_utf8_lossy(e.as_ref());
+                if text.trim().is_empty() {
                     buf.clear();
                     continue;
                 }
 
                 if in_is_truncated {
-                    is_truncated = text == "true";
+                    is_truncated = text.trim() == "true";
                 }
                 if in_next_key_marker {
-                    next_key_marker = Some(text.clone());
+                    next_key_marker
+                        .get_or_insert_with(String::new)
+                        .push_str(&text);
                 }
                 if in_next_version_id_marker {
-                    next_version_id_marker = Some(text.clone());
+                    next_version_id_marker
+                        .get_or_insert_with(String::new)
+                        .push_str(&text);
                 }
 
                 if elem != Elem::None {
                     match current_tag.as_str() {
-                        "Key" => e_key = Some(text),
-                        "VersionId" => e_version_id = Some(text),
-                        "IsLatest" => e_is_latest = Some(text),
-                        "LastModified" => e_last_modified = Some(text),
-                        "Size" => e_size = Some(text),
+                        "Key" => e_key.get_or_insert_with(String::new).push_str(&text),
+                        "VersionId" => e_version_id
+                            .get_or_insert_with(String::new)
+                            .push_str(&text),
+                        "IsLatest" => e_is_latest
+                            .get_or_insert_with(String::new)
+                            .push_str(&text),
+                        "LastModified" => e_last_modified
+                            .get_or_insert_with(String::new)
+                            .push_str(&text),
+                        "Size" => e_size.get_or_insert_with(String::new).push_str(&text),
                         _ => {}
+                    }
+                }
+            }
+            Ok(Event::GeneralRef(ref e)) => {
+                if let Some(ch) = super::xml_text::xml_entity_to_str(e.as_ref()) {
+                    if in_next_key_marker {
+                        next_key_marker.get_or_insert_with(String::new).push_str(&ch);
+                    }
+                    if in_next_version_id_marker {
+                        next_version_id_marker
+                            .get_or_insert_with(String::new)
+                            .push_str(&ch);
+                    }
+                    if elem != Elem::None {
+                        match current_tag.as_str() {
+                            "Key" => e_key.get_or_insert_with(String::new).push_str(&ch),
+                            "VersionId" => e_version_id
+                                .get_or_insert_with(String::new)
+                                .push_str(&ch),
+                            "IsLatest" => e_is_latest
+                                .get_or_insert_with(String::new)
+                                .push_str(&ch),
+                            "LastModified" => e_last_modified
+                                .get_or_insert_with(String::new)
+                                .push_str(&ch),
+                            "Size" => e_size.get_or_insert_with(String::new).push_str(&ch),
+                            _ => {}
+                        }
                     }
                 }
             }
@@ -5326,16 +5557,24 @@ fn parse_object_versions_page(xml_str: &str) -> Result<VersionsPage, ProviderErr
                             let size = if is_delete_marker {
                                 0
                             } else {
-                                e_size.as_ref().and_then(|s| s.parse().ok()).unwrap_or(0)
+                                e_size
+                                    .as_ref()
+                                    .and_then(|s| s.trim().parse().ok())
+                                    .unwrap_or(0)
                             };
                             entries.push(TrashEntry {
                                 display_key: key.clone(),
                                 key,
-                                version_id: e_version_id.clone().unwrap_or_default(),
+                                version_id: e_version_id
+                                    .as_ref()
+                                    .map(|v| v.trim().to_string())
+                                    .unwrap_or_default(),
                                 is_delete_marker,
-                                is_latest: e_is_latest.as_deref() == Some("true"),
+                                is_latest: e_is_latest.as_deref().map(str::trim) == Some("true"),
                                 size,
-                                last_modified: e_last_modified.clone(),
+                                last_modified: e_last_modified
+                                    .as_ref()
+                                    .map(|m| m.trim().to_string()),
                             });
                         }
                         elem = Elem::None;
@@ -5359,8 +5598,8 @@ fn parse_object_versions_page(xml_str: &str) -> Result<VersionsPage, ProviderErr
     Ok((
         entries,
         is_truncated,
-        next_key_marker,
-        next_version_id_marker,
+        next_key_marker.map(|m| m.trim().to_string()),
+        next_version_id_marker.map(|m| m.trim().to_string()),
     ))
 }
 

--- a/src-tauri/src/providers/webdav.rs
+++ b/src-tauri/src/providers/webdav.rs
@@ -504,7 +504,9 @@ impl WebDavProvider {
         use quick_xml::reader::Reader;
 
         let mut reader = Reader::from_str(xml);
-        reader.config_mut().trim_text(true);
+        // No trim_text: fragments around XML entities must survive intact;
+        // scalars are trimmed once at consumption below.
+        reader.config_mut().trim_text(false);
         let mut buf = Vec::new();
 
         let mut in_response = false;
@@ -557,7 +559,7 @@ impl WebDavProvider {
                 Ok(Event::Text(ref t)) => {
                     if let Some(tag) = current_tag.as_deref() {
                         let text = String::from_utf8_lossy(t.as_ref()).to_string();
-                        if !text.is_empty() {
+                        if !text.trim().is_empty() {
                             match tag {
                                 "getcontentlength" => size_text.push_str(&text),
                                 "getlastmodified" => modified_text.push_str(&text),
@@ -1413,7 +1415,10 @@ impl WebDavProvider {
     ) -> Result<Vec<NextcloudTrashEntry>, ProviderError> {
         let mut entries = Vec::new();
         let mut reader = Reader::from_str(xml);
-        reader.config_mut().trim_text(true);
+        // No trim_text: fragments around XML entities must survive intact
+        // (entity-adjacent spaces are part of the name); scalars are
+        // trimmed once at consumption below.
+        reader.config_mut().trim_text(false);
         let mut buf = Vec::new();
 
         let mut in_response = false;
@@ -1501,7 +1506,7 @@ impl WebDavProvider {
                 Ok(Event::Text(ref e)) => {
                     if let Some(ref tag) = current_tag {
                         let raw = String::from_utf8_lossy(e.as_ref()).to_string();
-                        if !raw.is_empty() {
+                        if !raw.trim().is_empty() {
                             match tag.as_str() {
                                 "href" => href.push_str(&raw),
                                 "trashbin-filename" => trash_filename.push_str(&raw),
@@ -1703,7 +1708,10 @@ impl WebDavProvider {
 
         // Event-based quick-xml parser
         let mut reader = Reader::from_str(xml);
-        reader.config_mut().trim_text(true);
+        // No trim_text: fragments around XML entities must survive intact
+        // (entity-adjacent spaces are part of the name); values are
+        // trimmed once at consumption below.
+        reader.config_mut().trim_text(false);
         let mut buf = Vec::new();
 
         let mut in_response = false;
@@ -1778,8 +1786,8 @@ impl WebDavProvider {
                                 continue;
                             }
 
-                            let decoded_href =
-                                urlencoding::decode(&href).unwrap_or_else(|_| href.clone().into());
+                            let decoded_href = urlencoding::decode(href.trim())
+                                .unwrap_or_else(|_| href.trim().into());
                             let clean_path = decoded_href.trim_end_matches('/');
                             let base_clean = base_path.trim_end_matches('/');
                             let url_clean = self.config.url.trim_end_matches('/');
@@ -1808,7 +1816,7 @@ impl WebDavProvider {
                                 continue;
                             }
 
-                            let href_ends_slash = href.ends_with('/');
+                            let href_ends_slash = href.trim_end().ends_with('/');
                             let is_dir =
                                 is_collection || is_collection_by_iscollection || href_ends_slash;
 
@@ -1828,9 +1836,9 @@ impl WebDavProvider {
                             // ...) the input has no percent-encoding and decode is a
                             // no-op; on the Filen bridge it un-mangles the name. Issue
                             // #128.
-                            let name = if !displayname.is_empty() {
-                                urlencoding::decode(&displayname)
-                                    .unwrap_or_else(|_| displayname.clone().into())
+                            let name = if !displayname.trim().is_empty() {
+                                urlencoding::decode(displayname.trim())
+                                    .unwrap_or_else(|_| displayname.trim().into())
                                     .into_owned()
                             } else {
                                 decoded_href
@@ -1851,15 +1859,15 @@ impl WebDavProvider {
                                 format!("{}/{}", base_clean, name)
                             };
 
-                            let mime_type = if getcontenttype.is_empty() {
+                            let mime_type = if getcontenttype.trim().is_empty() {
                                 None
                             } else {
-                                Some(getcontenttype.clone())
+                                Some(getcontenttype.trim().to_string())
                             };
 
                             let mut metadata = HashMap::new();
-                            if !getetag.is_empty() {
-                                metadata.insert("etag".to_string(), getetag.clone());
+                            if !getetag.trim().is_empty() {
+                                metadata.insert("etag".to_string(), getetag.trim().to_string());
                             }
 
                             entries.push(RemoteEntry {
@@ -1891,7 +1899,7 @@ impl WebDavProvider {
                 Ok(Event::Text(ref e)) => {
                     if let Some(ref tag) = current_tag {
                         let raw = String::from_utf8_lossy(e.as_ref()).to_string();
-                        if !raw.is_empty() {
+                        if !raw.trim().is_empty() {
                             match tag.as_str() {
                                 "href" => href.push_str(&raw),
                                 "displayname" => displayname.push_str(&raw),
@@ -1958,7 +1966,9 @@ impl WebDavProvider {
     fn extract_xml_properties(&self, xml: &str) -> HashMap<String, String> {
         let mut props = HashMap::new();
         let mut reader = Reader::from_str(xml);
-        reader.config_mut().trim_text(true);
+        // No trim_text: fragments around XML entities must survive intact;
+        // values are trimmed once at element end (see the End arm).
+        reader.config_mut().trim_text(false);
         let mut buf = Vec::new();
         let mut current_tag: Option<String> = None;
         let mut in_resourcetype = false;
@@ -1993,12 +2003,19 @@ impl WebDavProvider {
                     }
                     if current_tag.as_deref() == Some(local.as_str()) {
                         current_tag = None;
+                        // Values accumulated raw so entity-adjacent spaces
+                        // survive; trim once here so scalar consumers (quota,
+                        // dates) can parse without caring about indentation.
+                        if let Some(v) = props.get_mut(local.as_str()) {
+                            let trimmed = v.trim().to_string();
+                            *v = trimmed;
+                        }
                     }
                 }
                 Ok(Event::Text(ref e)) => {
                     if let Some(ref tag) = current_tag {
                         let raw = String::from_utf8_lossy(e.as_ref()).to_string();
-                        if !raw.is_empty() {
+                        if !raw.trim().is_empty() {
                             if tag == "iscollection" && raw.trim() == "1" {
                                 props.insert("_is_collection".to_string(), "true".to_string());
                             }
@@ -4377,6 +4394,46 @@ mod tests {
         assert_eq!(entries[0].size, 1024);
         assert_eq!(entries[1].name, "subdir");
         assert!(entries[1].is_dir);
+    }
+
+    /// LIVE-1 regression: with trim_text(true), a displayname like
+    /// `sp ace & ünïcodé.txt` lost the spaces adjacent to `&amp;`, so the
+    /// listing showed a name that does not exist on the server and every
+    /// operation on it 404'd. Names must round-trip exactly.
+    #[test]
+    fn parse_propfind_preserves_entity_adjacent_whitespace_in_names() {
+        let provider = WebDavProvider::new(test_config("https://example.com/dav"))
+            .expect("Failed to create WebDavProvider");
+
+        let xml = r#"<?xml version="1.0"?>
+        <d:multistatus xmlns:d="DAV:">
+            <d:response>
+                <d:href>/dav/sp%20ace%20%26%20%C3%BCn%C3%AFcod%C3%A9.txt</d:href>
+                <d:propstat>
+                    <d:prop>
+                        <d:displayname>sp ace &amp; ünïcodé.txt</d:displayname>
+                        <d:resourcetype/>
+                        <d:getcontentlength>65536</d:getcontentlength>
+                    </d:prop>
+                </d:propstat>
+            </d:response>
+            <d:response>
+                <d:href>/dav/a%20%26%20b.txt</d:href>
+                <d:propstat>
+                    <d:prop>
+                        <d:resourcetype/>
+                        <d:getcontentlength>19</d:getcontentlength>
+                    </d:prop>
+                </d:propstat>
+            </d:response>
+        </d:multistatus>"#;
+
+        let entries = provider.parse_propfind_response(xml, "/dav").unwrap();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].name, "sp ace & ünïcodé.txt");
+        assert_eq!(entries[0].size, 65536);
+        // No displayname: falls back to the (decoded) href leaf.
+        assert_eq!(entries[1].name, "a & b.txt");
     }
 
     /// Issue #128 (Filen WebDAV bridge): the local bridge ships

--- a/src-tauri/src/providers/webdav.rs
+++ b/src-tauri/src/providers/webdav.rs
@@ -1506,7 +1506,14 @@ impl WebDavProvider {
                 Ok(Event::Text(ref e)) => {
                     if let Some(ref tag) = current_tag {
                         let raw = String::from_utf8_lossy(e.as_ref()).to_string();
-                        if !raw.trim().is_empty() {
+                        // Whitespace-only fragments are indentation EXCEPT
+                        // inside name/path-bearing tags, where the space is
+                        // payload (e.g. `a&amp; &amp;b.txt`).
+                        let payload_tag = matches!(
+                            tag.as_str(),
+                            "href" | "trashbin-filename" | "trashbin-original-location"
+                        );
+                        if !raw.trim().is_empty() || payload_tag {
                             match tag.as_str() {
                                 "href" => href.push_str(&raw),
                                 "trashbin-filename" => trash_filename.push_str(&raw),
@@ -1899,7 +1906,11 @@ impl WebDavProvider {
                 Ok(Event::Text(ref e)) => {
                     if let Some(ref tag) = current_tag {
                         let raw = String::from_utf8_lossy(e.as_ref()).to_string();
-                        if !raw.trim().is_empty() {
+                        // Whitespace-only fragments are indentation EXCEPT
+                        // inside href/displayname, where the space is part
+                        // of the name (e.g. `a&amp; &amp;b.txt`).
+                        let payload_tag = matches!(tag.as_str(), "href" | "displayname");
+                        if !raw.trim().is_empty() || payload_tag {
                             match tag.as_str() {
                                 "href" => href.push_str(&raw),
                                 "displayname" => displayname.push_str(&raw),
@@ -4434,6 +4445,64 @@ mod tests {
         assert_eq!(entries[0].size, 65536);
         // No displayname: falls back to the (decoded) href leaf.
         assert_eq!(entries[1].name, "a & b.txt");
+    }
+
+    /// CR-536 regression: a whitespace-ONLY Text fragment between two entity
+    /// refs (`a&amp; &amp;b.txt`) is part of the name, not indentation, and
+    /// must survive in displayname parsing.
+    #[test]
+    fn parse_propfind_preserves_whitespace_only_fragments_around_entities() {
+        let provider = WebDavProvider::new(test_config("https://example.com/dav"))
+            .expect("Failed to create WebDavProvider");
+
+        let xml = r#"<?xml version="1.0"?>
+        <d:multistatus xmlns:d="DAV:">
+            <d:response>
+                <d:href>/dav/a%26%20%26b.txt</d:href>
+                <d:propstat>
+                    <d:prop>
+                        <d:displayname>a&amp; &amp;b.txt</d:displayname>
+                        <d:resourcetype/>
+                        <d:getcontentlength>10</d:getcontentlength>
+                    </d:prop>
+                </d:propstat>
+            </d:response>
+        </d:multistatus>"#;
+
+        let entries = provider.parse_propfind_response(xml, "/dav").unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "a& &b.txt");
+        assert_eq!(entries[0].size, 10);
+    }
+
+    /// CR-536 regression, Nextcloud trashbin parser: same whitespace-only
+    /// fragment preservation for trashbin-filename / original-location.
+    #[test]
+    fn parse_trashbin_preserves_whitespace_only_fragments_around_entities() {
+        let provider = WebDavProvider::new(test_config("https://example.com"))
+            .expect("Failed to create WebDavProvider");
+
+        let xml = r#"<?xml version="1.0"?>
+        <d:multistatus xmlns:d="DAV:" xmlns:nc="http://nextcloud.org/ns">
+            <d:response>
+                <d:href>/remote.php/dav/trashbin/user/trash/a%26%20%26b.txt.d1700000000</d:href>
+                <d:propstat>
+                    <d:prop>
+                        <nc:trashbin-filename>a&amp; &amp;b.txt</nc:trashbin-filename>
+                        <nc:trashbin-original-location>docs/a&amp; &amp;b.txt</nc:trashbin-original-location>
+                        <nc:trashbin-deletion-time>1700000000</nc:trashbin-deletion-time>
+                        <d:getcontentlength>10</d:getcontentlength>
+                        <d:resourcetype/>
+                    </d:prop>
+                </d:propstat>
+            </d:response>
+        </d:multistatus>"#;
+
+        let entries = provider.parse_trashbin_response(xml).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "a& &b.txt");
+        assert_eq!(entries[0].original_path, "docs/a& &b.txt");
+        assert_eq!(entries[0].deleted_at, 1700000000);
     }
 
     /// Issue #128 (Filen WebDAV bridge): the local bridge ships


### PR DESCRIPTION
Closes **LIVE-1**, the blocker of the independent pre-release audit (PR #535, security-evidence §8.1).

## The bug
Every name-bearing quick-xml reader was configured `trim_text(true)`. For a key like `sp ace & ünïcodé.txt` the server sends `<Key>sp ace &amp; ünïcodé.txt</Key>`; quick-xml emits `Text("sp ace ") + GeneralRef("amp") + Text(" ünïcodé.txt")` and each fragment was trimmed, so listings showed `sp ace&ünïcodé.txt`. Upload stores the correct name, so GET of the listed name 404'd, and `sync --direction download --delete` planned `delete_local` on the user's real file (data-loss class, live-verified on release code against the axpbuntu lab).

## The fix
17 readers across 4 providers moved to the same pattern: `trim_text(false)`, whitespace-only indentation fragments skipped, Key/name fragments accumulate raw with `GeneralRef` expansion via `xml_text::xml_entity_to_str`, scalar fields (sizes, dates, etags, markers, quota, hrefs) trimmed once at consumption.
- `s3.rs`: ListObjectsV2, extract_xml_tag, all-keys pagination, find, ListObjectVersions, tagging, batch-delete errors, trash page (8 readers)
- `webdav.rs`: single-file PROPFIND, Nextcloud trashbin, main PROPFIND listing, extract_xml_properties (4)
- `azure.rs`: blob list, deleted-blobs list, XML error parse (3)
- `jottacloud.rs`: device names, mountpoint names (2); folder/trash listings verified safe (names arrive as attributes via `attr_value`) and annotated as such
- `sts.rs` deliberately untouched (credentials are base64, no entities)

## Verification
- 5 new regression tests: entity-adjacent whitespace round-trips exactly (S3 versions page + batch-delete errors, WebDAV PROPFIND displayname + href fallback, Jottacloud device/mountpoint names)
- `cargo test --lib providers::` 810/810 green; clippy clean; fmt applied
- LIVE on axpbuntu lab with a release CLI built from this branch:
  - MinIO + Nextcloud: `put` /`ls` /`get` of `raw & name2.txt` and `sp ace & ünïcodé.txt` round-trip with sha256 intact; the listing shows the real names
  - `sync --direction download --delete --dry-run` on both: plan is downloads-only, **zero `delete_local`** (the cascade is dead)

Agent: Kimi L2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with Azure Blob Storage, Amazon S3, Jottacloud, and WebDAV responses containing special characters or entity-encoded text.
  - Corrected file, folder, device, mount point, metadata, and error names so spaces and characters are preserved accurately.
  - Improved pagination handling and normalization of dates, sizes, tags, and other response details.
  - Added safeguards for more reliable parsing of listings, versions, trash contents, and batch-operation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->