### PR TITLE
fix(catalog): one order and one name per connection method

### DIFF
--- a/src/components/ProviderModeTabs.tsx
+++ b/src/components/ProviderModeTabs.tsx
@@ -15,13 +15,14 @@
  * Renders nothing when no group is active, so it can be unconditionally
  * mounted in the form layout.
  */
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { FileText } from 'lucide-react';
 import { useTranslation } from '../i18n';
 import {
     findActiveMode,
     findActiveModeGroup,
 } from './providerModeGroups';
+import { protocolBadgeRank } from './providerCatalog';
 import BridgeStatusBanner from './BridgeStatusBanner';
 import type { ProviderType } from '../types';
 
@@ -69,6 +70,23 @@ export const ProviderModeTabs: React.FC<ProviderModeTabsProps> = ({
     const group = findActiveModeGroup(activeProviderId, activeProtocol);
     const active = group ? findActiveMode(group, activeProviderId, activeProtocol) : null;
     const bridgeKind = active?.bridgeKind;
+
+    // Tabs follow the same order the Add Service badges do (#347). Sorted here
+    // rather than in the group definitions so there is one sequence, shared with
+    // the catalog, instead of two lists that have to be kept in agreement by
+    // hand — which is how FileLu ended up with FTP last here and second there.
+    // Stable, on a copy: equal ranks keep the authored order and the exported
+    // groups are never reordered under another consumer.
+    const orderedModes = useMemo(() => {
+        if (!group) return [];
+        return group.modes
+            .map((m, i) => ({ m, i }))
+            .sort((a, b) => {
+                const byRank = protocolBadgeRank(a.m.protocol) - protocolBadgeRank(b.m.protocol);
+                return byRank !== 0 ? byRank : a.i - b.i;
+            })
+            .map(({ m }) => m);
+    }, [group]);
 
     // Clear bridge-derived state when the active mode is not a local-bridge mode
     // (the banner clears its own on unmount, but a non-bridge group never mounts
@@ -120,7 +138,7 @@ export const ProviderModeTabs: React.FC<ProviderModeTabsProps> = ({
                 <span className="text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 mr-2">
                     {group.headerLabel}
                 </span>
-                {group.modes.map(mode => {
+                {orderedModes.map(mode => {
                     const isActive = active === mode;
                     return (
                         <button

--- a/src/components/protocolBadgeOrder.test.ts
+++ b/src/components/protocolBadgeOrder.test.ts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+import { describe, it, expect } from 'vitest';
+import {
+    PROVIDER_CATALOG,
+    freeProtocols,
+    paidProtocols,
+    protocolBadgeRank,
+    PROTOCOL_BADGE_ORDER,
+} from './providerCatalog';
+import { PROVIDER_MODE_GROUPS } from './providerModeGroups';
+
+/**
+ * One presentation order for connection methods, and one name per method,
+ * wherever they are listed (Ehud, #347).
+ *
+ * Before this, the Add Service badges sorted by catalog *category* — which
+ * ranked FTP and a native API the same — while the Quick Connect tabs followed
+ * their own hand-written order. FileLu read `API · FTP · WebDAV · S5 (S3)` in
+ * one place and `Native API · WebDAV · S3 · FTP` in the other, and its S3 tab
+ * was labelled `S3` while its badge said `S5 (S3)`.
+ */
+describe('connection methods are ordered and named the same everywhere (#347)', () => {
+    const methodsOf = (logoId: string) => {
+        const c = PROVIDER_CATALOG.find(x => x.logoId === logoId);
+        if (!c) throw new Error(`no catalog company for ${logoId}`);
+        return [...freeProtocols(c), ...paidProtocols(c)];
+    };
+
+    const groupModes = (id: string) => {
+        const g = PROVIDER_MODE_GROUPS.find(x => x.id === id);
+        if (!g) throw new Error(`no mode group ${id}`);
+        return g.modes;
+    };
+
+    it('ranks a native API before any wire protocol', () => {
+        // A company's own API is what it *is*, rather than a protocol it also
+        // speaks, and it carries the fullest feature set.
+        expect(protocolBadgeRank('filelu')).toBeLessThan(protocolBadgeRank('webdav'));
+        expect(protocolBadgeRank('mega')).toBeLessThan(protocolBadgeRank('s3'));
+    });
+
+    it('ranks the wire protocols in the agreed sequence', () => {
+        expect([...PROTOCOL_BADGE_ORDER]).toEqual(['webdav', 'sftp', 'ftps', 'ftp', 's3']);
+        const ranks = ['webdav', 'sftp', 'ftps', 'ftp', 's3'].map(protocolBadgeRank);
+        expect(ranks).toEqual([...ranks].sort((a, b) => a - b));
+    });
+
+    it('puts FileLu WebDAV before FTP before S3, the case that was inconsistent', () => {
+        // Was `API · FTP · WebDAV · S5 (S3)` because FTP and the API tied.
+        const order = methodsOf('filelu').map(p => p.protocol);
+        expect(order.indexOf('filelu')).toBeLessThan(order.indexOf('webdav'));
+        expect(order.indexOf('webdav')).toBeLessThan(order.indexOf('ftp'));
+        expect(order.indexOf('ftp')).toBeLessThan(order.indexOf('s3'));
+    });
+
+    it('sorts every company by that rank, with no exception left behind', () => {
+        for (const c of PROVIDER_CATALOG) {
+            for (const bucket of [freeProtocols(c), paidProtocols(c)]) {
+                const ranks = bucket.map(p => protocolBadgeRank(p.protocol));
+                expect(
+                    ranks,
+                    `${c.company} lists its methods out of order`,
+                ).toEqual([...ranks].sort((a, b) => a - b));
+            }
+        }
+    });
+
+    it('gives a branded method the same name in the tab and in the badge', () => {
+        // The tab said `S3` / `S4` while the badge said `S5 (S3)` / `S4 (S3)`.
+        const badgeLabel = (logoId: string, providerId: string) => {
+            const m = methodsOf(logoId).find(p => p.providerId === providerId);
+            return m?.labelOverride ?? m?.label;
+        };
+        const tabLabel = (groupId: string, providerId: string) =>
+            groupModes(groupId).find(m => m.providerId === providerId)?.label;
+
+        expect(badgeLabel('filelu', 'filelu-s3')).toBe('S5 (S3)');
+        expect(tabLabel('filelu', 'filelu-s3')).toBe('S5 (S3)');
+
+        expect(badgeLabel('mega', 'mega-s4')).toBe('S4 (S3)');
+        expect(tabLabel('mega', 'mega-s4')).toBe('S4 (S3)');
+    });
+});

--- a/src/components/providerCatalog.ts
+++ b/src/components/providerCatalog.ts
@@ -492,8 +492,41 @@ const BADGE_CATEGORY_RANK: Partial<Record<CatalogCategoryId, number>> = {
     webdav: 1,
     'object-storage': 2,
 };
-const badgeRank = (p: CatalogProtocolRef): number => BADGE_CATEGORY_RANK[p.category] ?? 0;
-const byBadgeRank = (a: CatalogProtocolRef, b: CatalogProtocolRef): number => badgeRank(a) - badgeRank(b);
+
+/**
+ * Refined for #347. The category rank above ranked FTP and a native API the
+ * same — both fall in the unranked bucket — so companies exposing both kept
+ * whichever order they happened to be authored in, and FileLu showed
+ * `API · FTP · WebDAV · S5 (S3)` in Add Service while its Quick Connect tabs
+ * read `Native API · WebDAV · S3 · FTP`. Ehud asked for one order used
+ * everywhere, and gave the sequence: roughly most to least chatty, by the
+ * number of round trips a transfer costs.
+ *
+ * This is a presentation order, not a recommendation. Which method is actually
+ * fastest depends on the shape of the transfer, and the "recommended" marker
+ * stays deferred on #368 rather than being guessed at here.
+ *
+ * A company's own API is unranked and sorts first: it is the fullest feature
+ * set, and it is what the company *is* rather than a wire protocol it also
+ * happens to speak. `PROTOCOL_BADGE_ORDER` is exported so the Quick Connect
+ * mode tabs sort by the same sequence instead of keeping a second opinion.
+ */
+export const PROTOCOL_BADGE_ORDER: readonly string[] = ['webdav', 'sftp', 'ftps', 'ftp', 's3'];
+
+/** Rank of a wire protocol in `PROTOCOL_BADGE_ORDER`; native APIs sort first. */
+export function protocolBadgeRank(protocol: string): number {
+    const i = PROTOCOL_BADGE_ORDER.indexOf(protocol);
+    return i === -1 ? -1 : i;
+}
+
+// Protocol first, then the category rank as the tie-breaker so a company whose
+// methods share a protocol keeps the arrangement the catalog authored.
+const badgeRank = (p: CatalogProtocolRef): number => protocolBadgeRank(p.protocol);
+const byBadgeRank = (a: CatalogProtocolRef, b: CatalogProtocolRef): number => {
+    const byProtocol = badgeRank(a) - badgeRank(b);
+    if (byProtocol !== 0) return byProtocol;
+    return (BADGE_CATEGORY_RANK[a.category] ?? 0) - (BADGE_CATEGORY_RANK[b.category] ?? 0);
+};
 
 /** Connection methods available on the free tier (blue badges). */
 export function freeProtocols(c: CatalogCompany): CatalogProtocolRef[] {

--- a/src/components/providerModeGroups.tsx
+++ b/src/components/providerModeGroups.tsx
@@ -130,7 +130,10 @@ export const PROVIDER_MODE_GROUPS: ProviderModeGroup[] = [
                 protocol: 's3',
                 icon: <Database size={14} />,
                 activeColor: 'text-amber-500',
-                label: 'S3',
+                // Branded "S5" by FileLu; the wire protocol stays S3. Same text
+                // the Add Service badge uses (#347): the tab and the badge for
+                // one method should not read differently.
+                label: 'S5 (S3)',
                 description:
                     'S3-compatible API on port 443. Use rclone, AWS CLI, or any S3 SDK.',
             },
@@ -308,7 +311,8 @@ export const PROVIDER_MODE_GROUPS: ProviderModeGroup[] = [
                 protocol: 's3',
                 icon: <Database size={14} />,
                 activeColor: 'text-amber-500',
-                label: 'S4',
+                // Branded "S4" by MEGA; matches the Add Service badge (#347).
+                label: 'S4 (S3)',
                 description:
                     'MEGA S4 object storage, S3-compatible (EU/CA regions). Access key + secret key + bucket. Requires a Pro plan.',
                 badge: 'PRO',


### PR DESCRIPTION
@EhudKirsh noticed on #347 that FileLu reads `API · FTP · WebDAV · S5 (S3)` in the Add Service table but `Native API · WebDAV · S3 · FTP` in its Quick Connect page, and that the same connection method is labelled `S5 (S3)` in one place and `S3` in the other. Two separate causes.

## The order

The badge sort ranked by catalog **category**, not by protocol. FTP and a native API both land in the unranked bucket, so they tied and kept whatever order the company happened to be authored in — which is why FTP sat second for FileLu and last in Quick Connect.

The rank is now per wire protocol — `webdav, sftp, ftps, ftp, s3` — with a native API unranked and therefore first, and the category rank kept as the tie-breaker. The sequence is the one you proposed, roughly most to least chatty by round trips.

Worth being explicit: this is a **presentation** order, not a recommendation. Which method is actually fastest depends on the shape of the transfer — many small files versus few large ones, as you said yourself — so the "recommended/fastest" marker stays deferred on #368 until the benchmark harness produces real per-protocol numbers, rather than being guessed at here.

A native API sorts first because it is what the company *is* rather than a wire protocol it also happens to speak, and it carries the fullest feature set.

## The tabs

Quick Connect kept its own hand-written order. The tabs now sort by the same exported rank, so there is one sequence instead of two lists that have to be kept in agreement by hand. Sorted on a copy with a stable sort: the exported groups are never reordered under another consumer, and equal ranks keep the authored arrangement.

## The names

The two branded S3 tabs now carry the name their badge already used: `S5 (S3)` for FileLu, `S4 (S3)` for MEGA.

## Tests

Five new, in `src/components/protocolBadgeOrder.test.ts`, all verified failing against the pre-fix tree. One of them walks the **whole** catalog rather than only the two companies in the report, so a future entry authored out of order fails here instead of shipping — the original defect was exactly this kind of quiet drift.

Gates: `npm run typecheck` clean, `npm run test:unit` 77 files / 699 tests green.

Still open from the same review: the icon/symbol inconsistencies between the Quick Connect pages and the My Servers table (☁ meaning OAuth in one and API in the other, and the S3 glyph differing between MEGA, FileLu and Filen).
