### PR TITLE
docs: correct the rclone OAuth export claim, disambiguate ECC

### DIFF
--- a/docs/AEROVAULT-V3-SPEC.md
+++ b/docs/AEROVAULT-V3-SPEC.md
@@ -201,6 +201,12 @@ The v2 wire format stores the HMAC-SHA512 at bytes `448..512` and computes it ov
 
 ## 11. v4 Evolution Note (T-AEROVAULT-ECC, shipped)
 
+> **ECC here means error-correcting code**, the Reed-Solomon parity that lets a
+> damaged vault be repaired. It does **not** mean Elliptic Curve Cryptography, which
+> is the usual reading of the abbreviation in a security document and is not used
+> anywhere in the AeroVault stack: the cipher is AES-256-GCM-SIV and the hash is
+> BLAKE3. The header field is spelled `ecc` for the same reason.
+
 v4 = v3 + non-critical "error-correction.reed-solomon" extension (always critical=false). The extension carries a v2 Reed-Solomon payload (AVEC magic, version=2, K=10/P=2 fixed grid over the concatenated live-block stream, per-shard 16-byte truncated BLAKE3 for erasure localization, parity data). 
 
 - Overhead target: ~P/K = 20% (clamped shard size; proven on real incompressible data).
@@ -252,7 +258,7 @@ An empty `avec_bytes` for a segment means that region is not protected.
   parity carries no wholesale checksum because each Reed-Solomon shard self-checks and a
   rotted shard is routed around as an erasure. v1 sidecars are still read.
 - **Add-later win**: `export-parity` writes/refreshes a sidecar for an existing vault by
-  reading the encrypted container without rewriting it (Kopia can only enable ECC at repo
+  reading the encrypted container without rewriting it (Kopia can only enable error correction at repo
   creation). `strip-parity` drops the embedded copy, refusing unless a sidecar exists (or
   `--force`) so a vault is never silently left with no recovery.
 - **Source resolution** (scrub/repair): explicit `--parity` -> `<vault>.aerocorrect`

--- a/docs/CLI-GUIDE.md
+++ b/docs/CLI-GUIDE.md
@@ -1601,7 +1601,11 @@ aeroftp-cli export restic --output ./restic-env.sh
 aeroftp-cli export s3cmd  --output ./.s3cfg
 ```
 
-OAuth-based providers (pCloud, Dropbox, Google Drive, Box, OneDrive, Yandex, Zoho, Koofr, Internxt, kDrive) **cannot be exported to rclone** because rclone uses its own OAuth flow with provider-issued client IDs; those entries are emitted as `# manual setup required` comments instead. Passwords for non-OAuth profiles are re-encoded in the target tool's native obfuscation (rclone reversible obscure, WinSCP password mask, FileZilla base64). Use `--json` on any subcommand for a machine-readable summary of what was exported and what was skipped.
+OAuth profiles **are** exported to rclone for every provider that has a matching rclone backend: Google Drive, Dropbox, OneDrive, Box, pCloud Drive, Yandex Disk, Koofr and Jottacloud. Each remote is written with its `client_id`, `client_secret` and `token`, so it is usable and refreshable without re-authorising. This requires all three to be in the vault, which is the case for a profile you authorised in AeroFTP with your own OAuth app; when any of them is missing, the remote is still written and a comment tells you to run `rclone config reconnect <remote>:` before use, rather than emitting a silently broken half-remote.
+
+Keep in mind that AeroFTP and rclone use different redirect URIs. Register both under the same app in the provider's developer console so the one `client_id` / `client_secret` pair works in both tools.
+
+The providers with no rclone export today are Zoho WorkDrive, 4shared, Internxt and kDrive; those entries are emitted as `# manual setup required` comments instead. Zoho WorkDrive is a gap rather than a limitation, tracked in [#458](https://github.com/axpdev-lab/aeroftp/issues/458): rclone does have a `zoho` backend, so the export is reachable. Passwords for non-OAuth profiles are re-encoded in the target tool's native obfuscation (rclone reversible obscure, WinSCP password mask, FileZilla base64). Use `--json` on any subcommand for a machine-readable summary of what was exported and what was skipped.
 
 ### profile-export / profile-import - Native `.aeroftp` Profile Backup
 

--- a/docs/architecture/wrapper-stack.md
+++ b/docs/architecture/wrapper-stack.md
@@ -147,6 +147,11 @@ The AeroVault v3 defaults are:
 | `cipher_hash` | `blake3-256` | 1 |
 | `ecc` | absent in v3 (reserved extension slot) | n/a |
 
+> The `ecc` field is an **error-correcting code**, the Reed-Solomon parity that
+> repairs a damaged vault. It is not Elliptic Curve Cryptography, which is what
+> the abbreviation usually means on a security page: the cipher in this stack is
+> AES-256-GCM-SIV and the hash is BLAKE3, both named in the table above.
+
 v4 reuses the same header layout and only adds the `ecc` field, so
 **v3 + error correction = v4** and a v3-only build opens a v4 vault for the
 data it understands.


### PR DESCRIPTION
Two documentation defects reported by @EhudKirsh on #347.

## The rclone OAuth export claim was false

> Well, I managed to import some OAuth from `rclone.conf` to AeroFTP, so I don't see why it can't also be the other way around.

You were right, and it is worse than a stale sentence: the manual was denying a capability that ships.

`CLI-GUIDE.md` said OAuth-based providers "**cannot be exported to rclone** because rclone uses its own OAuth flow with provider-issued client IDs", and listed ten of them as emitted-as-comments-only. The code does the opposite. `export_rclone` has real branches for Google Drive, Dropbox, OneDrive, Box, pCloud, Yandex and Koofr (plus Jottacloud), and each one calls `push_oauth_credentials`, which writes `client_id`, `client_secret` and `token` whenever the vault holds all three. The `# manual setup required` comment is the **fallback** for a missing piece, not the rule.

That is the worse direction for a doc to be wrong in: a user reads "cannot" and never tries.

The paragraph now names the providers that do export, states the condition (all three credentials in the vault, which is the case for a profile you authorised with your own OAuth app), and describes the fallback. Your practical note is in there too, because it is the part that makes it work rather than merely be possible: AeroFTP and rclone use different redirect URIs, so both have to be registered under the same app for one credential pair to serve both tools.

The genuinely unsupported ones are Zoho WorkDrive, 4shared, Internxt and kDrive. Zoho is flagged as a **gap rather than a limitation**, since rclone does have a `zoho` backend, which is the same finding already logged as row 13 of the tracker.

## ECC was ambiguous in security documents

> just in case it's used elsewhere to mistakenly refer to Error Correction instead of to Elliptic Curve Cryptography.

Checked every occurrence across the docs. The good news is that it is used **consistently** for error correction, so there is no case of it meaning the wrong thing. The problem is the abbreviation itself: on a page that also names AES-256-GCM-SIV and BLAKE3, "ECC" reads as Elliptic Curve Cryptography to a security reader, and consistency does not help when the reader has never seen the convention.

Both `AEROVAULT-V3-SPEC.md` and `docs/architecture/wrapper-stack.md` now say explicitly what it means and what it does not, and the one bare "ECC" sitting in prose next to the cipher names is spelled out.

## Deliberately not done

A blanket rename of every bare "Yandex" to "Yandex Disk". The remaining occurrences refer to the company or sit in broad provider lists, where the short form is correct. The product name is used where the sentence names the product, which is where you raised it.

Note for review: this changes the copies in this repository. If `docs.aeroftp.app` carries its own copy of `wrapper-stack.md` rather than rendering this one, that site needs the same edit and I will do it separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that ECC refers to Reed–Solomon error-correcting parity.
  * Documented the encryption and hashing algorithms used in the AeroVault stack.
  * Expanded export guidance for OAuth profiles, reconnect instructions, unsupported providers, and redirect URI requirements.
  * Clarified that error correction can be enabled at the repository level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->