### PR TITLE
fix(commands): drain the remaining sync commands off the main thread

### DIFF
--- a/src-tauri/src/cloud_config.rs
+++ b/src-tauri/src/cloud_config.rs
@@ -238,6 +238,10 @@ fn get_config_path() -> PathBuf {
 
 /// Load cloud configuration from disk
 pub fn load_cloud_config() -> CloudConfig {
+    load_cloud_config_unlocked()
+}
+
+fn load_cloud_config_unlocked() -> CloudConfig {
     let config_path = get_config_path();
 
     if config_path.exists() {
@@ -257,12 +261,35 @@ pub fn load_cloud_config() -> CloudConfig {
     CloudConfig::default()
 }
 
+/// Load → mutate → save under one write lock.
+///
+/// Use this for every read-modify-write of `cloud_config.json`. Taking the lock
+/// only around `save_cloud_config` still allows two concurrent mutators on the
+/// blocking pool to both load the same snapshot and last-write-win (lost
+/// update). The main-thread command path used to serialise this for free;
+/// `spawn_blocking` does not.
+pub fn with_cloud_config_mut<F, T>(f: F) -> Result<T, String>
+where
+    F: FnOnce(&mut CloudConfig) -> Result<T, String>,
+{
+    let _lock = CONFIG_WRITE_LOCK
+        .lock()
+        .map_err(|_| "Config write lock poisoned".to_string())?;
+    let mut config = load_cloud_config_unlocked();
+    let out = f(&mut config)?;
+    save_cloud_config_unlocked(&config)?;
+    Ok(out)
+}
+
 /// Save cloud configuration to disk (serialized via write lock, atomic temp+rename)
 pub fn save_cloud_config(config: &CloudConfig) -> Result<(), String> {
     let _lock = CONFIG_WRITE_LOCK
         .lock()
         .map_err(|_| "Config write lock poisoned".to_string())?;
+    save_cloud_config_unlocked(config)
+}
 
+fn save_cloud_config_unlocked(config: &CloudConfig) -> Result<(), String> {
     let config_path = get_config_path();
 
     // Ensure parent directory exists

--- a/src-tauri/src/cloud_pairs.rs
+++ b/src-tauri/src/cloud_pairs.rs
@@ -165,6 +165,10 @@ fn get_pairs_path() -> PathBuf {
 
 /// Load pairs config (absent file => empty pairs, back-compat path).
 pub fn load_cloud_pairs_config() -> CloudPairsConfig {
+    load_cloud_pairs_config_unlocked()
+}
+
+fn load_cloud_pairs_config_unlocked() -> CloudPairsConfig {
     let path = get_pairs_path();
     if path.exists() {
         match fs::read_to_string(&path) {
@@ -182,12 +186,29 @@ pub fn load_cloud_pairs_config() -> CloudPairsConfig {
     CloudPairsConfig::default()
 }
 
+/// Load → mutate → save under one write lock (see `cloud_config::with_cloud_config_mut`).
+pub fn with_cloud_pairs_mut<F, T>(f: F) -> Result<T, String>
+where
+    F: FnOnce(&mut CloudPairsConfig) -> Result<T, String>,
+{
+    let _lock = PAIRS_WRITE_LOCK
+        .lock()
+        .map_err(|_| "Pairs write lock poisoned".to_string())?;
+    let mut config = load_cloud_pairs_config_unlocked();
+    let out = f(&mut config)?;
+    save_cloud_pairs_config_unlocked(&config)?;
+    Ok(out)
+}
+
 /// Save pairs config (atomic + lock protected).
 pub fn save_cloud_pairs_config(config: &CloudPairsConfig) -> Result<(), String> {
     let _lock = PAIRS_WRITE_LOCK
         .lock()
         .map_err(|_| "Pairs write lock poisoned".to_string())?;
+    save_cloud_pairs_config_unlocked(config)
+}
 
+fn save_cloud_pairs_config_unlocked(config: &CloudPairsConfig) -> Result<(), String> {
     let path = get_pairs_path();
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|e| format!("Failed to create pairs dir: {}", e))?;

--- a/src-tauri/src/cloud_service.rs
+++ b/src-tauri/src/cloud_service.rs
@@ -572,11 +572,17 @@ impl CloudService {
 
         result.duration_secs = start_time.elapsed().as_secs();
 
-        // Update config with last sync time
+        // Update config with last sync time (RMW under the shared file lock so a
+        // concurrent GUI mutator cannot have its excluded_folders/etc clobbered
+        // by a full-config rewrite of our in-memory snapshot).
         {
+            let now = Utc::now();
             let mut cfg = self.config.write().await;
-            cfg.last_sync = Some(Utc::now());
-            let _ = crate::cloud_config::save_cloud_config(&cfg);
+            cfg.last_sync = Some(now);
+            let _ = crate::cloud_config::with_cloud_config_mut(|disk| {
+                disk.last_sync = Some(now);
+                Ok(())
+            });
         }
 
         // Persist the post-sync baseline (index) for delete propagation on next cycles.
@@ -910,11 +916,17 @@ impl CloudService {
 
         result.duration_secs = start_time.elapsed().as_secs();
 
-        // Update config with last sync time
+        // Update config with last sync time (RMW under the shared file lock so a
+        // concurrent GUI mutator cannot have its excluded_folders/etc clobbered
+        // by a full-config rewrite of our in-memory snapshot).
         {
+            let now = Utc::now();
             let mut cfg = self.config.write().await;
-            cfg.last_sync = Some(Utc::now());
-            let _ = crate::cloud_config::save_cloud_config(&cfg);
+            cfg.last_sync = Some(now);
+            let _ = crate::cloud_config::with_cloud_config_mut(|disk| {
+                disk.last_sync = Some(now);
+                Ok(())
+            });
         }
 
         // Persist the post-sync baseline (index) for delete propagation on next cycles.

--- a/src-tauri/src/cloud_service.rs
+++ b/src-tauri/src/cloud_service.rs
@@ -572,17 +572,19 @@ impl CloudService {
 
         result.duration_secs = start_time.elapsed().as_secs();
 
-        // Update config with last sync time (RMW under the shared file lock so a
-        // concurrent GUI mutator cannot have its excluded_folders/etc clobbered
-        // by a full-config rewrite of our in-memory snapshot).
+        // Update last_sync in memory, drop the async guard, then RMW the on-disk
+        // config under the shared file lock. Holding self.config across the
+        // blocking filesystem write would pin the async worker for the whole I/O.
+        let now = Utc::now();
         {
-            let now = Utc::now();
             let mut cfg = self.config.write().await;
             cfg.last_sync = Some(now);
-            let _ = crate::cloud_config::with_cloud_config_mut(|disk| {
-                disk.last_sync = Some(now);
-                Ok(())
-            });
+        }
+        if let Err(e) = crate::cloud_config::with_cloud_config_mut(|disk| {
+            disk.last_sync = Some(now);
+            Ok(())
+        }) {
+            tracing::warn!("Failed to persist cloud last_sync: {e}");
         }
 
         // Persist the post-sync baseline (index) for delete propagation on next cycles.
@@ -916,17 +918,19 @@ impl CloudService {
 
         result.duration_secs = start_time.elapsed().as_secs();
 
-        // Update config with last sync time (RMW under the shared file lock so a
-        // concurrent GUI mutator cannot have its excluded_folders/etc clobbered
-        // by a full-config rewrite of our in-memory snapshot).
+        // Update last_sync in memory, drop the async guard, then RMW the on-disk
+        // config under the shared file lock. Holding self.config across the
+        // blocking filesystem write would pin the async worker for the whole I/O.
+        let now = Utc::now();
         {
-            let now = Utc::now();
             let mut cfg = self.config.write().await;
             cfg.last_sync = Some(now);
-            let _ = crate::cloud_config::with_cloud_config_mut(|disk| {
-                disk.last_sync = Some(now);
-                Ok(())
-            });
+        }
+        if let Err(e) = crate::cloud_config::with_cloud_config_mut(|disk| {
+            disk.last_sync = Some(now);
+            Ok(())
+        }) {
+            tracing::warn!("Failed to persist cloud last_sync: {e}");
         }
 
         // Persist the post-sync baseline (index) for delete propagation on next cycles.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2431,7 +2431,7 @@ fn detect_install_format() -> String {
 /// over from an earlier non-portable install (or from a pre-v3.7.8
 /// portable that shared that folder): the banner offers a one-click
 /// "Open folder" / "Dismiss" so the user can clean it up manually.
-#[derive(serde::Serialize)]
+#[derive(serde::Serialize, Default)]
 struct PortableInfo {
     is_portable: bool,
     data_root: Option<String>,
@@ -2441,7 +2441,17 @@ struct PortableInfo {
 }
 
 #[tauri::command]
-fn portable_info(app: tauri::AppHandle) -> PortableInfo {
+async fn portable_info(app: tauri::AppHandle) -> PortableInfo {
+    tokio::task::spawn_blocking(move || portable_info_blocking(app))
+        .await
+        .unwrap_or_else(|err| {
+            tracing::warn!("portable_info task failed: {err}");
+            PortableInfo::default()
+        })
+}
+
+/// The body of `portable_info`, kept synchronous and run on the blocking pool.
+fn portable_info_blocking(app: tauri::AppHandle) -> PortableInfo {
     let is_portable = portable::is_portable();
     let data_root = if is_portable {
         portable::app_data_dir(&app)
@@ -2460,7 +2470,14 @@ fn portable_info(app: tauri::AppHandle) -> PortableInfo {
 }
 
 #[tauri::command]
-fn copy_to_clipboard(text: String) -> Result<(), String> {
+async fn copy_to_clipboard(text: String) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || copy_to_clipboard_blocking(text))
+        .await
+        .unwrap_or_else(|err| Err(format!("copy_to_clipboard task failed: {err}")))
+}
+
+/// The body of `copy_to_clipboard`, kept synchronous and run on the blocking pool.
+fn copy_to_clipboard_blocking(text: String) -> Result<(), String> {
     let mut clipboard =
         arboard::Clipboard::new().map_err(|e| format!("Clipboard init failed: {}", e))?;
     #[cfg(target_os = "linux")]
@@ -5387,7 +5404,7 @@ struct CrateVersionResult {
     error: Option<String>,
 }
 
-#[derive(Clone, serde::Serialize)]
+#[derive(Clone, serde::Serialize, Default)]
 struct SystemInfo {
     app_version: String,
     os: String,
@@ -6056,7 +6073,17 @@ async fn check_crate_versions(crate_names: Vec<String>) -> Vec<CrateVersionResul
 }
 
 #[tauri::command]
-fn get_system_info() -> SystemInfo {
+async fn get_system_info() -> SystemInfo {
+    tokio::task::spawn_blocking(get_system_info_blocking)
+        .await
+        .unwrap_or_else(|err| {
+            tracing::warn!("get_system_info task failed: {err}");
+            SystemInfo::default()
+        })
+}
+
+/// The body of `get_system_info`, kept synchronous and run on the blocking pool.
+fn get_system_info_blocking() -> SystemInfo {
     let config_dir = portable::aeroftp_data_root()
         .map(|d| d.to_string_lossy().to_string())
         .unwrap_or_else(|| "unknown".into());
@@ -6455,7 +6482,17 @@ async fn open_local_file(path: String) -> Result<(), String> {
 /// foreign absolute path whose whole chain is absent), so the caller omits
 /// `defaultPath` and the picker opens at the OS default location.
 #[tauri::command]
-fn safe_picker_start_dir(path: Option<String>) -> Option<String> {
+async fn safe_picker_start_dir(path: Option<String>) -> Option<String> {
+    tokio::task::spawn_blocking(move || safe_picker_start_dir_blocking(path))
+        .await
+        .unwrap_or_else(|err| {
+            tracing::warn!("safe_picker_start_dir task failed: {err}");
+            None
+        })
+}
+
+/// The body of `safe_picker_start_dir`, kept synchronous and run on the blocking pool.
+fn safe_picker_start_dir_blocking(path: Option<String>) -> Option<String> {
     let raw = path?;
     let trimmed = raw.trim();
     if trimmed.is_empty() {
@@ -6475,19 +6512,23 @@ fn safe_picker_start_dir(path: Option<String>) -> Option<String> {
 
 #[cfg(test)]
 mod safe_picker_start_dir_tests {
-    use super::safe_picker_start_dir;
+    // The command is async; these cases drive the same body directly.
+    use super::safe_picker_start_dir_blocking;
 
     #[test]
     fn none_and_empty_yield_none() {
-        assert_eq!(safe_picker_start_dir(None), None);
-        assert_eq!(safe_picker_start_dir(Some(String::new())), None);
-        assert_eq!(safe_picker_start_dir(Some("   ".to_string())), None);
+        assert_eq!(safe_picker_start_dir_blocking(None), None);
+        assert_eq!(safe_picker_start_dir_blocking(Some(String::new())), None);
+        assert_eq!(
+            safe_picker_start_dir_blocking(Some("   ".to_string())),
+            None
+        );
     }
 
     #[test]
     fn existing_directory_is_returned_unchanged() {
         let dir = std::env::temp_dir();
-        let got = safe_picker_start_dir(Some(dir.to_string_lossy().into_owned()));
+        let got = safe_picker_start_dir_blocking(Some(dir.to_string_lossy().into_owned()));
         assert_eq!(got, Some(dir.to_string_lossy().into_owned()));
     }
 
@@ -6500,7 +6541,7 @@ mod safe_picker_start_dir_tests {
         let stale = base
             .join("aeroftp-does-not-exist-xyz")
             .join("nested-missing");
-        let got = safe_picker_start_dir(Some(stale.to_string_lossy().into_owned()));
+        let got = safe_picker_start_dir_blocking(Some(stale.to_string_lossy().into_owned()));
         assert_eq!(got, Some(base.to_string_lossy().into_owned()));
     }
 
@@ -6511,7 +6552,9 @@ mod safe_picker_start_dir_tests {
         // caller omits defaultPath and the picker opens at the OS default.
         #[cfg(unix)]
         {
-            let got = safe_picker_start_dir(Some(r"C:\Users\other\Downloads\AeroFTP".to_string()));
+            let got = safe_picker_start_dir_blocking(Some(
+                r"C:\Users\other\Downloads\AeroFTP".to_string(),
+            ));
             assert_eq!(got, None);
         }
     }
@@ -6528,7 +6571,7 @@ mod safe_picker_start_dir_tests {
             r"C:\Windows\Imported\Path",
             "relative/does/not/exist",
         ] {
-            if let Some(dir) = safe_picker_start_dir(Some(candidate.to_string())) {
+            if let Some(dir) = safe_picker_start_dir_blocking(Some(candidate.to_string())) {
                 assert!(
                     std::path::Path::new(&dir).is_dir(),
                     "returned start dir {dir:?} for input {candidate:?} must exist",
@@ -12556,7 +12599,17 @@ fn get_compare_options_default() -> CompareOptions {
 }
 
 #[tauri::command]
-fn load_sync_index_cmd(
+async fn load_sync_index_cmd(
+    local_path: String,
+    remote_path: String,
+) -> Result<Option<SyncIndex>, String> {
+    tokio::task::spawn_blocking(move || load_sync_index_cmd_blocking(local_path, remote_path))
+        .await
+        .unwrap_or_else(|err| Err(format!("load_sync_index_cmd task failed: {err}")))
+}
+
+/// The body of `load_sync_index_cmd`, kept synchronous and run on the blocking pool.
+fn load_sync_index_cmd_blocking(
     local_path: String,
     remote_path: String,
 ) -> Result<Option<SyncIndex>, String> {
@@ -12566,7 +12619,14 @@ fn load_sync_index_cmd(
 }
 
 #[tauri::command]
-fn save_sync_index_cmd(index: SyncIndex) -> Result<(), String> {
+async fn save_sync_index_cmd(index: SyncIndex) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || save_sync_index_cmd_blocking(index))
+        .await
+        .unwrap_or_else(|err| Err(format!("save_sync_index_cmd task failed: {err}")))
+}
+
+/// The body of `save_sync_index_cmd`, kept synchronous and run on the blocking pool.
+fn save_sync_index_cmd_blocking(index: SyncIndex) -> Result<(), String> {
     validate_path(&index.local_path)?;
     validate_path(&index.remote_path)?;
     save_sync_index(&index)
@@ -12575,7 +12635,17 @@ fn save_sync_index_cmd(index: SyncIndex) -> Result<(), String> {
 // ============ Sync Journal Commands (Phase 2: Reliability) ============
 
 #[tauri::command]
-fn load_sync_journal_cmd(
+async fn load_sync_journal_cmd(
+    local_path: String,
+    remote_path: String,
+) -> Result<Option<SyncJournal>, String> {
+    tokio::task::spawn_blocking(move || load_sync_journal_cmd_blocking(local_path, remote_path))
+        .await
+        .unwrap_or_else(|err| Err(format!("load_sync_journal_cmd task failed: {err}")))
+}
+
+/// The body of `load_sync_journal_cmd`, kept synchronous and run on the blocking pool.
+fn load_sync_journal_cmd_blocking(
     local_path: String,
     remote_path: String,
 ) -> Result<Option<SyncJournal>, String> {
@@ -12585,66 +12655,158 @@ fn load_sync_journal_cmd(
 }
 
 #[tauri::command]
-fn save_sync_journal_cmd(journal: SyncJournal) -> Result<(), String> {
+async fn save_sync_journal_cmd(journal: SyncJournal) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || save_sync_journal_cmd_blocking(journal))
+        .await
+        .unwrap_or_else(|err| Err(format!("save_sync_journal_cmd task failed: {err}")))
+}
+
+/// The body of `save_sync_journal_cmd`, kept synchronous and run on the blocking pool.
+fn save_sync_journal_cmd_blocking(journal: SyncJournal) -> Result<(), String> {
     validate_path(&journal.local_path)?;
     validate_path(&journal.remote_path)?;
     save_sync_journal(&journal)
 }
 
 #[tauri::command]
-fn delete_sync_journal_cmd(local_path: String, remote_path: String) -> Result<(), String> {
+async fn delete_sync_journal_cmd(local_path: String, remote_path: String) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || delete_sync_journal_cmd_blocking(local_path, remote_path))
+        .await
+        .unwrap_or_else(|err| Err(format!("delete_sync_journal_cmd task failed: {err}")))
+}
+
+/// The body of `delete_sync_journal_cmd`, kept synchronous and run on the blocking pool.
+fn delete_sync_journal_cmd_blocking(local_path: String, remote_path: String) -> Result<(), String> {
     validate_path(&local_path)?;
     validate_path(&remote_path)?;
     delete_sync_journal(&local_path, &remote_path)
 }
 
 #[tauri::command]
-fn list_sync_journals_cmd() -> Result<Vec<sync::JournalSummary>, String> {
+async fn list_sync_journals_cmd() -> Result<Vec<sync::JournalSummary>, String> {
+    tokio::task::spawn_blocking(list_sync_journals_cmd_blocking)
+        .await
+        .unwrap_or_else(|err| Err(format!("list_sync_journals_cmd task failed: {err}")))
+}
+
+/// The body of `list_sync_journals_cmd`, kept synchronous and run on the blocking pool.
+fn list_sync_journals_cmd_blocking() -> Result<Vec<sync::JournalSummary>, String> {
     sync::list_sync_journals()
 }
 
 #[tauri::command]
-fn cleanup_old_journals_cmd(max_age_days: u32) -> Result<u32, String> {
+async fn cleanup_old_journals_cmd(max_age_days: u32) -> Result<u32, String> {
+    tokio::task::spawn_blocking(move || cleanup_old_journals_cmd_blocking(max_age_days))
+        .await
+        .unwrap_or_else(|err| Err(format!("cleanup_old_journals_cmd task failed: {err}")))
+}
+
+/// The body of `cleanup_old_journals_cmd`, kept synchronous and run on the blocking pool.
+fn cleanup_old_journals_cmd_blocking(max_age_days: u32) -> Result<u32, String> {
     sync::cleanup_old_journals(max_age_days)
 }
 
 #[tauri::command]
-fn clear_all_journals_cmd() -> Result<u32, String> {
+async fn clear_all_journals_cmd() -> Result<u32, String> {
+    tokio::task::spawn_blocking(clear_all_journals_cmd_blocking)
+        .await
+        .unwrap_or_else(|err| Err(format!("clear_all_journals_cmd task failed: {err}")))
+}
+
+/// The body of `clear_all_journals_cmd`, kept synchronous and run on the blocking pool.
+fn clear_all_journals_cmd_blocking() -> Result<u32, String> {
     sync::clear_all_journals()
 }
 
 // ============ Transfer Queue Journal (TQ-7a: persistence + restart detection) ============
 
 #[tauri::command]
-fn save_transfer_queue_journal_cmd(
+async fn save_transfer_queue_journal_cmd(
+    entries: Vec<transfer_queue_journal::TransferQueueJournalEntry>,
+) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || save_transfer_queue_journal_cmd_blocking(entries))
+        .await
+        .unwrap_or_else(|err| {
+            Err(format!(
+                "save_transfer_queue_journal_cmd task failed: {err}"
+            ))
+        })
+}
+
+/// The body of `save_transfer_queue_journal_cmd`, kept synchronous and run on the blocking pool.
+fn save_transfer_queue_journal_cmd_blocking(
     entries: Vec<transfer_queue_journal::TransferQueueJournalEntry>,
 ) -> Result<(), String> {
     transfer_queue_journal::save_transfer_queue_journal(entries)
 }
 
 #[tauri::command]
-fn load_transfer_queue_journal_cmd(
+async fn load_transfer_queue_journal_cmd(
+) -> Result<Option<transfer_queue_journal::TransferQueueJournal>, String> {
+    tokio::task::spawn_blocking(load_transfer_queue_journal_cmd_blocking)
+        .await
+        .unwrap_or_else(|err| {
+            Err(format!(
+                "load_transfer_queue_journal_cmd task failed: {err}"
+            ))
+        })
+}
+
+/// The body of `load_transfer_queue_journal_cmd`, kept synchronous and run on the blocking pool.
+fn load_transfer_queue_journal_cmd_blocking(
 ) -> Result<Option<transfer_queue_journal::TransferQueueJournal>, String> {
     transfer_queue_journal::load_transfer_queue_journal()
 }
 
 #[tauri::command]
-fn clear_transfer_queue_journal_cmd() -> Result<(), String> {
+async fn clear_transfer_queue_journal_cmd() -> Result<(), String> {
+    tokio::task::spawn_blocking(clear_transfer_queue_journal_cmd_blocking)
+        .await
+        .unwrap_or_else(|err| {
+            Err(format!(
+                "clear_transfer_queue_journal_cmd task failed: {err}"
+            ))
+        })
+}
+
+/// The body of `clear_transfer_queue_journal_cmd`, kept synchronous and run on the blocking pool.
+fn clear_transfer_queue_journal_cmd_blocking() -> Result<(), String> {
     transfer_queue_journal::clear_transfer_queue_journal()
 }
 
 #[tauri::command]
-fn load_sync_profiles_cmd() -> Result<Vec<sync::SyncProfile>, String> {
+async fn load_sync_profiles_cmd() -> Result<Vec<sync::SyncProfile>, String> {
+    tokio::task::spawn_blocking(load_sync_profiles_cmd_blocking)
+        .await
+        .unwrap_or_else(|err| Err(format!("load_sync_profiles_cmd task failed: {err}")))
+}
+
+/// The body of `load_sync_profiles_cmd`, kept synchronous and run on the blocking pool.
+fn load_sync_profiles_cmd_blocking() -> Result<Vec<sync::SyncProfile>, String> {
     sync::load_sync_profiles()
 }
 
 #[tauri::command]
-fn save_sync_profile_cmd(profile: sync::SyncProfile) -> Result<(), String> {
+async fn save_sync_profile_cmd(profile: sync::SyncProfile) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || save_sync_profile_cmd_blocking(profile))
+        .await
+        .unwrap_or_else(|err| Err(format!("save_sync_profile_cmd task failed: {err}")))
+}
+
+/// The body of `save_sync_profile_cmd`, kept synchronous and run on the blocking pool.
+fn save_sync_profile_cmd_blocking(profile: sync::SyncProfile) -> Result<(), String> {
     sync::save_sync_profile(&profile)
 }
 
 #[tauri::command]
-fn delete_sync_profile_cmd(id: String) -> Result<(), String> {
+async fn delete_sync_profile_cmd(id: String) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || delete_sync_profile_cmd_blocking(id))
+        .await
+        .unwrap_or_else(|err| Err(format!("delete_sync_profile_cmd task failed: {err}")))
+}
+
+/// The body of `delete_sync_profile_cmd`, kept synchronous and run on the blocking pool.
+fn delete_sync_profile_cmd_blocking(id: String) -> Result<(), String> {
     sync::delete_sync_profile(&id)
 }
 
@@ -12670,17 +12832,40 @@ async fn get_parallel_scan_files(
 }
 
 #[tauri::command]
-fn get_sync_schedule_cmd() -> Result<sync_scheduler::SyncSchedule, String> {
+async fn get_sync_schedule_cmd() -> Result<sync_scheduler::SyncSchedule, String> {
+    tokio::task::spawn_blocking(get_sync_schedule_cmd_blocking)
+        .await
+        .unwrap_or_else(|err| Err(format!("get_sync_schedule_cmd task failed: {err}")))
+}
+
+/// The body of `get_sync_schedule_cmd`, kept synchronous and run on the blocking pool.
+fn get_sync_schedule_cmd_blocking() -> Result<sync_scheduler::SyncSchedule, String> {
     Ok(sync_scheduler::load_sync_schedule())
 }
 
 #[tauri::command]
-fn save_sync_schedule_cmd(schedule: sync_scheduler::SyncSchedule) -> Result<(), String> {
+async fn save_sync_schedule_cmd(schedule: sync_scheduler::SyncSchedule) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || save_sync_schedule_cmd_blocking(schedule))
+        .await
+        .unwrap_or_else(|err| Err(format!("save_sync_schedule_cmd task failed: {err}")))
+}
+
+/// The body of `save_sync_schedule_cmd`, kept synchronous and run on the blocking pool.
+fn save_sync_schedule_cmd_blocking(schedule: sync_scheduler::SyncSchedule) -> Result<(), String> {
     sync_scheduler::save_sync_schedule(&schedule)
 }
 
 #[tauri::command]
-fn get_watcher_status_cmd(watch_path: Option<String>) -> Result<serde_json::Value, String> {
+async fn get_watcher_status_cmd(watch_path: Option<String>) -> Result<serde_json::Value, String> {
+    tokio::task::spawn_blocking(move || get_watcher_status_cmd_blocking(watch_path))
+        .await
+        .unwrap_or_else(|err| Err(format!("get_watcher_status_cmd task failed: {err}")))
+}
+
+/// The body of `get_watcher_status_cmd`, kept synchronous and run on the blocking pool.
+fn get_watcher_status_cmd_blocking(
+    watch_path: Option<String>,
+) -> Result<serde_json::Value, String> {
     // Validate the watch path if provided
     if let Some(ref p) = watch_path {
         filesystem::validate_path(p)?;
@@ -13081,17 +13266,41 @@ async fn sftp_probe_delta_eligibility(
 // =============================
 
 #[tauri::command]
-fn get_multi_path_config() -> sync::MultiPathConfig {
+async fn get_multi_path_config() -> sync::MultiPathConfig {
+    tokio::task::spawn_blocking(get_multi_path_config_blocking)
+        .await
+        .unwrap_or_else(|err| {
+            tracing::warn!("get_multi_path_config task failed: {err}");
+            sync::MultiPathConfig::default()
+        })
+}
+
+/// The body of `get_multi_path_config`, kept synchronous and run on the blocking pool.
+fn get_multi_path_config_blocking() -> sync::MultiPathConfig {
     sync::load_multi_path_config()
 }
 
 #[tauri::command]
-fn save_multi_path_config_cmd(config: sync::MultiPathConfig) -> Result<(), String> {
+async fn save_multi_path_config_cmd(config: sync::MultiPathConfig) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || save_multi_path_config_cmd_blocking(config))
+        .await
+        .unwrap_or_else(|err| Err(format!("save_multi_path_config_cmd task failed: {err}")))
+}
+
+/// The body of `save_multi_path_config_cmd`, kept synchronous and run on the blocking pool.
+fn save_multi_path_config_cmd_blocking(config: sync::MultiPathConfig) -> Result<(), String> {
     sync::save_multi_path_config(&config)
 }
 
 #[tauri::command]
-fn add_path_pair(pair: sync::PathPair) -> Result<sync::MultiPathConfig, String> {
+async fn add_path_pair(pair: sync::PathPair) -> Result<sync::MultiPathConfig, String> {
+    tokio::task::spawn_blocking(move || add_path_pair_blocking(pair))
+        .await
+        .unwrap_or_else(|err| Err(format!("add_path_pair task failed: {err}")))
+}
+
+/// The body of `add_path_pair`, kept synchronous and run on the blocking pool.
+fn add_path_pair_blocking(pair: sync::PathPair) -> Result<sync::MultiPathConfig, String> {
     let mut config = sync::load_multi_path_config();
     config.pairs.push(pair);
     sync::save_multi_path_config(&config)?;
@@ -13099,7 +13308,14 @@ fn add_path_pair(pair: sync::PathPair) -> Result<sync::MultiPathConfig, String> 
 }
 
 #[tauri::command]
-fn remove_path_pair(pair_id: String) -> Result<sync::MultiPathConfig, String> {
+async fn remove_path_pair(pair_id: String) -> Result<sync::MultiPathConfig, String> {
+    tokio::task::spawn_blocking(move || remove_path_pair_blocking(pair_id))
+        .await
+        .unwrap_or_else(|err| Err(format!("remove_path_pair task failed: {err}")))
+}
+
+/// The body of `remove_path_pair`, kept synchronous and run on the blocking pool.
+fn remove_path_pair_blocking(pair_id: String) -> Result<sync::MultiPathConfig, String> {
     let mut config = sync::load_multi_path_config();
     config.pairs.retain(|p| p.id != pair_id);
     sync::save_multi_path_config(&config)?;
@@ -13111,7 +13327,30 @@ fn remove_path_pair(pair_id: String) -> Result<sync::MultiPathConfig, String> {
 // =============================
 
 #[tauri::command]
-fn export_sync_template_cmd(
+async fn export_sync_template_cmd(
+    name: String,
+    description: String,
+    profile_id: String,
+    local_path: String,
+    remote_path: String,
+    exclude_patterns: Vec<String>,
+) -> Result<String, String> {
+    tokio::task::spawn_blocking(move || {
+        export_sync_template_cmd_blocking(
+            name,
+            description,
+            profile_id,
+            local_path,
+            remote_path,
+            exclude_patterns,
+        )
+    })
+    .await
+    .unwrap_or_else(|err| Err(format!("export_sync_template_cmd task failed: {err}")))
+}
+
+/// The body of `export_sync_template_cmd`, kept synchronous and run on the blocking pool.
+fn export_sync_template_cmd_blocking(
     name: String,
     description: String,
     profile_id: String,
@@ -13143,7 +13382,14 @@ fn export_sync_template_cmd(
 }
 
 #[tauri::command]
-fn import_sync_template_cmd(json_content: String) -> Result<sync::SyncTemplate, String> {
+async fn import_sync_template_cmd(json_content: String) -> Result<sync::SyncTemplate, String> {
+    tokio::task::spawn_blocking(move || import_sync_template_cmd_blocking(json_content))
+        .await
+        .unwrap_or_else(|err| Err(format!("import_sync_template_cmd task failed: {err}")))
+}
+
+/// The body of `import_sync_template_cmd`, kept synchronous and run on the blocking pool.
+fn import_sync_template_cmd_blocking(json_content: String) -> Result<sync::SyncTemplate, String> {
     let template: sync::SyncTemplate = serde_json::from_str(&json_content)
         .map_err(|e| format!("Invalid template format: {}", e))?;
     if template.schema_version != 1 {
@@ -13168,7 +13414,14 @@ struct SyncScriptExportArgs {
 }
 
 #[tauri::command]
-fn export_sync_script_cmd(args: SyncScriptExportArgs) -> Result<String, String> {
+async fn export_sync_script_cmd(args: SyncScriptExportArgs) -> Result<String, String> {
+    tokio::task::spawn_blocking(move || export_sync_script_cmd_blocking(args))
+        .await
+        .unwrap_or_else(|err| Err(format!("export_sync_script_cmd task failed: {err}")))
+}
+
+/// The body of `export_sync_script_cmd`, kept synchronous and run on the blocking pool.
+fn export_sync_script_cmd_blocking(args: SyncScriptExportArgs) -> Result<String, String> {
     let format = sync::SyncScriptFormat::parse(&args.format)
         .ok_or_else(|| format!("Unsupported script format: {}", args.format))?;
     let profiles = sync::load_sync_profiles()?;
@@ -13189,7 +13442,14 @@ fn export_sync_script_cmd(args: SyncScriptExportArgs) -> Result<String, String> 
 }
 
 #[tauri::command]
-fn import_sync_script_cmd(script_content: String) -> Result<sync::SyncScriptMeta, String> {
+async fn import_sync_script_cmd(script_content: String) -> Result<sync::SyncScriptMeta, String> {
+    tokio::task::spawn_blocking(move || import_sync_script_cmd_blocking(script_content))
+        .await
+        .unwrap_or_else(|err| Err(format!("import_sync_script_cmd task failed: {err}")))
+}
+
+/// The body of `import_sync_script_cmd`, kept synchronous and run on the blocking pool.
+fn import_sync_script_cmd_blocking(script_content: String) -> Result<sync::SyncScriptMeta, String> {
     sync::import_sync_script(&script_content)
 }
 
@@ -13228,7 +13488,16 @@ struct AerosyncExportScriptResult {
 }
 
 #[tauri::command]
-fn aerosync_export_script_cmd(
+async fn aerosync_export_script_cmd(
+    args: AerosyncExportScriptArgs,
+) -> Result<AerosyncExportScriptResult, String> {
+    tokio::task::spawn_blocking(move || aerosync_export_script_cmd_blocking(args))
+        .await
+        .unwrap_or_else(|err| Err(format!("aerosync_export_script_cmd task failed: {err}")))
+}
+
+/// The body of `aerosync_export_script_cmd`, kept synchronous and run on the blocking pool.
+fn aerosync_export_script_cmd_blocking(
     args: AerosyncExportScriptArgs,
 ) -> Result<AerosyncExportScriptResult, String> {
     let profiles = sync::load_sync_profiles()?;
@@ -13331,7 +13600,16 @@ struct AerosyncImportScriptResult {
 }
 
 #[tauri::command]
-fn aerosync_import_script_cmd(
+async fn aerosync_import_script_cmd(
+    args: AerosyncImportScriptArgs,
+) -> Result<AerosyncImportScriptResult, String> {
+    tokio::task::spawn_blocking(move || aerosync_import_script_cmd_blocking(args))
+        .await
+        .unwrap_or_else(|err| Err(format!("aerosync_import_script_cmd task failed: {err}")))
+}
+
+/// The body of `aerosync_import_script_cmd`, kept synchronous and run on the blocking pool.
+fn aerosync_import_script_cmd_blocking(
     args: AerosyncImportScriptArgs,
 ) -> Result<AerosyncImportScriptResult, String> {
     let input_path = std::path::PathBuf::from(&args.input_path);
@@ -13369,7 +13647,20 @@ fn aerosync_import_script_cmd(
 // =============================
 
 #[tauri::command]
-fn create_sync_snapshot_cmd(local_path: String, remote_path: String) -> Result<String, String> {
+async fn create_sync_snapshot_cmd(
+    local_path: String,
+    remote_path: String,
+) -> Result<String, String> {
+    tokio::task::spawn_blocking(move || create_sync_snapshot_cmd_blocking(local_path, remote_path))
+        .await
+        .unwrap_or_else(|err| Err(format!("create_sync_snapshot_cmd task failed: {err}")))
+}
+
+/// The body of `create_sync_snapshot_cmd`, kept synchronous and run on the blocking pool.
+fn create_sync_snapshot_cmd_blocking(
+    local_path: String,
+    remote_path: String,
+) -> Result<String, String> {
     let index = sync::load_sync_index(&local_path, &remote_path)?
         .ok_or_else(|| "No sync index found: run sync first".to_string())?;
     let snapshot = sync::create_sync_snapshot(&local_path, &remote_path, &index);
@@ -13378,7 +13669,17 @@ fn create_sync_snapshot_cmd(local_path: String, remote_path: String) -> Result<S
 }
 
 #[tauri::command]
-fn list_sync_snapshots_cmd(
+async fn list_sync_snapshots_cmd(
+    local_path: Option<String>,
+    remote_path: Option<String>,
+) -> Result<Vec<sync::SyncSnapshot>, String> {
+    tokio::task::spawn_blocking(move || list_sync_snapshots_cmd_blocking(local_path, remote_path))
+        .await
+        .unwrap_or_else(|err| Err(format!("list_sync_snapshots_cmd task failed: {err}")))
+}
+
+/// The body of `list_sync_snapshots_cmd`, kept synchronous and run on the blocking pool.
+fn list_sync_snapshots_cmd_blocking(
     local_path: Option<String>,
     remote_path: Option<String>,
 ) -> Result<Vec<sync::SyncSnapshot>, String> {
@@ -13391,7 +13692,20 @@ fn list_sync_snapshots_cmd(
 }
 
 #[tauri::command]
-fn delete_sync_snapshot_cmd(
+async fn delete_sync_snapshot_cmd(
+    snapshot_id: String,
+    local_path: Option<String>,
+    remote_path: Option<String>,
+) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || {
+        delete_sync_snapshot_cmd_blocking(snapshot_id, local_path, remote_path)
+    })
+    .await
+    .unwrap_or_else(|err| Err(format!("delete_sync_snapshot_cmd task failed: {err}")))
+}
+
+/// The body of `delete_sync_snapshot_cmd`, kept synchronous and run on the blocking pool.
+fn delete_sync_snapshot_cmd_blocking(
     snapshot_id: String,
     local_path: Option<String>,
     remote_path: Option<String>,
@@ -13404,7 +13718,20 @@ fn delete_sync_snapshot_cmd(
 }
 
 #[tauri::command]
-fn load_sync_snapshot_cmd(
+async fn load_sync_snapshot_cmd(
+    snapshot_id: String,
+    local_path: Option<String>,
+    remote_path: Option<String>,
+) -> Result<sync::SyncSnapshot, String> {
+    tokio::task::spawn_blocking(move || {
+        load_sync_snapshot_cmd_blocking(snapshot_id, local_path, remote_path)
+    })
+    .await
+    .unwrap_or_else(|err| Err(format!("load_sync_snapshot_cmd task failed: {err}")))
+}
+
+/// The body of `load_sync_snapshot_cmd`, kept synchronous and run on the blocking pool.
+fn load_sync_snapshot_cmd_blocking(
     snapshot_id: String,
     local_path: Option<String>,
     remote_path: Option<String>,
@@ -14404,7 +14731,46 @@ fn get_default_retry_policy() -> RetryPolicy {
 }
 
 #[tauri::command]
-fn verify_local_transfer(
+async fn verify_local_transfer(
+    local_path: String,
+    expected_size: u64,
+    expected_mtime: Option<String>,
+    expected_hash: Option<String>,
+    policy: VerifyPolicy,
+) -> VerifyResult {
+    // Kept for the failure path, which the closure would otherwise move out of
+    // reach.
+    let reported_path = local_path.clone();
+    let reported_policy = policy.clone();
+    tokio::task::spawn_blocking(move || {
+        verify_local_transfer_blocking(
+            local_path,
+            expected_size,
+            expected_mtime,
+            expected_hash,
+            policy,
+        )
+    })
+    .await
+    .unwrap_or_else(|err| {
+        tracing::warn!("verify_local_transfer task failed: {err}");
+        // Fail closed: the verification never ran, so it did not pass.
+        VerifyResult {
+            path: reported_path,
+            passed: false,
+            policy: reported_policy,
+            expected_size,
+            actual_size: None,
+            size_match: false,
+            mtime_match: None,
+            hash_match: None,
+            message: Some(format!("verification task failed: {err}")),
+        }
+    })
+}
+
+/// The body of `verify_local_transfer`, kept synchronous and run on the blocking pool.
+fn verify_local_transfer_blocking(
     local_path: String,
     expected_size: u64,
     expected_mtime: Option<String>,
@@ -14824,12 +15190,29 @@ async fn ai_execute_tool(
 // ============ AeroCloud Commands ============
 
 #[tauri::command]
-fn get_cloud_config() -> CloudConfig {
+async fn get_cloud_config() -> CloudConfig {
+    tokio::task::spawn_blocking(get_cloud_config_blocking)
+        .await
+        .unwrap_or_else(|err| {
+            tracing::warn!("get_cloud_config task failed: {err}");
+            CloudConfig::default()
+        })
+}
+
+/// The body of `get_cloud_config`, kept synchronous and run on the blocking pool.
+fn get_cloud_config_blocking() -> CloudConfig {
     cloud_config::load_cloud_config()
 }
 
 #[tauri::command]
-fn save_cloud_config_cmd(config: CloudConfig) -> Result<(), String> {
+async fn save_cloud_config_cmd(config: CloudConfig) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || save_cloud_config_cmd_blocking(config))
+        .await
+        .unwrap_or_else(|err| Err(format!("save_cloud_config_cmd task failed: {err}")))
+}
+
+/// The body of `save_cloud_config_cmd`, kept synchronous and run on the blocking pool.
+fn save_cloud_config_cmd_blocking(config: CloudConfig) -> Result<(), String> {
     cloud_config::save_cloud_config(&config)
 }
 
@@ -14837,17 +15220,45 @@ fn save_cloud_config_cmd(config: CloudConfig) -> Result<(), String> {
 // Mirrors the style of multi-path commands but targets CloudPathPair / CloudPairsConfig.
 // Seeding from legacy happens on first add via GUI (or CLI already supports).
 #[tauri::command]
-fn get_cloud_pairs_config() -> cloud_pairs::CloudPairsConfig {
+async fn get_cloud_pairs_config() -> cloud_pairs::CloudPairsConfig {
+    tokio::task::spawn_blocking(get_cloud_pairs_config_blocking)
+        .await
+        .unwrap_or_else(|err| {
+            tracing::warn!("get_cloud_pairs_config task failed: {err}");
+            cloud_pairs::CloudPairsConfig::default()
+        })
+}
+
+/// The body of `get_cloud_pairs_config`, kept synchronous and run on the blocking pool.
+fn get_cloud_pairs_config_blocking() -> cloud_pairs::CloudPairsConfig {
     cloud_pairs::load_cloud_pairs_config()
 }
 
 #[tauri::command]
-fn save_cloud_pairs_config_cmd(config: cloud_pairs::CloudPairsConfig) -> Result<(), String> {
+async fn save_cloud_pairs_config_cmd(config: cloud_pairs::CloudPairsConfig) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || save_cloud_pairs_config_cmd_blocking(config))
+        .await
+        .unwrap_or_else(|err| Err(format!("save_cloud_pairs_config_cmd task failed: {err}")))
+}
+
+/// The body of `save_cloud_pairs_config_cmd`, kept synchronous and run on the blocking pool.
+fn save_cloud_pairs_config_cmd_blocking(
+    config: cloud_pairs::CloudPairsConfig,
+) -> Result<(), String> {
     cloud_pairs::save_cloud_pairs_config(&config)
 }
 
 #[tauri::command]
-fn add_cloud_pair(
+async fn add_cloud_pair(
+    pair: cloud_pairs::CloudPathPair,
+) -> Result<cloud_pairs::CloudPairsConfig, String> {
+    tokio::task::spawn_blocking(move || add_cloud_pair_blocking(pair))
+        .await
+        .unwrap_or_else(|err| Err(format!("add_cloud_pair task failed: {err}")))
+}
+
+/// The body of `add_cloud_pair`, kept synchronous and run on the blocking pool.
+fn add_cloud_pair_blocking(
     pair: cloud_pairs::CloudPathPair,
 ) -> Result<cloud_pairs::CloudPairsConfig, String> {
     let mut config = cloud_pairs::load_cloud_pairs_config();
@@ -14860,7 +15271,14 @@ fn add_cloud_pair(
 }
 
 #[tauri::command]
-fn remove_cloud_pair(pair_id: String) -> Result<cloud_pairs::CloudPairsConfig, String> {
+async fn remove_cloud_pair(pair_id: String) -> Result<cloud_pairs::CloudPairsConfig, String> {
+    tokio::task::spawn_blocking(move || remove_cloud_pair_blocking(pair_id))
+        .await
+        .unwrap_or_else(|err| Err(format!("remove_cloud_pair task failed: {err}")))
+}
+
+/// The body of `remove_cloud_pair`, kept synchronous and run on the blocking pool.
+fn remove_cloud_pair_blocking(pair_id: String) -> Result<cloud_pairs::CloudPairsConfig, String> {
     let mut config = cloud_pairs::load_cloud_pairs_config();
     let before = config.pairs.len();
     config.pairs.retain(|p| p.id != pair_id);
@@ -14872,7 +15290,16 @@ fn remove_cloud_pair(pair_id: String) -> Result<cloud_pairs::CloudPairsConfig, S
 }
 
 #[tauri::command]
-fn update_cloud_pair(
+async fn update_cloud_pair(
+    pair: cloud_pairs::CloudPathPair,
+) -> Result<cloud_pairs::CloudPairsConfig, String> {
+    tokio::task::spawn_blocking(move || update_cloud_pair_blocking(pair))
+        .await
+        .unwrap_or_else(|err| Err(format!("update_cloud_pair task failed: {err}")))
+}
+
+/// The body of `update_cloud_pair`, kept synchronous and run on the blocking pool.
+fn update_cloud_pair_blocking(
     pair: cloud_pairs::CloudPathPair,
 ) -> Result<cloud_pairs::CloudPairsConfig, String> {
     let mut config = cloud_pairs::load_cloud_pairs_config();
@@ -14887,28 +15314,68 @@ fn update_cloud_pair(
 
 /// Update excluded folders for selective sync
 #[tauri::command]
-fn update_excluded_folders(excluded_folders: Vec<String>) -> Result<(), String> {
+async fn update_excluded_folders(excluded_folders: Vec<String>) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || update_excluded_folders_blocking(excluded_folders))
+        .await
+        .unwrap_or_else(|err| Err(format!("update_excluded_folders task failed: {err}")))
+}
+
+/// The body of `update_excluded_folders`, kept synchronous and run on the blocking pool.
+fn update_excluded_folders_blocking(excluded_folders: Vec<String>) -> Result<(), String> {
     let mut config = cloud_config::load_cloud_config();
     config.excluded_folders = excluded_folders;
     cloud_config::save_cloud_config(&config)
 }
 
 #[tauri::command]
-fn list_file_versions(relative_path: String) -> Result<Vec<sync_versioning::VersionEntry>, String> {
+async fn list_file_versions(
+    relative_path: String,
+) -> Result<Vec<sync_versioning::VersionEntry>, String> {
+    tokio::task::spawn_blocking(move || list_file_versions_blocking(relative_path))
+        .await
+        .unwrap_or_else(|err| Err(format!("list_file_versions task failed: {err}")))
+}
+
+/// The body of `list_file_versions`, kept synchronous and run on the blocking pool.
+fn list_file_versions_blocking(
+    relative_path: String,
+) -> Result<Vec<sync_versioning::VersionEntry>, String> {
     let config = cloud_config::load_cloud_config();
     let v = sync_versioning::SyncVersioning::new(&config.local_folder, config.versioning_strategy);
     v.list_versions(&relative_path)
 }
 
 #[tauri::command]
-fn list_all_file_versions() -> Result<Vec<sync_versioning::VersionEntry>, String> {
+async fn list_all_file_versions() -> Result<Vec<sync_versioning::VersionEntry>, String> {
+    tokio::task::spawn_blocking(list_all_file_versions_blocking)
+        .await
+        .unwrap_or_else(|err| Err(format!("list_all_file_versions task failed: {err}")))
+}
+
+/// The body of `list_all_file_versions`, kept synchronous and run on the blocking pool.
+fn list_all_file_versions_blocking() -> Result<Vec<sync_versioning::VersionEntry>, String> {
     let config = cloud_config::load_cloud_config();
     let v = sync_versioning::SyncVersioning::new(&config.local_folder, config.versioning_strategy);
     v.list_all_versions()
 }
 
 #[tauri::command]
-fn restore_file_version(archive_path: String, original_relative: String) -> Result<(), String> {
+async fn restore_file_version(
+    archive_path: String,
+    original_relative: String,
+) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || {
+        restore_file_version_blocking(archive_path, original_relative)
+    })
+    .await
+    .unwrap_or_else(|err| Err(format!("restore_file_version task failed: {err}")))
+}
+
+/// The body of `restore_file_version`, kept synchronous and run on the blocking pool.
+fn restore_file_version_blocking(
+    archive_path: String,
+    original_relative: String,
+) -> Result<(), String> {
     let config = cloud_config::load_cloud_config();
     // Security: validate archive_path is within .aeroversions/ (prevent path traversal)
     let versions_dir = config.local_folder.join(".aeroversions");
@@ -14938,14 +15405,31 @@ fn restore_file_version(archive_path: String, original_relative: String) -> Resu
 }
 
 #[tauri::command]
-fn cleanup_versions() -> Result<sync_versioning::CleanupStats, String> {
+async fn cleanup_versions() -> Result<sync_versioning::CleanupStats, String> {
+    tokio::task::spawn_blocking(cleanup_versions_blocking)
+        .await
+        .unwrap_or_else(|err| Err(format!("cleanup_versions task failed: {err}")))
+}
+
+/// The body of `cleanup_versions`, kept synchronous and run on the blocking pool.
+fn cleanup_versions_blocking() -> Result<sync_versioning::CleanupStats, String> {
     let config = cloud_config::load_cloud_config();
     let v = sync_versioning::SyncVersioning::new(&config.local_folder, config.versioning_strategy);
     v.cleanup()
 }
 
 #[tauri::command]
-fn versions_disk_usage() -> u64 {
+async fn versions_disk_usage() -> u64 {
+    tokio::task::spawn_blocking(versions_disk_usage_blocking)
+        .await
+        .unwrap_or_else(|err| {
+            tracing::warn!("versions_disk_usage task failed: {err}");
+            0
+        })
+}
+
+/// The body of `versions_disk_usage`, kept synchronous and run on the blocking pool.
+fn versions_disk_usage_blocking() -> u64 {
     let config = cloud_config::load_cloud_config();
     let v = sync_versioning::SyncVersioning::new(&config.local_folder, config.versioning_strategy);
     v.disk_usage()
@@ -14954,7 +15438,20 @@ fn versions_disk_usage() -> u64 {
 /// Archive a local file before deleting it during sync (backup-before-delete safety net).
 /// Uses TrashCan strategy with 30-day retention, archiving to <sync_root>/.aeroversions/.
 #[tauri::command]
-fn archive_before_sync_delete(
+async fn archive_before_sync_delete(
+    sync_root: String,
+    file_path: String,
+    versioning_strategy: Option<String>,
+) -> Result<String, String> {
+    tokio::task::spawn_blocking(move || {
+        archive_before_sync_delete_blocking(sync_root, file_path, versioning_strategy)
+    })
+    .await
+    .unwrap_or_else(|err| Err(format!("archive_before_sync_delete task failed: {err}")))
+}
+
+/// The body of `archive_before_sync_delete`, kept synchronous and run on the blocking pool.
+fn archive_before_sync_delete_blocking(
     sync_root: String,
     file_path: String,
     versioning_strategy: Option<String>,
@@ -15099,7 +15596,17 @@ async fn setup_aerocloud(
 }
 
 #[tauri::command]
-fn get_cloud_status() -> CloudSyncStatus {
+async fn get_cloud_status() -> CloudSyncStatus {
+    tokio::task::spawn_blocking(get_cloud_status_blocking)
+        .await
+        .unwrap_or_else(|err| {
+            tracing::warn!("get_cloud_status task failed: {err}");
+            CloudSyncStatus::NotConfigured
+        })
+}
+
+/// The body of `get_cloud_status`, kept synchronous and run on the blocking pool.
+fn get_cloud_status_blocking() -> CloudSyncStatus {
     let config = cloud_config::load_cloud_config();
 
     if !config.enabled {
@@ -15117,7 +15624,14 @@ fn get_cloud_status() -> CloudSyncStatus {
 }
 
 #[tauri::command]
-fn enable_aerocloud(enabled: bool) -> Result<CloudConfig, String> {
+async fn enable_aerocloud(enabled: bool) -> Result<CloudConfig, String> {
+    tokio::task::spawn_blocking(move || enable_aerocloud_blocking(enabled))
+        .await
+        .unwrap_or_else(|err| Err(format!("enable_aerocloud task failed: {err}")))
+}
+
+/// The body of `enable_aerocloud`, kept synchronous and run on the blocking pool.
+fn enable_aerocloud_blocking(enabled: bool) -> Result<CloudConfig, String> {
     let mut config = cloud_config::load_cloud_config();
 
     if enabled {
@@ -15217,7 +15731,14 @@ async fn disable_aerocloud(app: AppHandle) -> Result<(), String> {
 /// Generate a shareable link for a file in AeroCloud
 /// Returns the public URL if public_url_base is configured
 #[tauri::command]
-fn generate_share_link(local_path: String) -> Result<String, String> {
+async fn generate_share_link(local_path: String) -> Result<String, String> {
+    tokio::task::spawn_blocking(move || generate_share_link_blocking(local_path))
+        .await
+        .unwrap_or_else(|err| Err(format!("generate_share_link task failed: {err}")))
+}
+
+/// The body of `generate_share_link`, kept synchronous and run on the blocking pool.
+fn generate_share_link_blocking(local_path: String) -> Result<String, String> {
     let config = cloud_config::load_cloud_config();
 
     if !config.enabled {
@@ -15255,7 +15776,14 @@ fn generate_share_link(local_path: String) -> Result<String, String> {
 
 /// Generate share link from remote path (when browsing remote files)
 #[tauri::command]
-fn generate_share_link_remote(remote_path: String) -> Result<String, String> {
+async fn generate_share_link_remote(remote_path: String) -> Result<String, String> {
+    tokio::task::spawn_blocking(move || generate_share_link_remote_blocking(remote_path))
+        .await
+        .unwrap_or_else(|err| Err(format!("generate_share_link_remote task failed: {err}")))
+}
+
+/// The body of `generate_share_link_remote`, kept synchronous and run on the blocking pool.
+fn generate_share_link_remote_blocking(remote_path: String) -> Result<String, String> {
     let config = cloud_config::load_cloud_config();
 
     if !config.enabled {
@@ -15336,13 +15864,33 @@ fn generate_server_share_link(
 }
 
 #[tauri::command]
-fn get_default_cloud_folder() -> String {
+async fn get_default_cloud_folder() -> String {
+    tokio::task::spawn_blocking(get_default_cloud_folder_blocking)
+        .await
+        .unwrap_or_else(|err| {
+            tracing::warn!("get_default_cloud_folder task failed: {err}");
+            CloudConfig::default()
+                .local_folder
+                .to_string_lossy()
+                .to_string()
+        })
+}
+
+/// The body of `get_default_cloud_folder`, kept synchronous and run on the blocking pool.
+fn get_default_cloud_folder_blocking() -> String {
     let default_config = CloudConfig::default();
     default_config.local_folder.to_string_lossy().to_string()
 }
 
 #[tauri::command]
-fn update_conflict_strategy(strategy: ConflictStrategy) -> Result<(), String> {
+async fn update_conflict_strategy(strategy: ConflictStrategy) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || update_conflict_strategy_blocking(strategy))
+        .await
+        .unwrap_or_else(|err| Err(format!("update_conflict_strategy task failed: {err}")))
+}
+
+/// The body of `update_conflict_strategy`, kept synchronous and run on the blocking pool.
+fn update_conflict_strategy_blocking(strategy: ConflictStrategy) -> Result<(), String> {
     let mut config = cloud_config::load_cloud_config();
     config.conflict_strategy = strategy;
     cloud_config::save_cloud_config(&config)
@@ -16190,7 +16738,17 @@ async fn bootstrap_master_credential_store(
 /// `available` is true only inside a Flatpak sandbox, when a native
 /// `~/.config/aeroftp` exists, and when the user has not already decided.
 #[tauri::command]
-fn flatpak_config_import_status() -> serde_json::Value {
+async fn flatpak_config_import_status() -> serde_json::Value {
+    tokio::task::spawn_blocking(flatpak_config_import_status_blocking)
+        .await
+        .unwrap_or_else(|err| {
+            tracing::warn!("flatpak_config_import_status task failed: {err}");
+            serde_json::json!({"available": false})
+        })
+}
+
+/// The body of `flatpak_config_import_status`, kept synchronous and run on the blocking pool.
+fn flatpak_config_import_status_blocking() -> serde_json::Value {
     let status = portable::flatpak_host_import_status();
     serde_json::json!({
         "available": status.available,
@@ -16205,7 +16763,14 @@ fn flatpak_config_import_status() -> serde_json::Value {
 /// is shown once. The vault is copied encrypted and still needs the master
 /// password to unlock.
 #[tauri::command]
-fn flatpak_config_import_apply(accept: bool) -> Result<serde_json::Value, String> {
+async fn flatpak_config_import_apply(accept: bool) -> Result<serde_json::Value, String> {
+    tokio::task::spawn_blocking(move || flatpak_config_import_apply_blocking(accept))
+        .await
+        .unwrap_or_else(|err| Err(format!("flatpak_config_import_apply task failed: {err}")))
+}
+
+/// The body of `flatpak_config_import_apply`, kept synchronous and run on the blocking pool.
+fn flatpak_config_import_apply_blocking(accept: bool) -> Result<serde_json::Value, String> {
     let report = portable::flatpak_host_import_apply(accept)?;
     Ok(serde_json::json!({
         "imported": report.imported,
@@ -17535,7 +18100,17 @@ async fn mount_uninstall_autostart(id: String) -> Result<(), String> {
 }
 
 #[tauri::command]
-fn mount_autostart_blocked() -> Option<String> {
+async fn mount_autostart_blocked() -> Option<String> {
+    tokio::task::spawn_blocking(mount_autostart_blocked_blocking)
+        .await
+        .unwrap_or_else(|err| {
+            tracing::warn!("mount_autostart_blocked task failed: {err}");
+            None
+        })
+}
+
+/// The body of `mount_autostart_blocked`, kept synchronous and run on the blocking pool.
+fn mount_autostart_blocked_blocking() -> Option<String> {
     mount_manager::autostart_blocked_reason()
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13333,7 +13333,9 @@ async fn export_sync_template_cmd(
     profile_id: String,
     local_path: String,
     remote_path: String,
-    exclude_patterns: Vec<String>,
+    // `None` (or an empty list) means "the preset's own", see
+    // `sync::resolve_exclude_patterns`.
+    exclude_patterns: Option<Vec<String>>,
 ) -> Result<String, String> {
     tokio::task::spawn_blocking(move || {
         export_sync_template_cmd_blocking(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13301,10 +13301,10 @@ async fn add_path_pair(pair: sync::PathPair) -> Result<sync::MultiPathConfig, St
 
 /// The body of `add_path_pair`, kept synchronous and run on the blocking pool.
 fn add_path_pair_blocking(pair: sync::PathPair) -> Result<sync::MultiPathConfig, String> {
-    let mut config = sync::load_multi_path_config();
-    config.pairs.push(pair);
-    sync::save_multi_path_config(&config)?;
-    Ok(config)
+    sync::with_multi_path_config_mut(|config| {
+        config.pairs.push(pair);
+        Ok(config.clone())
+    })
 }
 
 #[tauri::command]
@@ -13316,10 +13316,10 @@ async fn remove_path_pair(pair_id: String) -> Result<sync::MultiPathConfig, Stri
 
 /// The body of `remove_path_pair`, kept synchronous and run on the blocking pool.
 fn remove_path_pair_blocking(pair_id: String) -> Result<sync::MultiPathConfig, String> {
-    let mut config = sync::load_multi_path_config();
-    config.pairs.retain(|p| p.id != pair_id);
-    sync::save_multi_path_config(&config)?;
-    Ok(config)
+    sync::with_multi_path_config_mut(|config| {
+        config.pairs.retain(|p| p.id != pair_id);
+        Ok(config.clone())
+    })
 }
 
 // =============================
@@ -15261,13 +15261,13 @@ async fn add_cloud_pair(
 fn add_cloud_pair_blocking(
     pair: cloud_pairs::CloudPathPair,
 ) -> Result<cloud_pairs::CloudPairsConfig, String> {
-    let mut config = cloud_pairs::load_cloud_pairs_config();
-    if cloud_pairs::pair_exists(&pair.local_path, &pair.remote_path, &config.pairs) {
-        return Err("A pair with the same local and remote path already exists".to_string());
-    }
-    config.pairs.push(pair);
-    cloud_pairs::save_cloud_pairs_config(&config)?;
-    Ok(config)
+    cloud_pairs::with_cloud_pairs_mut(|config| {
+        if cloud_pairs::pair_exists(&pair.local_path, &pair.remote_path, &config.pairs) {
+            return Err("A pair with the same local and remote path already exists".to_string());
+        }
+        config.pairs.push(pair);
+        Ok(config.clone())
+    })
 }
 
 #[tauri::command]
@@ -15279,14 +15279,14 @@ async fn remove_cloud_pair(pair_id: String) -> Result<cloud_pairs::CloudPairsCon
 
 /// The body of `remove_cloud_pair`, kept synchronous and run on the blocking pool.
 fn remove_cloud_pair_blocking(pair_id: String) -> Result<cloud_pairs::CloudPairsConfig, String> {
-    let mut config = cloud_pairs::load_cloud_pairs_config();
-    let before = config.pairs.len();
-    config.pairs.retain(|p| p.id != pair_id);
-    if config.pairs.len() == before {
-        return Err("Pair not found".to_string());
-    }
-    cloud_pairs::save_cloud_pairs_config(&config)?;
-    Ok(config)
+    cloud_pairs::with_cloud_pairs_mut(|config| {
+        let before = config.pairs.len();
+        config.pairs.retain(|p| p.id != pair_id);
+        if config.pairs.len() == before {
+            return Err("Pair not found".to_string());
+        }
+        Ok(config.clone())
+    })
 }
 
 #[tauri::command]
@@ -15302,14 +15302,14 @@ async fn update_cloud_pair(
 fn update_cloud_pair_blocking(
     pair: cloud_pairs::CloudPathPair,
 ) -> Result<cloud_pairs::CloudPairsConfig, String> {
-    let mut config = cloud_pairs::load_cloud_pairs_config();
-    if let Some(existing) = config.pairs.iter_mut().find(|p| p.id == pair.id) {
-        *existing = pair;
-    } else {
-        return Err("Pair not found".to_string());
-    }
-    cloud_pairs::save_cloud_pairs_config(&config)?;
-    Ok(config)
+    cloud_pairs::with_cloud_pairs_mut(|config| {
+        if let Some(existing) = config.pairs.iter_mut().find(|p| p.id == pair.id) {
+            *existing = pair;
+        } else {
+            return Err("Pair not found".to_string());
+        }
+        Ok(config.clone())
+    })
 }
 
 /// Update excluded folders for selective sync
@@ -15322,9 +15322,10 @@ async fn update_excluded_folders(excluded_folders: Vec<String>) -> Result<(), St
 
 /// The body of `update_excluded_folders`, kept synchronous and run on the blocking pool.
 fn update_excluded_folders_blocking(excluded_folders: Vec<String>) -> Result<(), String> {
-    let mut config = cloud_config::load_cloud_config();
-    config.excluded_folders = excluded_folders;
-    cloud_config::save_cloud_config(&config)
+    cloud_config::with_cloud_config_mut(|config| {
+        config.excluded_folders = excluded_folders;
+        Ok(())
+    })
 }
 
 #[tauri::command]
@@ -15632,19 +15633,19 @@ async fn enable_aerocloud(enabled: bool) -> Result<CloudConfig, String> {
 
 /// The body of `enable_aerocloud`, kept synchronous and run on the blocking pool.
 fn enable_aerocloud_blocking(enabled: bool) -> Result<CloudConfig, String> {
-    let mut config = cloud_config::load_cloud_config();
+    let config = cloud_config::with_cloud_config_mut(|config| {
+        if enabled {
+            // Validate before enabling
+            cloud_config::validate_config(config)?;
+            cloud_config::ensure_cloud_folder(config)?;
+        }
 
-    if enabled {
-        // Validate before enabling
-        cloud_config::validate_config(&config)?;
-        cloud_config::ensure_cloud_folder(&config)?;
-    }
-
-    config.enabled = enabled;
-    // Always clear the paused flag on explicit enable/disable so the two
-    // state machines (enable vs pause) never conflict on re-enable.
-    config.paused = false;
-    cloud_config::save_cloud_config(&config)?;
+        config.enabled = enabled;
+        // Always clear the paused flag on explicit enable/disable so the two
+        // state machines (enable vs pause) never conflict on re-enable.
+        config.paused = false;
+        Ok(config.clone())
+    })?;
 
     info!("AeroCloud {}", if enabled { "enabled" } else { "disabled" });
 
@@ -15656,19 +15657,20 @@ fn enable_aerocloud_blocking(enabled: bool) -> Result<CloudConfig, String> {
 /// The auto-start effect in the frontend respects this flag on next launch.
 #[tauri::command]
 async fn pause_aerocloud(app: AppHandle) -> Result<CloudConfig, String> {
-    let mut config = cloud_config::load_cloud_config();
-    if !config.enabled {
-        return Err("AeroCloud is not configured".to_string());
-    }
-
     // Stop the worker if running. stop_background_sync emits "idle"; we override
     // with "paused" below so the frontend can distinguish the two states.
+    // Worker stop is outside the config lock so we never hold it across .await.
     if BACKGROUND_SYNC_RUNNING.load(Ordering::SeqCst) {
         let _ = stop_background_sync(app.clone()).await;
     }
 
-    config.paused = true;
-    cloud_config::save_cloud_config(&config)?;
+    let config = cloud_config::with_cloud_config_mut(|config| {
+        if !config.enabled {
+            return Err("AeroCloud is not configured".to_string());
+        }
+        config.paused = true;
+        Ok(config.clone())
+    })?;
 
     let _ = app.emit(
         "cloud-sync-status",
@@ -15689,13 +15691,13 @@ async fn resume_aerocloud(
     app: AppHandle,
     state: tauri::State<'_, AppState>,
 ) -> Result<CloudConfig, String> {
-    let mut config = cloud_config::load_cloud_config();
-    if !config.enabled {
-        return Err("AeroCloud is not configured".to_string());
-    }
-
-    config.paused = false;
-    cloud_config::save_cloud_config(&config)?;
+    let config = cloud_config::with_cloud_config_mut(|config| {
+        if !config.enabled {
+            return Err("AeroCloud is not configured".to_string());
+        }
+        config.paused = false;
+        Ok(config.clone())
+    })?;
 
     // Best-effort start. If a worker is already running start_background_sync
     // returns Ok early. If the config is invalid we surface the error so the
@@ -15891,9 +15893,10 @@ async fn update_conflict_strategy(strategy: ConflictStrategy) -> Result<(), Stri
 
 /// The body of `update_conflict_strategy`, kept synchronous and run on the blocking pool.
 fn update_conflict_strategy_blocking(strategy: ConflictStrategy) -> Result<(), String> {
-    let mut config = cloud_config::load_cloud_config();
-    config.conflict_strategy = strategy;
-    cloud_config::save_cloud_config(&config)
+    cloud_config::with_cloud_config_mut(|config| {
+        config.conflict_strategy = strategy;
+        Ok(())
+    })
 }
 
 #[tauri::command]

--- a/src-tauri/src/sync.rs
+++ b/src-tauri/src/sync.rs
@@ -28,6 +28,11 @@ use std::sync::Mutex;
 static JOURNAL_WRITE_LOCK: std::sync::LazyLock<Mutex<()>> =
     std::sync::LazyLock::new(|| Mutex::new(()));
 
+/// Serializes concurrent multi-path config read-modify-write (same shape as
+/// `cloud_config::CONFIG_WRITE_LOCK`).
+static MULTI_PATH_WRITE_LOCK: std::sync::LazyLock<Mutex<()>> =
+    std::sync::LazyLock::new(|| Mutex::new(()));
+
 /// Tolerance for timestamp comparison (seconds)
 /// Accounts for filesystem and timezone differences
 const TIMESTAMP_TOLERANCE_SECS: i64 = 30;
@@ -3788,6 +3793,10 @@ pub struct MultiPathConfig {
 
 /// Load multi-path config from disk
 pub fn load_multi_path_config() -> MultiPathConfig {
+    load_multi_path_config_unlocked()
+}
+
+fn load_multi_path_config_unlocked() -> MultiPathConfig {
     let Some(dir) = crate::portable::aeroftp_data_root() else {
         return MultiPathConfig::default();
     };
@@ -3802,8 +3811,29 @@ pub fn load_multi_path_config() -> MultiPathConfig {
     }
 }
 
+/// Load → mutate → save under one write lock (see `cloud_config::with_cloud_config_mut`).
+pub fn with_multi_path_config_mut<F, T>(f: F) -> Result<T, String>
+where
+    F: FnOnce(&mut MultiPathConfig) -> Result<T, String>,
+{
+    let _lock = MULTI_PATH_WRITE_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let mut config = load_multi_path_config_unlocked();
+    let out = f(&mut config)?;
+    save_multi_path_config_unlocked(&config)?;
+    Ok(out)
+}
+
 /// Save multi-path config to disk (atomic temp+rename)
 pub fn save_multi_path_config(config: &MultiPathConfig) -> Result<(), String> {
+    let _lock = MULTI_PATH_WRITE_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    save_multi_path_config_unlocked(config)
+}
+
+fn save_multi_path_config_unlocked(config: &MultiPathConfig) -> Result<(), String> {
     let dir = crate::portable::aeroftp_data_root()
         .ok_or_else(|| "Cannot determine AeroFTP data root".to_string())?;
     std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;

--- a/src-tauri/src/sync_command_audit.rs
+++ b/src-tauri/src/sync_command_audit.rs
@@ -23,23 +23,28 @@
 //! the shorter spelling, and the count of main-thread commands climbs back.
 //!
 //! This test is the answer to that. It reads the sources, collects every
-//! synchronous command, and compares the set against two explicit lists:
-//! `MAIN_THREAD_ALLOWED`, the ones that are justified, and
-//! `MAIN_THREAD_NOT_YET_MOVED`, the ones that are not and are being drained.
-//! A new synchronous command matches neither and is red. Same shape as
-//! `pickPathIsTheOnlyPicker.test.ts` on the frontend side, which stops a new
-//! call site from reintroducing the silent picker.
+//! synchronous command, and asserts the set is **exactly** `MAIN_THREAD_ALLOWED`
+//! below. A new synchronous command is not in it and is red until somebody
+//! either moves the work off the main thread or writes down why it belongs
+//! there. Same shape as `pickPathIsTheOnlyPicker.test.ts` on the frontend side,
+//! which stops a new call site from reintroducing the silent picker.
 //!
-//! It is deliberately a set equality and not a "no more than N" check, in both
-//! directions: making an allowlisted command `async` fails too, and so does
-//! converting a pending one without deleting its line. Neither list can rot
-//! into a record of what used to be true, and neither can grow.
+//! Set equality in both directions, so the list cannot rot: an entry whose
+//! command has become `async`, been renamed or been deleted also fails, which
+//! keeps the list a description of the present rather than a history.
 //!
 //! The counting is worth a line of its own, because the number that started
 //! this work was wrong. It was taken with a regex anchored at `pub fn`
 //! immediately after the attribute, which silently skipped every command
 //! declared inside a nested `mod` -- that is, most of `lib.rs`. It reported 38
-//! synchronous commands. There are 82, out of 853.
+//! synchronous commands. There were 82, out of 853. There are now 23, and every
+//! one of them is here with its reason.
+//!
+//! Getting from 82 to 23 took two passes. The first shipped the commands that
+//! do filesystem, keystore and clipboard work outside `lib.rs` and froze the
+//! remainder in a second list that could only shrink; the second drained that
+//! list and deleted it. The ratchet is gone because it is empty, which is the
+//! only good reason to delete one.
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
@@ -61,7 +66,8 @@ const MAIN_THREAD_ALLOWED: &[(&str, &str)] = &[
     ),
     (
         "compare_hashes",
-        "constant-time compare of two hex strings, no I/O.",
+        "constant-time compare of two hex strings the caller already sent over \
+         IPC; no I/O and linear in a string the UI itself produced.",
     ),
     (
         "generate_password",
@@ -76,7 +82,8 @@ const MAIN_THREAD_ALLOWED: &[(&str, &str)] = &[
     ),
     (
         "calculate_entropy",
-        "arithmetic over a character-group set the command builds itself.",
+        "arithmetic over a character-group set the command builds itself, so \
+         its size is bounded by this file rather than by the caller.",
     ),
     (
         "native_rsync_feature_compiled",
@@ -90,100 +97,82 @@ const MAIN_THREAD_ALLOWED: &[(&str, &str)] = &[
         "local_sync_cancel",
         "one atomic store; the cancellation is observed by the worker itself.",
     ),
-];
-
-/// Commands that are still synchronous and should not be.
-///
-/// This list is a **ratchet, frozen at the commit that introduced it**, and the
-/// test below asserts the synchronous set is exactly `MAIN_THREAD_ALLOWED` plus
-/// this one. That has three consequences, and they are the point:
-///
-///   * a **new** synchronous command is red immediately, so the count cannot
-///     climb again by addition, which is how it got here;
-///   * converting one of these without deleting its line is **also** red, so
-///     the list has to shrink as the work lands and cannot drift into fiction;
-///   * the list can never grow. Adding to it is not a way to get green.
-///
-/// Everything here does real blocking work on the main thread -- most of it is
-/// the sync index / journal / profile / snapshot / cloud-config family, which
-/// is JSON read and write against the config directory -- except for a handful
-/// that touch GTK and will end up in `MAIN_THREAD_ALLOWED` instead once each
-/// has been read and the reason written down. Neither outcome is "leave it".
-const MAIN_THREAD_NOT_YET_MOVED: &[&str] = &[
-    "speech_model_status",              // lib.rs:245
-    "preview_provider_totp",            // lib.rs:467
-    "portable_info",                    // lib.rs:2444
-    "copy_to_clipboard",                // lib.rs:2463
-    "log_update_detection",             // lib.rs:2607
-    "restart_app",                      // lib.rs:3017
-    "is_running_as_snap",               // lib.rs:5370
-    "get_dependencies",                 // lib.rs:5406
-    "get_system_info",                  // lib.rs:6059
-    "safe_picker_start_dir",            // lib.rs:6458
-    "set_close_to_tray",                // lib.rs:10906
-    "is_autostart_launch",              // lib.rs:10916
-    "toggle_menu_bar",                  // lib.rs:11159
-    "rebuild_menu",                     // lib.rs:11170
-    "get_compare_options_default",      // lib.rs:12532
-    "load_sync_index_cmd",              // lib.rs:12537
-    "save_sync_index_cmd",              // lib.rs:12547
-    "load_sync_journal_cmd",            // lib.rs:12556
-    "save_sync_journal_cmd",            // lib.rs:12566
-    "delete_sync_journal_cmd",          // lib.rs:12573
-    "list_sync_journals_cmd",           // lib.rs:12580
-    "cleanup_old_journals_cmd",         // lib.rs:12585
-    "clear_all_journals_cmd",           // lib.rs:12590
-    "save_transfer_queue_journal_cmd",  // lib.rs:12597
-    "load_transfer_queue_journal_cmd",  // lib.rs:12604
-    "clear_transfer_queue_journal_cmd", // lib.rs:12610
-    "load_sync_profiles_cmd",           // lib.rs:12615
-    "save_sync_profile_cmd",            // lib.rs:12620
-    "delete_sync_profile_cmd",          // lib.rs:12625
-    "get_sync_schedule_cmd",            // lib.rs:12651
-    "save_sync_schedule_cmd",           // lib.rs:12656
-    "get_watcher_status_cmd",           // lib.rs:12661
-    "get_multi_path_config",            // lib.rs:13062
-    "save_multi_path_config_cmd",       // lib.rs:13067
-    "add_path_pair",                    // lib.rs:13072
-    "remove_path_pair",                 // lib.rs:13080
-    "export_sync_template_cmd",         // lib.rs:13092
-    "import_sync_template_cmd",         // lib.rs:13124
-    "export_sync_script_cmd",           // lib.rs:13149
-    "import_sync_script_cmd",           // lib.rs:13170
-    "aerosync_export_script_cmd",       // lib.rs:13209
-    "aerosync_import_script_cmd",       // lib.rs:13312
-    "create_sync_snapshot_cmd",         // lib.rs:13350
-    "list_sync_snapshots_cmd",          // lib.rs:13359
-    "delete_sync_snapshot_cmd",         // lib.rs:13372
-    "load_sync_snapshot_cmd",           // lib.rs:13385
-    "get_default_retry_policy",         // lib.rs:14380
-    "verify_local_transfer",            // lib.rs:14385
-    "classify_transfer_error",          // lib.rs:14407
-    "get_cloud_config",                 // lib.rs:14805
-    "save_cloud_config_cmd",            // lib.rs:14810
-    "get_cloud_pairs_config",           // lib.rs:14818
-    "save_cloud_pairs_config_cmd",      // lib.rs:14823
-    "add_cloud_pair",                   // lib.rs:14828
-    "remove_cloud_pair",                // lib.rs:14841
-    "update_cloud_pair",                // lib.rs:14853
-    "update_excluded_folders",          // lib.rs:14868
-    "list_file_versions",               // lib.rs:14875
-    "list_all_file_versions",           // lib.rs:14882
-    "restore_file_version",             // lib.rs:14889
-    "cleanup_versions",                 // lib.rs:14919
-    "versions_disk_usage",              // lib.rs:14926
-    "archive_before_sync_delete",       // lib.rs:14935
-    "get_cloud_status",                 // lib.rs:15080
-    "enable_aerocloud",                 // lib.rs:15098
-    "generate_share_link",              // lib.rs:15198
-    "generate_share_link_remote",       // lib.rs:15236
-    "generate_server_share_link",       // lib.rs:15272
-    "get_default_cloud_folder",         // lib.rs:15317
-    "update_conflict_strategy",         // lib.rs:15323
-    "is_background_sync_running",       // lib.rs:16012
-    "flatpak_config_import_status",     // lib.rs:16171
-    "flatpak_config_import_apply",      // lib.rs:16186
-    "mount_autostart_blocked",          // lib.rs:17516
+    (
+        "restart_app",
+        "must be on the main thread: it tears down the single-instance plugin \
+         and calls AppHandle::restart, which drives the event loop.",
+    ),
+    (
+        "toggle_menu_bar",
+        "must be on the main thread: set_menu / remove_menu are GTK window \
+         operations on Linux.",
+    ),
+    (
+        "rebuild_menu",
+        "must be on the main thread, and already knows it: MenuItem creation \
+         and Drop touch GTK, so the body marshals the build through a channel \
+         onto the main thread. tauri-runtime-wry's send_user_message runs that \
+         closure inline when the caller already is the main thread, so making \
+         the command async would add an event-loop round trip and move no work.",
+    ),
+    (
+        "speech_model_status",
+        "the macOS variant, which returns a constant struct because local STT \
+         is not built there; the platforms that have a real implementation \
+         already answer asynchronously.",
+    ),
+    (
+        "log_update_detection",
+        "writes one line to the log and returns; the tracing subscriber is \
+         non-blocking.",
+    ),
+    (
+        "is_running_as_snap",
+        "reads the SNAP environment variable of this process; no syscall, and \
+         the value cannot change while we run.",
+    ),
+    (
+        "is_autostart_launch",
+        "scans this process's own argv for --autostart.",
+    ),
+    (
+        "set_close_to_tray",
+        "one atomic store into a static the window-close handler reads; there \
+         is nothing to wait for.",
+    ),
+    (
+        "is_background_sync_running",
+        "one atomic load from a static the background worker maintains; the \
+         frontend polls it and must not pay a thread hop for a bool.",
+    ),
+    (
+        "get_compare_options_default",
+        "returns CompareOptions::default(), a struct of literals.",
+    ),
+    (
+        "get_default_retry_policy",
+        "returns RetryPolicy::default(), a struct of literals.",
+    ),
+    (
+        "get_dependencies",
+        "builds a Vec from version strings that build.rs baked in at compile \
+         time; nothing is read at runtime.",
+    ),
+    (
+        "generate_server_share_link",
+        "string work only: prefix checks, trims, and percent-encoding of path \
+         segments.",
+    ),
+    (
+        "preview_provider_totp",
+        "one HMAC over the current time step, on a secret already held in \
+         memory; bounded and microseconds long.",
+    ),
+    (
+        "classify_transfer_error",
+        "lowercases an error string we produced ourselves and substring-matches \
+         it against a fixed table.",
+    ),
 ];
 
 /// One `#[tauri::command]` found in the sources.
@@ -339,18 +328,7 @@ fn no_command_blocks_the_main_thread_unless_it_is_on_the_list() {
         MAIN_THREAD_ALLOWED.len(),
         "MAIN_THREAD_ALLOWED contains a duplicate name"
     );
-    let not_yet: BTreeSet<&str> = MAIN_THREAD_NOT_YET_MOVED.iter().copied().collect();
-    assert_eq!(
-        not_yet.len(),
-        MAIN_THREAD_NOT_YET_MOVED.len(),
-        "MAIN_THREAD_NOT_YET_MOVED contains a duplicate name"
-    );
-    let overlap: Vec<&&str> = justified.intersection(&not_yet).collect();
-    assert!(
-        overlap.is_empty(),
-        "{overlap:?} is both justified and pending, which cannot both be true"
-    );
-    let allowed: BTreeSet<&str> = justified.union(&not_yet).copied().collect();
+    let allowed = &justified;
 
     let sync_commands: Vec<&FoundCommand> = found.iter().filter(|c| !c.is_async).collect();
     let sync_names: BTreeSet<&str> = sync_commands.iter().map(|c| c.name.as_str()).collect();
@@ -376,9 +354,8 @@ fn no_command_blocks_the_main_thread_unless_it_is_on_the_list() {
              `clippy::await_holding_lock`.\n\n\
              If a command genuinely has to stay on the main thread, or its work is bounded \
              by its own validation and touches nothing outside the process, add it to \
-             MAIN_THREAD_ALLOWED in this file together with the reason.\n\n\
-             MAIN_THREAD_NOT_YET_MOVED is not the place for it: that list is frozen and \
-             only shrinks."
+             MAIN_THREAD_ALLOWED in this file together with the reason. A bare name with \
+             no reason fails the next test down."
         );
     }
 
@@ -392,18 +369,6 @@ fn no_command_blocks_the_main_thread_unless_it_is_on_the_list() {
         "MAIN_THREAD_ALLOWED still lists {stale_justified:?}, but no synchronous command by \
          that name exists any more. Either it was made async -- in which case drop the entry, \
          the list is not a history -- or it was renamed or removed and the entry went stale."
-    );
-
-    let drained: Vec<&str> = not_yet
-        .iter()
-        .filter(|name| !sync_names.contains(*name))
-        .copied()
-        .collect();
-    assert!(
-        drained.is_empty(),
-        "{drained:?} are no longer synchronous, which is the point -- now delete them from \
-         MAIN_THREAD_NOT_YET_MOVED. The list has to shrink as the work lands, otherwise it \
-         stops describing anything."
     );
 }
 


### PR DESCRIPTION
Opening this so the work exists outside a local worktree — it had four commits and no PR.

Continuation of the off-main-thread command work: `fix/tauri-sync-commands-off-main-thread` moved the first batch and is already on `main`; this drains the rest of the sync commands out of `lib.rs`.

- **The remaining main-thread commands leave `lib.rs`.** Each one that did blocking disk or network work on the Tauri command thread now runs under `spawn_blocking`.
- **Read-modify-write on the cloud, pairs and multipath state is serialised after the `spawn_blocking` move.** Moving the work off the command thread is what made the interleaving reachable: two commands could each read the on-disk state, modify their own copy and write it back, and the second write would drop the first one's change. The critical section is now held across the whole read-modify-write.
- **The async lock is no longer held across the disk round trip**, which is the shape that turns a slow write into a stall of every other command waiting on the same state.

Not yet reviewed by anyone; opened for review rather than for merge. It is four commits behind a `main` that has moved a fair amount, so it needs a CI run before it is judged — if the checks come back with conflicts or failures I will take them, but the point of this PR is that the work stops depending on one machine staying alive.
