### PR TITLE
fix(users): draw provider logos as avatars, and stop cropping them

### DIFF
--- a/src/components/IconPickerDialog.tsx
+++ b/src/components/IconPickerDialog.tsx
@@ -128,9 +128,17 @@ function reactLogoToSvgDataUrl(LogoComp: React.FC<{ size?: number }>): string | 
             // MinIO, Koofr, FileLu, Blomp, OpenDrive...) used to silently fail
             // here, leaving the click as a no-op. Fall back to the image src
             // so the selection still works for the whole shipped catalog.
+            //
+            // The authored attribute, not the `src` property: the property
+            // resolves against the document, so it hands back an absolute URL
+            // (`http://tauri.localhost/icons/providers/filelu.png`) whose origin
+            // is an accident of how the app was loaded. Storing that in a user
+            // record makes the avatar depend on an origin that can change; the
+            // path the component actually declares does not.
             const img = container.querySelector('img');
-            if (img && img.src) {
-                return img.src;
+            const authoredSrc = img?.getAttribute('src');
+            if (authoredSrc) {
+                return authoredSrc;
             }
             logger.warn(`icon-picker: no <svg> or <img> found after render for ${compName}`);
             return null;

--- a/src/components/UserAvatar.tsx
+++ b/src/components/UserAvatar.tsx
@@ -27,8 +27,31 @@ const fallbackInitial = (name: string): string => {
     return (trimmed[0] || 'U').toUpperCase();
 };
 
-const isImageAvatar = (avatar?: string | null): boolean =>
-    !!avatar && /^data:image\/(png|jpe?g|gif|webp|svg\+xml);/i.test(avatar);
+/** A self-contained image the picker produced from an inline SVG logo. */
+const DATA_IMAGE_RE = /^data:image\/(png|jpe?g|gif|webp|svg\+xml)[;,]/i;
+
+/**
+ * A logo that ships with the app, addressed by its path under `public/icons/`.
+ *
+ * The picker cannot always produce a data URL: providers whose logo is a PNG
+ * (Hetzner, FileLu, AWS, MinIO, Koofr, Blomp, OpenDrive...) render as `<img>`
+ * rather than as an inline `<svg>`, so what gets stored is the asset's own
+ * path. Those avatars used to fall through to the text branch and render the
+ * path as a string, which is issue #550: some provider icons "did not render".
+ *
+ * Deliberately a strict allowlist rather than a general URL test. The value
+ * reaches us from stored user data, so anything with a scheme or a
+ * protocol-relative prefix stays rejected: an avatar must never be able to
+ * fetch from a host we did not ship, which would turn a user record into a
+ * tracking pixel.
+ */
+const APP_ICON_PATH_RE = /^\/icons\/[A-Za-z0-9._/-]+\.(png|jpe?g|gif|webp|svg)$/i;
+
+export const isImageAvatar = (avatar?: string | null): boolean => {
+    if (!avatar) return false;
+    if (DATA_IMAGE_RE.test(avatar)) return true;
+    return APP_ICON_PATH_RE.test(avatar) && !avatar.includes('..');
+};
 
 export const UserAvatar: React.FC<UserAvatarProps> = ({
     name,
@@ -46,7 +69,11 @@ export const UserAvatar: React.FC<UserAvatarProps> = ({
             aria-hidden="true"
         >
             {imageAvatar ? (
-                <img src={avatarEmoji ?? undefined} alt="" className="h-full w-full object-cover" />
+                // `contain`, not `cover`: an avatar is a logo, and `cover` crops
+                // whatever does not fit the square. On a logo with content at the
+                // edge that removes part of the mark rather than some background
+                // — AeroFTP's own rocket lost its red tip (#550).
+                <img src={avatarEmoji ?? undefined} alt="" className="h-full w-full object-contain" />
             ) : (
                 avatarEmoji || fallbackInitial(name)
             )}

--- a/src/components/userAvatar.test.ts
+++ b/src/components/userAvatar.test.ts
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+import { describe, it, expect } from 'vitest';
+import { isImageAvatar } from './UserAvatar';
+import avatarRaw from './UserAvatar.tsx?raw';
+import pickerRaw from './IconPickerDialog.tsx?raw';
+
+/**
+ * Issue #550: picking a provider logo for a user avatar left some of them
+ * looking blank, and the ones that did draw were cropped at the edges.
+ *
+ * Two independent causes in the same feature, so two groups below.
+ */
+describe('avatar images (#550)', () => {
+    describe('which values count as an image', () => {
+        it('accepts an app icon path, which is what a PNG-backed logo stores', () => {
+            // Providers whose logo is a PNG (Hetzner, FileLu, AWS, MinIO, Koofr,
+            // Blomp, OpenDrive...) render as <img>, so the picker cannot
+            // serialize them to a data URL and stores the asset path instead.
+            // Only data URLs passed, so those avatars fell through to the text
+            // branch and painted the path as a string inside the circle.
+            expect(isImageAvatar('/icons/providers/filelu.png')).toBe(true);
+            expect(isImageAvatar('/icons/providers/hetzner-storage-box.png')).toBe(true);
+            expect(isImageAvatar('/icons/aeroftp.svg')).toBe(true);
+        });
+
+        it('accepts a data URL, which is what an inline-SVG logo stores', () => {
+            // Azure and the other inline-<svg> providers already worked.
+            expect(isImageAvatar('data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=')).toBe(true);
+            expect(isImageAvatar('data:image/png;base64,iVBORw0KGgo=')).toBe(true);
+            // A data URL is not required to carry `;base64`.
+            expect(isImageAvatar('data:image/svg+xml,%3Csvg%3E%3C/svg%3E')).toBe(true);
+        });
+
+        it('refuses anything that would fetch from a host we did not ship', () => {
+            // The value arrives from stored user data, so the test is an
+            // allowlist rather than "does it look like a URL". An avatar must
+            // never be able to turn a user record into a tracking pixel.
+            expect(isImageAvatar('https://evil.example/pixel.png')).toBe(false);
+            expect(isImageAvatar('http://evil.example/pixel.png')).toBe(false);
+            expect(isImageAvatar('//evil.example/pixel.png')).toBe(false);
+            expect(isImageAvatar('/icons/../../../etc/passwd.png')).toBe(false);
+            expect(isImageAvatar('javascript:alert(1)')).toBe(false);
+            expect(isImageAvatar('/uploads/anything.png')).toBe(false);
+        });
+
+        it('treats an emoji or an empty value as not an image', () => {
+            expect(isImageAvatar('🚀')).toBe(false);
+            expect(isImageAvatar('')).toBe(false);
+            expect(isImageAvatar(null)).toBe(false);
+            expect(isImageAvatar(undefined)).toBe(false);
+        });
+    });
+
+    describe('how the image is fitted', () => {
+        it('shows the whole logo instead of cropping it to the circle', () => {
+            // `cover` fills the square by cutting whatever overflows. On a logo
+            // with content at the edge that removes part of the mark rather than
+            // some background: AeroFTP's own rocket lost its red tip.
+            expect(avatarRaw).toContain('object-contain');
+            expect(avatarRaw).not.toContain('object-cover');
+        });
+    });
+
+    describe('what the picker stores', () => {
+        it('stores the path the logo declares, not the URL it resolved to', () => {
+            // `img.src` resolves against the document, so it yields an absolute
+            // URL whose origin is an accident of how the app was loaded
+            // (`http://tauri.localhost/...`). Persisting that into a user record
+            // ties the avatar to an origin that can change between builds.
+            expect(pickerRaw).toContain("img?.getAttribute('src')");
+            expect(pickerRaw).not.toMatch(/if \(img && img\.src\) \{\s*return img\.src;/);
+        });
+    });
+});


### PR DESCRIPTION
Closes #550. Two unrelated causes in the same feature, which is why the report describes two different-looking symptoms.

## Some provider icons did not render

The picker serializes an inline `<svg>` logo into a data URL at click time. A provider whose logo is a PNG — Hetzner Storage Box, FileLu, AWS, MinIO, Koofr, Blomp, OpenDrive and the rest of the PNG-backed catalog — renders as `<img>` and has no SVG to serialize, so what gets stored is the asset reference instead.

`UserAvatar` accepted data URLs only. Those avatars therefore failed the test, fell through to the text branch, and painted the reference as a string inside the circle — which reads as "the icon doesn't render". Azure worked because it is an inline `<svg>`, and that is exactly the split the report observed.

Two changes:

- The picker stores the path the component declares, not the absolute URL `img.src` resolves to. The `src` property resolves against the document, so it returns `http://tauri.localhost/icons/providers/filelu.png` — an origin that is an accident of how the app was loaded. Persisting that into a user record ties the avatar to it.
- `UserAvatar` accepts that path, via a strict allowlist rather than a general "does it look like a URL" test. The value arrives from stored user data, so anything carrying a scheme, a protocol-relative `//` prefix or a `..` traversal stays rejected: an avatar must never be able to fetch from a host we did not ship. The data-URL test also now accepts the `,` form, not only `;base64`.

## Icons were cropped

`object-cover` fills the square by cutting whatever overflows. On a photo that removes background; on a logo with content at the edge it removes part of the mark. AeroFTP's own rocket losing its red tip is the case the report names, and it is the general behaviour rather than a quirk of that file. Now `object-contain`.

## Tests

Six new, in `src/components/userAvatar.test.ts`. Verified against the pre-fix tree: four fail, and the two that pass are the hostile-value and emoji cases, which were already correct — so the four that matter are pinning the fix rather than restating it.

Gates: `npm run typecheck` clean, `npm run test:unit` 77 files / 700 tests green.

Thanks to @EhudKirsh for separating the two symptoms in the report — the PNG/SVG split was the thing that made the cause findable.
