### PR TITLE
fix(gui): show file thumbnails whole instead of centre-cropped

### DIFF
--- a/src/components/ImageThumbnail.tsx
+++ b/src/components/ImageThumbnail.tsx
@@ -52,7 +52,10 @@ export const ImageThumbnail: React.FC<ImageThumbnailProps> = ({
     if (error || !src) {
         return <div className="file-grid-icon">{fallbackIcon}</div>;
     }
-    return <img src={src} alt={name} className={className || "file-grid-thumbnail"} />;
+    // `object-contain`: show the file whole. `cover` crops whatever does not fit
+    // the square, which on a wide photo is both edges and on a screenshot is
+    // usually the part that identifies it (discussion #347).
+    return <img src={src} alt={name} className={className || "file-grid-thumbnail object-contain"} />;
 };
 
 export default ImageThumbnail;

--- a/src/components/LargeIconsGrid.tsx
+++ b/src/components/LargeIconsGrid.tsx
@@ -195,7 +195,9 @@ const LargeIconCard = React.memo<LargeIconCardProps>(({
             </div>
           }
           isRemote={false}
-          className="w-24 h-24 object-cover rounded-lg"
+          // `object-contain`: Large Icons is the view a user switches to in
+          // order to see the picture, so cropping its edges away defeats it.
+          className="w-24 h-24 object-contain rounded-lg"
         />
       );
     }

--- a/src/components/ProviderThumbnail.tsx
+++ b/src/components/ProviderThumbnail.tsx
@@ -67,7 +67,9 @@ export function ProviderThumbnail({ path, name, size = 48, className }: Props) {
     <img
       src={imgSrc}
       alt={name}
-      className={`object-cover rounded ${className || ''}`}
+      // Same rule as `.file-grid-thumbnail`: show the whole image, letterboxed
+      // inside a fixed box, rather than a centre crop of it.
+      className={`object-contain rounded ${className || ''}`}
       style={{ width: size, height: size }}
       onError={() => setFailed(true)}
     />

--- a/src/components/fileThumbnailFit.test.ts
+++ b/src/components/fileThumbnailFit.test.ts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+import { describe, it, expect } from 'vitest';
+import largeIcons from './LargeIconsGrid.tsx?raw';
+import providerThumb from './ProviderThumbnail.tsx?raw';
+import imageThumb from './ImageThumbnail.tsx?raw';
+
+/**
+ * A file thumbnail shows the whole file, not the middle of it.
+ *
+ * `object-fit: cover` fills the square by cropping whatever does not fit, which
+ * on a wide photo is both edges and on a screenshot is usually the part that
+ * identifies it. Reported on discussion #347: Icons and Large Icons were hiding
+ * the edges of every image, where the platform's own file manager does not.
+ *
+ * All three file-thumbnail components now state the fit themselves rather than
+ * inheriting it from `.file-grid-thumbnail`. That is deliberate: a `?raw` import
+ * of a stylesheet comes back empty under Vite, so a rule kept in `styles.css`
+ * would be the one part of this decision no test could read. The class still
+ * carries the box — size, radius, and the background behind the letterboxing.
+ *
+ * Avatars and the chat attachment chips are not in this set: those are
+ * decorative crops of a known shape, and `cover` is right for them.
+ */
+describe('file thumbnails are shown whole (#347)', () => {
+    const surfaces: Array<[string, string]> = [
+        ['ImageThumbnail (Icons grid, and the remote panel)', imageThumb],
+        ['LargeIconsGrid (Large Icons)', largeIcons],
+        ['ProviderThumbnail (provider-supplied)', providerThumb],
+    ];
+
+    for (const [name, source] of surfaces) {
+        it(`fits the image inside its box: ${name}`, () => {
+            expect(source, name).toMatch(/object-contain/);
+            expect(source, name).not.toMatch(/object-cover/);
+        });
+    }
+
+    it('keeps the Large Icons tile at a fixed size, so the grid does not reflow', () => {
+        // `contain` letterboxes inside the box instead of resizing it; the fixed
+        // box is what keeps the change invisible to the layout.
+        expect(largeIcons).toMatch(/w-24 h-24 object-contain/);
+    });
+
+    it('leaves the box class on ImageThumbnail so the fit is the only thing added', () => {
+        expect(imageThumb).toMatch(/className \|\| "file-grid-thumbnail object-contain"/);
+    });
+});

--- a/src/styles.css
+++ b/src/styles.css
@@ -875,10 +875,15 @@ html {
   height: 32px;
 }
 
+/* Box only. How the image is fitted inside it is decided by the components that
+   render a file thumbnail (`object-contain` there), so the three of them state
+   the same rule in the same way and a test can read it — a `?raw` import of a
+   stylesheet comes back empty under Vite, so a rule left here would be the one
+   part of the decision nothing could check. The size, the background behind the
+   letterboxing and the radius stay here. */
 .file-grid-thumbnail {
   width: 48px;
   height: 48px;
-  object-fit: cover;
   border-radius: 6px;
   margin-bottom: 8px;
   background: var(--color-bg-tertiary);


### PR DESCRIPTION
From the 2026-07-31 wishlist batch on #347:

> **Where:** AeroFile 📁 in Icons and Large Icons view. **What:** Please don't hide the edges of images. Each icon should show its image in full.

Right, and for a reason worth naming: `object-fit: cover` fills the square by cropping whatever does not fit. On a wide photo that is both edges; on a screenshot it is usually the part that would have told you which screenshot it is. A thumbnail exists to identify the file, so cropping the identifying part out of it defeats the view.

Three components render a file thumbnail — `ImageThumbnail` (the Icons grid, and the remote panel), the Large Icons tile, and the provider-supplied one — and all three now state `object-contain` themselves.

`.file-grid-thumbnail` keeps the box: the 48px square, the radius, and the background the letterboxing sits on. It no longer decides the fit. That part is deliberate rather than tidy-minded — a `?raw` import of a stylesheet comes back empty under Vite, so a rule left in `styles.css` would have been the one part of this decision no test could read. With the fit stated in the components, all three surfaces are checkable and none of them can contend with the stylesheet.

The boxes keep their size, so nothing in the grid reflows. Avatars and the chat attachment chips keep `cover`: those are decorative crops of a known shape, not a file listing.

Pinned by `fileThumbnailFit.test.ts`, verified failing on `main` across all five assertions.
