### PR TITLE
feat(gui): run the directory actions on the directory you are in

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14652,24 +14652,10 @@ const App: React.FC = () => {
       { label: t('contextMenu.copyPath'), icon: <Copy size={14} />, action: () => { navigator.clipboard.writeText(file.path); notify.success(t('contextMenu.pathCopied')); } },
       { label: t('contextMenu.copyName'), icon: <Clipboard size={14} />, action: () => { navigator.clipboard.writeText(file.name); notify.success(t('contextMenu.nameCopied')); }, divider: true },
       { label: t('contextMenu.openInFileManager'), icon: <ExternalLink size={14} />, action: () => openInFileManager(file.is_dir ? file.path : currentLocalPath) },
-      // Directory-specific actions: Calculate Size, Find Duplicates, Disk Usage
-      ...(file.is_dir ? [
-        {
-          label: t('contextMenu.calculateSize'),
-          icon: <HardDrive size={14} />,
-          action: () => calculateFolderSize(file.path || `${currentLocalPath}/${file.name}`),
-        },
-        {
-          label: t('contextMenu.findDuplicates'),
-          icon: <Copy size={14} />,
-          action: () => setDuplicateFinderPath(file.path || `${currentLocalPath}/${file.name}`),
-        },
-        {
-          label: t('contextMenu.diskUsage'),
-          icon: <HardDrive size={14} />,
-          action: () => setDiskUsagePath(file.path || `${currentLocalPath}/${file.name}`),
-        },
-      ] : []),
+      // Directory-specific actions: Calculate Size, Find Duplicates, Disk Usage.
+      // Same list the empty-area and breadcrumb menus raise, so a folder answers
+      // the same way whether you reach it from its parent or from inside it.
+      ...(file.is_dir ? directoryActionItems(file.path || `${currentLocalPath}/${file.name}`) : []),
     ];
 
     // Helper: get paths for compression
@@ -15177,6 +15163,53 @@ const App: React.FC = () => {
     contextMenu.show(e, items);
   };
 
+  /**
+   * What can be done to a directory, given its path.
+   *
+   * These used to exist only on a folder *entry* in the listing, which meant
+   * running any of them on the folder you were already inside required leaving
+   * it, finding it in the parent, and right-clicking it there (discussion #347).
+   * They are now built from a path so the same three can be raised from the
+   * empty space of the panel and from a breadcrumb segment.
+   */
+  const directoryActionItems = (dirPath: string): ContextMenuItem[] => [
+    {
+      label: t('contextMenu.calculateSize'), icon: <HardDrive size={14} />,
+      action: () => calculateFolderSize(dirPath),
+    },
+    {
+      label: t('contextMenu.findDuplicates'), icon: <Copy size={14} />,
+      action: () => setDuplicateFinderPath(dirPath),
+    },
+    {
+      label: t('contextMenu.diskUsage'), icon: <HardDrive size={14} />,
+      action: () => setDiskUsagePath(dirPath),
+    },
+  ];
+
+  /**
+   * Context menu for one segment of the local breadcrumb, i.e. for a directory
+   * named in the path bar — including the one you are in, which is the case the
+   * listing could never offer.
+   */
+  const showLocalPathContextMenu = (e: React.MouseEvent, dirPath: string) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!dirPath) return;
+    contextMenu.show(e, [
+      {
+        label: t('contextMenu.openInFileManager'), icon: <ExternalLink size={14} />,
+        action: () => openInFileManager(dirPath),
+      },
+      {
+        label: t('contextMenu.copyPath'), icon: <Copy size={14} />,
+        action: () => { navigator.clipboard.writeText(dirPath); notify.success(t('contextMenu.pathCopied')); },
+        divider: true,
+      },
+      ...directoryActionItems(dirPath),
+    ]);
+  };
+
   // Empty-area context menu for local panel (right-click on background).
   // Dual-panel aware: targets the panel that received the click.
   const showLocalEmptyContextMenu = (e: React.MouseEvent, localPanelId: 'local' | 'local2' = activeLocalPanelId) => {
@@ -15204,7 +15237,11 @@ const App: React.FC = () => {
         label: t('contextMenu.selectAll') || 'Select All', icon: <CheckCircle2 size={14} />,
         action: () => ctxPanel.setSelection(new Set(ctxPanel.files.map(f => f.name))),
         disabled: ctxPanel.files.length === 0,
+        divider: true,
       },
+      // Aimed at the directory this panel is showing, so they no longer require
+      // going up a level to find it (#347).
+      ...(ctxPanel.currentPath ? directoryActionItems(ctxPanel.currentPath) : []),
     ];
     contextMenu.show(e, items);
   };
@@ -18374,6 +18411,7 @@ const App: React.FC = () => {
                   onPanelDragLeave={handlePanelDragLeave}
                   onContextMenu={showLocalContextMenu}
                   onEmptyContextMenu={showLocalEmptyContextMenu}
+                  onPathContextMenu={showLocalPathContextMenu}
                   onOpenUniversalPreview={openUniversalPreview}
                   onOpenDevToolsPreview={openDevToolsPreview}
                   onUploadFile={uploadFile}
@@ -18517,6 +18555,7 @@ const App: React.FC = () => {
                     onPanelDragLeave={handlePanelDragLeave}
                     onContextMenu={(e, file) => { setActiveLocalPanelId('local2'); showLocalContextMenu(e, file, 'local2'); }}
                     onEmptyContextMenu={(e) => { setActiveLocalPanelId('local2'); showLocalEmptyContextMenu(e, 'local2'); }}
+                    onPathContextMenu={(e, p) => { setActiveLocalPanelId('local2'); showLocalPathContextMenu(e, p); }}
                     onOpenUniversalPreview={openUniversalPreview}
                     onOpenDevToolsPreview={openDevToolsPreview}
                     onUploadFile={uploadFile}

--- a/src/components/BreadcrumbBar.tsx
+++ b/src/components/BreadcrumbBar.tsx
@@ -27,6 +27,13 @@ interface BreadcrumbBarProps {
   listSubdirectories?: (path: string) => Promise<SubDirectory[]>;
   /** Icon for the root segment button. Defaults to a hard-drive (local disk). */
   rootIcon?: React.ReactNode;
+  /**
+   * Right-click on a segment, with that segment's full path. Lets the host raise
+   * the directory actions on any folder named in the bar — including the current
+   * one, which the file listing cannot offer without going up a level (#347).
+   * Omitted by the remote pane, where those actions are local-only.
+   */
+  onSegmentContextMenu?: (e: React.MouseEvent, path: string) => void;
   t: (key: string) => string;
 }
 
@@ -83,6 +90,7 @@ export const BreadcrumbBar: React.FC<BreadcrumbBarProps> = ({
   minPath,
   listSubdirectories,
   rootIcon,
+  onSegmentContextMenu,
   t,
 }) => {
   const [isEditing, setIsEditing] = useState(false);
@@ -335,6 +343,7 @@ export const BreadcrumbBar: React.FC<BreadcrumbBarProps> = ({
         {/* Root segment (always visible) */}
         <button
           onClick={() => handleSegmentClick(segments[0].fullPath)}
+          onContextMenu={onSegmentContextMenu ? (e) => onSegmentContextMenu(e, segments[0].fullPath) : undefined}
           className={`flex-shrink-0 p-1 rounded transition-colors ${
             isAboveMinPath(segments[0].fullPath)
               ? 'text-gray-600 cursor-not-allowed'
@@ -467,6 +476,7 @@ export const BreadcrumbBar: React.FC<BreadcrumbBarProps> = ({
                 const locked = isAboveMinPath(seg.fullPath);
                 return <button
                   onClick={() => handleSegmentClick(seg.fullPath)}
+                  onContextMenu={onSegmentContextMenu ? (e) => onSegmentContextMenu(e, seg.fullPath) : undefined}
                   className={`text-sm px-1 py-0.5 rounded transition-colors truncate max-w-[150px] ${
                     locked
                       ? 'text-gray-600 cursor-not-allowed'

--- a/src/components/BreadcrumbBar.tsx
+++ b/src/components/BreadcrumbBar.tsx
@@ -383,6 +383,10 @@ export const BreadcrumbBar: React.FC<BreadcrumbBarProps> = ({
                     const locked = isAboveMinPath(seg.fullPath);
                     return <button
                       key={seg.fullPath}
+                      // Collapsed ancestors answer the same right-click as the
+                      // visible ones: once the path is long enough to overflow,
+                      // the folder you want is exactly the one that got hidden.
+                      onContextMenu={onSegmentContextMenu ? (e) => onSegmentContextMenu(e, seg.fullPath) : undefined}
                       onClick={() => !locked && handleDropdownNavigate(seg.fullPath)}
                       className={`flex items-center gap-2 px-3 py-1.5 text-sm w-full text-left transition-colors ${
                         locked ? 'text-gray-600 cursor-not-allowed' : 'text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700 cursor-pointer'

--- a/src/components/LocalFilePanel.tsx
+++ b/src/components/LocalFilePanel.tsx
@@ -173,6 +173,8 @@ export interface LocalFilePanelProps {
   // --- Context Menu ---
   onContextMenu: (e: React.MouseEvent, file: LocalFile) => void;
   onEmptyContextMenu: (e: React.MouseEvent) => void;
+  /** Right-click on a breadcrumb segment, with that segment's full path (#347). */
+  onPathContextMenu?: (e: React.MouseEvent, path: string) => void;
 
   // --- File Actions ---
   onOpenUniversalPreview: (file: LocalFile, isRemote: boolean) => void;
@@ -298,6 +300,7 @@ export const LocalFilePanel: React.FC<LocalFilePanelProps> = ({
   onPanelDragLeave,
   onContextMenu,
   onEmptyContextMenu,
+  onPathContextMenu,
   onOpenUniversalPreview,
   onOpenDevToolsPreview,
   onUploadFile,
@@ -614,6 +617,7 @@ export const LocalFilePanel: React.FC<LocalFilePanelProps> = ({
                 onNavigate={onNavigate}
                 isCoherent={isPathCoherent}
                 minPath={isSyncNavigation && syncBasePaths ? syncBasePaths.local : undefined}
+                onSegmentContextMenu={onPathContextMenu}
                 t={t}
               />
             </div>
@@ -661,6 +665,7 @@ export const LocalFilePanel: React.FC<LocalFilePanelProps> = ({
                 onNavigate={onNavigate}
                 isCoherent={isPathCoherent && !isSyncPathMismatch}
                 minPath={isSyncNavigation && syncBasePaths ? syncBasePaths.local : undefined}
+                onSegmentContextMenu={onPathContextMenu}
                 t={t}
               />
             </div>

--- a/src/components/currentDirectoryActions.test.ts
+++ b/src/components/currentDirectoryActions.test.ts
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+import { describe, it, expect } from 'vitest';
+import appRaw from '../App.tsx?raw';
+import breadcrumb from './BreadcrumbBar.tsx?raw';
+import localPanel from './LocalFilePanel.tsx?raw';
+
+/**
+ * Calculate Size, Find Duplicates and Disk Usage can be run on the directory you
+ * are in.
+ *
+ * They used to exist only on a folder *entry* in the listing, so running any of
+ * them on the current directory meant leaving it, finding it again in the
+ * parent, and right-clicking it there — which is what discussion #347 asked
+ * about. They are now built from a path, and the same three are raised from the
+ * folder entry, from the empty space of the panel, and from a segment of the
+ * breadcrumb (the last of which is the current directory itself).
+ */
+describe('directory actions reach the current directory (#347)', () => {
+    const body = (name: string): string => {
+        const start = appRaw.indexOf(`const ${name} = `);
+        expect(start, `${name} exists in App.tsx`).toBeGreaterThan(-1);
+        return appRaw.slice(start, start + 1800);
+    };
+
+    it('builds the three actions from a path, in one place', () => {
+        const items = body('directoryActionItems');
+        for (const key of ['contextMenu.calculateSize', 'contextMenu.findDuplicates', 'contextMenu.diskUsage']) {
+            expect(items, key).toContain(key);
+        }
+        // From the argument, not from a listing entry: that is what lets the same
+        // list serve a folder row, the panel background and a breadcrumb segment.
+        expect(items).toMatch(/calculateFolderSize\(dirPath\)/);
+        expect(items).toMatch(/setDuplicateFinderPath\(dirPath\)/);
+        expect(items).toMatch(/setDiskUsagePath\(dirPath\)/);
+    });
+
+    it('offers them on the empty space of the panel', () => {
+        expect(body('showLocalEmptyContextMenu')).toMatch(/directoryActionItems\(ctxPanel\.currentPath\)/);
+    });
+
+    it('offers them on a breadcrumb segment', () => {
+        expect(body('showLocalPathContextMenu')).toMatch(/directoryActionItems\(dirPath\)/);
+    });
+
+    it('still offers them on a folder in the listing, from the same list', () => {
+        // Not a fourth copy: a copy is what lets the three menus drift apart.
+        expect(appRaw).toMatch(/file\.is_dir \? directoryActionItems\(/);
+        const copies = [...appRaw.matchAll(/label: t\('contextMenu\.findDuplicates'\)/g)];
+        expect(copies.length, 'one definition of the Find Duplicates item').toBe(1);
+    });
+
+    it('wires the breadcrumb through to both local panels', () => {
+        expect(breadcrumb).toMatch(/onSegmentContextMenu\?: \(e: React\.MouseEvent, path: string\) => void/);
+        // Root segment and every other segment, so the whole bar answers.
+        expect([...breadcrumb.matchAll(/onContextMenu=\{onSegmentContextMenu \?/g)]).toHaveLength(2);
+        expect([...localPanel.matchAll(/onSegmentContextMenu=\{onPathContextMenu\}/g)]).toHaveLength(2);
+        expect([...appRaw.matchAll(/onPathContextMenu=/g)]).toHaveLength(2);
+    });
+
+    it('leaves the remote breadcrumb alone', () => {
+        // `find_duplicate_files`, `calculate_folder_size` and the disk-usage scan
+        // all take a local path. Offering them on a cloud breadcrumb would be a
+        // menu entry that cannot work.
+        const remoteBar = appRaw.slice(appRaw.indexOf('currentPath={(rcloneCryptVaultId'));
+        expect(remoteBar.slice(0, 1200)).not.toMatch(/onSegmentContextMenu/);
+    });
+});

--- a/src/components/currentDirectoryActions.test.ts
+++ b/src/components/currentDirectoryActions.test.ts
@@ -53,8 +53,9 @@ describe('directory actions reach the current directory (#347)', () => {
 
     it('wires the breadcrumb through to both local panels', () => {
         expect(breadcrumb).toMatch(/onSegmentContextMenu\?: \(e: React\.MouseEvent, path: string\) => void/);
-        // Root segment and every other segment, so the whole bar answers.
-        expect([...breadcrumb.matchAll(/onContextMenu=\{onSegmentContextMenu \?/g)]).toHaveLength(2);
+        // Root, every visible segment, and the collapsed ones in the overflow
+        // dropdown: a long path hides exactly the ancestors worth right-clicking.
+        expect([...breadcrumb.matchAll(/onContextMenu=\{onSegmentContextMenu \?/g)]).toHaveLength(3);
         expect([...localPanel.matchAll(/onSegmentContextMenu=\{onPathContextMenu\}/g)]).toHaveLength(2);
         expect([...appRaw.matchAll(/onPathContextMenu=/g)]).toHaveLength(2);
     });
@@ -63,7 +64,11 @@ describe('directory actions reach the current directory (#347)', () => {
         // `find_duplicate_files`, `calculate_folder_size` and the disk-usage scan
         // all take a local path. Offering them on a cloud breadcrumb would be a
         // menu entry that cannot work.
-        const remoteBar = appRaw.slice(appRaw.indexOf('currentPath={(rcloneCryptVaultId'));
-        expect(remoteBar.slice(0, 1200)).not.toMatch(/onSegmentContextMenu/);
+        // Anchor first. `indexOf` returning -1 would make `slice(-1)` the last
+        // character of the file, and the negative assertion would pass without
+        // having looked at the remote breadcrumb at all.
+        const remoteStart = appRaw.indexOf('currentPath={(rcloneCryptVaultId');
+        expect(remoteStart, 'remote breadcrumb exists in App.tsx').toBeGreaterThan(-1);
+        expect(appRaw.slice(remoteStart, remoteStart + 1200)).not.toMatch(/onSegmentContextMenu/);
     });
 });


### PR DESCRIPTION
From the 2026-07-31 wishlist batch on #347:

> **What:** Be able to right-click on the empty space in a folder or even on the folder's name itself at the top path bar and have the option to detect duplicates from there […] **Why:** To not require going up a directory, as is currently the case.

Confirmed, and it was worse than an inconvenience: Calculate Size, Find Duplicates and Disk Usage existed only on a folder *entry* in the listing, so the folder you had open was the one folder you could not run them on without leaving it first.

The three are now built from a path rather than from a listing row, and the same list is raised from three places: the folder entry, the empty space of the panel, and a segment of the breadcrumb. The last of those did not exist at all, and its final segment is the current directory — that is the "or even on the folder's name itself at the top path bar" half. Right-clicking any earlier segment offers the same three for that ancestor, which turns out to be useful for the same reason.

One definition serves all three menus. A copy is what lets them drift apart, and there were already three copies of the same three items before this.

The remote breadcrumb deliberately does not get it: `find_duplicate_files`, the folder-size walk and the disk-usage scan all take a local path, so offering them over a cloud path would be a menu entry that cannot work. That exclusion is pinned by a test too, so it stays a decision rather than an oversight.

Pinned by `currentDirectoryActions.test.ts`, verified failing on `main` across five of its six assertions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added context-menu actions for directories accessed through breadcrumbs and the currently open local directory.
  * Directory actions are now consistently available from folder entries, empty panel space, and breadcrumb segments.
  * Remote breadcrumb menus remain unchanged.

* **Bug Fixes**
  * Improved consistency of directory actions across local navigation views.

* **Tests**
  * Added coverage for directory actions and breadcrumb interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->