### PR TITLE
fix(gui): make the delete confirmation reachable, and give overlays one stacking scale

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15982,18 +15982,13 @@ const App: React.FC = () => {
             isOpen={true}
             scanPath={duplicateFinderPath}
             onClose={() => setDuplicateFinderPath(null)}
+            // The setting governs the dialog's own confirmation. Raising a second
+            // one here is what made #537: `ConfirmDialog` is mounted far above in
+            // this tree, so it rendered behind the finder's overlay, unreachable
+            // behind its backdrop, while this promise never settled and the
+            // "Delete Selected" button span forever.
+            confirmBeforeDelete={confirmBeforeDelete}
             onDeleteFiles={async (paths) => {
-              // Respect confirmBeforeDelete setting
-              if (confirmBeforeDelete) {
-                const confirmed = await new Promise<boolean>(resolve => {
-                  setConfirmDialog({
-                    message: t('duplicates.deleteConfirm', { count: paths.length }),
-                    onConfirm: () => { setConfirmDialog(null); resolve(true); },
-                    onCancel: () => { setConfirmDialog(null); resolve(false); },
-                  });
-                });
-                if (!confirmed) return;
-              }
               for (const p of paths) {
                 try {
                   await invoke('delete_to_trash', { path: p });

--- a/src/components/AccountLockScreen.tsx
+++ b/src/components/AccountLockScreen.tsx
@@ -24,6 +24,7 @@ import {
 } from '../utils/userPartitions';
 import { PROFILES_CHANGED_EVENT } from '../utils/serverProfileStore';
 import { mapUserPartitionError } from '../utils/userPartitionErrors';
+import { MODAL_Z } from '../utils/modalLayers';
 
 const LOCK_PATTERN_KEY = 'aeroftp_lock_pattern';
 const DEFAULT_PATTERN = 'isometric';
@@ -231,7 +232,9 @@ export const AccountLockScreen: React.FC<AccountLockScreenProps> = ({ onContinue
 
     return (
         <div
-            className="fixed inset-0 z-[200] flex flex-col items-center justify-center overflow-auto bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 text-gray-100"
+            // Same layer as the master-password lock screen: this one also
+            // renders over a fully mounted app tree (see MODAL_Z.lock).
+            className={`fixed inset-0 ${MODAL_Z.lock} flex flex-col items-center justify-center overflow-auto bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 text-gray-100`}
         >
             {/* Background pattern overlay. This screen reuses the lock screen's
                 always-dark backdrop (theme-independent) so the chosen lock

--- a/src/components/Dialogs/index.tsx
+++ b/src/components/Dialogs/index.tsx
@@ -18,6 +18,7 @@ import { PROFILES_CHANGED_EVENT } from '../../utils/serverProfileStore';
 import { dispatchMasterPasswordChanged } from '../../utils/masterPasswordEvents';
 import { PasswordStrengthBar } from '../vault/PasswordStrengthBar';
 import { PasswordMatchHint } from '../common/PasswordMatchHint';
+import { MODAL_Z } from '../../utils/modalLayers';
 
 // ============ Alert Dialog ============
 interface AlertDialogProps {
@@ -115,7 +116,10 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
     };
 
     return (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" role="dialog" aria-modal="true" aria-label={message}>
+        // `MODAL_Z.globalConfirm`, not a bare `z-50`: this dialog is mounted before
+        // every modal in App.tsx, so on an equal z-index the modal that asked the
+        // question paints over it and its backdrop eats the clicks (#537).
+        <div className={`fixed inset-0 bg-black/50 flex items-center justify-center ${MODAL_Z.globalConfirm}`} role="dialog" aria-modal="true" aria-label={message}>
             <div className="bg-white dark:bg-gray-800 rounded-lg p-6 shadow-2xl max-w-sm animate-scale-in">
                 <p className="text-gray-900 dark:text-gray-100 mb-4">{message}</p>
                 <div className="flex justify-end gap-2">

--- a/src/components/DuplicateFinderDialog.test.ts
+++ b/src/components/DuplicateFinderDialog.test.ts
@@ -68,6 +68,32 @@ describe('the delete flow asks exactly once (#537)', () => {
   });
 });
 
+describe('a slow delete does not write back a stale snapshot', () => {
+  it('reconciles against current state rather than the captured one', () => {
+    // `runDelete` closes over `groups` and `selectedPaths` at the time the
+    // button was pressed. Deleting many files takes long enough for a re-scan to
+    // land or the selection to move underneath it, and writing the captured
+    // values back would discard the newer results and clear ticks the user made
+    // after pressing. Both writes are therefore functional updates keyed by the
+    // set of paths that were actually deleted.
+    const body = dialogRaw.slice(dialogRaw.indexOf('const runDelete'));
+    const scope = body.slice(0, body.indexOf('const handleDelete'));
+    expect(scope).toMatch(/setGroups\(\(current\) =>/);
+    expect(scope).toMatch(/setSelectedPaths\(\(prev\) =>/);
+    expect(scope).not.toMatch(/setGroups\(updatedGroups\)/);
+    expect(scope).not.toMatch(/setSelectedPaths\(new Set\(\)\)/);
+    // Closing over `groups` is what made the snapshot stale in the first place.
+    expect(scope).toMatch(/\}, \[selectedPaths, onDeleteFiles\]\)/);
+  });
+
+  it('lets nothing start a new scan while a delete is in flight', () => {
+    // The mode toggles and the fuzzy-cutoff field all re-run the scan. A scan
+    // completing mid-delete is the other half of the same race.
+    expect([...dialogRaw.matchAll(/disabled=\{isScanning \|\| isDeleting\}/g)]).toHaveLength(3);
+    expect(dialogRaw).not.toMatch(/disabled=\{isScanning\}/);
+  });
+});
+
 describe('every string the dialog asks for exists', () => {
   const resolve = (key: string): unknown => {
     let cursor: unknown = (en as { translations: Record<string, unknown> }).translations;

--- a/src/components/DuplicateFinderDialog.test.ts
+++ b/src/components/DuplicateFinderDialog.test.ts
@@ -3,6 +3,8 @@
 
 import { describe, it, expect } from 'vitest';
 import dialogRaw from './DuplicateFinderDialog.tsx?raw';
+import appRaw from '../App.tsx?raw';
+import en from '../i18n/locales/en.json';
 
 describe('DuplicateFinderDialog open-handlers surface failures', () => {
   it('routes open_local_file and open_in_file_manager rejects to setError', () => {
@@ -32,5 +34,58 @@ describe('DuplicateFinderDialog open-handlers surface failures', () => {
       /placeholder=\{t\('duplicates\.fuzzyCutoffPlaceholder'\)/,
     );
     expect(dialogRaw).not.toMatch(/placeholder="auto"/);
+  });
+});
+
+describe('the delete flow asks exactly once (#537)', () => {
+  /** The JSX body of the `<DuplicateFinderDialog … />` element in App.tsx. */
+  const mountSite = (): string => {
+    const start = appRaw.indexOf('<DuplicateFinderDialog');
+    expect(start, 'DuplicateFinderDialog is mounted in App.tsx').toBeGreaterThan(-1);
+    const end = appRaw.indexOf('/>', appRaw.indexOf('onDeleteFiles', start));
+    return appRaw.slice(start, end);
+  };
+
+  it('does not let the caller raise a second confirmation', () => {
+    // This is the deadlock. `ConfirmDialog` is mounted ~300 lines earlier in
+    // App.tsx, so the confirm this used to open rendered *behind* the finder's
+    // overlay and its backdrop swallowed the clicks, while the promise the
+    // callback awaited never settled and "Delete Selected" span forever.
+    expect(mountSite()).not.toMatch(/setConfirmDialog/);
+  });
+
+  it('hands the setting to the dialog instead of acting on it in the callback', () => {
+    expect(mountSite()).toMatch(/confirmBeforeDelete=\{confirmBeforeDelete\}/);
+  });
+
+  it('lets the dialog skip its own prompt when the setting is off', () => {
+    // `confirmBeforeDelete` has to reach the branch, not just the props: with the
+    // caller's prompt gone, a dialog that ignored the setting would confirm even
+    // for users who turned confirmations off.
+    const handler = dialogRaw.slice(dialogRaw.indexOf('const handleDelete'));
+    expect(handler.slice(0, 400)).toMatch(/if \(!confirmBeforeDelete\)/);
+    expect(handler.slice(0, 400)).toMatch(/runDelete\(\)/);
+  });
+});
+
+describe('every string the dialog asks for exists', () => {
+  const resolve = (key: string): unknown => {
+    let cursor: unknown = (en as { translations: Record<string, unknown> }).translations;
+    for (const part of key.split('.')) {
+      if (typeof cursor !== 'object' || cursor === null) return undefined;
+      cursor = (cursor as Record<string, unknown>)[part];
+    }
+    return cursor;
+  };
+
+  it('resolves in en.json, which is the fallback for all 47 locales', () => {
+    // `t()` returns the key itself when nothing resolves, so a typo is not a
+    // silent miss: it prints "duplicates.confirmDelete" at the user. That is
+    // what the delete confirmation of #537 did — the key was in none of the 47
+    // locale files, so the question it asked was its own name.
+    const keys = [...dialogRaw.matchAll(/\bt\(\s*'([\w.]+)'/g)].map((m) => m[1]);
+    expect(keys.length).toBeGreaterThan(20);
+    const missing = [...new Set(keys)].filter((k) => resolve(k) === undefined);
+    expect(missing, 'keys used by the dialog but absent from en.json').toEqual([]);
   });
 });

--- a/src/components/DuplicateFinderDialog.test.ts
+++ b/src/components/DuplicateFinderDialog.test.ts
@@ -83,7 +83,17 @@ describe('a slow delete does not write back a stale snapshot', () => {
     expect(scope).not.toMatch(/setGroups\(updatedGroups\)/);
     expect(scope).not.toMatch(/setSelectedPaths\(new Set\(\)\)/);
     // Closing over `groups` is what made the snapshot stale in the first place.
-    expect(scope).toMatch(/\}, \[selectedPaths, onDeleteFiles\]\)/);
+    expect(scope).toMatch(/\}, \[selectedPaths, onDeleteFiles, scan\]\)/);
+  });
+
+  it('re-scans when the delete rejects, because it may have deleted some', () => {
+    // `onDeleteFiles` walks the list, so a reject can arrive with earlier paths
+    // already gone. Which ones is not knowable here, and keeping the old rows
+    // would leave the dialog offering to delete files that no longer exist.
+    const body = dialogRaw.slice(dialogRaw.indexOf('const runDelete'));
+    const catchBlock = body.slice(body.indexOf('} catch (err) {'), body.indexOf('} finally {'));
+    expect(catchBlock).toMatch(/setError\(/);
+    expect(catchBlock).toMatch(/void scan\(\)/);
   });
 
   it('lets nothing start a new scan while a delete is in flight', () => {

--- a/src/components/DuplicateFinderDialog.tsx
+++ b/src/components/DuplicateFinderDialog.tsx
@@ -308,10 +308,16 @@ export const DuplicateFinderDialog: React.FC<DuplicateFinderDialogProps> = ({
       });
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
+      // A reject does not mean nothing was deleted: `onDeleteFiles` walks the
+      // list, so it can fail partway with earlier paths already gone. Which ones
+      // is not knowable from here, and keeping the old rows would leave the
+      // dialog offering to delete files that no longer exist. Re-scanning is the
+      // only answer that cannot be wrong.
+      void scan();
     } finally {
       setIsDeleting(false);
     }
-  }, [selectedPaths, onDeleteFiles]);
+  }, [selectedPaths, onDeleteFiles, scan]);
 
   /**
    * The one confirmation in this flow. `confirmBeforeDelete` decides whether it

--- a/src/components/DuplicateFinderDialog.tsx
+++ b/src/components/DuplicateFinderDialog.tsx
@@ -283,22 +283,35 @@ export const DuplicateFinderDialog: React.FC<DuplicateFinderDialogProps> = ({
     setIsDeleting(true);
     try {
       await onDeleteFiles(paths);
-      // Remove deleted files from groups and update state
-      const updatedGroups: DuplicateGroup[] = [];
-      for (const group of groups) {
-        const remaining = group.files.filter(f => !selectedPaths.has(f));
-        if (remaining.length > 1) {
-          updatedGroups.push({ ...group, files: remaining });
+      // Reconcile against whatever the state is NOW, not against the snapshot
+      // this callback closed over. A delete of many files takes long enough for
+      // a re-scan to land or the selection to move underneath it, and writing
+      // back the captured `groups` would then discard the newer results and
+      // clear a selection the user made after pressing the button.
+      const deleted = new Set(paths);
+      setGroups((current) => {
+        const updatedGroups: DuplicateGroup[] = [];
+        for (const group of current) {
+          const remaining = group.files.filter(f => !deleted.has(f));
+          if (remaining.length > 1) {
+            updatedGroups.push({ ...group, files: remaining });
+          }
         }
-      }
-      setGroups(updatedGroups);
-      setSelectedPaths(new Set());
+        return updatedGroups;
+      });
+      // Drop only what was actually deleted; anything ticked in the meantime
+      // stays ticked.
+      setSelectedPaths((prev) => {
+        const next = new Set(prev);
+        for (const p of deleted) next.delete(p);
+        return next;
+      });
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
       setIsDeleting(false);
     }
-  }, [selectedPaths, groups, onDeleteFiles]);
+  }, [selectedPaths, onDeleteFiles]);
 
   /**
    * The one confirmation in this flow. `confirmBeforeDelete` decides whether it
@@ -396,7 +409,7 @@ export const DuplicateFinderDialog: React.FC<DuplicateFinderDialogProps> = ({
         <div className="flex items-center gap-2 px-4 py-2 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50">
           <span className="text-xs text-gray-500 dark:text-gray-400 mr-1">Mode:</span>
           <button
-            disabled={isScanning}
+            disabled={isScanning || isDeleting}
             onClick={() => setMode('exact')}
             className={`px-3 py-1 text-xs rounded border transition-colors disabled:opacity-50 ${
               mode === 'exact'
@@ -407,7 +420,7 @@ export const DuplicateFinderDialog: React.FC<DuplicateFinderDialogProps> = ({
             Exact
           </button>
           <button
-            disabled={isScanning}
+            disabled={isScanning || isDeleting}
             onClick={() => setMode('non-identical')}
             className={`px-3 py-1 text-xs rounded border transition-colors disabled:opacity-50 ${
               mode === 'non-identical'
@@ -457,7 +470,7 @@ export const DuplicateFinderDialog: React.FC<DuplicateFinderDialogProps> = ({
                 max={200}
                 value={threshold ?? ''}
                 placeholder={t('duplicates.fuzzyCutoffPlaceholder') || 'auto'}
-                disabled={isScanning}
+                disabled={isScanning || isDeleting}
                 onChange={(e) => {
                   const raw = e.target.value.trim();
                   setThreshold(raw === '' ? null : Math.max(0, Math.min(200, Number(raw))));

--- a/src/components/DuplicateFinderDialog.tsx
+++ b/src/components/DuplicateFinderDialog.tsx
@@ -21,6 +21,7 @@ import { DuplicateGroup } from '../types/aerofile';
 import { Checkbox } from './ui/Checkbox';
 import { useDraggableModal } from '../hooks/useDraggableModal';
 import { useClipboardCopy } from '../hooks/useClipboardCopy';
+import { MODAL_Z } from '../utils/modalLayers';
 
 /** Payload of the backend's `duplicate-scan-progress` event (filesystem.rs). */
 interface DuplicateScanProgress {
@@ -49,7 +50,18 @@ interface DuplicateFinderDialogProps {
   isOpen: boolean;
   scanPath: string;
   onClose: () => void;
+  /**
+   * Deletes the given paths. It must NOT ask the user anything: this dialog owns
+   * the confirmation, and a second prompt raised by the caller is exactly the
+   * deadlock of #537 — it renders behind this modal, unreachable behind its
+   * backdrop, while the promise it gates never settles.
+   */
   onDeleteFiles: (paths: string[]) => Promise<void>;
+  /**
+   * The app's "confirm before delete" setting. It governs *this* dialog's own
+   * confirmation; when it is off the delete runs straight away.
+   */
+  confirmBeforeDelete?: boolean;
 }
 
 /** Extract the filename from a full path */
@@ -93,6 +105,7 @@ export const DuplicateFinderDialog: React.FC<DuplicateFinderDialogProps> = ({
   scanPath,
   onClose,
   onDeleteFiles,
+  confirmBeforeDelete = true,
 }) => {
   const t = useTranslation();
   const modalDrag = useDraggableModal();
@@ -262,14 +275,7 @@ export const DuplicateFinderDialog: React.FC<DuplicateFinderDialogProps> = ({
   // Inline confirmation dialog state (replaces window.confirm for styled UX)
   const [pendingDeleteConfirm, setPendingDeleteConfirm] = useState(false);
 
-  // Delete selected files: shows styled confirmation first
-  const handleDelete = useCallback(() => {
-    const paths = Array.from(selectedPaths);
-    if (paths.length === 0) return;
-    setPendingDeleteConfirm(true);
-  }, [selectedPaths]);
-
-  const confirmDelete = useCallback(async () => {
+  const runDelete = useCallback(async () => {
     setPendingDeleteConfirm(false);
     const paths = Array.from(selectedPaths);
     if (paths.length === 0) return;
@@ -293,6 +299,19 @@ export const DuplicateFinderDialog: React.FC<DuplicateFinderDialogProps> = ({
       setIsDeleting(false);
     }
   }, [selectedPaths, groups, onDeleteFiles]);
+
+  /**
+   * The one confirmation in this flow. `confirmBeforeDelete` decides whether it
+   * is raised at all; `onDeleteFiles` must not raise a second one (#537).
+   */
+  const handleDelete = useCallback(() => {
+    if (selectedPaths.size === 0) return;
+    if (!confirmBeforeDelete) {
+      void runDelete();
+      return;
+    }
+    setPendingDeleteConfirm(true);
+  }, [selectedPaths, confirmBeforeDelete, runDelete]);
 
   // Summary calculations
   const summary = useMemo(() => {
@@ -343,7 +362,7 @@ export const DuplicateFinderDialog: React.FC<DuplicateFinderDialogProps> = ({
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+    <div className={`fixed inset-0 ${MODAL_Z.modal} flex items-center justify-center bg-black/50`}>
       <div
         {...modalDrag.panelProps}
         className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-[700px] max-h-[80vh] flex flex-col animate-scale-in"
@@ -739,10 +758,13 @@ export const DuplicateFinderDialog: React.FC<DuplicateFinderDialogProps> = ({
 
       {/* Styled confirmation dialog (replaces window.confirm) */}
       {pendingDeleteConfirm && (
-        <div className="fixed inset-0 z-[60] bg-black/50 flex items-center justify-center" role="dialog" aria-modal="true">
+        <div className={`fixed inset-0 ${MODAL_Z.modalConfirm} bg-black/50 flex items-center justify-center`} role="dialog" aria-modal="true">
           <div className="bg-white dark:bg-gray-800 rounded-lg p-6 shadow-2xl max-w-sm animate-scale-in">
             <p className="text-gray-900 dark:text-gray-100 mb-4">
-              {t('duplicates.confirmDelete', { count: selectedPaths.size })}
+              {/* `deleteConfirm`, the key that exists. `duplicates.confirmDelete`
+                  was in none of the 47 locales, so this line printed its own key
+                  name at the user instead of a question (#537). */}
+              {t('duplicates.deleteConfirm', { count: selectedPaths.size })}
             </p>
             <div className="flex justify-end gap-2">
               <button
@@ -752,7 +774,7 @@ export const DuplicateFinderDialog: React.FC<DuplicateFinderDialogProps> = ({
                 {t('common.cancel')}
               </button>
               <button
-                onClick={confirmDelete}
+                onClick={runDelete}
                 className="px-4 py-2 text-white rounded-lg bg-red-500 hover:bg-red-600"
               >
                 {t('common.delete')}

--- a/src/components/GuardedCloseConfirm.tsx
+++ b/src/components/GuardedCloseConfirm.tsx
@@ -11,6 +11,7 @@
 import React, { useEffect } from 'react';
 import { AlertTriangle, Loader2 } from 'lucide-react';
 import { useTranslation } from '../i18n';
+import { MODAL_Z } from '../utils/modalLayers';
 import type { GuardKind } from '../hooks/useGuardedClose';
 
 interface GuardedCloseConfirmProps {
@@ -39,7 +40,7 @@ export const GuardedCloseConfirm: React.FC<GuardedCloseConfirmProps> = ({ kind, 
 
   return (
     <div
-      className="fixed inset-0 z-[10001] flex items-center justify-center bg-black/40 backdrop-blur-[1px]"
+      className={`fixed inset-0 ${MODAL_Z.guardedClose} flex items-center justify-center bg-black/40 backdrop-blur-[1px]`}
       role="alertdialog"
       aria-modal="true"
       onClick={(e) => { if (e.target === e.currentTarget) onKeep(); }}

--- a/src/components/LockScreen.tsx
+++ b/src/components/LockScreen.tsx
@@ -8,6 +8,7 @@ import { getVersion } from '@tauri-apps/api/app';
 import { Shield, Lock, Eye, EyeOff, ShieldCheck, AlertCircle, KeyRound } from 'lucide-react';
 import { useTranslation } from '../i18n';
 import { WindowControls } from './WindowControls';
+import { MODAL_Z } from '../utils/modalLayers';
 
 // ============ Lock Screen Background Patterns ============
 // Each pattern is a lightweight inline SVG data URI.
@@ -204,7 +205,12 @@ export const LockScreen: React.FC<LockScreenProps> = ({ onUnlock, mode = 'master
     };
 
     return (
-        <div className="fixed inset-0 z-[100] flex items-center justify-center bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900">
+        // `MODAL_Z.lock`: locking hides nothing on its own — `isAppLocked` gates
+        // no rendering in App.tsx, the whole tree stays mounted underneath — so
+        // this overlay has to outrank every dialog. At z-100 it did not: any
+        // dialog of the z-9999 tier left open when the idle probe fired stayed
+        // legible on top of the lock screen.
+        <div className={`fixed inset-0 ${MODAL_Z.lock} flex items-center justify-center bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900`}>
             {/* Background pattern overlay */}
             {pattern.svg && (
                 <div className="absolute inset-0 opacity-[0.04]">

--- a/src/utils/modalLayerSweep.test.ts
+++ b/src/utils/modalLayerSweep.test.ts
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+import { describe, it, expect } from 'vitest';
+import { MODAL_LAYER, MODAL_Z } from './modalLayers';
+
+/**
+ * Sweeps every full-screen overlay in the source and checks it against the
+ * scale in `modalLayers.ts`.
+ *
+ * A per-component test cannot catch this class of bug: what broke in #537 was
+ * not one component but the *relation* between two of them, and the app has 144
+ * `fixed inset-0` overlays across 6 tiers. The question "can anything cover the
+ * confirm the user is being asked to answer?" is only answerable over the whole
+ * set, so it is asked here, over the whole set.
+ *
+ * On the code this replaced the sweep fails twice: `ConfirmDialog` sat at z-50,
+ * under all 67 overlays of the z-9998..10001 tiers, and the two lock screens sat
+ * at z-100 and z-200, under those same 67.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const overlayModules = import.meta.glob('../**/*.tsx', {
+    query: '?raw',
+    import: 'default',
+    eager: true,
+}) as Record<string, string>;
+
+/** `z-50` / `z-[9999]` → 50 / 9999. Anything else → null. */
+const readZ = (token: string): number | null => {
+    const arbitrary = token.match(/^z-\[(\d+)\]$/);
+    if (arbitrary) return Number(arbitrary[1]);
+    const scale = token.match(/^z-(\d+)$/);
+    return scale ? Number(scale[1]) : null;
+};
+
+interface Overlay {
+    file: string;
+    line: number;
+    z: number;
+    /** Which key of the scale it came through, when it uses `MODAL_Z`. */
+    layer: keyof typeof MODAL_LAYER | null;
+}
+
+/**
+ * Every `fixed inset-0` in the tree, with the z-index it ends up at. The class
+ * may be a literal (`z-[9999]`) or a `MODAL_Z` reference; both are resolved.
+ * The class can also sit a line or two away from `fixed inset-0` when the JSX
+ * wraps, so a small window around the match is searched.
+ */
+const collectOverlays = (): Overlay[] => {
+    const found: Overlay[] = [];
+    for (const [file, source] of Object.entries(overlayModules)) {
+        const lines = source.split('\n');
+        for (let i = 0; i < lines.length; i++) {
+            if (!lines[i].includes('fixed inset-0')) continue;
+            const window = lines.slice(Math.max(0, i - 2), i + 3).join('\n');
+
+            const viaScale = window.match(/MODAL_Z\.([A-Za-z]+)/);
+            if (viaScale) {
+                const key = viaScale[1] as keyof typeof MODAL_LAYER;
+                expect(MODAL_LAYER[key], `${file}:${i + 1} uses MODAL_Z.${key}`).toBeTypeOf('number');
+                found.push({ file, line: i + 1, z: MODAL_LAYER[key], layer: key });
+                continue;
+            }
+
+            const literal = window.match(/\bz-(?:\[\d+\]|\d+)(?![\w-])/);
+            const z = literal ? readZ(literal[0]) : null;
+            // An overlay with no z at all falls back to `z-index: auto` and is
+            // ordered purely by where it happens to sit in the DOM — the same
+            // trap by another route. There are none; keep it that way.
+            expect(z, `${file}:${i + 1} is a full-screen overlay with no z-index`).not.toBeNull();
+            found.push({ file, line: i + 1, z: z as number, layer: null });
+        }
+    }
+    return found;
+};
+
+const overlays = collectOverlays();
+const at = (o: Overlay) => `${o.file.replace('../', 'src/')}:${o.line} (z=${o.z})`;
+
+describe('overlay stacking sweep (#537)', () => {
+    it('finds the overlays to check', () => {
+        // A guard on the sweep itself: if the glob or the pattern ever stops
+        // matching, the assertions below would pass over an empty set.
+        expect(overlays.length).toBeGreaterThan(100);
+    });
+
+    it('lets nothing but the quit guard and the lock screens cover the app-wide confirm', () => {
+        const covering = overlays.filter(
+            (o) => o.z >= MODAL_LAYER.globalConfirm && o.layer !== 'globalConfirm'
+                && o.layer !== 'guardedClose' && o.layer !== 'lock',
+        );
+        expect(covering.map(at), 'overlays at or above the app-wide confirm').toEqual([]);
+    });
+
+    it('renders the app-wide confirm above every dialog that can be waiting on it', () => {
+        const confirms = overlays.filter((o) => o.layer === 'globalConfirm');
+        expect(confirms.length, 'ConfirmDialog must use MODAL_Z.globalConfirm').toBe(1);
+        const dialogs = overlays.filter((o) => o.layer !== 'globalConfirm' && o.layer !== 'guardedClose' && o.layer !== 'lock');
+        const highest = Math.max(...dialogs.map((o) => o.z));
+        expect(MODAL_LAYER.globalConfirm).toBeGreaterThan(highest);
+    });
+
+    it('lets nothing cover the lock screens', () => {
+        const locks = overlays.filter((o) => o.layer === 'lock');
+        // Both LockScreen and AccountLockScreen.
+        expect(locks.length, 'lock screens on MODAL_Z.lock').toBe(2);
+        const others = overlays.filter((o) => o.layer !== 'lock');
+        const highest = Math.max(...others.map((o) => o.z));
+        expect(MODAL_LAYER.lock).toBeGreaterThan(highest);
+    });
+
+    it('keeps the quit guard above the app-wide confirm', () => {
+        expect(MODAL_LAYER.guardedClose).toBeGreaterThan(MODAL_LAYER.globalConfirm);
+        expect(MODAL_LAYER.lock).toBeGreaterThan(MODAL_LAYER.guardedClose);
+    });
+
+    it('has the Find Duplicates modal and its own confirm on the modal tiers', () => {
+        // The pair from #537, named explicitly: the modal must stay under the
+        // app-wide confirm, and its own confirm must stay over itself.
+        const dedupe = overlays.filter((o) => o.file.includes('DuplicateFinderDialog'));
+        expect(dedupe.map((o) => o.layer).sort()).toEqual(['modal', 'modalConfirm']);
+    });
+});
+
+describe('MODAL_Z classes are literal enough for Tailwind to emit', () => {
+    it('spells every class out', () => {
+        for (const value of Object.values(MODAL_Z)) {
+            expect(value).toMatch(/^z-(?:\[\d+\]|\d+)$/);
+        }
+    });
+});

--- a/src/utils/modalLayerSweep.test.ts
+++ b/src/utils/modalLayerSweep.test.ts
@@ -2,7 +2,7 @@
 // Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
 
 import { describe, it, expect } from 'vitest';
-import { MODAL_LAYER, MODAL_Z } from './modalLayers';
+import { MODAL_LAYER, MODAL_Z, modalZIndexOf } from './modalLayers';
 
 /**
  * Sweeps every full-screen overlay in the source and checks it against the
@@ -19,20 +19,11 @@ import { MODAL_LAYER, MODAL_Z } from './modalLayers';
  * at z-100 and z-200, under those same 67.
  */
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const overlayModules = import.meta.glob('../**/*.tsx', {
     query: '?raw',
     import: 'default',
     eager: true,
 }) as Record<string, string>;
-
-/** `z-50` / `z-[9999]` → 50 / 9999. Anything else → null. */
-const readZ = (token: string): number | null => {
-    const arbitrary = token.match(/^z-\[(\d+)\]$/);
-    if (arbitrary) return Number(arbitrary[1]);
-    const scale = token.match(/^z-(\d+)$/);
-    return scale ? Number(scale[1]) : null;
-};
 
 interface Overlay {
     file: string;
@@ -40,54 +31,108 @@ interface Overlay {
     z: number;
     /** Which key of the scale it came through, when it uses `MODAL_Z`. */
     layer: keyof typeof MODAL_LAYER | null;
+    /** Set when the overlay declares no z-index at all. */
+    unlayered?: true;
 }
 
 /**
- * Every `fixed inset-0` in the tree, with the z-index it ends up at. The class
- * may be a literal (`z-[9999]`) or a `MODAL_Z` reference; both are resolved.
- * The class can also sit a line or two away from `fixed inset-0` when the JSX
- * wraps, so a small window around the match is searched.
+ * The text of the `className` value that contains `index`, or null.
+ *
+ * Reading a fixed window of lines around `fixed inset-0` is not good enough: the
+ * window reaches into the neighbouring element, so a `z-` class belonging to a
+ * sibling can be recorded as this overlay's. The attribute value is the only
+ * span that certainly belongs to the same element, so that is what is read,
+ * whether it is a quoted string or a `{...}` expression with a template literal
+ * inside it.
  */
+const classNameValueAt = (source: string, index: number): string | null => {
+    let from = source.lastIndexOf('className=', index);
+    while (from !== -1) {
+        let cursor = from + 'className='.length;
+        let end: number;
+        if (source[cursor] === '"' || source[cursor] === "'") {
+            end = source.indexOf(source[cursor], cursor + 1);
+            if (end === -1) return null;
+        } else if (source[cursor] === '{') {
+            let depth = 0;
+            end = cursor;
+            for (; end < source.length; end++) {
+                if (source[end] === '{') depth++;
+                else if (source[end] === '}' && --depth === 0) break;
+            }
+        } else {
+            return null;
+        }
+        if (index <= end) return source.slice(cursor, end + 1);
+        // The match sits after this attribute closes: it belongs to a later one.
+        from = source.indexOf('className=', end);
+        if (from === -1 || from > index) return null;
+    }
+    return null;
+};
+
+/**
+ * Comments blanked out, newlines kept so line numbers still line up.
+ *
+ * A comment that *mentions* `fixed inset-0`, and `SaveAllMenu` has one
+ * explaining why its confirm is portalled, is not an overlay. Counting it as one
+ * makes the sweep report a missing z-index for an element that does not exist.
+ */
+const withoutComments = (source: string): string =>
+    source
+        .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))
+        .replace(/(^|[^:])\/\/[^\n]*/g, (m, lead) => lead + ' '.repeat(m.length - lead.length));
+
+/** Every `fixed inset-0` in the tree, with the z-index it ends up at. */
 const collectOverlays = (): Overlay[] => {
     const found: Overlay[] = [];
-    for (const [file, source] of Object.entries(overlayModules)) {
-        const lines = source.split('\n');
-        for (let i = 0; i < lines.length; i++) {
-            if (!lines[i].includes('fixed inset-0')) continue;
-            const window = lines.slice(Math.max(0, i - 2), i + 3).join('\n');
+    for (const [file, raw] of Object.entries(overlayModules)) {
+        const source = withoutComments(raw);
+        let at = source.indexOf('fixed inset-0');
+        while (at !== -1) {
+            const line = source.slice(0, at).split('\n').length;
+            const value = classNameValueAt(source, at) ?? '';
 
-            const viaScale = window.match(/MODAL_Z\.([A-Za-z]+)/);
-            if (viaScale) {
-                const key = viaScale[1] as keyof typeof MODAL_LAYER;
-                expect(MODAL_LAYER[key], `${file}:${i + 1} uses MODAL_Z.${key}`).toBeTypeOf('number');
-                found.push({ file, line: i + 1, z: MODAL_LAYER[key], layer: key });
-                continue;
+            const viaScale = value.match(/MODAL_Z\.([A-Za-z]+)/);
+            const literal = value.match(/\bz-(?:\[\d+\]|\d+)(?![\w-])/);
+            if (viaScale && (MODAL_LAYER as Record<string, number>)[viaScale[1]] !== undefined) {
+                const layer = viaScale[1] as keyof typeof MODAL_LAYER;
+                found.push({ file, line, z: MODAL_LAYER[layer], layer });
+            } else if (literal) {
+                found.push({ file, line, z: modalZIndexOf(literal[0]) as number, layer: null });
+            } else {
+                found.push({ file, line, z: -1, layer: null, unlayered: true });
             }
-
-            const literal = window.match(/\bz-(?:\[\d+\]|\d+)(?![\w-])/);
-            const z = literal ? readZ(literal[0]) : null;
-            // An overlay with no z at all falls back to `z-index: auto` and is
-            // ordered purely by where it happens to sit in the DOM — the same
-            // trap by another route. There are none; keep it that way.
-            expect(z, `${file}:${i + 1} is a full-screen overlay with no z-index`).not.toBeNull();
-            found.push({ file, line: i + 1, z: z as number, layer: null });
+            at = source.indexOf('fixed inset-0', at + 1);
         }
     }
     return found;
 };
 
-const overlays = collectOverlays();
+let cached: Overlay[] | null = null;
+/** Collected on first use, inside a test, so a parse problem fails a named test
+ *  rather than aborting the whole file during evaluation. */
+const overlays = (): Overlay[] => (cached ??= collectOverlays());
+
 const at = (o: Overlay) => `${o.file.replace('../', 'src/')}:${o.line} (z=${o.z})`;
 
 describe('overlay stacking sweep (#537)', () => {
     it('finds the overlays to check', () => {
         // A guard on the sweep itself: if the glob or the pattern ever stops
         // matching, the assertions below would pass over an empty set.
-        expect(overlays.length).toBeGreaterThan(100);
+        expect(overlays().length).toBeGreaterThan(100);
+    });
+
+    it('finds a z-index on every one of them', () => {
+        // An overlay with no z at all falls back to `z-index: auto` and is
+        // ordered purely by where it happens to sit in the DOM, which is the
+        // same trap by another route.
+        const unlayered = overlays().filter((o) => o.unlayered).map(at);
+        expect(unlayered, 'full-screen overlays with no z-index').toEqual([]);
     });
 
     it('lets nothing but the quit guard and the lock screens cover the app-wide confirm', () => {
-        const covering = overlays.filter(
+        const covering = overlays().filter(
             (o) => o.z >= MODAL_LAYER.globalConfirm && o.layer !== 'globalConfirm'
                 && o.layer !== 'guardedClose' && o.layer !== 'lock',
         );
@@ -95,18 +140,18 @@ describe('overlay stacking sweep (#537)', () => {
     });
 
     it('renders the app-wide confirm above every dialog that can be waiting on it', () => {
-        const confirms = overlays.filter((o) => o.layer === 'globalConfirm');
+        const confirms = overlays().filter((o) => o.layer === 'globalConfirm');
         expect(confirms.length, 'ConfirmDialog must use MODAL_Z.globalConfirm').toBe(1);
-        const dialogs = overlays.filter((o) => o.layer !== 'globalConfirm' && o.layer !== 'guardedClose' && o.layer !== 'lock');
+        const dialogs = overlays().filter((o) => o.layer !== 'globalConfirm' && o.layer !== 'guardedClose' && o.layer !== 'lock');
         const highest = Math.max(...dialogs.map((o) => o.z));
         expect(MODAL_LAYER.globalConfirm).toBeGreaterThan(highest);
     });
 
     it('lets nothing cover the lock screens', () => {
-        const locks = overlays.filter((o) => o.layer === 'lock');
+        const locks = overlays().filter((o) => o.layer === 'lock');
         // Both LockScreen and AccountLockScreen.
         expect(locks.length, 'lock screens on MODAL_Z.lock').toBe(2);
-        const others = overlays.filter((o) => o.layer !== 'lock');
+        const others = overlays().filter((o) => o.layer !== 'lock');
         const highest = Math.max(...others.map((o) => o.z));
         expect(MODAL_LAYER.lock).toBeGreaterThan(highest);
     });
@@ -119,7 +164,7 @@ describe('overlay stacking sweep (#537)', () => {
     it('has the Find Duplicates modal and its own confirm on the modal tiers', () => {
         // The pair from #537, named explicitly: the modal must stay under the
         // app-wide confirm, and its own confirm must stay over itself.
-        const dedupe = overlays.filter((o) => o.file.includes('DuplicateFinderDialog'));
+        const dedupe = overlays().filter((o) => o.file.includes('DuplicateFinderDialog'));
         expect(dedupe.map((o) => o.layer).sort()).toEqual(['modal', 'modalConfirm']);
     });
 });

--- a/src/utils/modalLayers.test.ts
+++ b/src/utils/modalLayers.test.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+import { describe, it, expect } from 'vitest';
+import { MODAL_LAYER, MODAL_Z, modalZIndexOf } from './modalLayers';
+
+describe('modal stacking scale (#537)', () => {
+    it('puts the app-wide confirm above every modal', () => {
+        // The whole point of the scale. `ConfirmDialog` is mounted before every
+        // modal in App.tsx, so at equal z-index the modal wins on DOM order and
+        // the confirm becomes invisible and unclickable underneath it.
+        expect(MODAL_LAYER.globalConfirm).toBeGreaterThan(MODAL_LAYER.modal);
+        expect(MODAL_LAYER.globalConfirm).toBeGreaterThan(MODAL_LAYER.modalConfirm);
+    });
+
+    it("puts a modal's own confirm above that modal", () => {
+        expect(MODAL_LAYER.modalConfirm).toBeGreaterThan(MODAL_LAYER.modal);
+    });
+
+    it('keeps the Tailwind classes in step with the numbers', () => {
+        // A class that drifts from its number is worse than no scale at all: the
+        // test would keep passing while the rendered order silently changed.
+        for (const key of Object.keys(MODAL_LAYER) as (keyof typeof MODAL_LAYER)[]) {
+            expect(modalZIndexOf(MODAL_Z[key]), key).toBe(MODAL_LAYER[key]);
+        }
+    });
+
+    it('reads both the built-in scale and arbitrary z classes', () => {
+        expect(modalZIndexOf('z-50')).toBe(50);
+        expect(modalZIndexOf('z-[60]')).toBe(60);
+        expect(modalZIndexOf('z-[70]')).toBe(70);
+        expect(modalZIndexOf('z-auto')).toBeNull();
+        expect(modalZIndexOf('flex')).toBeNull();
+    });
+});

--- a/src/utils/modalLayers.test.ts
+++ b/src/utils/modalLayers.test.ts
@@ -17,6 +17,23 @@ describe('modal stacking scale (#537)', () => {
         expect(MODAL_LAYER.modalConfirm).toBeGreaterThan(MODAL_LAYER.modal);
     });
 
+    it('keeps the elevated tier ordered the same way, and above the modal tier', () => {
+        // The dialogs that opted above the pack follow the same rule internally:
+        // a trash manager's own confirm over the trash manager, both over an
+        // ordinary modal, and all of them under the app-wide confirm.
+        expect(MODAL_LAYER.elevatedModal).toBeGreaterThan(MODAL_LAYER.modalConfirm);
+        expect(MODAL_LAYER.elevatedConfirm).toBeGreaterThan(MODAL_LAYER.elevatedModal);
+        expect(MODAL_LAYER.globalConfirm).toBeGreaterThan(MODAL_LAYER.elevatedConfirm);
+    });
+
+    it('orders the whole scale strictly, with no two layers sharing a number', () => {
+        // Equal z-index is what made #537: at a tie, DOM order decides, and the
+        // element mounted later wins whatever the intent was.
+        const values = Object.values(MODAL_LAYER);
+        expect(new Set(values).size, 'no two layers share a z-index').toBe(values.length);
+        expect([...values].sort((a, b) => a - b)).toEqual(values);
+    });
+
     it('keeps the Tailwind classes in step with the numbers', () => {
         // A class that drifts from its number is worse than no scale at all: the
         // test would keep passing while the rendered order silently changed.

--- a/src/utils/modalLayers.ts
+++ b/src/utils/modalLayers.ts
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+/**
+ * The one stacking order for the app's full-screen overlays.
+ *
+ * Every one of them is `position: fixed; inset: 0`, so what the user can see and
+ * click is decided entirely by z-index and, at equal z-index, by the order the
+ * elements appear in the DOM. Issue #537 is what that costs when the numbers are
+ * scattered as literals: the app-wide `ConfirmDialog` and the Find Duplicates
+ * modal were both `z-50`, and the confirm is mounted first in `App.tsx`, so the
+ * modal painted over the very question it was waiting on and its own backdrop
+ * swallowed every click aimed at the buttons underneath. The only way to answer
+ * the confirm was to close the window that had raised it.
+ *
+ * Three rules follow from that, and all three are pinned in `modalLayers.test.ts`
+ * against every `fixed inset-0` overlay in the source:
+ *
+ * 1. A module's modal sits at `modal`; a confirmation it raises for itself, from
+ *    inside its own overlay, sits at `modalConfirm`.
+ * 2. The app-wide confirm sits above *every* dialog. Not just above `modal`: the
+ *    twelve `setConfirmDialog` call sites include the overwrite and delete
+ *    prompts, and those fire from flows started inside the `elevatedModal` tier
+ *    (AeroSync, the transfer plan, the trash managers). A confirm below them
+ *    would repeat #537 there.
+ * 3. The lock screens sit above everything. `isAppLocked` gates no rendering in
+ *    `App.tsx` — the whole tree stays mounted behind the lock overlay — so any
+ *    dialog left open when the idle probe fires would otherwise stay legible
+ *    over the lock screen, which was true of the entire `elevatedModal` tier.
+ */
+export const MODAL_LAYER = {
+    /** A module's own full-screen modal: Find Duplicates, Disk Usage, Properties. */
+    modal: 50,
+    /** A confirmation a modal raises inside its own overlay. */
+    modalConfirm: 60,
+    /** Dialogs that already opted above the pack: trash managers, AeroSync, hub. */
+    elevatedModal: 9999,
+    /** Confirmations those raise inside their own overlay. */
+    elevatedConfirm: 10000,
+    /** The app-wide `ConfirmDialog`. Above every dialog that can be waiting on it. */
+    globalConfirm: 10050,
+    /** The quit guard: it arbitrates leaving the app, so it outranks the confirm. */
+    guardedClose: 10060,
+    /** Lock screens. Nothing may cover them. */
+    lock: 10100,
+} as const;
+
+/**
+ * The same scale as Tailwind classes.
+ *
+ * These have to be literal strings. Tailwind generates utilities by scanning the
+ * source for class names, so a computed `` `z-[${n}]` `` would produce a class
+ * that never makes it into the stylesheet — the element would fall back to
+ * `z-index: auto` and land right back in the DOM-order trap. The test checks
+ * each string against its number so the two cannot drift apart.
+ */
+export const MODAL_Z = {
+    modal: 'z-50',
+    modalConfirm: 'z-[60]',
+    elevatedModal: 'z-[9999]',
+    elevatedConfirm: 'z-[10000]',
+    globalConfirm: 'z-[10050]',
+    guardedClose: 'z-[10060]',
+    lock: 'z-[10100]',
+} as const;
+
+/** The z-index a `MODAL_Z` class resolves to, or null if it is not one of ours. */
+export function modalZIndexOf(className: string): number | null {
+    const arbitrary = className.match(/^z-\[(\d+)\]$/);
+    if (arbitrary) return Number(arbitrary[1]);
+    const scale = className.match(/^z-(\d+)$/);
+    if (scale) return Number(scale[1]);
+    return null;
+}


### PR DESCRIPTION
Fixes #537.

## What happened

Find Duplicates asked for confirmation twice. The dialog raises its own prompt, and the App callback behind `onDeleteFiles` raised a second one through `setConfirmDialog` whenever "confirm before delete" was on. `ConfirmDialog` is mounted ~300 lines earlier in `App.tsx` than the finder, and both sat at `z-50` — so at an equal z-index DOM order decided it. The finder painted over the very question it was waiting on, and its full-viewport backdrop swallowed every click aimed at the buttons underneath.

That accounts for each step in the report: the button "loads up forever" because the promise the callback awaited never settled; dragging the finder aside reveals the confirm but does not free it, because the panel moves and the overlay does not; and closing the finder unmounts the overlay, at which point the confirm becomes clickable and the delete goes through to the Recycle Bin.

## The fix

The dialog owns the confirmation outright. It takes `confirmBeforeDelete` and skips its own prompt when the setting is off; the callback only deletes. One question, in the window that asked it.

The stacking half is fixed for the whole app rather than for this one pair. `src/utils/modalLayers.ts` holds the scale — modal, a modal's own confirm, the elevated dialog tier, the app-wide confirm, the quit guard, the lock screens — and the sweep that came with it found two more of the same defect:

- The app-wide confirm had to clear more than `z-50`. Of the twelve `setConfirmDialog` call sites, the overwrite and delete prompts fire from flows started inside the z-9998..10000 tier (AeroSync, the transfer plan, the trash managers), so a confirm below them would have repeated this bug there.
- The lock screens sat at z-100 and z-200, under that same tier. `isAppLocked` gates no rendering in `App.tsx` — the whole tree stays mounted behind the lock overlay — so a dialog left open when the idle probe fired stayed legible on top of the lock screen. Both now sit above everything.

One more thing surfaced on the way: the in-dialog confirm asked for `duplicates.confirmDelete`, a key present in none of the 47 locale files, so `t()` printed the key name at the user instead of a question. It now uses `duplicates.deleteConfirm`, which exists.

## Pins

Four, each verified failing on the code it replaces:

- `modalLayerSweep.test.ts` walks all 144 `fixed inset-0` overlays in the source and refuses any that can cover the app-wide confirm or the lock screens, and any with no z-index at all.
- The `DuplicateFinderDialog` mount site in `App.tsx` must carry no `setConfirmDialog`.
- The dialog must branch on `confirmBeforeDelete` rather than confirm unconditionally.
- Every `t()` key the dialog uses must resolve in `en.json`, the fallback all 47 locales fall through to.

## On the alternative in the report

Hold-to-confirm is a real pattern, but not as a replacement for this one: a press-and-hold has no keyboard equivalent and is hard to complete with a motor impairment. Worth considering later as something a user can opt into, not as the default path to a delete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Duplicate-file deletion now supports configurable confirmation prompts, preventing duplicate confirmations.
  * Improved layering ensures lock screens, confirmations, and dialogs appear in the correct order.

* **Bug Fixes**
  * Fixed modal stacking behavior across lock screens, guarded close dialogs, and duplicate-file dialogs.

* **Tests**
  * Added coverage for deletion confirmation behavior, translation keys, and modal layering consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->