### PR TITLE
fix(deps): bump event-listener to 5.4.2 (RUSTSEC-2026-0221, main CI red)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2952,11 +2952,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]


### PR DESCRIPTION
## Problem

The `Checks` workflow is red on `main` since 2026-08-01 (runs on `4c047995d`, `5253be46d`, nightly `bd070fd99`), failing at the **Rust dependency audit (cargo audit)** step:

- `RUSTSEC-2026-0221`: `event-listener 5.4.1` flagged **unsound** (`!Send` tags can cross thread boundaries via `StackSlot`, memory-corruption/thread-safety). Advisory **issued 2026-07-31**, patched in `>=5.4.2`.

Not flaky and not caused by #538 (locales only): the date explains why PR CIs were green and main went red overnight. Transitive dependency via `zbus` / `tauri-plugin-single-instance`, `keyring`, `iroh-docs`.

## Fix

`cargo update -p event-listener` -> lockfile-only change, `5.4.1` -> `5.4.2` (patched range). Single lock entry; 166 other packages unchanged per `cargo update --dry-run --verbose`.

Local `cargo audit` could not re-verify (unstable network to crates.io right now); CI runs it authoritatively.