### PR TITLE
test(thumbnails): anchor the #347 pin on the element it is about

### DIFF
--- a/src/components/common/ConfirmOverlay.tsx
+++ b/src/components/common/ConfirmOverlay.tsx
@@ -51,7 +51,14 @@ export const ConfirmOverlay: React.FC<ConfirmOverlayProps> = ({
     // pull focus back to Cancel each time. That is reachable: CloudPanel
     // re-renders on Tauri cloud events, which can fire while the question is up.
     const onCancelRef = React.useRef(onCancel);
-    onCancelRef.current = onCancel;
+    // Written in an effect, not during render. Rendering must be pure: React may
+    // render a component without committing it, and under StrictMode does so
+    // deliberately, so a render-time write can publish a callback belonging to a
+    // tree that was thrown away. An effect with no dependency array runs after
+    // every commit, which keeps it just as current.
+    React.useEffect(() => {
+        onCancelRef.current = onCancel;
+    });
 
     const boxRef = React.useRef<HTMLDivElement>(null);
 

--- a/src/components/remoteThumbnails.test.ts
+++ b/src/components/remoteThumbnails.test.ts
@@ -6,38 +6,54 @@ import grid from './LargeIconsGrid.tsx?raw';
 import appRaw from '../App.tsx?raw';
 import providerThumb from './ProviderThumbnail.tsx?raw';
 import imageThumb from './ImageThumbnail.tsx?raw';
+import { jsxTagContaining, jsxTags, withoutComments } from '../utils/jsxTag';
 
 /**
  * Large Icons over a cloud drive could not show a picture at all.
  *
  * `LargeIconsGrid` renders both panels, but passed `isRemote={false}` to every
- * thumbnail regardless — the value was written into the component, not taken
+ * thumbnail regardless: the value was written into the component, not taken
  * from a prop, and the component had no such prop to take. On the remote panel
  * each preview therefore asked the *local* filesystem for a remote path, failed,
  * and fell back to a generic icon. Reported on discussion #347.
+ *
+ * The first version of this file was reviewed after it had already merged, and
+ * four of its assertions were shown to check less than their names claimed: they
+ * anchored on a character window rather than on an element, asserted that a
+ * declaration existed rather than that it was used, and scanned one file while
+ * saying "every call site". Each is now anchored on the element it is about, and
+ * each was re-verified by breaking the property and watching it fail.
  */
 describe('remote panel thumbnails (#347)', () => {
-    /** Source with comments removed: a doc comment naming the old bug is not the
-     *  old bug, and an assertion that cannot tell them apart is worthless. */
-    const code = (source: string): string =>
-        source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+    const appCode = withoutComments(appRaw);
+    const gridCode = withoutComments(grid);
 
     it('takes isRemote from a prop instead of deciding it', () => {
-        expect(code(grid)).not.toMatch(/isRemote=\{false\}/);
+        expect(gridCode).not.toMatch(/isRemote=\{false\}/);
         expect(grid).toMatch(/isRemote\?: boolean/);
         expect(grid).toMatch(/isRemote=\{isRemote\}/);
     });
 
-    it('tells the grid it is the remote panel where it is', () => {
-        const mount = appRaw.slice(appRaw.indexOf('<LargeIconsGrid'));
-        const remoteMount = mount.slice(0, mount.indexOf('files={sortedRemoteFiles') + 200);
-        expect(remoteMount, 'the remote Large Icons grid').toMatch(/\bisRemote\b/);
+    it('puts the flag on the grid element that renders the remote panel', () => {
+        // Anchored on the element carrying `files={sortedRemoteFiles}`, not on a
+        // window around it. The window version passed on the *prose* of the
+        // comment above the tag, and would have passed on a sibling grid's
+        // `isRemote={false}` had the two mounts ever been reordered.
+        const tag = jsxTagContaining(appCode, 'LargeIconsGrid', 'files={sortedRemoteFiles');
+        expect(tag, 'the grid element that renders sortedRemoteFiles').toBeTruthy();
+        expect(tag!, 'the remote grid must claim to be remote').toMatch(
+            /\bisRemote(?:\s*=\s*\{true\})?[\s/>]/,
+        );
+        expect(tag!, 'and must not claim the opposite').not.toMatch(/isRemote\s*=\s*\{false\}/);
     });
 
-    it('uses the path the backend listed rather than rebuilding one', () => {
-        // Rejoining `currentPath` with a forward slash was merely usually right,
-        // and on Windows produced a mixed-separator path.
-        expect(grid).toMatch(/const imagePath = file\.path\s*\n?\s*\|\|/);
+    it('hands the thumbnail the path the backend listed, not one it rebuilt', () => {
+        // Asserting the declaration alone let the component keep passing a
+        // rebuilt path to the thumbnail while the variable sat unused.
+        expect(gridCode).toMatch(/const imagePath = file\.path\s*\n?\s*\|\|/);
+        const tag = jsxTagContaining(gridCode, 'ImageThumbnail', 'fallbackIcon');
+        expect(tag, 'the thumbnail element in LargeIconsGrid').toBeTruthy();
+        expect(tag!, 'it must be given imagePath').toMatch(/path=\{imagePath\}/);
     });
 
     it('falls back to reading the file when a provider thumbnail fails', () => {
@@ -45,15 +61,23 @@ describe('remote panel thumbnails (#347)', () => {
         // Ending at a document icon made a whole Icons view look preview-less.
         expect(providerThumb).toMatch(/fallback\?: React\.ReactNode/);
         expect(providerThumb).toMatch(/if \(fallback\) return/);
-        const mount = appRaw.slice(appRaw.indexOf('<ProviderThumbnail'));
-        expect(mount.slice(0, 900)).toMatch(/fallback=\{[\s\S]*<ImageThumbnail/);
+        const tag = jsxTagContaining(appCode, 'ProviderThumbnail', 'fallback=');
+        expect(tag, 'the provider thumbnail element').toBeTruthy();
+        expect(tag!).toMatch(/fallback=\{[\s\S]*<ImageThumbnail/);
     });
 
-    it('caches through the shared cache, and only with a signature', () => {
+    it('routes both components through the shared cache, keyed with the signature', () => {
+        // What this can check is the wiring: that neither component builds a key
+        // of its own and so bypasses the gate. That the gate itself holds, no
+        // signature meaning no cache entry, is a behaviour and is pinned as one
+        // in `thumbnailCache.test.ts` ("refuses to cache anything it cannot tell
+        // apart in time"), against the real module rather than against its text.
         for (const [name, source] of [['ImageThumbnail', imageThumb], ['ProviderThumbnail', providerThumb]] as const) {
             expect(source, name).toMatch(/from '\.\.\/utils\/thumbnailCache'/);
-            expect(source, name).toMatch(/keyFor\(/);
-            expect(source, name).toMatch(/putThumbnail\(/);
+            expect(withoutComments(source), `${name} must key through keyFor, with the signature`)
+                .toMatch(/keyFor\([^;]*\bsignature\b[^;]*\)/);
+            expect(withoutComments(source), `${name} must not assemble a key itself`)
+                .not.toMatch(/const cacheKey\s*=\s*[`'"]/);
         }
         // The old private Map is gone, so there is one budget rather than two.
         expect(providerThumb).not.toMatch(/new Map<string, string>\(\)/);
@@ -66,13 +90,31 @@ describe('remote panel thumbnails (#347)', () => {
         expect(imageThumb).not.toMatch(/^\s*loadImage\(\);\s*$/m);
     });
 
-    it('passes a signature at every call site that renders a file thumbnail', () => {
-        // A call site that forgets it silently opts out of the cache, which is
-        // the bug this replaces in a quieter form.
-        const sites = [...appRaw.matchAll(/<(?:Image|Provider)Thumbnail[\s\S]{0,700}?\/>/g)].map((m) => m[0]);
-        expect(sites.length, 'thumbnail mounts in App.tsx').toBeGreaterThanOrEqual(2);
-        for (const site of sites) {
-            expect(site, site.slice(0, 60)).toMatch(/signature=\{signatureOf\(/);
+    it('passes a signature at every production thumbnail mount, in every file', () => {
+        // The first version scanned `App.tsx` alone while its name said "every
+        // call site". Three of the five mounts live elsewhere, one of them in
+        // `LargeIconsGrid.tsx`, which is the file this very change edited: a
+        // signature dropped there would have been invisible to it.
+        const modules = import.meta.glob('../**/*.tsx', {
+            query: '?raw',
+            import: 'default',
+            eager: true,
+        }) as Record<string, string>;
+
+        const mounts: { where: string; tag: string }[] = [];
+        for (const [file, source] of Object.entries(modules)) {
+            if (file.includes('.test.')) continue;
+            const code = withoutComments(source);
+            for (const name of ['ImageThumbnail', 'ProviderThumbnail']) {
+                for (const tag of jsxTags(code, name)) {
+                    mounts.push({ where: `${file} <${name}>`, tag });
+                }
+            }
+        }
+        // A glob that matched nothing would make the loop below vacuously true.
+        expect(mounts.length, 'production thumbnail mounts found').toBeGreaterThanOrEqual(5);
+        for (const { where, tag } of mounts) {
+            expect(tag, `${where} silently opts out of the cache`).toMatch(/signature=\{/);
         }
     });
 });

--- a/src/utils/jsxTag.test.ts
+++ b/src/utils/jsxTag.test.ts
@@ -42,6 +42,35 @@ describe('withoutComments', () => {
         expect(withoutComments(odd)).toContain('still in the string');
     });
 
+    it('treats a template interpolation as the code it is', () => {
+        // `${...}` is not literal text: a comment in there is a real comment,
+        // and staying in template mode across it leaves the comment standing,
+        // which is the false positive a comment-stripping scan exists to stop.
+        const src = 'const a = `x ${ y /* drop me */ } z`; const after = 1;\n';
+        const out = withoutComments(src);
+        expect(out, 'the comment inside the interpolation').not.toContain('drop me');
+        expect(out, 'the literal text around it survives').toContain('x $');
+        expect(out).toContain('z`');
+        expect(out).toContain('const after = 1;');
+        expect(out.length).toBe(src.length);
+    });
+
+    it('does not let a brace inside an interpolation close it early', () => {
+        // An object literal or a block inside `${}` has braces of its own.
+        const src = 'const a = `${ f({ k: 1 }) } // not a comment`; const b = 2;\n';
+        const out = withoutComments(src);
+        expect(out, 'still inside the template after the object literal').toContain('// not a comment');
+        expect(out).toContain('const b = 2;');
+    });
+
+    it('handles a template nested inside an interpolation', () => {
+        const src = 'const a = `${ `inner ${ q } // deep` } // outer`; const c = 3;\n';
+        const out = withoutComments(src);
+        expect(out, 'both // are literal text, not comments').toContain('// deep');
+        expect(out).toContain('// outer');
+        expect(out).toContain('const c = 3;');
+    });
+
     it('blanks real comments of both kinds', () => {
         const src = 'a; /* block\nspanning */ b; // line\nc;';
         const out = withoutComments(src);

--- a/src/utils/jsxTag.test.ts
+++ b/src/utils/jsxTag.test.ts
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+import { describe, it, expect } from 'vitest';
+import { jsxTagAt, jsxTagContaining, jsxTags, withoutComments } from './jsxTag';
+
+/**
+ * The helper several source-scanning pins now depend on, so its own failure mode
+ * is a false green in all of them.
+ */
+describe('withoutComments', () => {
+    it('preserves every offset, so line numbers and indices still line up', () => {
+        const src = 'const a = 1; // note\nconst b = 2;\n';
+        const out = withoutComments(src);
+        expect(out.length).toBe(src.length);
+        expect(out.split('\n').length).toBe(src.split('\n').length);
+        expect(out).toContain('const b = 2;');
+        expect(out).not.toContain('note');
+    });
+
+    it('leaves comment delimiters that are inside a string literal alone', () => {
+        // A regex hunting for `//` finds it here and blanks the rest of the line,
+        // deleting the very code an assertion was about.
+        const src = `const u = "https://x/y"; const keep = 1;\nconst s = 'a // b'; const also = 2;\nconst t = \`x /* y \`; const third = 3;\n`;
+        const out = withoutComments(src);
+        expect(out, 'code after a URL').toContain('const keep = 1;');
+        expect(out, 'code after a // inside a single-quoted string').toContain('const also = 2;');
+        expect(out, 'code after a /* inside a template').toContain('const third = 3;');
+        expect(out, 'the literals themselves are not comments').toContain('https://x/y');
+    });
+
+    it('ends a literal on an even backslash run and not on an odd one', () => {
+        // `"C:\\"` closes: the two backslashes escape each other. Reading only the
+        // previous character says it is escaped and swallows the rest of the file.
+        const even = 'const p = "C:\\\\"; // gone\nconst after = 1;\n';
+        expect(withoutComments(even)).toContain('const after = 1;');
+        expect(withoutComments(even)).not.toContain('gone');
+
+        // `"\\"" ` does not close on the escaped quote.
+        const odd = 'const q = "a\\"// still in the string"; const tail = 2;\n';
+        expect(withoutComments(odd)).toContain('const tail = 2;');
+        expect(withoutComments(odd)).toContain('still in the string');
+    });
+
+    it('blanks real comments of both kinds', () => {
+        const src = 'a; /* block\nspanning */ b; // line\nc;';
+        const out = withoutComments(src);
+        expect(out).not.toContain('block');
+        expect(out).not.toContain('spanning');
+        expect(out).not.toContain('line');
+        expect(out).toContain('a;');
+        expect(out).toContain('b;');
+        expect(out).toContain('c;');
+    });
+});
+
+describe('jsxTagAt / jsxTagContaining', () => {
+    const nested = `
+        <ProviderThumbnail
+          path={file.path}
+          signature={signatureOf(file.size, file.modified)}
+          fallback={
+            <ImageThumbnail path={other} signature={sigB} />
+          }
+          cacheScope={scope}
+        />
+    `;
+
+    it('does not let a nested element end the tag that contains it', () => {
+        // `<Name[\\s\\S]*?/>` stops at the inner element's `/>`, which returns the
+        // outer tag's name carrying the inner tag's props.
+        const tag = jsxTagAt(nested, nested.indexOf('<ProviderThumbnail'))!;
+        expect(tag).toContain('fallback=');
+        expect(tag.endsWith('/>')).toBe(true);
+        expect(tag).toContain('<ImageThumbnail');
+        expect(tag, "the outer tag's own last prop").toContain('cacheScope={scope}');
+        // The naive match ends at the *inner* element's `/>`: it swallows the
+        // inner props and never reaches the outer tag's own, so an assertion
+        // about either element is answered by the other.
+        const naive = nested.match(/<ProviderThumbnail[\s\S]*?\/>/)![0];
+        expect(naive.length, 'the naive match stops early').toBeLessThan(tag.length);
+        expect(naive, 'and never sees the outer tag reach its end').not.toContain('cacheScope={scope}');
+    });
+
+    it('finds both elements separately', () => {
+        expect(jsxTags(nested, 'ProviderThumbnail')).toHaveLength(1);
+        expect(jsxTags(nested, 'ImageThumbnail')).toHaveLength(1);
+    });
+
+    it('does not match an element whose name merely starts the same', () => {
+        const src = '<Thumb a={1} /><ThumbList b={2} />';
+        expect(jsxTags(src, 'Thumb')).toHaveLength(1);
+        expect(jsxTags(src, 'Thumb')[0]).toContain('a={1}');
+    });
+
+    it('returns the element that owns the needle, not the one nearest to it', () => {
+        const two = `
+            <Grid files={local} isRemote={false} />
+            <Grid files={remote} isRemote />
+        `;
+        const tag = jsxTagContaining(two, 'Grid', 'files={remote}')!;
+        expect(tag).toContain('isRemote ');
+        expect(tag, 'the sibling flag must not leak in').not.toContain('isRemote={false}');
+    });
+
+    it('is not fooled by a > inside a prop expression', () => {
+        const src = '<Row render={(a) => a > 1} label="x" />';
+        const tag = jsxTagAt(src, 0)!;
+        expect(tag).toContain('label="x"');
+        expect(tag.endsWith('/>')).toBe(true);
+    });
+
+    it('returns null for a tag that never closes', () => {
+        expect(jsxTagAt('<Broken prop={', 0)).toBeNull();
+        expect(jsxTagContaining('<Grid files={x} />', 'Grid', 'nope')).toBeNull();
+    });
+});

--- a/src/utils/jsxTag.ts
+++ b/src/utils/jsxTag.ts
@@ -17,27 +17,110 @@
  *   element's, so the match is the outer tag's name attached to the inner tag's
  *   props, and an assertion about either one is answered by the other.
  *
- * These read the element's own span with one lexer, tracking string and template
- * literals as well as brace depth, so neither a nested element inside a prop nor
- * a delimiter inside a literal can end the tag that contains it.
+ * Everything here reads one classification of the source, produced once by
+ * `classify`, rather than each function doing its own approximate scan. Three
+ * flaws have already been found at this level, each of which would have made a
+ * pin pass for the wrong reason, so the lexing lives in one place with its own
+ * tests.
  */
 
-/** Where the scanner is: ordinary code, inside a literal, or inside a comment. */
-type Mode = 'code' | 'line-comment' | 'block-comment' | '"' | "'" | '`';
+/** What the character at an index belongs to. */
+export const enum Ctx {
+    /** Syntax: identifiers, punctuation, and the `${` and `}` of an interpolation. */
+    Code = 0,
+    /** Inside a `//` or a block comment, including its delimiters. */
+    Comment = 1,
+    /** The body of a string or template literal, including its quotes. */
+    Literal = 2,
+}
 
-/**
- * True when the character at `i` is escaped, i.e. preceded by an odd number of
- * backslashes.
- *
- * `source[i - 1] !== '\\'` is the tempting version and it is wrong on an even
- * run: in `"C:\\"` the final quote closes the string, because the two
- * backslashes escape each other. This codebase is full of Windows paths, so that
- * is not a hypothetical.
- */
+/** True when the character at `i` is escaped: preceded by an odd backslash run. */
 function isEscaped(source: string, i: number): boolean {
     let run = 0;
     for (let k = i - 1; k >= 0 && source[k] === '\\'; k--) run++;
     return run % 2 === 1;
+}
+
+/**
+ * Classify every character of the source once.
+ *
+ * A template literal is not one flat region: `` `a ${ b // c\n } d` `` contains
+ * real code between `${` and its matching `}`, and a comment inside it is a real
+ * comment. Staying in literal mode across an interpolation leaves that comment in
+ * the text, which is the false positive a comment-stripping scan exists to
+ * prevent. So the state is a stack: a template can hold an interpolation, and an
+ * interpolation can hold another template, to any depth.
+ */
+export function classify(source: string): Uint8Array {
+    const out = new Uint8Array(source.length);
+    // Each frame is either a template literal, or the code inside a `${}` with
+    // the brace depth reached so far, so that object literals and blocks inside
+    // the interpolation do not close it early.
+    const stack: ({ kind: 'template' } | { kind: 'interp'; depth: number })[] = [];
+    let mode: 'code' | 'line' | 'block' | '"' | "'" | 'template' = 'code';
+
+    for (let i = 0; i < source.length; i++) {
+        const c = source[i];
+        const next = source[i + 1];
+
+        switch (mode) {
+            case 'line':
+                out[i] = Ctx.Comment;
+                if (c === '\n') { out[i] = Ctx.Code; mode = 'code'; }
+                continue;
+            case 'block':
+                out[i] = Ctx.Comment;
+                if (c === '*' && next === '/') { out[i + 1] = Ctx.Comment; i++; mode = 'code'; }
+                continue;
+            case '"':
+            case "'":
+                out[i] = Ctx.Literal;
+                if (c === mode && !isEscaped(source, i)) mode = 'code';
+                continue;
+            case 'template':
+                if (c === '$' && next === '{' && !isEscaped(source, i)) {
+                    out[i] = Ctx.Literal;      // the `$` is still template text
+                    out[i + 1] = Ctx.Code;     // the `{` opens real code
+                    i++;
+                    stack.push({ kind: 'template' });
+                    stack.push({ kind: 'interp', depth: 0 });
+                    mode = 'code';
+                    continue;
+                }
+                out[i] = Ctx.Literal;
+                if (c === '`' && !isEscaped(source, i)) {
+                    // Closing this template. If it was opened inside an
+                    // interpolation, that interpolation is still running.
+                    const outer = stack[stack.length - 1];
+                    mode = outer && outer.kind === 'interp' ? 'code' : 'code';
+                }
+                continue;
+            default: {
+                const top = stack[stack.length - 1];
+                if (c === '/' && next === '/') { mode = 'line'; out[i] = Ctx.Comment; continue; }
+                if (c === '/' && next === '*') { mode = 'block'; out[i] = Ctx.Comment; continue; }
+                if (c === '"' || c === "'") { out[i] = Ctx.Literal; mode = c; continue; }
+                if (c === '`') { out[i] = Ctx.Literal; mode = 'template'; continue; }
+                if (top && top.kind === 'interp') {
+                    if (c === '{') top.depth++;
+                    else if (c === '}') {
+                        if (top.depth === 0) {
+                            // Closes the interpolation: back into the template
+                            // that opened it.
+                            stack.pop();
+                            const tpl = stack.pop();
+                            out[i] = Ctx.Code;
+                            mode = tpl ? 'template' : 'code';
+                            continue;
+                        }
+                        top.depth--;
+                    }
+                }
+                out[i] = Ctx.Code;
+            }
+        }
+    }
+    return out;
 }
 
 /**
@@ -50,29 +133,10 @@ function isEscaped(source: string, i: number): boolean {
  * the others.
  */
 export function withoutComments(source: string): string {
+    const ctx = classify(source);
     const out = source.split('');
-    let mode: Mode = 'code';
     for (let i = 0; i < source.length; i++) {
-        const c = source[i];
-        const next = source[i + 1];
-        switch (mode) {
-            case 'code':
-                if (c === '/' && next === '/') { mode = 'line-comment'; out[i] = ' '; }
-                else if (c === '/' && next === '*') { mode = 'block-comment'; out[i] = ' '; }
-                else if (c === '"' || c === "'" || c === '`') mode = c;
-                break;
-            case 'line-comment':
-                if (c === '\n') mode = 'code';
-                else out[i] = ' ';
-                break;
-            case 'block-comment':
-                if (c === '*' && next === '/') { out[i] = ' '; out[i + 1] = ' '; i++; mode = 'code'; }
-                else if (c !== '\n') out[i] = ' ';
-                break;
-            default:
-                if (c === mode && !isEscaped(source, i)) mode = 'code';
-                break;
-        }
+        if (ctx[i] === Ctx.Comment && source[i] !== '\n') out[i] = ' ';
     }
     return out.join('');
 }
@@ -83,16 +147,11 @@ export function withoutComments(source: string): string {
  * Returns null when the tag never closes, which is a malformed input rather than
  * a passing test.
  */
-export function jsxTagAt(source: string, at: number): string | null {
+export function jsxTagAt(source: string, at: number, ctx = classify(source)): string | null {
     let depth = 0;
-    let quote: '"' | "'" | '`' | null = null;
     for (let i = at; i < source.length; i++) {
+        if (ctx[i] !== Ctx.Code) continue;
         const c = source[i];
-        if (quote) {
-            if (c === quote && !isEscaped(source, i)) quote = null;
-            continue;
-        }
-        if (c === '"' || c === "'" || c === '`') { quote = c; continue; }
         if (c === '{') { depth++; continue; }
         if (c === '}') { depth--; continue; }
         // Only a `>` outside every prop expression closes this tag. Inside one,
@@ -105,10 +164,13 @@ export function jsxTagAt(source: string, at: number): string | null {
 /** Every `<Name …>` tag in the source, in order. Comments are not stripped here:
  *  the caller decides, since some assertions are about comments. */
 export function jsxTags(source: string, name: string): string[] {
+    const ctx = classify(source);
     const out: string[] = [];
     const open = new RegExp(`<${name}(?![A-Za-z0-9_])`, 'g');
     for (const m of source.matchAll(open)) {
-        const tag = jsxTagAt(source, m.index ?? 0);
+        const start = m.index ?? 0;
+        if (ctx[start] !== Ctx.Code) continue;
+        const tag = jsxTagAt(source, start, ctx);
         if (tag) out.push(tag);
     }
     return out;
@@ -123,12 +185,14 @@ export function jsxTags(source: string, name: string): string[] {
 export function jsxTagContaining(source: string, name: string, needle: string): string | null {
     const idx = source.indexOf(needle);
     if (idx === -1) return null;
+    const ctx = classify(source);
     const open = new RegExp(`<${name}(?![A-Za-z0-9_])`, 'g');
     let found: string | null = null;
     for (const m of source.matchAll(open)) {
         const start = m.index ?? 0;
         if (start > idx) break;
-        const tag = jsxTagAt(source, start);
+        if (ctx[start] !== Ctx.Code) continue;
+        const tag = jsxTagAt(source, start, ctx);
         if (tag && start + tag.length > idx) found = tag;
     }
     return found;

--- a/src/utils/jsxTag.ts
+++ b/src/utils/jsxTag.ts
@@ -17,15 +17,64 @@
  *   element's, so the match is the outer tag's name attached to the inner tag's
  *   props, and an assertion about either one is answered by the other.
  *
- * These read the element's own span, tracking brace depth and string literals, so
- * a nested element inside a prop cannot end the tag that contains it.
+ * These read the element's own span with one lexer, tracking string and template
+ * literals as well as brace depth, so neither a nested element inside a prop nor
+ * a delimiter inside a literal can end the tag that contains it.
  */
 
-/** Blank comment bodies, keeping every offset so indices still line up. */
+/** Where the scanner is: ordinary code, inside a literal, or inside a comment. */
+type Mode = 'code' | 'line-comment' | 'block-comment' | '"' | "'" | '`';
+
+/**
+ * True when the character at `i` is escaped, i.e. preceded by an odd number of
+ * backslashes.
+ *
+ * `source[i - 1] !== '\\'` is the tempting version and it is wrong on an even
+ * run: in `"C:\\"` the final quote closes the string, because the two
+ * backslashes escape each other. This codebase is full of Windows paths, so that
+ * is not a hypothetical.
+ */
+function isEscaped(source: string, i: number): boolean {
+    let run = 0;
+    for (let k = i - 1; k >= 0 && source[k] === '\\'; k--) run++;
+    return run % 2 === 1;
+}
+
+/**
+ * Blank out comment bodies, keeping every offset so indices still line up.
+ *
+ * String-aware on purpose: a regex that hunts for `//` finds it inside
+ * `'https://…'` and inside any literal that happens to contain one, and then
+ * blanks the rest of the line, silently deleting the code an assertion was about.
+ * Guarding the URL case alone (`[^:]//`) covers the common example and none of
+ * the others.
+ */
 export function withoutComments(source: string): string {
-    return source
-        .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))
-        .replace(/(^|[^:])\/\/[^\n]*/g, (m, lead) => lead + ' '.repeat(m.length - lead.length));
+    const out = source.split('');
+    let mode: Mode = 'code';
+    for (let i = 0; i < source.length; i++) {
+        const c = source[i];
+        const next = source[i + 1];
+        switch (mode) {
+            case 'code':
+                if (c === '/' && next === '/') { mode = 'line-comment'; out[i] = ' '; }
+                else if (c === '/' && next === '*') { mode = 'block-comment'; out[i] = ' '; }
+                else if (c === '"' || c === "'" || c === '`') mode = c;
+                break;
+            case 'line-comment':
+                if (c === '\n') mode = 'code';
+                else out[i] = ' ';
+                break;
+            case 'block-comment':
+                if (c === '*' && next === '/') { out[i] = ' '; out[i + 1] = ' '; i++; mode = 'code'; }
+                else if (c !== '\n') out[i] = ' ';
+                break;
+            default:
+                if (c === mode && !isEscaped(source, i)) mode = 'code';
+                break;
+        }
+    }
+    return out.join('');
 }
 
 /**
@@ -36,11 +85,11 @@ export function withoutComments(source: string): string {
  */
 export function jsxTagAt(source: string, at: number): string | null {
     let depth = 0;
-    let quote: string | null = null;
+    let quote: '"' | "'" | '`' | null = null;
     for (let i = at; i < source.length; i++) {
         const c = source[i];
         if (quote) {
-            if (c === quote && source[i - 1] !== '\\') quote = null;
+            if (c === quote && !isEscaped(source, i)) quote = null;
             continue;
         }
         if (c === '"' || c === "'" || c === '`') { quote = c; continue; }

--- a/src/utils/jsxTag.ts
+++ b/src/utils/jsxTag.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+/**
+ * Reading one JSX element out of source text, for the tests that scan source.
+ *
+ * The repo pins several invariants by scanning the source rather than by
+ * rendering, because vitest runs on `environment: node` with no DOM harness. That
+ * works only if the scan reads *the element it means*. Two ways of faking it have
+ * already produced tests that passed while checking nothing:
+ *
+ * - a window of N characters or lines around an anchor, which reaches into the
+ *   neighbouring element, so a prop belonging to a sibling is read as this one's
+ *   (`modalLayerSweep.test.ts` carries the same warning about `className`);
+ * - a non-greedy `<Name[\s\S]*?/>`, which stops at the *first* `/>` in range. On
+ *   `<ProviderThumbnail … fallback={<ImageThumbnail … />} />` that is the inner
+ *   element's, so the match is the outer tag's name attached to the inner tag's
+ *   props, and an assertion about either one is answered by the other.
+ *
+ * These read the element's own span, tracking brace depth and string literals, so
+ * a nested element inside a prop cannot end the tag that contains it.
+ */
+
+/** Blank comment bodies, keeping every offset so indices still line up. */
+export function withoutComments(source: string): string {
+    return source
+        .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))
+        .replace(/(^|[^:])\/\/[^\n]*/g, (m, lead) => lead + ' '.repeat(m.length - lead.length));
+}
+
+/**
+ * The full text of the JSX tag opening at `at`, up to and including its own `>`.
+ *
+ * Returns null when the tag never closes, which is a malformed input rather than
+ * a passing test.
+ */
+export function jsxTagAt(source: string, at: number): string | null {
+    let depth = 0;
+    let quote: string | null = null;
+    for (let i = at; i < source.length; i++) {
+        const c = source[i];
+        if (quote) {
+            if (c === quote && source[i - 1] !== '\\') quote = null;
+            continue;
+        }
+        if (c === '"' || c === "'" || c === '`') { quote = c; continue; }
+        if (c === '{') { depth++; continue; }
+        if (c === '}') { depth--; continue; }
+        // Only a `>` outside every prop expression closes this tag. Inside one,
+        // it belongs to a nested element or to an arrow function.
+        if (c === '>' && depth === 0) return source.slice(at, i + 1);
+    }
+    return null;
+}
+
+/** Every `<Name …>` tag in the source, in order. Comments are not stripped here:
+ *  the caller decides, since some assertions are about comments. */
+export function jsxTags(source: string, name: string): string[] {
+    const out: string[] = [];
+    const open = new RegExp(`<${name}(?![A-Za-z0-9_])`, 'g');
+    for (const m of source.matchAll(open)) {
+        const tag = jsxTagAt(source, m.index ?? 0);
+        if (tag) out.push(tag);
+    }
+    return out;
+}
+
+/**
+ * The `<Name …>` tag whose own span contains `needle`.
+ *
+ * This is the anchor that a character window gets wrong: it answers "which
+ * element carries this prop", not "what text sits near it".
+ */
+export function jsxTagContaining(source: string, name: string, needle: string): string | null {
+    const idx = source.indexOf(needle);
+    if (idx === -1) return null;
+    const open = new RegExp(`<${name}(?![A-Za-z0-9_])`, 'g');
+    let found: string | null = null;
+    for (const m of source.matchAll(open)) {
+        const start = m.index ?? 0;
+        if (start > idx) break;
+        const tag = jsxTagAt(source, start);
+        if (tag && start + tag.length > idx) found = tag;
+    }
+    return found;
+}

--- a/src/utils/noNativeDialogs.test.ts
+++ b/src/utils/noNativeDialogs.test.ts
@@ -87,6 +87,9 @@ describe('native browser dialogs', () => {
         // is reachable while a Tauri event storm re-renders the panel behind.
         const overlay = sources['../components/common/ConfirmOverlay.tsx'];
         expect(overlay).toMatch(/onCancelRef\.current\(\)/);
+        // And the ref is written from an effect, never during render: a render
+        // that React discards would otherwise publish its callback anyway.
+        expect(overlay).toMatch(/useEffect\(\(\) => \{\s*onCancelRef\.current = onCancel;\s*\}\);/);
         // Anchored on the effect's own closing dependency array rather than on a
         // fixed window: the effect grew when the focus trap landed, and a window
         // that no longer reached the end would have failed on a correct file.


### PR DESCRIPTION
Closes the review findings that arrived on [#544](https://github.com/axpdev-lab/aeroftp/pull/544) and [#546](https://github.com/axpdev-lab/aeroftp/pull/546) after those PRs had already merged. Four of the five are about the pin rather than the fix, which matters because the tracker cites that pin as the evidence.

## The four on #544 were right

Each assertion's name claimed more than the assertion checked.

| Assertion | What the name promises | What it actually checked |
|---|---|---|
| `tells the grid it is the remote panel` | the remote grid carries `isRemote` | a character window from the first `<LargeIconsGrid>` in `App.tsx` to 200 characters past the first `files={sortedRemoteFiles}`, with comments left in. The prose above the tag satisfied it; a sibling's `isRemote={false}` would have too, had the mounts ever been reordered |
| `uses the path the backend listed` | the thumbnail receives `imagePath` | that `imagePath` was **declared**. The component could keep passing a rebuilt path while the variable sat unused |
| `caches ... and only with a signature` | the cache calls are conditional on a signature | that the tokens `keyFor(` and `putThumbnail(` appear somewhere in the file |
| `at every call site that renders a file thumbnail` | every call site | `App.tsx` alone. Three of the five production mounts are elsewhere, one of them in `LargeIconsGrid.tsx`, the file #544 itself edited |

## What replaces them

All four are anchored on the element they are about, through a new `src/utils/jsxTag.ts` that reads a tag's own span by tracking brace depth and string literals.

Both cheap ways of faking that have already shipped bugs in this repo. A character window reaches into the neighbouring element, which is why `modalLayerSweep.test.ts` carries the same warning about `className`. And a non-greedy `<Name[\s\S]*?/>` stops at the **first** `/>` in range, so on `<ProviderThumbnail … fallback={<ImageThumbnail … />} />` it returns the outer tag's name attached to the inner tag's props, and an assertion about either one is answered by the other. That exact shape is live in `App.tsx`.

On the signature gate specifically: the behaviour, no signature meaning no cache entry, is already pinned as a behaviour in `thumbnailCache.test.ts` ("refuses to cache anything it cannot tell apart in time"), against the real module rather than against its text. Duplicating it here as another source scan would be worse, not better. What this file checks now is the wiring the behavioural test cannot see: that neither component assembles a key of its own and so walks around the gate.

## Verification

Every hardened assertion was re-verified by breaking the property in the source and watching that assertion, and only that one, go red:

| Mutation | Result |
|---|---|
| remote grid declares `isRemote={false}` | red: *the remote grid must claim to be remote* |
| thumbnail gets a rebuilt path instead of `imagePath` | red: *it must be given imagePath* |
| `keyFor` loses its `signature` argument | red: *must key through keyFor, with the signature* |
| the `LargeIconsGrid` mount drops `signature=` | red: *LargeIconsGrid.tsx `<ImageThumbnail>` silently opts out of the cache* |

The last one is the one worth reading twice. With that same mutation applied, the **previous** version of the file reported `Tests 7 passed (7)` and exit code 0.

## Also, from the #546 review

`onCancelRef.current = onCancel` moved out of render and into an effect. Rendering must be pure: React may render a tree and then discard it, deliberately so under StrictMode, and a render-time write can publish a callback belonging to a tree that was thrown away. Pinned in `noNativeDialogs.test.ts`, verified failing with the write put back in render.

The two findings on [#543](https://github.com/axpdev-lab/aeroftp/pull/543) were already applied in `cca8cd7` before that PR merged; they were simply never answered on the comments, which is done now.

## Verified

`tsc --noEmit`, vitest 82 files / 729 tests, `i18n:validate` 46/46 clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation handling in confirmation overlays so the latest callback is used safely after updates.

* **Tests**
  * Expanded coverage for remote thumbnail rendering, provider fallbacks, cache behavior, and required thumbnail configuration.
  * Added validation for confirmation overlay behavior and prevention of native browser dialogs.
  * Strengthened JSX source inspection coverage to improve reliability of interface validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->