### PR TITLE
fix(add-service): give the grid and the table the same controls

### DIFF
--- a/src/components/IntroHub/CatalogTable.tsx
+++ b/src/components/IntroHub/CatalogTable.tsx
@@ -19,7 +19,6 @@ import type { CatalogProtocol } from '../providerCatalog';
 import { CountryFlag } from '../CountryFlag';
 import { useTranslation } from '../../i18n';
 import { middleClickOpen } from '../../utils/middleClick';
-import { SearchBox } from '../SearchBox';
 import { useTableColumns, type TableColumnDef } from '../../hooks/useTableColumns';
 import { TableColumnsManager } from '../ui/TableColumnsManager';
 import type { HealthStatus } from '../../hooks/useProviderHealth';
@@ -36,21 +35,29 @@ import {
 } from '../providerCatalog';
 
 type CatalogColId = 'company' | 'parent' | 'region' | 'freeGb' | 'free' | 'paid' | 'health';
-type TierFilter = 'all' | 'free' | 'freecard' | 'paid';
+export type TierFilter = 'all' | 'free' | 'freecard' | 'paid';
 
 // The pricing filter is a preference, not a transient toggle (Ehud #274): it
 // survives tab switches and restarts like the view mode, the Discover category
 // and the column settings do.
+//
+// It is owned by DiscoverPanel rather than by this table: the same filter now
+// applies to the grid too, and a control that exists once but is stored twice
+// is how the two views drifted apart in the first place (Ehud #347).
 const TIER_FILTER_KEY = 'aeroftp-discover-tier';
-const TIER_FILTERS: readonly TierFilter[] = ['all', 'free', 'freecard', 'paid'];
+export const TIER_FILTERS: readonly TierFilter[] = ['all', 'free', 'freecard', 'paid'];
 
-function loadTierFilter(): TierFilter {
+export function loadTierFilter(): TierFilter {
     try {
         const saved = localStorage.getItem(TIER_FILTER_KEY);
         return TIER_FILTERS.includes(saved as TierFilter) ? (saved as TierFilter) : 'all';
     } catch {
         return 'all';
     }
+}
+
+export function persistTierFilter(id: TierFilter): void {
+    try { localStorage.setItem(TIER_FILTER_KEY, id); } catch { /* ignore */ }
 }
 
 const CATALOG_COLUMNS: TableColumnDef<CatalogColId>[] = [
@@ -142,10 +149,11 @@ interface CatalogTableProps {
     category: CatalogCategoryId | 'all';
     /** `openInBackground` (middle-click, Ehud #274) opens the tab without focus. */
     onSelectProvider: (protocol: ProviderType, providerId?: string, openInBackground?: boolean) => void;
-    /** Controlled search string (lifted to IntroHub to survive tab switches, Ehud
-     *  #274); falls back to local state when omitted. */
-    query?: string;
-    onQueryChange?: (value: string) => void;
+    /** Search string, owned by the panel: the same box filters both views, so
+     *  the table no longer keeps a copy of its own (Ehud #347). */
+    query: string;
+    /** Tier filter, owned by the panel for the same reason. */
+    tierFilter: TierFilter;
     getHealth: (logoId: string) => HealthStatus;
     /** When false the health feature is off: dots render dimmed grey. */
     healthEnabled: boolean;
@@ -155,18 +163,8 @@ interface CatalogTableProps {
     onOpenUrl: (url: string) => void;
 }
 
-export function CatalogTable({ companies, category, onSelectProvider, getHealth, healthEnabled, getSignupUrl, onOpenUrl, query: controlledQuery, onQueryChange }: CatalogTableProps) {
+export function CatalogTable({ companies, category, onSelectProvider, getHealth, healthEnabled, getSignupUrl, onOpenUrl, query, tierFilter }: CatalogTableProps) {
     const t = useTranslation();
-    // Search string is controlled by the parent (IntroHub) when provided so it
-    // survives tab switches (Ehud #274); otherwise falls back to local state.
-    const [localQuery, setLocalQuery] = useState('');
-    const query = controlledQuery ?? localQuery;
-    const setQuery = onQueryChange ?? setLocalQuery;
-    const [tierFilter, setTierFilterState] = useState<TierFilter>(loadTierFilter);
-    const setTierFilter = useCallback((id: TierFilter) => {
-        setTierFilterState(id);
-        try { localStorage.setItem(TIER_FILTER_KEY, id); } catch { /* ignore */ }
-    }, []);
     const [showColumns, setShowColumns] = useState(false);
     const columnsBtnRef = useRef<HTMLDivElement>(null);
 
@@ -383,40 +381,12 @@ export function CatalogTable({ companies, category, onSelectProvider, getHealth,
 
     return (
         <div className="flex flex-col h-full min-h-0">
-            {/* Toolbar: search + column manager */}
-            <div className="flex items-center gap-2 mb-3">
-                <SearchBox
-                    value={query}
-                    onChange={setQuery}
-                    onClear={() => setQuery('')}
-                    clearAriaLabel={t('common.close')}
-                    clearIconSize={13}
-                    placeholder={t('introHub.list.searchPlaceholder')}
-                    containerClassName="flex-1 max-w-md"
-                    className="w-full pl-3 pr-8 py-1.5 bg-gray-50 dark:bg-gray-700/60 border border-gray-200 dark:border-gray-600 rounded-lg text-xs focus:outline-none focus:ring-2 focus:ring-blue-500/40"
-                />
-                {/* Free / paid tier filter (parity with `aeroftp-cli catalog --free/--paid`) */}
-                <div className="flex items-center rounded-md border border-gray-200 dark:border-gray-600 overflow-hidden">
-                    {([
-                        ['all', t('introHub.filter.all')],
-                        ['free', t('providers.freeTier')],
-                        ['freecard', t('providers.freeCardTier')],
-                        ['paid', t('providers.paidTier')],
-                    ] as [TierFilter, string][]).map(([id, label]) => (
-                        <button
-                            key={id}
-                            onClick={() => setTierFilter(id)}
-                            aria-pressed={tierFilter === id}
-                            className={`px-2.5 py-1.5 text-[11px] transition-colors ${
-                                tierFilter === id
-                                    ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 font-medium'
-                                    : 'text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700/50'
-                            }`}
-                        >
-                            {label}
-                        </button>
-                    ))}
-                </div>
+            {/* Toolbar: column manager only. The search box and the tier filter
+                apply to both views, so they live in the panel above the view
+                switch rather than inside the table (Ehud, #347): keeping a
+                second copy here is what made the query and the tier reset when
+                switching between grid and table. */}
+            <div className="flex items-center justify-end gap-2 mb-3">
                 <div className="relative" ref={columnsBtnRef}>
                     <button
                         onClick={() => setShowColumns(v => !v)}

--- a/src/components/IntroHub/DiscoverPanel.tsx
+++ b/src/components/IntroHub/DiscoverPanel.tsx
@@ -18,8 +18,8 @@ import { useIntroHubIconSize } from '../../hooks/useIntroHubIconSize';
 import { useDiscoverHealthCheck } from '../../hooks/useDiscoverHealthCheck';
 import { openUrl } from '../../utils/openUrl';
 import { middleClickOpen } from '../../utils/middleClick';
-import { CatalogTable } from './CatalogTable';
-import { PROVIDER_CATALOG, companyInCategory, isDevOnlyProvider } from '../providerCatalog';
+import { CatalogTable, loadTierFilter, persistTierFilter, TIER_FILTERS, type TierFilter } from './CatalogTable';
+import { PROVIDER_CATALOG, companyInCategory, companyTierInCategory, isDevOnlyProvider } from '../providerCatalog';
 
 /** All category sidebar entries share these keys; 'all' is a virtual category. */
 type DiscoverCategoryId = CatalogCategoryId | 'all';
@@ -89,12 +89,12 @@ const CATEGORY_COLORS: Record<CatalogCategoryId, string> = {
 
 interface DiscoverPanelProps {
     onSelectProvider: (protocol: ProviderType, providerId?: string, demo?: { server: string; port: number; username: string; password: string }, openInBackground?: boolean) => void;
-    // Search strings lifted to IntroHub (Ehud #274) so they survive tab switches
-    // (DiscoverPanel unmounts on switch) and reset only when the app quits.
-    gridQuery: string;
-    onGridQueryChange: (value: string) => void;
-    listQuery: string;
-    onListQueryChange: (value: string) => void;
+    // One search string, lifted to IntroHub (Ehud #274) so it survives tab
+    // switches (DiscoverPanel unmounts on switch) and resets only when the app
+    // quits. Grid and table used to hold one each, which is why a term typed in
+    // one view was gone after switching to the other (Ehud #347).
+    query: string;
+    onQueryChange: (value: string) => void;
 }
 
 function ServiceCard({
@@ -196,7 +196,7 @@ function ServiceCard({
     );
 }
 
-export function DiscoverPanel({ onSelectProvider, gridQuery, onGridQueryChange, listQuery, onListQueryChange }: DiscoverPanelProps) {
+export function DiscoverPanel({ onSelectProvider, query, onQueryChange }: DiscoverPanelProps) {
     const t = useTranslation();
     const introHubIconSize = useIntroHubIconSize();
     const categories = useMemo(() => buildDiscoverCategories(), []);
@@ -230,10 +230,14 @@ export function DiscoverPanel({ onSelectProvider, gridQuery, onGridQueryChange, 
         const saved = localStorage.getItem(VIEW_MODE_KEY);
         return saved === 'list' ? 'list' : 'grid';
     });
-    // Grid-view search (the list view has its own search inside CatalogTable).
-    // Both are controlled by IntroHub (Ehud #274) so they survive tab switches;
-    // `setGridQuery` just forwards to the lifted setter.
-    const setGridQuery = onGridQueryChange;
+    // Tier filter, owned here because it now applies to both views. Persisted,
+    // like the view mode and the category: it is a preference, not a transient
+    // toggle (Ehud #274).
+    const [tierFilter, setTierFilterState] = useState<TierFilter>(loadTierFilter);
+    const setTierFilter = useCallback((id: TierFilter) => {
+        setTierFilterState(id);
+        persistTierFilter(id);
+    }, []);
 
     // Provider health scan: per-tab eager (small categories) + chunked
     // sequential for the large All / list views (My Servers pattern). The
@@ -260,15 +264,45 @@ export function DiscoverPanel({ onSelectProvider, gridQuery, onGridQueryChange, 
         return base;
     }, [categories, activeCategory, peerTile]);
 
-    // Grid view, filtered by the search box (health scans still cover the full
-    // category, so a query never changes reachability results).
+    // Resolve a grid tile back to its catalog company, so the tier filter can
+    // apply to the grid as well as to the table. Same keying the signup-URL map
+    // below uses: provider id first, then protocol.
+    const companyByKey = useMemo(() => {
+        const map = new Map<string, CatalogCompany>();
+        for (const c of PROVIDER_CATALOG) {
+            for (const p of c.protocols) {
+                if (p.providerId && !map.has(p.providerId)) map.set(p.providerId, c);
+                if (!map.has(p.protocol)) map.set(p.protocol, c);
+            }
+        }
+        return map;
+    }, []);
+
+    // Grid view, filtered by the shared search box and the shared tier filter
+    // (health scans still cover the full category, so neither changes
+    // reachability results).
+    //
+    // A tile with no catalog company behind it — the AeroShare tile, the generic
+    // protocol entries — is never hidden by a tier: it has no price to filter on,
+    // and dropping it would remove the entry point rather than narrow a choice.
     const visibleGridItems = useMemo(() => {
-        const q = gridQuery.trim().toLowerCase();
-        if (!q) return activeItems;
-        return activeItems.filter(item =>
-            [item.name, item.description, item.badge, item.protocol, item.providerId, item.id, ...(item.searchAliases ?? [])]
-                .filter(Boolean).join(' ').toLowerCase().includes(q));
-    }, [activeItems, gridQuery]);
+        const q = query.trim().toLowerCase();
+        let items = activeItems;
+        if (q) {
+            items = items.filter(item =>
+                [item.name, item.description, item.badge, item.protocol, item.providerId, item.id, ...(item.searchAliases ?? [])]
+                    .filter(Boolean).join(' ').toLowerCase().includes(q));
+        }
+        if (tierFilter !== 'all') {
+            const wanted = tierFilter === 'freecard' ? 'free-card' : tierFilter;
+            items = items.filter(item => {
+                const company = companyByKey.get(item.providerId || '') ?? companyByKey.get(item.protocol);
+                if (!company) return true;
+                return companyTierInCategory(company, activeCategory) === wanted;
+            });
+        }
+        return items;
+    }, [activeItems, query, tierFilter, companyByKey, activeCategory]);
 
     // Signup/website URL per company, resolved from the discover items (which
     // carry the registry/protocol signupUrl). Keyed by providerId first, then
@@ -524,8 +558,10 @@ export function DiscoverPanel({ onSelectProvider, gridQuery, onGridQueryChange, 
                     </button>
                 </div>
 
-                {/* Info banner per category (grid view, the 6 named categories) */}
-                {viewMode === 'grid' && activeCategory !== 'all' && (() => {
+                {/* Info banner per category (both views, the 6 named categories).
+                    It describes the category, not the way it is drawn, so it has
+                    no reason to disappear in the table (Ehud #347). */}
+                {activeCategory !== 'all' && (() => {
                     const infoKeyMap: Record<CatalogCategoryId, string> = {
                         'protocols': 'protocols',
                         'object-storage': 's3',
@@ -548,63 +584,61 @@ export function DiscoverPanel({ onSelectProvider, gridQuery, onGridQueryChange, 
                     );
                 })()}
 
+                {/* Search and tier filter: one instance, above the view switch,
+                    so switching between grid and table changes the body and
+                    nothing else. Each view used to render its own copy backed by
+                    its own state, which is why a typed query and a chosen tier
+                    were lost on switching, and why the box moved (Ehud #347). */}
+                <div className="flex items-center gap-2 mb-3">
+                    <SearchBox
+                        value={query}
+                        onChange={onQueryChange}
+                        onClear={() => onQueryChange('')}
+                        clearAriaLabel={t('common.close')}
+                        clearIconSize={13}
+                        placeholder={t('introHub.list.searchPlaceholder')}
+                        containerClassName="flex-1 max-w-md"
+                        className="w-full pl-3 pr-8 py-1.5 bg-gray-50 dark:bg-gray-700/60 border border-gray-200 dark:border-gray-600 rounded-lg text-xs focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+                    />
+                    {/* Free / paid tier filter (parity with `aeroftp-cli catalog --free/--paid`) */}
+                    <div className="flex items-center rounded-md border border-gray-200 dark:border-gray-600 overflow-hidden">
+                        {TIER_FILTERS.map((id) => (
+                            <button
+                                key={id}
+                                onClick={() => setTierFilter(id)}
+                                aria-pressed={tierFilter === id}
+                                className={`px-2.5 py-1.5 text-[11px] transition-colors ${
+                                    tierFilter === id
+                                        ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 font-medium'
+                                        : 'text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700/50'
+                                }`}
+                            >
+                                {id === 'all' ? t('introHub.filter.all')
+                                    : id === 'free' ? t('providers.freeTier')
+                                    : id === 'freecard' ? t('providers.freeCardTier')
+                                    : t('providers.paidTier')}
+                            </button>
+                        ))}
+                    </div>
+                </div>
+
                 {viewMode === 'list' ? (
                     /* Company-centric list view (issue #224) */
                     <div className="flex-1 min-h-0 flex flex-col">
                         <CatalogTable
                             companies={catalogCompanies}
                             category={activeCategory}
-                            query={listQuery}
-                            onQueryChange={onListQueryChange}
+                            query={query}
+                            tierFilter={tierFilter}
                             onSelectProvider={(protocol, providerId, openInBackground) => onSelectProvider(protocol, providerId, undefined, openInBackground)}
                             getHealth={(logoId) => getStatus(logoId).status}
                             healthEnabled={healthEnabled}
                             getSignupUrl={resolveCompanySignupUrl}
                             onOpenUrl={openUrl}
                         />
-                        {/* Custom / generic servers below the table, filtered to
-                            the active tab (Ehud #274): hidden entirely in tabs
-                            with no generic protocol (cloud / media / developer). */}
-                        {(() => {
-                            const customProfiles = CUSTOM_PROFILES.filter(
-                                (p) => activeCategory === 'all' || p.categories.includes(activeCategory),
-                            );
-                            if (customProfiles.length === 0) return null;
-                            return (
-                                <div className="mt-3 pt-3 border-t border-gray-200 dark:border-gray-700">
-                                    <div className="text-[11px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-2">
-                                        {t('introHub.list.customProfiles')}
-                                    </div>
-                                    <div className="flex flex-wrap gap-2">
-                                        {customProfiles.map((p) => (
-                                            <button
-                                                key={p.labelKey}
-                                                onClick={() => onSelectProvider(p.protocol, p.providerId)}
-                                                {...middleClickOpen(() => onSelectProvider(p.protocol, p.providerId, undefined, true))}
-                                                className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-200 hover:border-blue-300 dark:hover:border-blue-500/40 hover:bg-gray-50 dark:hover:bg-gray-750 transition-colors"
-                                            >
-                                                <Server size={12} className="text-gray-400" />
-                                                {t(p.labelKey)}
-                                            </button>
-                                        ))}
-                                    </div>
-                                </div>
-                            );
-                        })()}
                     </div>
                 ) : (
                     <>
-                        {/* Grid search (the list view has its own search inside CatalogTable) */}
-                        <SearchBox
-                            value={gridQuery}
-                            onChange={setGridQuery}
-                            onClear={() => setGridQuery('')}
-                            clearAriaLabel={t('common.close')}
-                            clearIconSize={13}
-                            placeholder={t('introHub.list.searchPlaceholder')}
-                            containerClassName="mb-3 max-w-md"
-                            className="w-full pl-3 pr-8 py-1.5 bg-gray-50 dark:bg-gray-700/60 border border-gray-200 dark:border-gray-600 rounded-lg text-xs focus:outline-none focus:ring-2 focus:ring-blue-500/40"
-                        />
                         {/* Provider grid */}
                         <div className="flex-1 overflow-y-auto">
                             {visibleGridItems.length === 0 ? (
@@ -639,6 +673,39 @@ export function DiscoverPanel({ onSelectProvider, gridQuery, onGridQueryChange, 
                         </div>
                     </>
                 )}
+
+                {/* Custom / generic servers, filtered to the active tab (Ehud
+                    #274) and hidden entirely in tabs with no generic protocol
+                    (cloud / media / developer). Below both views: these are the
+                    same entry points whichever way the catalog is drawn, and
+                    having them only under the table is one of the differences
+                    that made switching views feel like changing page (#347). */}
+                {(() => {
+                    const customProfiles = CUSTOM_PROFILES.filter(
+                        (p) => activeCategory === 'all' || p.categories.includes(activeCategory),
+                    );
+                    if (customProfiles.length === 0) return null;
+                    return (
+                        <div className="mt-3 pt-3 border-t border-gray-200 dark:border-gray-700">
+                            <div className="text-[11px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-2">
+                                {t('introHub.list.customProfiles')}
+                            </div>
+                            <div className="flex flex-wrap gap-2">
+                                {customProfiles.map((p) => (
+                                    <button
+                                        key={p.labelKey}
+                                        onClick={() => onSelectProvider(p.protocol, p.providerId)}
+                                        {...middleClickOpen(() => onSelectProvider(p.protocol, p.providerId, undefined, true))}
+                                        className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-200 hover:border-blue-300 dark:hover:border-blue-500/40 hover:bg-gray-50 dark:hover:bg-gray-750 transition-colors"
+                                    >
+                                        <Server size={12} className="text-gray-400" />
+                                        {t(p.labelKey)}
+                                    </button>
+                                ))}
+                            </div>
+                        </div>
+                    );
+                })()}
             </div>
         </div>
     );

--- a/src/components/IntroHub/IntroHub.tsx
+++ b/src/components/IntroHub/IntroHub.tsx
@@ -138,12 +138,14 @@ export function IntroHub(props: IntroHubProps) {
     // Dynamic form tabs
     const [formTabs, setFormTabs] = useState<FormTabState[]>([]);
 
-    // Discover search strings are lifted here (Ehud #274) so switching tabs —
-    // which unmounts DiscoverPanel — no longer wipes them. They live in memory
-    // and reset only when the app quits, exactly as requested. `grid` backs the
-    // card view's search box; `list` backs the CatalogTable search box.
-    const [discoverGridQuery, setDiscoverGridQuery] = useState('');
-    const [discoverListQuery, setDiscoverListQuery] = useState('');
+    // The Discover search string is lifted here (Ehud #274) so switching tabs —
+    // which unmounts DiscoverPanel — no longer wipes it. It lives in memory and
+    // resets only when the app quits, exactly as requested.
+    //
+    // One string, not one per view: the grid and the table each used to keep
+    // their own, so a term typed in one was gone after switching to the other
+    // (Ehud #347). Both now render the same box, backed by this.
+    const [discoverQuery, setDiscoverQuery] = useState('');
 
     // Command Palette
     // showPalette removed: CommandPalette was redundant with filter chips
@@ -458,10 +460,8 @@ export function IntroHub(props: IntroHubProps) {
                 {activeTab === 'discover' && (
                     <DiscoverPanel
                         onSelectProvider={handleSelectProvider}
-                        gridQuery={discoverGridQuery}
-                        onGridQueryChange={setDiscoverGridQuery}
-                        listQuery={discoverListQuery}
-                        onListQueryChange={setDiscoverListQuery}
+                        query={discoverQuery}
+                        onQueryChange={setDiscoverQuery}
                     />
                 )}
 

--- a/src/components/IntroHub/discoverViewParity.test.ts
+++ b/src/components/IntroHub/discoverViewParity.test.ts
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+import { describe, it, expect } from 'vitest';
+import panelRaw from './DiscoverPanel.tsx?raw';
+import tableRaw from './CatalogTable.tsx?raw';
+import hubRaw from './IntroHub.tsx?raw';
+
+/**
+ * Add Service kept two of everything: the grid and the table each rendered
+ * their own search box, backed by their own state, and the tier filter existed
+ * only inside the table. Typing a term in one view and switching lost it, the
+ * box moved, and the filters vanished (Ehud, #347).
+ *
+ * The shape of the fix is "shared chrome, one body per view", and that is what
+ * these check — the arrangement is the fix, so a future edit that re-adds a
+ * second copy is what has to fail here.
+ */
+describe('Add Service: grid and table share their controls (#347)', () => {
+    it('keeps a single search string in the parent', () => {
+        // Two states was the actual defect: `discoverGridQuery` and
+        // `discoverListQuery` could not agree by construction.
+        expect(hubRaw).toContain('const [discoverQuery, setDiscoverQuery]');
+        expect(hubRaw).not.toContain('discoverGridQuery');
+        expect(hubRaw).not.toContain('discoverListQuery');
+    });
+
+    it('passes that one string down, with no per-view variant', () => {
+        expect(panelRaw).toContain('query: string;');
+        expect(panelRaw).not.toContain('gridQuery');
+        expect(panelRaw).not.toContain('listQuery');
+    });
+
+    it('renders the search box once, outside the view switch', () => {
+        // One <SearchBox> in the panel and none in the table: two would mean the
+        // element differs between views again, which is what moved it.
+        expect((panelRaw.match(/<SearchBox/g) ?? []).length).toBe(1);
+        expect(tableRaw).not.toContain('<SearchBox');
+        // It must sit before the branch, otherwise it is inside one arm of it.
+        // Anchored on the JSX branch specifically: `viewMode === 'list' ?` also
+        // appears earlier as a plain expression when counting the header.
+        const branch = panelRaw.indexOf("{viewMode === 'list' ? (");
+        expect(branch).toBeGreaterThan(-1);
+        expect(panelRaw.indexOf('<SearchBox')).toBeLessThan(branch);
+    });
+
+    it('renders the tier filter once, in the panel rather than the table', () => {
+        expect(panelRaw).toContain('TIER_FILTERS.map');
+        expect(tableRaw).not.toContain('TIER_FILTERS.map');
+        // The table still filters by it; it just no longer owns it.
+        expect(tableRaw).toContain('tierFilter: TierFilter;');
+        expect(tableRaw).not.toContain('useState<TierFilter>');
+    });
+
+    it('applies the tier filter to the grid too, not only to the table', () => {
+        // The filter used to live in the table, so the grid ignored it entirely.
+        expect(panelRaw).toContain('companyTierInCategory(company, activeCategory)');
+    });
+
+    it('shows the custom/generic servers and the category banner in both views', () => {
+        // Both used to be inside one arm of the switch: custom servers under the
+        // table only, the banner under the grid only.
+        expect((panelRaw.match(/CUSTOM_PROFILES\.filter/g) ?? []).length).toBe(1);
+        expect(panelRaw).not.toContain("viewMode === 'grid' && activeCategory !== 'all'");
+        const customIdx = panelRaw.indexOf('CUSTOM_PROFILES.filter');
+        const switchEnd = panelRaw.lastIndexOf('                )}');
+        expect(customIdx).toBeGreaterThan(switchEnd);
+    });
+});


### PR DESCRIPTION
Add Service kept two of everything, and that is why switching between Grid view and Table view felt like changing page rather than changing layout.

The grid rendered its own search box backed by `discoverGridQuery`. The table rendered a second one, inside `CatalogTable`, backed by `discoverListQuery`. The tier filter (All / Free tier / Free + card / Paid) existed only inside the table. And the two views disagreed about what else belonged on the page: the custom/generic servers strip appeared only under the table, the per-category info banner only under the grid.

So a term typed in one view was gone after switching, the box moved position, the chosen tier was dropped, and whole sections appeared and disappeared. That is the set of symptoms in @EhudKirsh's request on #347 — "please make the search bar the same element in both the grid and table, and also pretty much keep all elements the same in both except for the actual grid or table".

## What changed

The panel now owns the chrome and the view switch owns only the body.

- **One search string**, lifted to `IntroHub` as `discoverQuery`. Two states could not agree by construction, so there is one.
- **One `SearchBox` and one tier filter**, rendered above the view switch — literally the same element in both views, in the same position. The table no longer holds a copy of either; it takes both as props.
- **The tier filter now applies to the grid too.** Each tile resolves back to its catalog company by provider id and then by protocol — the same keying the signup-URL map in this file already uses. A tile with no company behind it (the AeroShare tile, the generic protocol entries) is never hidden by a tier: it has no price to filter on, and dropping it would remove an entry point rather than narrow a choice.
- **Custom/generic servers and the category info banner render once**, for both views. The banner describes the category, not the way it is drawn, so it had no reason to vanish in the table.

The tier filter stays persisted exactly as before — it only changed owner, so `loadTierFilter` / `persistTierFilter` are now exported from `CatalogTable`.

## Tests

Six new, in `src/components/IntroHub/discoverViewParity.test.ts`, all verified failing against the pre-fix tree.

They pin the arrangement rather than the wording, because here the arrangement *is* the fix: a later edit that re-introduces a second search box, gives the table its own tier state again, or moves a shared section back inside one arm of the switch will fail. One of them is anchored on the JSX branch specifically, since `viewMode === 'list' ?` also appears earlier as a plain expression when counting the header — worth knowing before editing them.

Gates: `npm run typecheck` clean, `npm run test:unit` 77 files / 700 tests green.

Still open from the same review and not in this PR: the protocol badge order and the `S4 (S3)` / `S5 (S3)` tab labels, and the icon inconsistencies between Quick Connect and My Servers.
