### PR TITLE
fix(providers): promote Oracle Cloud and Nextcloud to stable, show Blomp in the production grid

### DIFF
--- a/src/components/ProtocolSelector.tsx
+++ b/src/components/ProtocolSelector.tsx
@@ -410,8 +410,10 @@ const getProtocols = (t: (key: string, params?: Record<string, string>) => strin
         isCloudStorage: true,
         tooltip: t('protocol.pcloudTooltip'),
     },
-    // Blomp: hidden in production until storage proxy 403 is resolved (stable: false in registry)
-    ...(import.meta.env.DEV ? [{
+    // Blomp: the account (container) listing 403 is by design, and swift.rs falls
+    // back to the per-account container. Live-verified and `stable: true` in the
+    // registry, so it belongs in the production grid like any other provider.
+    {
         type: 'swift' as const,
         name: 'Blomp',
         icon: <BlompLogo size={18} />,
@@ -421,7 +423,7 @@ const getProtocols = (t: (key: string, params?: Record<string, string>) => strin
         color: 'text-purple-500',
         isCloudStorage: true,
         tooltip: t('protocol.blompTooltip'),
-    }] : []),
+    },
 ];
 
 // Temporary fallback for getProtocolInfo when called outside component (no t function available)

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -953,7 +953,7 @@ export const PROVIDERS: ProviderConfig[] = [
         category: 's3',
         icon: 'Cloud',
         color: '#C74634',
-        stable: false,
+        stable: true,
         fields: [
             { ...COMMON_FIELDS.accessKeyId, label: 'Access Key', helpText: 'Identity → Users → Customer Secret Keys → Access Key' },
             { ...COMMON_FIELDS.secretAccessKey, label: 'Secret Key', helpText: 'Identity → Users → Customer Secret Keys → Secret Key' },

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -1665,7 +1665,9 @@ export const PROVIDERS: ProviderConfig[] = [
         category: 'webdav',
         icon: 'Cloud',
         color: '#0082C9',
-        stable: false, // Not tested yet
+        // Live-verified on two independent Nextcloud servers (self-hosted and
+        // Tab.digital): auto-detected DAV endpoint, quota, transfers, share links.
+        stable: true,
         fields: [
             {
                 ...COMMON_FIELDS.server,


### PR DESCRIPTION
## Why

Provider visibility flags had drifted from reality, and each drift was telling users something untrue.

**Oracle Cloud** showed the red "Experimental provider" banner, which says the service may be unavailable and that connections can fail through no fault of the user. The flag behind it, `ProviderConfig.stable`, means "not fully tested". Oracle arrived with the v1.5.0 provider batch and was never tested: when Alibaba OSS and Tencent COS were promoted in 5272f99c8, Oracle was left behind rather than found broken.

**Nextcloud** carried `stable: false, // Not tested yet` since the entry was written, so the GUI warned that Nextcloud "is not stable yet" while `ROADMAP.md` lists it among the supported presets. Both could not be true.

**Blomp** was promoted to production on 2026-07-28 in 798811bb7, with the registry recording `stable: true` and the live verification. The protocol grid never followed: it still wrapped Blomp in `import.meta.env.DEV` under a comment claiming it is "hidden in production until storage proxy 403 is resolved (stable: false in registry)", which the registry has contradicted since that release.

## Verification

Both promotions were tested against live accounts before the flag was flipped. Same battery, run end to end, with every test artifact removed afterwards.

| Operation | Oracle Cloud (eu-milan-1, S3 compat) | Nextcloud (self-hosted behind nginx) |
|---|---|---|
| connect | 398 ms | 934 ms, DAV endpoint auto-detected from the bare host |
| list, mkdir, stat | pass | pass |
| quota (`df`) | not supported, see below | pass, unmetered total via OCS |
| upload 64 KB | remote sha256 matches local | remote sha256 matches local |
| download roundtrip | byte identical | byte identical |
| rename, server-side copy | pass | pass |
| upload 32 MB | pass in 54 s, sha256 matches (multipart) | pass in 56 s, sha256 matches |
| public share link | not applicable | created, and 404 after the delete |
| recursive size scan | pass, `s3-list-recursive` | not applicable |
| delete, recursive delete | pass | pass |

Oracle's `df` returns `Operation not supported: storage_info`, which is normal for S3 backends with no quota API and is exactly what the manual "Total storage" field exists for. It is not a reason to warn a user about the service.

Nextcloud listing was cross-checked against a second, independent Nextcloud (Tab.digital) to separate server quirks from client behaviour. The self-hosted box exposes a phantom `remote.php` collection at every path depth, which is an nginx rewrite on that server: the second Nextcloud lists clean.

Local gate on the branch: `tsc --noEmit` clean, `vitest run` 80 files and 718 tests passing, re-run after each commit.

## Still flagged

DigitalOcean Spaces and S3Drive keep `stable: false`. They are untested, not known broken, and promoting them without a live run would repeat the mistake this series fixes.

## Not in this PR

The banner copy itself deserves a rewrite. It reads "{provider} is not stable yet and the service may be unavailable", which blames the third party, while the flag only records that we have not verified it. That is a copy change across every locale and belongs in its own PR.
