### PR TITLE
fix(mcp): guard destructive defaults in aeroftp_speed and remote_trash empty

### DIFF
--- a/src-tauri/src/ai_core/remote_tools.rs
+++ b/src-tauri/src/ai_core/remote_tools.rs
@@ -1251,8 +1251,9 @@ async fn remote_versions(ctx: &dyn ToolCtx, args: &Value) -> Result<Value, ToolE
 /// include_noncurrent to include older versions); undelete drops a delete marker
 /// so the object reappears; restore copies an older version forward; purge
 /// permanently removes one version or marker; empty purges the whole trash under
-/// the prefix (dry_run previews the count/bytes without deleting). All destructive
-/// actions are irreversible.
+/// the prefix (defaults to dry_run=true, a preview that deletes nothing; a real
+/// whole-bucket purge with an empty prefix also needs confirm_whole_bucket=true).
+/// All destructive actions are irreversible.
 async fn remote_trash(ctx: &dyn ToolCtx, args: &Value) -> Result<Value, ToolError> {
     let server = normalize_server(args)?;
     let action = get_str_opt(args, "action").unwrap_or_else(|| "list".to_string());
@@ -1314,7 +1315,16 @@ async fn remote_trash(ctx: &dyn ToolCtx, args: &Value) -> Result<Value, ToolErro
             Ok(json!({ "server": server, "key": key, "version_id": version_id, "purged": true }))
         }
         "empty" => {
-            let dry_run = get_bool_opt(args, "dry_run").unwrap_or(false);
+            // Destructive-default guards: preview unless told otherwise, and a
+            // real whole-bucket sweep needs an explicit acknowledgement.
+            let dry_run = get_bool_opt(args, "dry_run").unwrap_or(true);
+            let confirm_whole_bucket = get_bool_opt(args, "confirm_whole_bucket").unwrap_or(false);
+            if !dry_run && prefix.is_empty() && !confirm_whole_bucket {
+                return Err(ToolError::InvalidArgs {
+                    tool: "remote_trash".to_string(),
+                    reason: "action=empty with an empty prefix permanently purges every version and delete marker in the whole bucket: pass a non-empty 'prefix' to scope the purge, or set confirm_whole_bucket=true to acknowledge a whole-bucket purge".to_string(),
+                });
+            }
             let (count, bytes) = backend
                 .empty_object_versions(&prefix, include_noncurrent, dry_run)
                 .await
@@ -2459,6 +2469,19 @@ async fn speed(ctx: &dyn ToolCtx, args: &Value) -> Result<Value, ToolError> {
     let upload_sha = format!("{:x}", sha2::Sha256::digest(&payload));
 
     let backend = ctx.remote_backend(&server).await.map_err(backend_error)?;
+
+    // Overwrite guard: the test uploads to remote_path and then deletes it,
+    // so a path that already exists is a real user file about to be destroyed.
+    // Refuse instead of clobbering (no overwrite flag exists by design).
+    if backend.stat(&remote_path).await.is_ok() {
+        return Err(ToolError::InvalidArgs {
+            tool: "aeroftp_speed".to_string(),
+            reason: format!(
+                "remote_path '{remote_path}' already exists; the speed test would overwrite and then delete it. Omit remote_path for an auto-generated scratch path, or pick a path that does not exist"
+            ),
+        });
+    }
+
     let started = std::time::Instant::now();
     let mut upload_total_bps: f64 = 0.0;
     let mut download_total_bps: f64 = 0.0;
@@ -3321,6 +3344,9 @@ mod tests {
         renames: Mutex<Vec<(String, String)>>,
         deleted: Mutex<Vec<String>>,
         deleted_recursive: Mutex<Vec<String>>,
+        /// Every `empty_object_versions` call as (prefix, include_noncurrent,
+        /// dry_run), so trash tests can assert the flags the tool passed.
+        empty_calls: Mutex<Vec<(String, bool, bool)>>,
         /// When set, `delete` fails with this message, the way a provider's
         /// `rmdir` fails on a non-empty directory.
         delete_fails_with: Option<String>,
@@ -3360,6 +3386,7 @@ mod tests {
                 renames: Mutex::new(Vec::new()),
                 deleted: Mutex::new(Vec::new()),
                 deleted_recursive: Mutex::new(Vec::new()),
+                empty_calls: Mutex::new(Vec::new()),
                 delete_fails_with: None,
                 rename_fails_with: None,
             }
@@ -3483,6 +3510,19 @@ mod tests {
         }
         async fn storage_info(&self) -> Result<StorageQuota, String> {
             Err("unused".into())
+        }
+        async fn empty_object_versions(
+            &self,
+            prefix: &str,
+            include_noncurrent: bool,
+            dry_run: bool,
+        ) -> Result<(u64, u64), String> {
+            self.empty_calls.lock().unwrap().push((
+                prefix.to_string(),
+                include_noncurrent,
+                dry_run,
+            ));
+            Ok((7, 1234))
         }
     }
 
@@ -3875,5 +3915,129 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("Permission denied"), "got: {msg}");
         assert!(!msg.contains("recursive=true"), "must not mislead: {msg}");
+    }
+
+    // --- destructive-default guards: speed and trash empty -----------------
+
+    #[tokio::test]
+    async fn speed_refuses_an_existing_remote_path() {
+        // The speed test uploads to remote_path and then deletes it: a path
+        // that already exists is a real user file, so the tool must refuse
+        // before any upload.
+        let backend = Arc::new(FakeBackend::sample());
+        let ctx = test_ctx(Arc::clone(&backend));
+        let err = speed(
+            &ctx,
+            &json!({
+                "server": "s",
+                "remote_path": "/root/a.txt",
+                "size_mb": 1,
+            }),
+        )
+        .await
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("already exists"), "got: {msg}");
+        assert!(backend.uploads.lock().unwrap().is_empty());
+        assert!(backend.deleted.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn speed_runs_on_a_fresh_scratch_path() {
+        // The guard must not break the normal case: a path that does not
+        // exist yet runs the test and cleans up afterwards.
+        let mut fake = FakeBackend::sample();
+        fake.downloads
+            .insert("/scratch/speed.bin".to_string(), vec![0u8; 16]);
+        let backend = Arc::new(fake);
+        let ctx = test_ctx(Arc::clone(&backend));
+        let value = speed(
+            &ctx,
+            &json!({
+                "server": "s",
+                "remote_path": "/scratch/speed.bin",
+                "size_mb": 1,
+                "verify_integrity": false,
+            }),
+        )
+        .await
+        .expect("speed should run on a fresh path");
+        assert_eq!(value["cleanup_ok"], json!(true));
+        assert_eq!(
+            backend.deleted.lock().unwrap().as_slice(),
+            &["/scratch/speed.bin".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn trash_empty_defaults_to_dry_run() {
+        let backend = Arc::new(FakeBackend::sample());
+        let ctx = test_ctx(Arc::clone(&backend));
+        let value = remote_trash(&ctx, &json!({"server": "s", "action": "empty"}))
+            .await
+            .expect("empty with defaults is a preview");
+        assert_eq!(value["dry_run"], json!(true));
+        let calls = backend.empty_calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert!(calls[0].2, "backend must be called with dry_run=true");
+    }
+
+    #[tokio::test]
+    async fn trash_empty_whole_bucket_requires_confirm_flag() {
+        let backend = Arc::new(FakeBackend::sample());
+        let ctx = test_ctx(Arc::clone(&backend));
+        let err = remote_trash(
+            &ctx,
+            &json!({"server": "s", "action": "empty", "dry_run": false}),
+        )
+        .await
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("confirm_whole_bucket"), "got: {msg}");
+        assert!(backend.empty_calls.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn trash_empty_scoped_prefix_purges_without_confirm() {
+        let backend = Arc::new(FakeBackend::sample());
+        let ctx = test_ctx(Arc::clone(&backend));
+        let value = remote_trash(
+            &ctx,
+            &json!({
+                "server": "s",
+                "action": "empty",
+                "dry_run": false,
+                "prefix": "logs/",
+            }),
+        )
+        .await
+        .expect("a scoped purge needs no whole-bucket flag");
+        assert_eq!(value["dry_run"], json!(false));
+        let calls = backend.empty_calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "logs/");
+        assert!(!calls[0].2);
+    }
+
+    #[tokio::test]
+    async fn trash_empty_whole_bucket_with_confirm_flag_proceeds() {
+        let backend = Arc::new(FakeBackend::sample());
+        let ctx = test_ctx(Arc::clone(&backend));
+        let value = remote_trash(
+            &ctx,
+            &json!({
+                "server": "s",
+                "action": "empty",
+                "dry_run": false,
+                "confirm_whole_bucket": true,
+            }),
+        )
+        .await
+        .expect("explicit confirmation allows the whole-bucket purge");
+        assert_eq!(value["dry_run"], json!(false));
+        let calls = backend.empty_calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "");
+        assert!(!calls[0].2);
     }
 }

--- a/src-tauri/src/ai_core/remote_tools.rs
+++ b/src-tauri/src/ai_core/remote_tools.rs
@@ -86,6 +86,23 @@ fn backend_error(e: String) -> ToolError {
     }
 }
 
+/// True when a `RemoteBackend` error means "the path is not there", as opposed
+/// to "the lookup did not complete" (auth, connection, provider 5xx, unsupported
+/// operation). `RemoteBackend` errors are opaque `String`s, so this is a string
+/// probe; it mirrors `is_not_found_error` on the `ProviderError` side of the CLI.
+///
+/// Callers that use a failed `stat` as permission to write MUST go through this:
+/// treating every error as "absent" is fail-open, and on a transient error it
+/// hands out a write on a path that may hold user data.
+fn stat_error_is_not_found(e: &str) -> bool {
+    let msg = e.to_ascii_lowercase();
+    msg.contains("not found")
+        || msg.contains("no such")
+        || msg.contains("does not exist")
+        || msg.contains("doesn't exist")
+        || msg.contains("404")
+}
+
 /// Hard cap per pagina per `aeroftp_list_files` / `aeroftp_search_files`.
 /// Se l'agente passa un `limit` superiore, viene clampato a questo valore.
 const MAX_LIST_PAGE: usize = 5_000;
@@ -792,14 +809,7 @@ async fn preview_delete(
     let (is_dir, root_size): (bool, u64) = match backend.stat(path).await {
         Ok(r) => (r.is_dir, r.size),
         Err(e) => {
-            let em = e.to_lowercase();
-            if recursive
-                && (em.contains("not found")
-                    || em.contains("path not found")
-                    || em.contains("404")
-                    || em.contains("no such")
-                    || em.contains("does not exist"))
-            {
+            if recursive && stat_error_is_not_found(&e) {
                 // Assume pseudo-directory for recursive preview; contents will
                 // be discovered by list below.
                 (true, 0)
@@ -2456,7 +2466,12 @@ async fn speed(ctx: &dyn ToolCtx, args: &Value) -> Result<Value, ToolError> {
         .map(|n| (n as u32).clamp(1, SPEED_MAX_ITERATIONS))
         .unwrap_or(SPEED_DEFAULT_ITERATIONS);
     let verify_integrity = get_bool_opt(args, "verify_integrity").unwrap_or(true);
-    let remote_path = get_str_opt(args, "remote_path")
+    // Whether the path came from the caller decides how strict the overwrite
+    // guard below has to be: an auto-generated UUID scratch path cannot be
+    // user data, a caller-named one can be anything.
+    let caller_named_path = get_str_opt(args, "remote_path");
+    let path_is_caller_named = caller_named_path.is_some();
+    let remote_path = caller_named_path
         .unwrap_or_else(|| format!("/.aeroftp-speedtest-{}.bin", uuid::Uuid::new_v4()));
     validate_remote_path(&remote_path, "remote_path")?;
 
@@ -2473,13 +2488,31 @@ async fn speed(ctx: &dyn ToolCtx, args: &Value) -> Result<Value, ToolError> {
     // Overwrite guard: the test uploads to remote_path and then deletes it,
     // so a path that already exists is a real user file about to be destroyed.
     // Refuse instead of clobbering (no overwrite flag exists by design).
-    if backend.stat(&remote_path).await.is_ok() {
-        return Err(ToolError::InvalidArgs {
-            tool: "aeroftp_speed".to_string(),
-            reason: format!(
-                "remote_path '{remote_path}' already exists; the speed test would overwrite and then delete it. Omit remote_path for an auto-generated scratch path, or pick a path that does not exist"
-            ),
-        });
+    //
+    // The guard fails CLOSED on a caller-named path: `stat` returning an error
+    // is only taken as "absent" when the provider actually said not-found. An
+    // auth failure, a dropped connection or a provider 5xx must not be read as
+    // permission to write — that is the same fail-open shape this guard exists
+    // to close. An auto-generated UUID scratch path is exempt: it holds no user
+    // data by construction, so a flaky `stat` must not block a legitimate run.
+    match backend.stat(&remote_path).await {
+        Ok(_) => {
+            return Err(ToolError::InvalidArgs {
+                tool: "aeroftp_speed".to_string(),
+                reason: format!(
+                    "remote_path '{remote_path}' already exists; the speed test would overwrite and then delete it. Omit remote_path for an auto-generated scratch path, or pick a path that does not exist"
+                ),
+            });
+        }
+        Err(e) if path_is_caller_named && !stat_error_is_not_found(&e) => {
+            return Err(ToolError::InvalidArgs {
+                tool: "aeroftp_speed".to_string(),
+                reason: format!(
+                    "cannot confirm remote_path '{remote_path}' is free: the existence check failed with '{e}'. The speed test overwrites and then deletes this path, so it will not run on an unverified path. Retry, or omit remote_path for an auto-generated scratch path"
+                ),
+            });
+        }
+        Err(_) => {}
     }
 
     let started = std::time::Instant::now();
@@ -3351,6 +3384,9 @@ mod tests {
         /// `rmdir` fails on a non-empty directory.
         delete_fails_with: Option<String>,
         rename_fails_with: Option<String>,
+        /// When set, `stat` fails with this message for every path, the way a
+        /// provider fails on an expired token or a dropped connection.
+        stat_fails_with: Option<String>,
     }
 
     impl FakeBackend {
@@ -3389,6 +3425,7 @@ mod tests {
                 empty_calls: Mutex::new(Vec::new()),
                 delete_fails_with: None,
                 rename_fails_with: None,
+                stat_fails_with: None,
             }
         }
 
@@ -3410,6 +3447,9 @@ mod tests {
                 .ok_or_else(|| format!("not found: {path}"))
         }
         async fn stat(&self, path: &str) -> Result<RemoteEntry, String> {
+            if let Some(msg) = &self.stat_fails_with {
+                return Err(msg.clone());
+            }
             let (is_dir, size) = *self
                 .stats
                 .get(path)
@@ -3417,9 +3457,14 @@ mod tests {
             Ok(entry(path, is_dir, size))
         }
         async fn download_to_bytes(&self, _path: &str) -> Result<Vec<u8>, String> {
+            // Pre-seeded fixture first, then whatever a previous
+            // `upload_from_bytes` left there — a real backend reads back what
+            // was just written, which is what the speed test relies on for a
+            // path it generated itself.
             self.downloads
                 .get(_path)
                 .cloned()
+                .or_else(|| self.remote_files.lock().unwrap().get(_path).cloned())
                 .ok_or_else(|| format!("unused download: {_path}"))
         }
         async fn download_to_bytes_capped(
@@ -3966,6 +4011,65 @@ mod tests {
         assert_eq!(
             backend.deleted.lock().unwrap().as_slice(),
             &["/scratch/speed.bin".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn speed_refuses_a_caller_named_path_when_the_check_cannot_complete() {
+        // Fail-closed: a `stat` that fails for any reason OTHER than not-found
+        // (expired token, dropped connection, provider 5xx) is not permission
+        // to write. Reading every error as "absent" would hand the upload +
+        // delete a path that may well hold user data.
+        let mut fake = FakeBackend::sample();
+        fake.stat_fails_with = Some("503 Service Unavailable".to_string());
+        let backend = Arc::new(fake);
+        let ctx = test_ctx(Arc::clone(&backend));
+        let err = speed(
+            &ctx,
+            &json!({
+                "server": "s",
+                "remote_path": "/root/unverifiable.bin",
+                "size_mb": 1,
+            }),
+        )
+        .await
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("cannot confirm"), "got: {msg}");
+        assert!(
+            msg.contains("503"),
+            "the provider error must reach the caller: {msg}"
+        );
+        assert!(backend.uploads.lock().unwrap().is_empty());
+        assert!(backend.deleted.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn speed_still_runs_on_the_scratch_path_when_the_check_cannot_complete() {
+        // The strict check applies only to a caller-named path. The auto-generated
+        // UUID scratch path holds no user data by construction, so a provider
+        // whose `stat` is flaky or unsupported must not lose the speed test.
+        let mut fake = FakeBackend::sample();
+        fake.stat_fails_with = Some("stat unsupported by provider".to_string());
+        let backend = Arc::new(fake);
+        let ctx = test_ctx(Arc::clone(&backend));
+        let value = speed(
+            &ctx,
+            &json!({
+                "server": "s",
+                "size_mb": 1,
+                "verify_integrity": false,
+            }),
+        )
+        .await
+        .expect("an auto-generated scratch path must not be blocked by a flaky stat");
+        assert_eq!(value["cleanup_ok"], json!(true));
+        let uploaded = backend.uploads.lock().unwrap();
+        assert_eq!(uploaded.len(), 1);
+        assert!(
+            uploaded[0].0.starts_with("/.aeroftp-speedtest-"),
+            "got: {}",
+            uploaded[0].0
         );
     }
 

--- a/src-tauri/src/ai_core/tools.rs
+++ b/src-tauri/src/ai_core/tools.rs
@@ -1345,7 +1345,7 @@ pub static TOOL_DEFINITIONS: LazyLock<Vec<ToolDef>> = LazyLock::new(|| {
         },
         ToolDef {
             name: "remote_trash",
-            description: "Browse and manage the S3-family soft-delete trash under a prefix (every version and delete marker from ListObjectVersions). action=list returns entries ({key, display_key, version_id, is_delete_marker, is_latest, size, last_modified}); set include_noncurrent=true to also list older versions. action=undelete drops a delete marker so the object reappears (needs key+version_id); action=restore copies an older version forward (needs key+version_id); action=purge permanently removes one version or marker (needs key+version_id); action=empty purges the whole trash under the prefix (set dry_run=true to preview the count/bytes without deleting). All destructive actions are irreversible. S3 only. Defaults to list.",
+            description: "Browse and manage the S3-family soft-delete trash under a prefix (every version and delete marker from ListObjectVersions). action=list returns entries ({key, display_key, version_id, is_delete_marker, is_latest, size, last_modified}); set include_noncurrent=true to also list older versions. action=undelete drops a delete marker so the object reappears (needs key+version_id); action=restore copies an older version forward (needs key+version_id); action=purge permanently removes one version or marker (needs key+version_id); action=empty purges the whole trash under the prefix (defaults to dry_run=true, a preview that deletes nothing; a real whole-bucket purge with an empty prefix also needs confirm_whole_bucket=true). All destructive actions are irreversible. S3 only. Defaults to list.",
             input_schema: json!({
                 "type": "object",
                 "properties": {
@@ -1355,7 +1355,8 @@ pub static TOOL_DEFINITIONS: LazyLock<Vec<ToolDef>> = LazyLock::new(|| {
                     "key": {"type": "string", "description": "Raw object key from action=list; required for undelete, restore, purge"},
                     "version_id": {"type": "string", "description": "Required for undelete, restore, purge"},
                     "include_noncurrent": {"type": "boolean", "description": "List older (non-current) versions too. Default false."},
-                    "dry_run": {"type": "boolean", "description": "For action=empty: preview only, delete nothing. Default false."},
+                    "dry_run": {"type": "boolean", "description": "For action=empty: preview only, delete nothing. Default true."},
+                    "confirm_whole_bucket": {"type": "boolean", "description": "For action=empty with dry_run=false and an empty prefix: explicit acknowledgement of a whole-bucket purge. Default false."},
                 },
                 "required": [],
             }),
@@ -1668,7 +1669,7 @@ pub static TOOL_DEFINITIONS: LazyLock<Vec<ToolDef>> = LazyLock::new(|| {
                     "size_mb": {"type": "integer", "description": "Test payload size in MiB (default 4, cap 64)"},
                     "iterations": {"type": "integer", "description": "Number of upload/download cycles (default 1, cap 3)"},
                     "verify_integrity": {"type": "boolean", "description": "Compare SHA-256 of upload vs download (default: true)"},
-                    "remote_path": {"type": "string", "description": "Optional explicit remote test path (default: '/.aeroftp-speedtest-<uuid>.bin'). Caller is responsible for choosing a writable location."}
+                    "remote_path": {"type": "string", "description": "Optional explicit remote test path (default: '/.aeroftp-speedtest-<uuid>.bin'). Caller is responsible for choosing a writable location. The path must not already exist: an existing file is refused, never overwritten."}
                 },
                 "required": ["server"],
             }),

--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -4736,7 +4736,7 @@ enum VersionCommands {
         /// Preview the count and bytes without deleting anything
         #[arg(long)]
         dry_run: bool,
-        /// Skip the interactive confirmation prompt
+        /// Skip the interactive confirmation prompt (required in non-interactive runs)
         #[arg(long)]
         yes: bool,
     },
@@ -34029,9 +34029,21 @@ async fn cmd_versions_trash(
     code
 }
 
+/// Consent check for `versions empty-trash`: a real (non-dry-run) purge
+/// requires `--yes` or an interactive TTY confirmation. Non-interactive runs
+/// cannot answer the prompt, so without `--yes` they are refused outright.
+fn ensure_empty_trash_consent(dry_run: bool, yes: bool, interactive: bool) -> Result<(), String> {
+    if dry_run || yes || interactive {
+        Ok(())
+    } else {
+        Err("Refusing to purge trashed versions without --yes in non-interactive mode (use --dry-run to preview)".to_string())
+    }
+}
+
 /// `versions empty-trash`: purge every trashed version and delete marker under a
-/// prefix. Irreversible; `--dry-run` previews the count and bytes, and without
-/// `--yes` a real sweep prompts for confirmation on a TTY.
+/// prefix. Irreversible; `--dry-run` previews the count and bytes, without
+/// `--yes` a real sweep prompts for confirmation on a TTY, and non-interactive
+/// runs without `--yes` are refused.
 async fn cmd_versions_empty_trash(
     url: &str,
     prefix: &str,
@@ -34042,10 +34054,17 @@ async fn cmd_versions_empty_trash(
     format: OutputFormat,
 ) -> i32 {
     let rprefix = prefix.trim().to_string();
-    // Confirm the irreversible sweep before connecting (dry runs never prompt).
-    if !dry_run {
+    // Consent gate before connecting (dry runs and --yes pass straight through).
+    {
         use std::io::IsTerminal;
-        if !yes && std::io::stdin().is_terminal() {
+        if let Err(msg) = ensure_empty_trash_consent(dry_run, yes, std::io::stdin().is_terminal()) {
+            print_error(format, &msg, 2);
+            return 2;
+        }
+    }
+    // At this point a real sweep without --yes is interactive: prompt.
+    if !dry_run && !yes {
+        {
             let scope = if rprefix.is_empty() {
                 "the entire bucket".to_string()
             } else {
@@ -39959,6 +39978,20 @@ async fn run_single_speed_test(
             ))
         }
     };
+
+    // Overwrite guard: the test uploads to remote_test_path and then deletes
+    // it, so a path that already exists is a real user file about to be
+    // destroyed. Refuse instead of clobbering (no overwrite flag exists).
+    if provider.stat(remote_test_path).await.is_ok() {
+        let _ = provider.disconnect().await;
+        return Err((
+            format!(
+                "remote test path already exists: {} (refusing to overwrite; omit --remote-path for an auto-generated scratch path, or pick a path that does not exist)",
+                remote_test_path
+            ),
+            5,
+        ));
+    }
 
     let protocol = provider.provider_type().to_string();
 
@@ -65919,6 +65952,18 @@ mod tests {
     use super::*;
     use ftp_client_gui_lib::profile_loader::insert_profile_option;
     use serde_json::json;
+
+    #[test]
+    fn empty_trash_consent_refuses_non_interactive_without_yes() {
+        // A real purge in a piped/CI run used to skip the TTY prompt and
+        // sweep the trash with no confirmation at all.
+        let err = ensure_empty_trash_consent(false, false, false).unwrap_err();
+        assert!(err.contains("--yes"), "got: {err}");
+        // Dry runs, --yes, and an interactive TTY all pass the gate.
+        assert!(ensure_empty_trash_consent(true, false, false).is_ok());
+        assert!(ensure_empty_trash_consent(false, true, false).is_ok());
+        assert!(ensure_empty_trash_consent(false, false, true).is_ok());
+    }
 
     #[test]
     fn mode_endpoint_preset_rewrites_koofr_webdav_host() {

--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -4736,7 +4736,7 @@ enum VersionCommands {
         /// Preview the count and bytes without deleting anything
         #[arg(long)]
         dry_run: bool,
-        /// Skip the interactive confirmation prompt (required in non-interactive runs)
+        /// Skip the interactive confirmation prompt (required for real non-interactive purges)
         #[arg(long)]
         yes: bool,
     },
@@ -34032,6 +34032,35 @@ async fn cmd_versions_trash(
 /// Consent check for `versions empty-trash`: a real (non-dry-run) purge
 /// requires `--yes` or an interactive TTY confirmation. Non-interactive runs
 /// cannot answer the prompt, so without `--yes` they are refused outright.
+/// Decides whether the speed test may write to `path`, given what `stat` said.
+///
+/// The speed test uploads to `path` and then deletes it, so an occupied path is
+/// a user file about to be destroyed. The check fails CLOSED on a caller-named
+/// `--remote-path`: a failed lookup counts as "absent" only when the provider
+/// actually said not-found. An auth failure, a dropped connection or a provider
+/// 5xx is not permission to write.
+///
+/// `path_is_caller_named` is false for the auto-generated UUID scratch path,
+/// which holds no user data by construction: a flaky or unsupported `stat` must
+/// not cost a legitimate speed test there.
+fn ensure_speed_path_is_free(
+    lookup: Result<(), &ProviderError>,
+    path: &str,
+    path_is_caller_named: bool,
+) -> Result<(), String> {
+    match lookup {
+        Ok(()) => Err(format!(
+            "remote test path already exists: {} (refusing to overwrite; omit --remote-path for an auto-generated scratch path, or pick a path that does not exist)",
+            path
+        )),
+        Err(e) if path_is_caller_named && !is_not_found_error(e) => Err(format!(
+            "cannot confirm the remote test path is free: {} (existence check failed with: {}). The speed test overwrites and then deletes this path, so it will not run on an unverified path; retry, or omit --remote-path for an auto-generated scratch path",
+            path, e
+        )),
+        Err(_) => Ok(()),
+    }
+}
+
 fn ensure_empty_trash_consent(dry_run: bool, yes: bool, interactive: bool) -> Result<(), String> {
     if dry_run || yes || interactive {
         Ok(())
@@ -39857,6 +39886,7 @@ async fn cmd_speed(
         size,
         iterations,
         &remote_test_path,
+        remote_path.is_some(),
         !no_integrity,
         cli,
         format,
@@ -39950,6 +39980,10 @@ async fn run_single_speed_test(
     size: u64,
     iterations: u32,
     remote_test_path: &str,
+    // True when `remote_test_path` came from `--remote-path` rather than from
+    // the auto-generated UUID scratch path; it decides how strict the
+    // overwrite guard below has to be.
+    path_is_caller_named: bool,
     verify_integrity: bool,
     cli: &Cli,
     format: OutputFormat,
@@ -39982,15 +40016,21 @@ async fn run_single_speed_test(
     // Overwrite guard: the test uploads to remote_test_path and then deletes
     // it, so a path that already exists is a real user file about to be
     // destroyed. Refuse instead of clobbering (no overwrite flag exists).
-    if provider.stat(remote_test_path).await.is_ok() {
+    //
+    // The guard fails CLOSED on a `--remote-path` the caller named: a failed
+    // `stat` is only taken as "absent" when the provider actually said
+    // not-found. An auth failure, a dropped connection or a provider 5xx must
+    // not be read as permission to write. The auto-generated UUID scratch path
+    // is exempt: it holds no user data by construction, so a flaky `stat` must
+    // not block a legitimate run.
+    let lookup = provider.stat(remote_test_path).await;
+    if let Err(msg) = ensure_speed_path_is_free(
+        lookup.as_ref().map(|_| ()),
+        remote_test_path,
+        path_is_caller_named,
+    ) {
         let _ = provider.disconnect().await;
-        return Err((
-            format!(
-                "remote test path already exists: {} (refusing to overwrite; omit --remote-path for an auto-generated scratch path, or pick a path that does not exist)",
-                remote_test_path
-            ),
-            5,
-        ));
+        return Err((msg, 5));
     }
 
     let protocol = provider.provider_type().to_string();
@@ -40206,6 +40246,7 @@ async fn cmd_speed_compare(
             size,
             1,
             &remote_test_path,
+            false, // always the auto-generated scratch path in compare mode
             !no_integrity,
             cli_ref,
             OutputFormat::Json, // suppress per-test text output during compare
@@ -65963,6 +66004,37 @@ mod tests {
         assert!(ensure_empty_trash_consent(true, false, false).is_ok());
         assert!(ensure_empty_trash_consent(false, true, false).is_ok());
         assert!(ensure_empty_trash_consent(false, false, true).is_ok());
+    }
+
+    #[test]
+    fn speed_path_guard_fails_closed_on_a_lookup_it_could_not_complete() {
+        // An occupied path is refused whoever named it.
+        let occupied = ensure_speed_path_is_free(Ok(()), "/data/report.pdf", true).unwrap_err();
+        assert!(occupied.contains("already exists"), "got: {occupied}");
+
+        // A caller-named --remote-path proceeds only on an explicit not-found.
+        let missing = ProviderError::NotFound("/data/scratch.bin".into());
+        assert!(ensure_speed_path_is_free(Err(&missing), "/data/scratch.bin", true).is_ok());
+
+        // Anything else is not permission to write: reading a 5xx or an auth
+        // failure as "absent" is what hands the upload + delete a user file.
+        for opaque in [
+            ProviderError::ServerError("503 Service Unavailable".into()),
+            ProviderError::AuthenticationFailed("token expired".into()),
+            ProviderError::PermissionDenied("/data/scratch.bin".into()),
+            ProviderError::NotConnected,
+        ] {
+            let err = ensure_speed_path_is_free(Err(&opaque), "/data/scratch.bin", true)
+                .expect_err("an unverifiable caller-named path must be refused");
+            assert!(err.contains("cannot confirm"), "got: {err}");
+
+            // The auto-generated scratch path is exempt: it cannot be user data,
+            // so a provider with a flaky or unsupported stat still gets to run.
+            assert!(
+                ensure_speed_path_is_free(Err(&opaque), "/.aeroftp-speedtest-x.bin", false).is_ok(),
+                "the scratch path must not be blocked by {opaque}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes audit findings MCP-1 and MCP-2 (pre-tag audit, docs/security-evidence/SECURITY-EVIDENCE-v4.1.7.md §8.3).

MCP-1: `aeroftp_speed` and `cli speed --remote-path` uploaded a test payload to any caller-named remote path and deleted it afterwards, with no existence check: naming a real user file overwrote and then deleted it. Both surfaces now stat the remote path after connecting and refuse if it already exists (the error suggests omitting `remote_path` for an auto-generated scratch path). No overwrite flag added.

MCP-2: `remote_trash empty` defaulted `dry_run=false` with an empty prefix, so one call irreversibly purged every version and delete marker in the bucket. It now defaults `dry_run=true`, and a real whole-bucket purge additionally requires `confirm_whole_bucket: true`; a scoped prefix purges without the flag. Response shape unchanged.

Also fixed (same class, found during verification): CLI `versions empty-trash` skipped the TTY confirmation in non-interactive runs and purged silently; it now refuses without `--yes` when non-interactive.

Tests: 7 new unit tests (existing-path refusal, fresh scratch path ok, dry-run default, whole-bucket confirm gate, scoped purge, consent helper). Gates: cargo test (ai_core + cli) green, clippy -D warnings clean incl. `--cfg ci_lane3`, fmt clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Empty-trash operations now default to a safe dry run.
  * Whole-bucket purges require explicit confirmation, including `--yes` for non-interactive CLI use.
  * Scoped purges remain available without whole-bucket confirmation.
  * Remote speed tests refuse existing paths and fail safely when caller-specified paths cannot be verified.
  * Missing paths are distinguished from authorization and transient errors during cleanup.
* **Tests**
  * Added coverage for purge confirmation, dry-run behavior, path protection, and cleanup safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->