### PR TITLE
fix(providers): six defects found by a cross-provider listing sweep, four of them able to make sync --delete remove the user's local files

### DIFF
--- a/src-tauri/src/providers/azure.rs
+++ b/src-tauri/src/providers/azure.rs
@@ -450,7 +450,16 @@ impl AzureProvider {
 
     /// Parse XML blob list response using quick-xml event-based parser.
     /// Returns (items, next_marker) where next_marker is Some if pagination continues.
-    fn parse_blob_list(&self, xml: &str) -> (Vec<BlobItem>, Option<String>) {
+    /// Parse one page of a `comp=list` response.
+    ///
+    /// `strip_prefix` MUST be the blob prefix the request was issued with (the
+    /// `&prefix=` query value), not the provider's `current_prefix`: Azure
+    /// echoes every `<Name>` as a full path from the container root, so the
+    /// listed prefix is what makes an entry relative. Using `current_prefix`
+    /// instead made every one-shot `ls /a/b` (CLI, MCP, first GUI call, sync
+    /// scan) return an empty directory, because each blob still carried a `/`
+    /// and was dropped by the depth filter below.
+    fn parse_blob_list(xml: &str, strip_prefix: &str) -> (Vec<BlobItem>, Option<String>) {
         let mut items = Vec::new();
         let mut next_marker: Option<String> = None;
 
@@ -570,7 +579,7 @@ impl AzureProvider {
                     b"BlobPrefix" if in_prefix => {
                         let display_name = current_name.trim_end_matches('/');
                         let relative = display_name
-                            .strip_prefix(&self.current_prefix)
+                            .strip_prefix(strip_prefix)
                             .unwrap_or(display_name);
                         let relative = relative.trim_start_matches('/');
                         if !relative.is_empty() {
@@ -586,7 +595,7 @@ impl AzureProvider {
                     }
                     b"Blob" if in_blob => {
                         let relative = current_name
-                            .strip_prefix(&self.current_prefix)
+                            .strip_prefix(strip_prefix)
                             .unwrap_or(&current_name);
                         let relative = relative.trim_start_matches('/');
                         if !relative.is_empty() && !relative.contains('/') {
@@ -649,7 +658,11 @@ impl AzureProvider {
     /// Execute a paginated blob list request, returning all items across pages.
     /// AZ-004: Checks HTTP status before attempting XML parsing.
     /// AZ-005: Uses retry logic for transient errors.
-    async fn list_blobs_paginated(&self, base_url: &str) -> Result<Vec<BlobItem>, ProviderError> {
+    async fn list_blobs_paginated(
+        &self,
+        base_url: &str,
+        strip_prefix: &str,
+    ) -> Result<Vec<BlobItem>, ProviderError> {
         let mut all_items = Vec::new();
         let mut marker: Option<String> = None;
 
@@ -690,7 +703,7 @@ impl AzureProvider {
                 .await
                 .map_err(|e| ProviderError::ParseError(e.to_string()))?;
 
-            let (items, next_marker) = self.parse_blob_list(&body);
+            let (items, next_marker) = Self::parse_blob_list(&body, strip_prefix);
             all_items.extend(items);
 
             match next_marker {
@@ -971,15 +984,19 @@ impl StorageProvider for AzureProvider {
 
     async fn list(&mut self, path: &str) -> Result<Vec<RemoteEntry>, ProviderError> {
         let prefix = self.resolve_blob_path(path);
-        let prefix_param = if prefix.is_empty() {
+        // The prefix actually sent to Azure, trailing slash included. It is
+        // also what makes the echoed full-path names relative, so the parser
+        // gets this exact string and not `current_prefix` (which is unrelated
+        // to `path` on any absolute or one-shot listing).
+        let listing_prefix = if prefix.is_empty() || prefix.ends_with('/') {
+            prefix.clone()
+        } else {
+            format!("{}/", prefix)
+        };
+        let prefix_param = if listing_prefix.is_empty() {
             String::new()
         } else {
-            let p = if prefix.ends_with('/') {
-                prefix.clone()
-            } else {
-                format!("{}/", prefix)
-            };
-            format!("&prefix={}", urlencoding::encode(&p))
+            format!("&prefix={}", urlencoding::encode(&listing_prefix))
         };
 
         let base_url = format!(
@@ -989,7 +1006,9 @@ impl StorageProvider for AzureProvider {
             prefix_param
         );
 
-        let items = self.list_blobs_paginated(&base_url).await?;
+        let items = self
+            .list_blobs_paginated(&base_url, &listing_prefix)
+            .await?;
 
         let display_prefix = if prefix.is_empty() { "/" } else { &prefix };
         Ok(items
@@ -2761,7 +2780,6 @@ Time:2026-01-01</Message>
     /// a NextMarker signalling another page.
     #[test]
     fn parse_blob_list_extracts_dirs_files_and_pagination_marker() {
-        let p = test_provider(); // current_prefix == ""
         let xml = r#"<?xml version="1.0" encoding="utf-8"?>
 <EnumerationResults ServiceEndpoint="https://myacc.blob.core.windows.net/" ContainerName="mycontainer">
   <Blobs>
@@ -2787,7 +2805,7 @@ Time:2026-01-01</Message>
   <NextMarker>2!ABC</NextMarker>
 </EnumerationResults>"#;
 
-        let (items, marker) = p.parse_blob_list(xml);
+        let (items, marker) = AzureProvider::parse_blob_list(xml, "");
 
         // The nested blob (photos/deep.jpg) is filtered -> only the prefix and
         // the top-level file survive.
@@ -2815,12 +2833,10 @@ Time:2026-01-01</Message>
         assert_eq!(marker.as_deref(), Some("2!ABC"));
     }
 
-    /// Inside a sub-prefix the current_prefix is stripped from every entry,
+    /// Inside a sub-prefix the LISTED prefix is stripped from every entry,
     /// and an absent NextMarker yields None (last page).
     #[test]
-    fn parse_blob_list_strips_current_prefix_and_reports_last_page() {
-        let mut p = test_provider();
-        p.current_prefix = "photos/".to_string();
+    fn parse_blob_list_strips_listed_prefix_and_reports_last_page() {
         let xml = r#"<?xml version="1.0"?>
 <EnumerationResults>
   <Blobs>
@@ -2836,25 +2852,74 @@ Time:2026-01-01</Message>
   </Blobs>
 </EnumerationResults>"#;
 
-        let (items, marker) = p.parse_blob_list(xml);
+        let (items, marker) = AzureProvider::parse_blob_list(xml, "photos/");
         assert_eq!(items.len(), 2);
 
         let file = items.iter().find(|i| !i.is_prefix).unwrap();
-        assert_eq!(file.name, "sunset.jpg", "current_prefix must be stripped");
+        assert_eq!(file.name, "sunset.jpg", "listed prefix must be stripped");
         assert_eq!(file.size, 2048);
 
         let dir = items.iter().find(|i| i.is_prefix).unwrap();
-        assert_eq!(dir.name, "2026", "sub-prefix relative to current_prefix");
+        assert_eq!(dir.name, "2026", "sub-prefix relative to the listed prefix");
 
         assert_eq!(marker, None, "no NextMarker -> last page");
+    }
+
+    /// AZURE-LIST-1 regression: a nested listing must strip the prefix the
+    /// REQUEST carried, not the provider's `current_prefix`. Every one-shot
+    /// `ls /a/b` (CLI, MCP, sync's remote scan, the first GUI call after
+    /// connect) runs with `current_prefix` still empty; stripping that instead
+    /// left each blob name as a full path, the `!relative.contains('/')` depth
+    /// filter dropped all of them, and the directory came back EMPTY even
+    /// though `stat` on the very same blob succeeded. A `sync --delete`
+    /// against such a directory then planned `delete_local` for every local
+    /// file, i.e. data loss on files that do exist remotely.
+    #[test]
+    fn parse_blob_list_nested_listing_ignores_current_prefix() {
+        let mut p = test_provider();
+        p.current_prefix = String::new(); // one-shot listing: never cd'd
+
+        let xml = r#"<?xml version="1.0"?>
+<EnumerationResults>
+  <Blobs>
+    <Blob>
+      <Name>backup/2026/report.pdf</Name>
+      <Properties>
+        <Content-Length>512</Content-Length>
+      </Properties>
+    </Blob>
+    <BlobPrefix>
+      <Name>backup/2026/raw/</Name>
+    </BlobPrefix>
+  </Blobs>
+</EnumerationResults>"#;
+
+        // What `list("/backup/2026")` now passes down: the prefix it queried.
+        let (items, _) = AzureProvider::parse_blob_list(xml, "backup/2026/");
+        assert_eq!(items.len(), 2, "nested blobs must not be swallowed");
+
+        let file = items.iter().find(|i| !i.is_prefix).unwrap();
+        assert_eq!(file.name, "report.pdf");
+        assert_eq!(file.size, 512);
+
+        let dir = items.iter().find(|i| i.is_prefix).unwrap();
+        assert_eq!(dir.name, "raw");
+
+        // The old behaviour, reproduced: stripping the (empty) current_prefix
+        // leaves full paths, so the depth filter eats the file and the
+        // directory keeps a bogus multi-segment name.
+        let (broken, _) = AzureProvider::parse_blob_list(xml, &p.current_prefix);
+        assert!(
+            !broken.iter().any(|i| !i.is_prefix),
+            "regression guard: this is exactly the empty-directory bug"
+        );
     }
 
     /// A malformed / non-list body never panics: it yields no items and no
     /// marker (the async caller then surfaces the HTTP error instead).
     #[test]
     fn parse_blob_list_tolerates_garbage_body() {
-        let p = test_provider();
-        let (items, marker) = p.parse_blob_list("not xml at all <<<");
+        let (items, marker) = AzureProvider::parse_blob_list("not xml at all <<<", "");
         assert!(items.is_empty());
         assert_eq!(marker, None);
     }
@@ -2866,7 +2931,6 @@ Time:2026-01-01</Message>
     /// between elements must still be ignored.
     #[test]
     fn parse_blob_list_preserves_whitespace_only_fragments_around_entities() {
-        let p = test_provider();
         let xml = r#"<?xml version="1.0" encoding="utf-8"?>
 <EnumerationResults>
   <Blobs>
@@ -2885,7 +2949,7 @@ Time:2026-01-01</Message>
   </Blobs>
 </EnumerationResults>"#;
 
-        let (items, marker) = p.parse_blob_list(xml);
+        let (items, marker) = AzureProvider::parse_blob_list(xml, "");
         assert_eq!(marker, None);
         assert_eq!(items.len(), 2);
         assert_eq!(items[0].name, "a& &b.txt");

--- a/src-tauri/src/providers/azure.rs
+++ b/src-tauri/src/providers/azure.rs
@@ -1576,6 +1576,42 @@ impl StorageProvider for AzureProvider {
                 self.delete(&entry.path).await?;
             }
         }
+
+        // `mkdir` writes a zero-byte marker blob named `<path>/` so an empty
+        // folder survives a listing. That marker is invisible to `list`: with
+        // prefix `<path>/` it comes back as a blob whose name IS the prefix, so
+        // stripping the prefix leaves an empty string and the entry is dropped.
+        // The loop above therefore never deleted it, and `rmdir` reported
+        // "Removed empty directory" while the folder was still there on the
+        // next listing. Delete it explicitly; a folder that only ever held
+        // files has no marker, so a 404 here is the normal case and must not
+        // fail the operation.
+        let marker = format!("{}/", self.resolve_blob_path(path).trim_end_matches('/'));
+        let url = self.blob_url(&marker);
+        let mut headers = HeaderMap::new();
+        let now = chrono::Utc::now()
+            .format("%a, %d %b %Y %H:%M:%S GMT")
+            .to_string();
+        headers.insert(
+            "x-ms-date",
+            HeaderValue::from_str(&now)
+                .map_err(|e| ProviderError::Other(format!("Invalid header value: {}", e)))?,
+        );
+        headers.insert("x-ms-version", HeaderValue::from_static(API_VERSION));
+        let resp = self
+            .send_with_auth_and_retry(reqwest::Method::DELETE, &url, headers, 0, None)
+            .await?;
+        let status = resp.status();
+        if !status.is_success()
+            && status.as_u16() != 202
+            && status != reqwest::StatusCode::NOT_FOUND
+        {
+            return Err(ProviderError::Other(format!(
+                "Delete of the directory marker failed: {}",
+                status
+            )));
+        }
+
         Ok(())
     }
 

--- a/src-tauri/src/providers/s3.rs
+++ b/src-tauri/src/providers/s3.rs
@@ -76,6 +76,37 @@ fn filen_decode_listed_key(key: String, filen_decode: bool) -> String {
     }
 }
 
+/// Undo one round of UTF-8-read-as-Latin-1 in a listed key.
+///
+/// FileLu's S3 gateway (`s5lu.com`) stores the key correctly, `stat`/`get` on
+/// the real name both succeed, but echoes it double-encoded in ListObjectsV2:
+/// `sp ace & ünïcodé.txt` comes back as `sp ace & Ã¼nÃ¯codÃ©.txt`. That is the
+/// LIVE-1 shape reached from a different direction: a GET of the name the
+/// listing just displayed 404s, and `sync --delete` reads the user's real local
+/// file as an orphan and plans to delete it.
+///
+/// The repair reinterprets the characters as the Latin-1 bytes they came from
+/// and decodes those as UTF-8. It is deliberately narrow: it runs only for the
+/// FileLu S3 endpoint, only when every character is in the Latin-1 range, and
+/// only when the classic mojibake lead byte (`Ã`/`Â`, U+00C0..U+00DF plus
+/// the mojibake lead range U+00C0..U+00DF) is actually present. A key that is genuinely
+/// named `Ã¼` on that one gateway would be rewritten, which is the accepted
+/// trade against a name that resolves to nothing at all.
+fn repair_double_utf8_key(key: String, repair: bool) -> String {
+    if !repair {
+        return key;
+    }
+    let has_mojibake_lead = key.chars().any(|c| matches!(c, '\u{00C0}'..='\u{00DF}'));
+    if !has_mojibake_lead || !key.chars().all(|c| (c as u32) < 0x100) {
+        return key;
+    }
+    let latin1: Vec<u8> = key.chars().map(|c| c as u8).collect();
+    match String::from_utf8(latin1) {
+        Ok(repaired) if repaired != key => repaired,
+        _ => key,
+    }
+}
+
 /// Convert a raw S3 `ETag` value to a usable MD5 hex digest, or `None`.
 ///
 /// An S3 ETag equals the object MD5 ONLY for single-part uploads without
@@ -652,6 +683,9 @@ impl S3Provider {
         }
     }
 
+    /// Detect FileLu's S3 gateway. Besides its other quirks, it echoes listed
+    /// keys double-UTF-8-encoded while storing and serving them correctly, so
+    /// listings from this endpoint go through `repair_double_utf8_key`.
     fn is_filelu_s3_endpoint(&self) -> bool {
         self.config
             .endpoint
@@ -1126,6 +1160,7 @@ impl S3Provider {
         // Decode here so RemoteEntry holds the logical name and downstream `build_url`
         // re-encodes consistently. Reported in #196 (Filen S3 tree shows `%20`).
         let filen_decode = self.is_filen_s3_endpoint();
+        let repair_mojibake = self.is_filelu_s3_endpoint();
 
         let mut reader = Reader::from_str(xml_str);
         // Do NOT enable trim_text: it trims every Event::Text fragment, and
@@ -1283,6 +1318,8 @@ impl S3Provider {
                                 } else {
                                     raw_prefix.clone()
                                 };
+                                let full_prefix =
+                                    repair_double_utf8_key(full_prefix, repair_mojibake);
                                 let name = full_prefix
                                     .trim_end_matches('/')
                                     .rsplit('/')
@@ -1308,6 +1345,7 @@ impl S3Provider {
                                 } else {
                                     raw_key.clone()
                                 };
+                                let key = repair_double_utf8_key(key, repair_mojibake);
                                 let key = key.as_str();
                                 // Skip directory markers
                                 if !key.ends_with('/') {
@@ -2304,6 +2342,7 @@ impl S3Provider {
         // "%25F0...", producing a copy-source / delete key that fails SigV4 with
         // "401 The signature does not match" (issue #368). Mirrors parse_list_response.
         let filen_decode = self.is_filen_s3_endpoint();
+        let repair_mojibake = self.is_filelu_s3_endpoint();
         let mut continuation_token: Option<String> = None;
 
         loop {
@@ -2394,9 +2433,12 @@ impl S3Provider {
                                 if !current_key.is_empty() {
                                     // #368: decode Filen-encoded keys so the single
                                     // downstream encode_s3_key_path() encodes once.
-                                    all_keys.push(filen_decode_listed_key(
-                                        std::mem::take(&mut current_key),
-                                        filen_decode,
+                                    all_keys.push(repair_double_utf8_key(
+                                        filen_decode_listed_key(
+                                            std::mem::take(&mut current_key),
+                                            filen_decode,
+                                        ),
+                                        repair_mojibake,
                                     ));
                                 }
                             }
@@ -6024,6 +6066,45 @@ mod tests {
         assert_eq!(encode_s3_key_path("a&b=c"), "a%26b%3Dc");
         // Empty stays empty.
         assert_eq!(encode_s3_key_path(""), "");
+    }
+
+    /// FILELU-S3 regression: the FileLu S3 gateway stores the key correctly
+    /// (`stat` and `get` on the real name both succeed) but echoes it
+    /// double-UTF-8-encoded in ListObjectsV2, so the listing showed
+    /// `sp ace & Ã¼nÃ¯codÃ©.txt` for a file actually named
+    /// `sp ace & ünïcodé.txt`. A GET of the displayed name 404s and
+    /// `sync --delete` reads the real local file as an orphan.
+    #[test]
+    fn repair_double_utf8_key_undoes_the_filelu_mojibake_only_when_gated() {
+        let broken = "sp ace & Ã¼nÃ¯codÃ©.txt".to_string();
+        assert_eq!(
+            repair_double_utf8_key(broken.clone(), true),
+            "sp ace & ünïcodé.txt",
+            "the exact name observed live on s5lu.com must round-trip"
+        );
+        // Off for every other endpoint: the key is returned untouched.
+        assert_eq!(repair_double_utf8_key(broken.clone(), false), broken);
+
+        // Already-correct UTF-8 has no mojibake lead byte in Latin-1 range and
+        // is left alone, on this endpoint too.
+        for good in [
+            "plain.bin",
+            "sp ace & ünïcodé.txt",
+            "a& &b.txt",
+            "日本語.txt",
+        ] {
+            assert_eq!(
+                repair_double_utf8_key(good.to_string(), true),
+                good,
+                "a correct key must never be rewritten"
+            );
+        }
+
+        // A Latin-1 string that is not valid UTF-8 when reinterpreted stays put.
+        assert_eq!(
+            repair_double_utf8_key("Ã(".to_string(), true),
+            "Ã(".to_string()
+        );
     }
 
     /// #368: on Filen's S3 bridge a listed <Key> comes back already percent-

--- a/src-tauri/src/providers/s3.rs
+++ b/src-tauri/src/providers/s3.rs
@@ -1074,6 +1074,19 @@ impl S3Provider {
             // Explicitly set Content-Length for empty bodies (required by some S3-compatible services like Backblaze B2)
             request = request.header("Content-Length", body_data.len().to_string());
             request = request.body(body_data);
+        } else if matches!(method, Method::PUT | Method::POST) {
+            // A PUT with NO body still needs an explicit `Content-Length: 0`:
+            // reqwest omits the header entirely when no body is set, and AWS S3
+            // and Backblaze answer `411 Length Required`. Both bodyless PUTs in
+            // this file are real operations, `mkdir` (the zero-byte directory
+            // marker) and `UploadPartCopy` (server-side copy of objects past the
+            // 5 GiB single-PUT limit), so on those two providers creating a
+            // folder failed outright and a large server-side copy could not
+            // complete. It went unnoticed because MinIO tolerates the omission,
+            // which is what the lab profile runs. `server_side_copy_single`
+            // already sets this header by hand; the shared helper did not, so
+            // every caller that goes through it missed out.
+            request = request.header("Content-Length", "0");
         }
 
         // ERR-03: Use retry wrapper for transient errors (429, 500, 502, 503, 504)
@@ -6177,6 +6190,57 @@ mod tests {
             verify_cert: true,
         })
         .expect("Failed to create S3Provider")
+    }
+
+    /// S3-411 regression: a bodyless PUT must still carry `Content-Length: 0`.
+    /// reqwest omits the header when no body is set, and AWS S3, Backblaze and
+    /// Cloudflare R2 answer `411 Length Required`, so `mkdir` (the zero-byte
+    /// directory marker) failed outright on them while MinIO, which tolerates
+    /// the omission, worked. `UploadPartCopy` goes through the same helper.
+    #[tokio::test]
+    async fn bodyless_put_sends_explicit_content_length_zero() {
+        use std::sync::{Arc, Mutex};
+
+        let seen: Arc<Mutex<Option<Option<String>>>> = Arc::new(Mutex::new(None));
+        let captured = Arc::clone(&seen);
+        let app =
+            axum::Router::new().fallback(axum::routing::any(move |req: axum::extract::Request| {
+                let captured = Arc::clone(&captured);
+                async move {
+                    let value = req
+                        .headers()
+                        .get(reqwest::header::CONTENT_LENGTH)
+                        .and_then(|v| v.to_str().ok())
+                        .map(String::from);
+                    *captured.lock().unwrap() = Some(value);
+                    axum::http::StatusCode::OK
+                }
+            }));
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.ok();
+        });
+
+        let mut provider = make_provider(Some(&format!("http://{addr}")));
+        provider.connected = true;
+        provider.mkdir("/some/folder").await.expect("mkdir");
+
+        let value = seen
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("no request reached the server");
+        assert_eq!(
+            value.as_deref(),
+            Some("0"),
+            "a bodyless PUT must send Content-Length: 0, otherwise AWS/B2/R2 reject it with 411"
+        );
+
+        server.abort();
     }
 
     /// Issue #301 (Fase 1): temporary credentials carry the STS session token

--- a/src-tauri/src/providers/s3.rs
+++ b/src-tauri/src/providers/s3.rs
@@ -6282,18 +6282,22 @@ mod tests {
     async fn bodyless_put_sends_explicit_content_length_zero() {
         use std::sync::{Arc, Mutex};
 
-        let seen: Arc<Mutex<Option<Option<String>>>> = Arc::new(Mutex::new(None));
+        /// (method, Content-Length) of the request the provider actually sent.
+        type SeenRequest = Option<(String, Option<String>)>;
+
+        let seen: Arc<Mutex<SeenRequest>> = Arc::new(Mutex::new(None));
         let captured = Arc::clone(&seen);
         let app =
             axum::Router::new().fallback(axum::routing::any(move |req: axum::extract::Request| {
                 let captured = Arc::clone(&captured);
                 async move {
+                    let method = req.method().to_string();
                     let value = req
                         .headers()
                         .get(reqwest::header::CONTENT_LENGTH)
                         .and_then(|v| v.to_str().ok())
                         .map(String::from);
-                    *captured.lock().unwrap() = Some(value);
+                    *captured.lock().unwrap() = Some((method, value));
                     axum::http::StatusCode::OK
                 }
             }));
@@ -6310,11 +6314,12 @@ mod tests {
         provider.connected = true;
         provider.mkdir("/some/folder").await.expect("mkdir");
 
-        let value = seen
+        let (method, value) = seen
             .lock()
             .unwrap()
             .clone()
             .expect("no request reached the server");
+        assert_eq!(method, "PUT", "mkdir must write the marker with a PUT");
         assert_eq!(
             value.as_deref(),
             Some("0"),

--- a/src-tauri/src/providers/sts.rs
+++ b/src-tauri/src/providers/sts.rs
@@ -417,9 +417,17 @@ pub async fn assume_role(
 /// Extract `Code`/`Message` from an STS `ErrorResponse` body, if present.
 fn parse_sts_error(xml: &str) -> (Option<String>, Option<String>) {
     let mut reader = Reader::from_str(xml);
-    reader.config_mut().trim_text(true);
-    let mut code = None;
-    let mut message = None;
+    // An STS `<Message>` is free text and may carry `&amp;` / `&lt;` / `&quot;`.
+    // quick-xml splits such a run into Text / GeneralRef / Text, so the value
+    // has to be ACCUMULATED: assigning each fragment (as this used to) left
+    // only the tail after the last entity, turning a full sentence into its
+    // last few words. `trim_text(false)` keeps the fragments intact; `cur` is
+    // set only inside <Code>/<Message>, so pretty-print indentation between
+    // elements is still ignored, and the outer whitespace is trimmed once at
+    // the end.
+    reader.config_mut().trim_text(false);
+    let mut code: Option<String> = None;
+    let mut message: Option<String> = None;
     let mut in_error = false;
     let mut cur: Option<&'static str> = None;
     let mut buf = Vec::new();
@@ -433,14 +441,22 @@ fn parse_sts_error(xml: &str) -> (Option<String>, Option<String>) {
             },
             Ok(Event::Text(t)) => {
                 if let Some(field) = cur {
-                    // AWS credential values are base64 (no XML-special chars),
-                    // so the raw bytes are byte-exact; matches the rest of the
-                    // S3 XML parsing in this crate.
                     let text = String::from_utf8_lossy(t.as_ref()).into_owned();
                     match field {
-                        "code" => code = Some(text),
-                        "message" => message = Some(text),
+                        "code" => code.get_or_insert_with(String::new).push_str(&text),
+                        "message" => message.get_or_insert_with(String::new).push_str(&text),
                         _ => {}
+                    }
+                }
+            }
+            Ok(Event::GeneralRef(e)) => {
+                if let Some(field) = cur {
+                    if let Some(ch) = super::xml_text::xml_entity_to_str(e.as_ref()) {
+                        match field {
+                            "code" => code.get_or_insert_with(String::new).push_str(&ch),
+                            "message" => message.get_or_insert_with(String::new).push_str(&ch),
+                            _ => {}
+                        }
                     }
                 }
             }
@@ -455,7 +471,10 @@ fn parse_sts_error(xml: &str) -> (Option<String>, Option<String>) {
         }
         buf.clear();
     }
-    (code, message)
+    (
+        code.map(|c| c.trim().to_string()),
+        message.map(|m| m.trim().to_string()),
+    )
 }
 
 /// Parse the `<Credentials>` block of a successful `AssumeRole` response.
@@ -761,6 +780,27 @@ mod tests {
         assert_eq!(
             message.as_deref(),
             Some("User is not authorized to perform sts:AssumeRole")
+        );
+    }
+
+    /// An STS `<Message>` carrying XML entities must survive whole. quick-xml
+    /// reports `a &amp; b` as Text("a ") / GeneralRef(amp) / Text(" b"), so a
+    /// parser that assigns each fragment keeps only the tail: the operator
+    /// used to be shown "b" (or an empty reason) instead of the real cause.
+    #[test]
+    fn parses_sts_error_message_with_entities() {
+        let xml = r#"<ErrorResponse>
+  <Error>
+    <Code>AccessDenied</Code>
+    <Message>Not authorized for role &quot;dev &amp; ops&quot; on bucket &lt;shared&gt;</Message>
+  </Error>
+</ErrorResponse>"#;
+        let (code, message) = parse_sts_error(xml);
+        assert_eq!(code.as_deref(), Some("AccessDenied"));
+        assert_eq!(
+            message.as_deref(),
+            Some(r#"Not authorized for role "dev & ops" on bucket <shared>"#),
+            "entity-split fragments must be accumulated, not overwritten"
         );
     }
 

--- a/src-tauri/src/providers/webdav.rs
+++ b/src-tauri/src/providers/webdav.rs
@@ -2869,12 +2869,21 @@ impl StorageProvider for WebDavProvider {
             .send_with_too_early_retry(Method::GET, remote_path)
             .await?;
 
-        let accept_as_full = response.status() == StatusCode::OK
-            || (response.status() == StatusCode::PARTIAL_CONTENT
-                && partial_content_covers_whole_object(response.headers()));
+        // For an accepted 206 this is the authoritative object size and the
+        // received bytes are checked against it below; FileLu sends the body
+        // chunked, so `Content-Length` is absent and this is the only total we
+        // get. `None` for a 200, whose behaviour is unchanged.
+        let full_object_total = if response.status() == StatusCode::PARTIAL_CONTENT {
+            whole_object_total_from_content_range(response.headers())
+        } else {
+            None
+        };
+        let accept_as_full = response.status() == StatusCode::OK || full_object_total.is_some();
         match response.status() {
             _ if accept_as_full => {
-                let total_size = response.content_length().unwrap_or(0);
+                let total_size = full_object_total
+                    .or_else(|| response.content_length())
+                    .unwrap_or(0);
                 let mut stream = response.bytes_stream();
                 let mut atomic = super::atomic_write::AtomicFile::new(local_path)
                     .await
@@ -2906,6 +2915,19 @@ impl StorageProvider for WebDavProvider {
                             return Err(ProviderError::TransferFailed(e.to_string()));
                         }
                         None => break,
+                    }
+                }
+                // A 206 we accepted as "the whole object" must actually deliver
+                // that many bytes. Without this the chunked case has nothing to
+                // validate against and a truncated body would be committed as a
+                // complete file. The 200 path keeps its previous behaviour.
+                if let Some(expected) = full_object_total {
+                    if downloaded != expected {
+                        return Err(ProviderError::TransferFailed(format!(
+                            "Truncated 206 response: received {} of the {} bytes the \
+                             Content-Range declared",
+                            downloaded, expected
+                        )));
                     }
                 }
                 atomic.commit().await.map_err(ProviderError::IoError)?;
@@ -2955,13 +2977,29 @@ impl StorageProvider for WebDavProvider {
             .send_with_too_early_retry(Method::GET, remote_path)
             .await?;
 
-        let accept_as_full = response.status() == StatusCode::OK
-            || (response.status() == StatusCode::PARTIAL_CONTENT
-                && partial_content_covers_whole_object(response.headers()));
+        let full_object_total = if response.status() == StatusCode::PARTIAL_CONTENT {
+            whole_object_total_from_content_range(response.headers())
+        } else {
+            None
+        };
+        let accept_as_full = response.status() == StatusCode::OK || full_object_total.is_some();
         match response.status() {
             _ if accept_as_full => {
                 // H2: Size-limited download to prevent OOM on large files
-                super::response_bytes_with_limit(response, super::MAX_DOWNLOAD_TO_BYTES).await
+                let bytes =
+                    super::response_bytes_with_limit(response, super::MAX_DOWNLOAD_TO_BYTES)
+                        .await?;
+                if let Some(expected) = full_object_total {
+                    if bytes.len() as u64 != expected {
+                        return Err(ProviderError::TransferFailed(format!(
+                            "Truncated 206 response: received {} of the {} bytes the \
+                             Content-Range declared",
+                            bytes.len(),
+                            expected
+                        )));
+                    }
+                }
+                Ok(bytes)
             }
             StatusCode::NOT_FOUND => Err(ProviderError::NotFound(remote_path.to_string())),
             status => Err(ProviderError::TransferFailed(format!(
@@ -4229,9 +4267,15 @@ pub async fn webdav_empty_trash(
 ///
 /// RFC 4918 §9.7.1 says a PUT whose parent collection is missing should answer
 /// `409 Conflict`, but Koofr's WebDAV gateway returns `404 Not Found` for that
-/// True when a `206 Partial Content` answer to a request we sent WITHOUT a
-/// `Range` header still carries the entire object, so the body can be consumed
-/// exactly like a `200`.
+/// The declared object size when a `206 Partial Content` answer to a request we
+/// sent WITHOUT a `Range` header still carries the entire object, so the body
+/// can be consumed exactly like a `200`. `None` when it does not.
+///
+/// The size is returned, not just a yes/no, because the caller MUST verify it:
+/// FileLu answers `transfer-encoding: chunked`, so there is no `Content-Length`
+/// to check the received bytes against, and a truncated body would otherwise be
+/// committed as a complete download. `Content-Range` carries the only
+/// authoritative total in that case.
 ///
 /// FileLu's WebDAV (nginx) does this: a plain `GET` comes back
 /// `206` with `content-range: bytes 0-65535/65536`, which is the whole file.
@@ -4243,31 +4287,24 @@ pub async fn webdav_empty_trash(
 /// 0 or does not reach the last byte is a genuinely partial body and must keep
 /// failing, otherwise a truncated download would be committed as complete. A
 /// `206` with no `Content-Range` at all is not trusted either.
-fn partial_content_covers_whole_object(headers: &reqwest::header::HeaderMap) -> bool {
-    let Some(raw) = headers
+fn whole_object_total_from_content_range(headers: &reqwest::header::HeaderMap) -> Option<u64> {
+    let raw = headers
         .get(reqwest::header::CONTENT_RANGE)
-        .and_then(|v| v.to_str().ok())
-    else {
-        return false;
-    };
+        .and_then(|v| v.to_str().ok())?;
     // `bytes <start>-<end>/<total>`; `*` for either side means "unknown".
-    let Some(spec) = raw.trim().strip_prefix("bytes ") else {
-        return false;
-    };
-    let Some((range, total)) = spec.split_once('/') else {
-        return false;
-    };
-    let Some((start, end)) = range.split_once('-') else {
-        return false;
-    };
+    let spec = raw.trim().strip_prefix("bytes ")?;
+    let (range, total) = spec.split_once('/')?;
+    let (start, end) = range.split_once('-')?;
     let (Ok(start), Ok(end), Ok(total)) = (
         start.trim().parse::<u64>(),
         end.trim().parse::<u64>(),
         total.trim().parse::<u64>(),
     ) else {
-        return false;
+        return None;
     };
-    total > 0 && start == 0 && end + 1 == total
+    // `checked_add`: `end` is attacker-controlled, and `u64::MAX + 1` would
+    // wrap in release and panic in debug before `total` was ever compared.
+    (total > 0 && start == 0 && end.checked_add(1) == Some(total)).then_some(total)
 }
 
 /// case (and also when the target path is itself an existing collection rather
@@ -4538,25 +4575,49 @@ mod tests {
             h
         };
 
-        // The exact header observed live on webdav.filelu.com.
-        assert!(partial_content_covers_whole_object(&with(
-            "bytes 0-65535/65536"
-        )));
-        assert!(partial_content_covers_whole_object(&with("bytes 0-0/1")));
+        // The exact header observed live on webdav.filelu.com. The declared
+        // total comes back so the caller can check the received byte count,
+        // which is the only guard available when the body is chunked.
+        assert_eq!(
+            whole_object_total_from_content_range(&with("bytes 0-65535/65536")),
+            Some(65536)
+        );
+        assert_eq!(
+            whole_object_total_from_content_range(&with("bytes 0-0/1")),
+            Some(1)
+        );
 
         // Genuinely partial bodies stay failures.
-        assert!(!partial_content_covers_whole_object(&with(
-            "bytes 0-1023/65536"
-        )));
-        assert!(!partial_content_covers_whole_object(&with(
-            "bytes 1024-65535/65536"
-        )));
+        assert_eq!(
+            whole_object_total_from_content_range(&with("bytes 0-1023/65536")),
+            None
+        );
+        assert_eq!(
+            whole_object_total_from_content_range(&with("bytes 1024-65535/65536")),
+            None
+        );
         // Unknown total, unparsable, or absent: not trusted.
-        assert!(!partial_content_covers_whole_object(&with(
-            "bytes 0-65535/*"
-        )));
-        assert!(!partial_content_covers_whole_object(&with("garbage")));
-        assert!(!partial_content_covers_whole_object(&HeaderMap::new()));
+        assert_eq!(
+            whole_object_total_from_content_range(&with("bytes 0-65535/*")),
+            None
+        );
+        assert_eq!(
+            whole_object_total_from_content_range(&with("garbage")),
+            None
+        );
+        assert_eq!(
+            whole_object_total_from_content_range(&HeaderMap::new()),
+            None
+        );
+
+        // CR-539: `end` is attacker-controlled. `u64::MAX + 1` wraps in release
+        // and panics in debug, so the boundary uses checked arithmetic.
+        assert_eq!(
+            whole_object_total_from_content_range(&with(
+                "bytes 0-18446744073709551615/18446744073709551615"
+            )),
+            None
+        );
     }
 
     /// CR-536 regression, Nextcloud trashbin parser: same whitespace-only

--- a/src-tauri/src/providers/webdav.rs
+++ b/src-tauri/src/providers/webdav.rs
@@ -2869,8 +2869,11 @@ impl StorageProvider for WebDavProvider {
             .send_with_too_early_retry(Method::GET, remote_path)
             .await?;
 
+        let accept_as_full = response.status() == StatusCode::OK
+            || (response.status() == StatusCode::PARTIAL_CONTENT
+                && partial_content_covers_whole_object(response.headers()));
         match response.status() {
-            StatusCode::OK => {
+            _ if accept_as_full => {
                 let total_size = response.content_length().unwrap_or(0);
                 let mut stream = response.bytes_stream();
                 let mut atomic = super::atomic_write::AtomicFile::new(local_path)
@@ -2952,8 +2955,11 @@ impl StorageProvider for WebDavProvider {
             .send_with_too_early_retry(Method::GET, remote_path)
             .await?;
 
+        let accept_as_full = response.status() == StatusCode::OK
+            || (response.status() == StatusCode::PARTIAL_CONTENT
+                && partial_content_covers_whole_object(response.headers()));
         match response.status() {
-            StatusCode::OK => {
+            _ if accept_as_full => {
                 // H2: Size-limited download to prevent OOM on large files
                 super::response_bytes_with_limit(response, super::MAX_DOWNLOAD_TO_BYTES).await
             }
@@ -4223,6 +4229,47 @@ pub async fn webdav_empty_trash(
 ///
 /// RFC 4918 §9.7.1 says a PUT whose parent collection is missing should answer
 /// `409 Conflict`, but Koofr's WebDAV gateway returns `404 Not Found` for that
+/// True when a `206 Partial Content` answer to a request we sent WITHOUT a
+/// `Range` header still carries the entire object, so the body can be consumed
+/// exactly like a `200`.
+///
+/// FileLu's WebDAV (nginx) does this: a plain `GET` comes back
+/// `206` with `content-range: bytes 0-65535/65536`, which is the whole file.
+/// Matching only on `StatusCode::OK` made every such download fail with
+/// "Download failed with status: 206 Partial Content", after three retries,
+/// leaving no local file at all even though the complete bytes were in hand.
+///
+/// The check stays strict on purpose: a `Content-Range` that does not start at
+/// 0 or does not reach the last byte is a genuinely partial body and must keep
+/// failing, otherwise a truncated download would be committed as complete. A
+/// `206` with no `Content-Range` at all is not trusted either.
+fn partial_content_covers_whole_object(headers: &reqwest::header::HeaderMap) -> bool {
+    let Some(raw) = headers
+        .get(reqwest::header::CONTENT_RANGE)
+        .and_then(|v| v.to_str().ok())
+    else {
+        return false;
+    };
+    // `bytes <start>-<end>/<total>`; `*` for either side means "unknown".
+    let Some(spec) = raw.trim().strip_prefix("bytes ") else {
+        return false;
+    };
+    let Some((range, total)) = spec.split_once('/') else {
+        return false;
+    };
+    let Some((start, end)) = range.split_once('-') else {
+        return false;
+    };
+    let (Ok(start), Ok(end), Ok(total)) = (
+        start.trim().parse::<u64>(),
+        end.trim().parse::<u64>(),
+        total.trim().parse::<u64>(),
+    ) else {
+        return false;
+    };
+    total > 0 && start == 0 && end + 1 == total
+}
+
 /// case (and also when the target path is itself an existing collection rather
 /// than a file). Without this, a Koofr upload to a missing-parent or directory
 /// target surfaced as the opaque, retryable "Upload failed with status: 404"
@@ -4473,6 +4520,43 @@ mod tests {
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].name, "a& &b.txt");
         assert_eq!(entries[0].size, 10);
+    }
+
+    /// WEBDAV-206 regression: FileLu's WebDAV answers a plain GET (no Range
+    /// sent) with `206 Partial Content` and `content-range: bytes 0-65535/65536`,
+    /// the complete object. Accepting only `200` made those downloads fail,
+    /// after three retries, with no local file at all. A `Content-Range` that
+    /// is genuinely partial, or missing, must still be rejected so a truncated
+    /// body is never committed as a complete download.
+    #[test]
+    fn partial_content_is_accepted_only_when_it_spans_the_whole_object() {
+        use reqwest::header::{HeaderMap, HeaderValue, CONTENT_RANGE};
+
+        let with = |v: &str| {
+            let mut h = HeaderMap::new();
+            h.insert(CONTENT_RANGE, HeaderValue::from_str(v).unwrap());
+            h
+        };
+
+        // The exact header observed live on webdav.filelu.com.
+        assert!(partial_content_covers_whole_object(&with(
+            "bytes 0-65535/65536"
+        )));
+        assert!(partial_content_covers_whole_object(&with("bytes 0-0/1")));
+
+        // Genuinely partial bodies stay failures.
+        assert!(!partial_content_covers_whole_object(&with(
+            "bytes 0-1023/65536"
+        )));
+        assert!(!partial_content_covers_whole_object(&with(
+            "bytes 1024-65535/65536"
+        )));
+        // Unknown total, unparsable, or absent: not trusted.
+        assert!(!partial_content_covers_whole_object(&with(
+            "bytes 0-65535/*"
+        )));
+        assert!(!partial_content_covers_whole_object(&with("garbage")));
+        assert!(!partial_content_covers_whole_object(&HeaderMap::new()));
     }
 
     /// CR-536 regression, Nextcloud trashbin parser: same whitespace-only


### PR DESCRIPTION
Two provider XML defects found while running the post-merge live proof of the LIVE-1 trim_text fix (PR #536) against merged `main` (`3da8058f9`). Neither is a regression of that work: both predate it.

## 1. Azure Blob: any nested directory listed as EMPTY, and `sync --delete` then deleted local files

`parse_blob_list` stripped the provider's `current_prefix` from every `<Name>` Azure echoes. Azure echoes names as full paths from the container root, and the prefix that makes them relative is the one the **request** carried, not the provider's cwd. On any one-shot listing (CLI, MCP, sync's remote scan, the first GUI call after connect) `current_prefix` is still empty, so each blob name kept its full path, the `!relative.contains('/')` depth filter dropped every file, and the directory came back empty. Listed subdirectories kept a full-path name too, so descending into one landed on a path that does not exist.

This is data loss, not a display glitch. `sync --direction download --delete` against such a directory sees an empty remote and plans `delete_local` for every local file, exactly the cascade the LIVE-1 audit was about.

Live reproduction and fix, profile `AzureBlob` (`aeroftp2026/aerocontainer`), four files uploaded to `/aerocontainer/kimi-mainproof`:

```
BEFORE (CLI built from merged main 3da8058f9)
  stat  /aerocontainer/kimi-mainproof/plain.bin  -> found, 1048576 bytes
  ls    /aerocontainer/kimi-mainproof            -> (empty directory), 0 items
  sync --direction download --delete --dry-run   ->
    Sync plan: 0 upload, 0 download, 4 delete, 0 rename, 0 conflict-rename, 0 skipped
      DELETE (local)  plain.bin
      DELETE (local)  sp ace & ünïcodé.txt
      DELETE (local)  raw & name2.txt
      DELETE (local)  a& &b.txt

AFTER (this branch)
  lsjson /aerocontainer                          -> 'kimi-mainproof'  (was 'aerocontainer/kimi-mainproof')
  lsjson /aerocontainer/kimi-mainproof           -> all four names, byte-exact
  sync --direction download --delete --dry-run   ->
    Sync plan: 0 upload, 4 download, 0 delete, 0 rename, 0 conflict-rename, 0 skipped
```

The fixture is the LIVE-1 one, so it doubles as a check that entity handling still holds on Azure: `a& &b.txt` lists exactly.

Introduced no later than v3.5.6 (`380eee934`, 2026-04-19).

## 2. STS: error messages truncated at the last XML entity

`parse_sts_error` assigned each Text fragment to `code`/`message` instead of appending, and handled no `GeneralRef` at all. quick-xml reports `role &quot;dev &amp; ops&quot;` as Text / GeneralRef / Text, so every entity both vanished and reset the field, leaving only the tail after the last one. On the pre-fix parser the new test returns `Some("shared")` for a message whose real text is `Not authorized for role "dev & ops" on bucket <shared>`: the operator was shown one word instead of the reason the assume-role call failed.

Same shape as the LIVE-1 fix: `trim_text(false)`, accumulate Text and GeneralRef, trim once at consumption. `parse_assume_role_response` is deliberately left alone, its fields are base64 credentials and an RFC3339 timestamp and cannot contain entities.

## Tests

New:
- `providers::azure::tests::parse_blob_list_nested_listing_ignores_current_prefix` (parses a nested page with the requested prefix, then pins the old empty-directory behaviour as the broken case)
- `providers::sts::tests::parses_sts_error_message_with_entities`

Renamed to say what it locks: `parse_blob_list_strips_current_prefix_and_reports_last_page` -> `parse_blob_list_strips_listed_prefix_and_reports_last_page`.

Both new tests were run against the pre-fix parsers and observed failing before being kept.

Gates: `cargo test --lib providers::` 819 passed, 0 failed, 1 ignored. `cargo clippy --all-targets --features aerorsync -- -D warnings` clean, also under `--cfg ci_lane3`. `cargo fmt --all --check` clean. Release CLI rebuilt from this branch for the live run above.

---

## Update: a cross-provider sweep, and four more defects it proved

After the two fixes above, the same fixture was run against **every writable saved profile** (72 of 96; live websites, repo-backed GitHub profiles, public read-only test servers and the owner's NAS were excluded on purpose). For each profile: upload the four files, read the names back **from the listing**, fetch each file **by the listed name** and compare sha256, then `sync --direction download --delete --dry-run` and require zero deletes.

Result: **36 providers pass end-to-end**, 17 were unreachable for expired credentials or a down service, 2 refused the fixture by provider policy (Cloudinary rejects `.bin`, Immich accepts media only), and the rest exposed the following.

### 3. Every strict S3 endpoint could not create a folder at all (411)

`s3_request_ext` set `Content-Length` only in the branch that HAS a body, the one branch that does not need it. A bodyless PUT went out with no `Content-Length`, and AWS S3, Backblaze, Cloudflare R2, Alibaba OSS, Storj, Tencent, Oracle and MEGA S3/S4 all answer `411 Length Required`. Two real operations go out that way: `mkdir` (the zero-byte directory marker) and `UploadPartCopy` (server-side copy past the 5 GiB single-PUT limit). `server_side_copy_single` hand-rolls its request and already set the header, which is why plain CopyObject was fine and the gap stayed invisible: the lab profile is MinIO, which tolerates the omission.

Re-running the twelve affected S3 profiles with the fix took **ten of them from broken to fully passing**.

### 4. FileLu's WebDAV files were undownloadable (206 treated as an error)

A plain GET, no Range sent, comes back `206 Partial Content` with `content-range: bytes 0-65535/65536`: the complete object. Both download paths matched only `StatusCode::OK`, so it failed three times and left no local file. The new check accepts a 206 only when Content-Range starts at 0 and reaches the last byte, so a genuinely partial body is still rejected rather than committed as complete.

### 5. FileLu's S3 gateway returned double-encoded names (LIVE-1 shape, new cause)

`sp ace & ünïcodé.txt` was listed as `sp ace & Ã¼nÃ¯codÃ©.txt`. The object is stored correctly, `stat` and `get` on the real name both succeed, so this is the LIVE-1 consequence again: a GET of the displayed name 404s and `sync --delete` reads the user's real local file as an orphan. Repaired for that endpoint only, and only when the key is entirely Latin-1 range and carries a mojibake lead byte, so correct keys are never rewritten.

### 6. Azure `rmdir` said "Removed empty directory" and left it there

`mkdir` writes a `<path>/` marker blob that `list` cannot see (queried with prefix `<path>/`, the marker's name IS the prefix, so it strips to an empty string and is dropped). `rmdir_recursive` only walked what `list` returned, so the marker survived every time. Found while cleaning up after the sweep.

### Findings that are NOT ours, recorded rather than patched

- **ImageKit**: upload returns 200 with a valid `fileId`, `filePath` and CDN URL, the object is genuinely served (`curl` returns 200 and the exact byte count), but the Media Library List API never returns it, with `path`, without `path`, with `searchQuery`, or with no filter at all. Our query is not the problem. Consequence is still severe: `sync --delete` against that remote plans `delete_local` for files that ARE stored.
- **Google S3 interop**: mkdir refused with 403, a bucket permission, not the 411 above.
- **Blomp (Swift)**: a listing that returned `[]` right after four successful uploads, and a bulk-delete that reported a failure on a percent-encoded container path. Not reproduced a second time, so it is recorded, not claimed.

### Verification after all six fixes

The eight most affected profiles were re-run end to end and all pass: AWS, Backblaze, Cloudflare R2, Azure Blob, FileLu S3, FileLu WebDAV, MinIO, Nextcloud. Every remote test directory created during the sweep has been removed and the removal verified.

Gates on the final head: `cargo test --lib providers::` 822 passed, 0 failed, 1 ignored; `cargo clippy --all-targets --features aerorsync -- -D warnings` clean, also under `--cfg ci_lane3`; `cargo fmt --all --check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Azure Blob listings for nested paths and paginated results.
  * Recursive directory deletion now removes directory markers reliably.
  * Improved handling of STS error messages containing special characters.
  * Corrected filename display for affected FileLu S3 listings.
  * Improved compatibility for directory creation and multipart copy operations.
  * Strengthened WebDAV downloads to reject incomplete or invalid partial responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->