### PR TITLE
fix(ui): one glyph per connection method, shared by both surfaces

### DIFF
--- a/src/components/IntroHub/MyServersTable.tsx
+++ b/src/components/IntroHub/MyServersTable.tsx
@@ -2,7 +2,8 @@
 // Copyright (c) 2024-2026 axpnet -- AI-assisted (see AI-TRANSPARENCY.md)
 
 import * as React from 'react';
-import { Cloud, Database, Globe, KeyRound, Server as ServerIcon, Shield } from 'lucide-react';
+import { Cloud, Server as ServerIcon } from 'lucide-react';
+import { methodIcon } from '../connectionMethodIcons';
 import { getE2EBits, getProfileProtocolClass, ServerProfile, type ProviderType } from '../../types';
 import {
     MY_SERVERS_TABLE_COLUMNS,
@@ -78,18 +79,23 @@ const dateOf = (server: ServerProfile) => {
     return Number.isFinite(ts) ? ts : -1;
 };
 
+// Shapes come from the shared map (#347); only the tint is this table's own.
+// API used to draw `Database` here, the same glyph as S3 with a different
+// colour, and `Cloud` here meant OAuth while it meant a native API in Quick
+// Connect. Azure and AeroCloud are surfaces of their own rather than wire
+// methods, so they keep their local glyph.
 const PROTOCOL_ICON: Record<string, React.ReactNode> = {
-    OAuth: <Cloud size={14} className="text-blue-500" />,
-    API: <Database size={14} className="text-emerald-500" />,
-    WebDAV: <Globe size={14} className="text-cyan-500" />,
-    E2E: <Shield size={14} className="text-violet-500" />,
-    FTP: <ServerIcon size={14} className="text-gray-500" />,
-    FTPS: <ServerIcon size={14} className="text-sky-500" />,
-    SFTP: <KeyRound size={14} className="text-indigo-500" />,
-    S3: <Database size={14} className="text-orange-500" />,
+    OAuth: methodIcon('OAuth', { size: 14, className: 'text-blue-500' }),
+    API: methodIcon('API', { size: 14, className: 'text-emerald-500' }),
+    WebDAV: methodIcon('WebDAV', { size: 14, className: 'text-cyan-500' }),
+    E2E: methodIcon('E2E', { size: 14, className: 'text-violet-500' }),
+    FTP: methodIcon('FTP', { size: 14, className: 'text-gray-500' }),
+    FTPS: methodIcon('FTPS', { size: 14, className: 'text-sky-500' }),
+    SFTP: methodIcon('SFTP', { size: 14, className: 'text-indigo-500' }),
+    S3: methodIcon('S3', { size: 14, className: 'text-orange-500' }),
     Azure: <Cloud size={14} className="text-blue-600" />,
     AeroCloud: <Cloud size={14} className="text-purple-500" />,
-    Crypt: <Shield size={14} className="text-emerald-500" />,
+    Crypt: methodIcon('Crypt', { size: 14, className: 'text-emerald-500' }),
 };
 
 const badgeSortLabel = (server: ServerProfile) => {

--- a/src/components/connectionMethodIcons.test.ts
+++ b/src/components/connectionMethodIcons.test.ts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+import { describe, it, expect } from 'vitest';
+import { CONNECTION_METHOD_GLYPH } from './connectionMethodIcons';
+import modeGroupsRaw from './providerModeGroups.tsx?raw';
+import myServersRaw from './IntroHub/MyServersTable.tsx?raw';
+
+/**
+ * The icons for connection methods were assigned by hand at each site, so they
+ * disagreed across surfaces and collided within one (Ehud, #347):
+ *
+ *   - `Cloud` meant OAuth in the My Servers table and a native API in MEGA's
+ *     Quick Connect page.
+ *   - `Database` meant a native API in the table and S3 in Quick Connect, and
+ *     inside the table API and S3 both drew `Database`, separated only by a
+ *     colour that no legend explains.
+ *   - A native API drew `Cloud` for MEGA, Filen, Koofr and OpenDrive but `Key`
+ *     for FileLu; S3 drew `Database` for MEGA and FileLu but `Layers` for Filen.
+ */
+describe('one glyph per connection method (#347)', () => {
+    it('never gives two methods the same glyph', () => {
+        // The collision that mattered: a reader cannot tell API from S3 when the
+        // shape is identical and only the tint differs.
+        const shapes = Object.entries(CONNECTION_METHOD_GLYPH)
+            .filter(([m]) => m !== 'Crypt' && m !== 'FTPS');
+        const seen = new Map<unknown, string>();
+        for (const [method, glyph] of shapes) {
+            const clash = seen.get(glyph);
+            expect(clash, `${method} draws the same glyph as ${clash}`).toBeUndefined();
+            seen.set(glyph, method);
+        }
+    });
+
+    it('keeps the two deliberate aliases explicit', () => {
+        // FTPS is FTP over TLS and Crypt is an E2E overlay: sharing a shape with
+        // their family is the intent, not a leftover.
+        expect(CONNECTION_METHOD_GLYPH.FTPS).toBe(CONNECTION_METHOD_GLYPH.FTP);
+        expect(CONNECTION_METHOD_GLYPH.Crypt).toBe(CONNECTION_METHOD_GLYPH.E2E);
+    });
+
+    it('separates a native API from OAuth and from S3', () => {
+        expect(CONNECTION_METHOD_GLYPH.API).not.toBe(CONNECTION_METHOD_GLYPH.OAuth);
+        expect(CONNECTION_METHOD_GLYPH.API).not.toBe(CONNECTION_METHOD_GLYPH.S3);
+    });
+
+    it('leaves no surface picking its own icon for a method', () => {
+        // Both surfaces must go through the map. A literal lucide element on a
+        // mode or a protocol row is how the three surfaces drifted apart.
+        expect(modeGroupsRaw).not.toMatch(/icon: <(Key|Layers|Cloud|Globe|Database|Server)\b/);
+        expect(modeGroupsRaw).toContain("methodIcon('API'");
+        expect(modeGroupsRaw).toContain("methodIcon('S3'");
+
+        for (const method of ['OAuth', 'API', 'WebDAV', 'S3', 'SFTP']) {
+            expect(
+                myServersRaw,
+                `My Servers still hand-picks an icon for ${method}`,
+            ).toContain(`${method}: methodIcon('${method}'`);
+        }
+    });
+});

--- a/src/components/connectionMethodIcons.tsx
+++ b/src/components/connectionMethodIcons.tsx
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+/**
+ * One glyph per connection method, for every surface that draws them.
+ *
+ * Ehud reported three symptoms on #347 that are one defect: the icons were
+ * assigned by hand at each site, so they disagreed and, worse, collided.
+ *
+ *   - `Cloud` meant OAuth in the My Servers table and a native API in MEGA's
+ *     Quick Connect page, so the same glyph named two different things.
+ *   - `Database` meant a native API in the My Servers table and S3 in the
+ *     Quick Connect pages of MEGA and FileLu. Inside the My Servers table
+ *     itself API and S3 both drew `Database`, separated only by colour, which
+ *     no legend explains and no colour-blind reader can use.
+ *   - A native API drew `Cloud` for MEGA, Filen, Koofr and OpenDrive but `Key`
+ *     for FileLu, and S3 drew `Database` for MEGA and FileLu but `Layers` for
+ *     Filen.
+ *
+ * The map below is the only place these are decided. Adding a surface means
+ * importing it, not inventing a fourth opinion.
+ *
+ * On the two choices that had to change rather than merely be unified:
+ *
+ *   - A native API is `Braces`. It cannot keep `Database` (that is S3) or
+ *     `Cloud` (that is OAuth), and `Key`/`KeyRound` reads as SFTP. Curly braces
+ *     say "this provider's own JSON API" without borrowing anyone's meaning.
+ *   - S3 keeps `Database`, the reading three of the four surfaces already had;
+ *     Filen's `Layers` was the outlier.
+ *
+ * Colours stay per-surface: the table tints its glyphs to match its badge
+ * palette, the Quick Connect tabs tint on the active state. Only the shape is
+ * shared, because the shape is what carries the meaning.
+ */
+import * as React from 'react';
+import {
+    Braces,
+    Cloud,
+    Database,
+    Globe,
+    KeyRound,
+    Server,
+    Shield,
+    type LucideIcon,
+} from 'lucide-react';
+
+/** The connection methods that get a glyph. Keys match the catalog badge labels. */
+export type ConnectionMethod =
+    | 'OAuth'
+    | 'API'
+    | 'WebDAV'
+    | 'S3'
+    | 'FTP'
+    | 'FTPS'
+    | 'SFTP'
+    | 'E2E'
+    | 'Crypt';
+
+/** The lucide component for a method, so each caller picks its own size/colour. */
+export const CONNECTION_METHOD_GLYPH: Record<ConnectionMethod, LucideIcon> = {
+    OAuth: Cloud,
+    API: Braces,
+    WebDAV: Globe,
+    S3: Database,
+    FTP: Server,
+    FTPS: Server,
+    SFTP: KeyRound,
+    E2E: Shield,
+    Crypt: Shield,
+};
+
+/**
+ * Render the glyph for a method. Returns null for an unknown key rather than a
+ * placeholder: a method with no glyph should show nothing, not a wrong symbol.
+ */
+export function methodIcon(
+    method: string,
+    props: { size?: number; className?: string } = {},
+): React.ReactElement | null {
+    const Glyph = CONNECTION_METHOD_GLYPH[method as ConnectionMethod];
+    return Glyph ? <Glyph {...props} /> : null;
+}

--- a/src/components/providerModeGroups.tsx
+++ b/src/components/providerModeGroups.tsx
@@ -18,7 +18,7 @@
  * group automatically based on the form's current providerId+protocol.
  */
 import React from 'react';
-import { Key, Globe, Database, Server, Cloud, Layers } from 'lucide-react';
+import { methodIcon } from './connectionMethodIcons';
 import type { ProviderType } from '../types';
 
 export interface ProviderMode {
@@ -110,7 +110,7 @@ export const PROVIDER_MODE_GROUPS: ProviderModeGroup[] = [
                 // no providerId). Declaring providerId:'filelu' here forced the strict
                 // providerId match, which never fired on the native entry point.
                 protocol: 'filelu',
-                icon: <Key size={14} />,
+                icon: methodIcon('API', { size: 14 }),
                 activeColor: 'text-sky-500',
                 label: 'Native API',
                 description:
@@ -119,7 +119,7 @@ export const PROVIDER_MODE_GROUPS: ProviderModeGroup[] = [
             {
                 providerId: 'filelu-webdav',
                 protocol: 'webdav',
-                icon: <Globe size={14} />,
+                icon: methodIcon('WebDAV', { size: 14 }),
                 activeColor: 'text-emerald-500',
                 label: 'WebDAV',
                 description:
@@ -128,7 +128,7 @@ export const PROVIDER_MODE_GROUPS: ProviderModeGroup[] = [
             {
                 providerId: 'filelu-s3',
                 protocol: 's3',
-                icon: <Database size={14} />,
+                icon: methodIcon('S3', { size: 14 }),
                 activeColor: 'text-amber-500',
                 // Branded "S5" by FileLu; the wire protocol stays S3. Same text
                 // the Add Service badge uses (#347): the tab and the badge for
@@ -140,7 +140,7 @@ export const PROVIDER_MODE_GROUPS: ProviderModeGroup[] = [
             {
                 providerId: 'filelu-ftp',
                 protocol: 'ftp',
-                icon: <Server size={14} />,
+                icon: methodIcon('FTP', { size: 14 }),
                 activeColor: 'text-blue-500',
                 label: 'FTP',
                 description:
@@ -161,7 +161,7 @@ export const PROVIDER_MODE_GROUPS: ProviderModeGroup[] = [
                 // ProtocolSelector (`type: 'filen'`): no registry preset
                 // is involved, so providerId is intentionally omitted.
                 protocol: 'filen',
-                icon: <Cloud size={14} />,
+                icon: methodIcon('API', { size: 14 }),
                 activeColor: 'text-emerald-500',
                 label: 'Native API',
                 description:
@@ -171,7 +171,7 @@ export const PROVIDER_MODE_GROUPS: ProviderModeGroup[] = [
             {
                 providerId: 'filen-desktop-webdav',
                 protocol: 'webdav',
-                icon: <Globe size={14} />,
+                icon: methodIcon('WebDAV', { size: 14 }),
                 activeColor: 'text-blue-500',
                 label: 'WebDAV',
                 description:
@@ -182,7 +182,7 @@ export const PROVIDER_MODE_GROUPS: ProviderModeGroup[] = [
             {
                 providerId: 'filen-desktop-s3',
                 protocol: 's3',
-                icon: <Layers size={14} />,
+                icon: methodIcon('S3', { size: 14 }),
                 activeColor: 'text-amber-500',
                 label: 'S3',
                 description:
@@ -217,7 +217,7 @@ export const PROVIDER_MODE_GROUPS: ProviderModeGroup[] = [
                 // OpenDrive native API selected via ProtocolSelector
                 // (`type: 'opendrive'`); no registry preset is involved.
                 protocol: 'opendrive',
-                icon: <Cloud size={14} />,
+                icon: methodIcon('API', { size: 14 }),
                 activeColor: 'text-cyan-500',
                 label: 'Native API',
                 description:
@@ -226,7 +226,7 @@ export const PROVIDER_MODE_GROUPS: ProviderModeGroup[] = [
             {
                 providerId: 'opendrive-webdav',
                 protocol: 'webdav',
-                icon: <Globe size={14} />,
+                icon: methodIcon('WebDAV', { size: 14 }),
                 activeColor: 'text-blue-500',
                 label: 'WebDAV',
                 description:
@@ -251,7 +251,7 @@ export const PROVIDER_MODE_GROUPS: ProviderModeGroup[] = [
                 // only registry entry id 'koofr' is the WebDAV preset, so
                 // the native mode is intentionally preset-less (issue #213).
                 protocol: 'koofr',
-                icon: <Cloud size={14} />,
+                icon: methodIcon('API', { size: 14 }),
                 activeColor: 'text-teal-500',
                 label: 'Native API',
                 description:
@@ -260,7 +260,7 @@ export const PROVIDER_MODE_GROUPS: ProviderModeGroup[] = [
             {
                 providerId: 'koofr',
                 protocol: 'webdav',
-                icon: <Globe size={14} />,
+                icon: methodIcon('WebDAV', { size: 14 }),
                 activeColor: 'text-blue-500',
                 label: 'WebDAV',
                 description:
@@ -288,7 +288,7 @@ export const PROVIDER_MODE_GROUPS: ProviderModeGroup[] = [
                 // findActiveModeGroup covers both (activeProviderId undefined or
                 // equal to the protocol).
                 protocol: 'mega',
-                icon: <Cloud size={14} />,
+                icon: methodIcon('API', { size: 14 }),
                 activeColor: 'text-red-500',
                 label: 'API',
                 description:
@@ -298,7 +298,7 @@ export const PROVIDER_MODE_GROUPS: ProviderModeGroup[] = [
             {
                 providerId: 'megacmd-webdav',
                 protocol: 'webdav',
-                icon: <Globe size={14} />,
+                icon: methodIcon('WebDAV', { size: 14 }),
                 activeColor: 'text-blue-500',
                 label: 'WebDAV (MEGAcmd)',
                 description:
@@ -309,7 +309,7 @@ export const PROVIDER_MODE_GROUPS: ProviderModeGroup[] = [
             {
                 providerId: 'mega-s4',
                 protocol: 's3',
-                icon: <Database size={14} />,
+                icon: methodIcon('S3', { size: 14 }),
                 activeColor: 'text-amber-500',
                 // Branded "S4" by MEGA; matches the Add Service badge (#347).
                 label: 'S4 (S3)',


### PR DESCRIPTION
@EhudKirsh reported three icon inconsistencies on #347. They are one defect: the glyphs were assigned by hand at each site, so they disagreed across surfaces and collided within one.

- `Cloud` meant **OAuth** in the My Servers table and a **native API** in MEGA's Quick Connect page, so one glyph named two different things.
- `Database` meant a **native API** in the table and **S3** in Quick Connect. Worse than the mismatch you spotted: inside the My Servers table itself, API and S3 both drew `Database`, separated only by a colour that no legend explains and that a colour-blind reader cannot use at all.
- A native API drew `Cloud` for MEGA, Filen, Koofr and OpenDrive but `Key` for FileLu; S3 drew `Database` for MEGA and FileLu but `Layers` for Filen.

## What changed

`src/components/connectionMethodIcons.tsx` is now the only place these are decided, and both surfaces import it. Adding a third surface means importing the map, not inventing a fourth opinion.

Colours stay per-surface: the table tints to its badge palette, the Quick Connect tabs tint on the active state. Only the **shape** is shared, because the shape is what carries the meaning.

Two glyphs had to change rather than merely be unified:

- **A native API is now `Braces`.** It cannot keep `Database` (that is S3) or `Cloud` (that is OAuth), and `Key`/`KeyRound` already reads as SFTP. Curly braces say "this provider's own JSON API" without borrowing anyone else's meaning.
- **S3 keeps `Database`**, the reading three of the four surfaces already had. Filen's `Layers` was the outlier.

FTPS deliberately shares FTP's glyph, and Crypt shares E2E's. The test asserts those two aliases explicitly, so they read as intent rather than as leftover collisions.

## Tests

Four new. Being precise about what they prove: **one** is verified failing against the pre-fix tree, the one that pins the reported defect (no surface may hand-pick a lucide element for a method). The other three pin invariants of the shared map, which did not exist before this commit and therefore cannot fail against it. They earn their place going forward, not as evidence about the past.

Gates: `npm run typecheck` clean, `npm run test:unit` 80 files / 715 tests green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Standardized connection-method icons across provider modes and My Servers.
  * Added distinct visual icons for API, OAuth, WebDAV, S3, FTP, FTPS, SFTP, E2E, and Crypt connections.
  * Preserved dedicated Azure and AeroCloud cloud icons.
  * Added a fallback icon for unrecognized connection methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->