### PR TITLE
fix(crypt): enforce the anchor-escape rule on every profile save path

### DIFF
--- a/src/components/ConnectionScreen.tsx
+++ b/src/components/ConnectionScreen.tsx
@@ -1800,6 +1800,11 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
     // does not connect.
     const handleOAuthMetadataSave = async () => {
         if (!editingProfileId) return;
+        // #369: same anchor-escape rule as the primary save path. Without it
+        // this metadata save could persist a Remote Path that leaves the
+        // pinned overlay anchor outside the session (the vault reads as
+        // empty). The footer Save is disabled in that state; defense-in-depth.
+        if (remotePathEscapesOverlay) return;
         const existingServers = await loadSavedServerProfiles();
         const prevProfile = existingServers.find((s) => s.id === editingProfileId);
         if (!prevProfile) return;
@@ -1873,6 +1878,12 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
 
     const handleSaveAsNew = async () => {
         if (!protocol || !editingProfileId) return;
+        // #369: same anchor-escape rule as the primary save path. The copy
+        // carries the overlay binding to the new id, so persisting a Remote
+        // Path that leaves the pinned anchor outside would duplicate the
+        // profile straight into the orphaned state. Defense-in-depth behind
+        // the disabled button.
+        if (remotePathEscapesOverlay) return;
         // Validate name is different
         const existingServers = await loadSavedServerProfiles();
         const originalServer = existingServers.find((s: ServerProfile) => s.id === editingProfileId);
@@ -2011,6 +2022,11 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
     // 10 seconds.
     const handleConvertMode = async () => {
         if (!protocol || !editingProfileId || !modeChanged) return;
+        // #369: same anchor-escape rule as the primary save path. The converted
+        // profile carries the overlay binding to the new id, so it must not be
+        // persisted with a Remote Path that leaves the pinned anchor outside.
+        // Defense-in-depth behind the disabled button.
+        if (remotePathEscapesOverlay) return;
 
         const existingServers = await loadSavedServerProfiles();
         const originalIdx = existingServers.findIndex(s => s.id === editingProfileId);
@@ -2921,7 +2937,7 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                 </button>
                 <button
                     onClick={handleSaveAsNew}
-                    disabled={loading}
+                    disabled={loading || remotePathEscapesOverlay}
                     className="flex-1 min-w-[140px] py-3 px-4 rounded-lg font-medium text-white bg-green-600 hover:bg-green-700 transition-colors flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
                     title={t('connection.saveAsNewProfileTitle')}
                 >
@@ -2930,7 +2946,7 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                 </button>
                 <button
                     onClick={handleConvertMode}
-                    disabled={loading}
+                    disabled={loading || remotePathEscapesOverlay}
                     className="flex-1 min-w-[140px] py-3 px-4 rounded-lg font-medium text-white bg-orange-600 hover:bg-orange-700 transition-colors flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
                     title={t('connection.convertReplacesOriginal')}
                 >
@@ -3545,7 +3561,7 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                             </button>
                         )}
                         {showCancelSaveAsNew && editingProfileId && (
-                            <button onClick={handleSaveAsNew} className="px-4 py-3 bg-green-600 hover:bg-green-700 text-white font-medium rounded-lg transition-colors flex items-center gap-2" title={t('connection.saveAsNew')}>
+                            <button onClick={handleSaveAsNew} disabled={remotePathEscapesOverlay} className="px-4 py-3 bg-green-600 hover:bg-green-700 text-white font-medium rounded-lg transition-colors flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed" title={t('connection.saveAsNew')}>
                                 <Copy size={18} />
                             </button>
                         )}
@@ -3977,7 +3993,7 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                                 rightColumn={renderRightColumn(
                                     editingProfileId
                                         ? {
-                                            disabled: !oauthEditHasChanges(),
+                                            disabled: !oauthEditHasChanges() || remotePathEscapesOverlay,
                                             buttonColorClass: 'bg-green-600 hover:bg-green-700',
                                             hideSaveButton: false,
                                             saveOverride: handleOAuthMetadataSave,

--- a/src/components/ConnectionScreen.tsx
+++ b/src/components/ConnectionScreen.tsx
@@ -4009,6 +4009,12 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                                 isEditing={!!editingProfileId}
                                 existingNames={servers.map(s => s.name)}
                                 onConnected={async (displayName, extraOptions) => {
+                                    // #369: same anchor-escape rule as the other save
+                                    // paths. Edit mode implies saveConnection=true, so
+                                    // completing the OAuth sign-in would persist the
+                                    // escaping Remote Path + overlay fields below even
+                                    // though the footer Save is disabled in this state.
+                                    if (remotePathEscapesOverlay) return;
                                     // The saved profile id this live OAuth connection maps to. Seeded
                                     // from editingProfileId (edit mode) so the connect carries a
                                     // savedServerId even when several accounts share the provider:


### PR DESCRIPTION
Closes audit finding SEC-K1 (pre-tag audit, docs/security-evidence/SECURITY-EVIDENCE-v4.1.7.md §8.3).

The Remote Path anchor-escape rule from 01d1bf84f (issue #369) was only enforced on the primary save path. `handleOAuthMetadataSave` and `handleSaveAsNew` persisted `initialPath` while carrying the overlay binding, so they could write an anchor-orphaning profile whose encrypted folder sits outside the session (the vault then reads as empty).

Changes (all in src/components/ConnectionScreen.tsx, reusing the existing shared derived value `remotePathEscapesOverlay`, no new i18n keys):
- `handleOAuthMetadataSave`: early return on violation + disabled state on the OAuth edit footer button.
- `handleSaveAsNew`: early return + disabled on both save-as-new buttons.
- `handleConvertMode`: same guard (same footer, same persistence path; flagged as a small scope extension).

Gates: `npm run typecheck` pass; `npm run test:unit` 73 files / 662 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented saving, creating copies, or converting items when their remote path falls outside the configured security scope.
  * Added protection during OAuth sign-in callbacks to prevent unauthorized connections outside the configured scope.
  * Disabled affected Save-as-new and Convert actions, including OAuth editing controls, when the path is out of scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->