### PR TITLE
docs(release): gate the AUR push on a preflight that would have caught v3.5.2

### DIFF
--- a/.github/scripts/aur-preflight.sh
+++ b/.github/scripts/aur-preflight.sh
@@ -8,8 +8,11 @@
 #
 # Install it as the pre-push hook of that checkout so it cannot be forgotten:
 #
-#     ln -sf /path/to/aeroftp/.github/scripts/aur-preflight.sh \
-#            /path/to/aeroftp-bin/.git/hooks/pre-push
+#     ln -s /path/to/aeroftp/.github/scripts/aur-preflight.sh \
+#           /path/to/aeroftp-bin/.git/hooks/pre-push
+#
+# (`ln -s`, not `ln -sf`: refuse rather than silently replace a hook that is
+# already there and may be doing something else.)
 #
 # Why this exists: v3.5.2 was pushed with the sha256sums array closed after its
 # first element. The PKGBUILD could not be sourced at all, so makepkg died before
@@ -19,10 +22,11 @@
 #
 # Checks, in order:
 #   1. PKGBUILD parses as bash
-#   2. .SRCINFO agrees with PKGBUILD (regenerated diff on Arch, field compare off it)
-#   3. sha256sums[0] is a real digest, not SKIP or a leftover placeholder
+#   2. .SRCINFO agrees with PKGBUILD, value by value, sources and checksums
+#      included (regenerated diff on Arch, expanded compare off it)
+#   3. sha256sums[0] is a full 64 hex digest, not SKIP and not a placeholder
 #   4. no source line carries a version other than pkgver
-#   5. both release URLs resolve (skip with --offline)
+#   5. every release URL resolves (skip deliberately with --offline)
 #
 set -uo pipefail
 
@@ -31,6 +35,7 @@ repo=""
 for arg in "$@"; do
     case "$arg" in
         --offline) offline=1 ;;
+        -h|--help) sed -n '3,29p' "$0" | sed 's/^# \?//'; exit 0 ;;
         *) repo="$arg" ;;
     esac
 done
@@ -46,26 +51,43 @@ fi
 
 fail=0
 note() { echo "aur-preflight: $*" >&2; fail=1; }
-tmp=$(mktemp -d)
-trap 'rm -rf "$tmp"' EXIT
+
+# mktemp can fail (full or read-only TMPDIR). Bail out rather than carry an empty
+# path into the trap below.
+tmp=$(mktemp -d) || { echo "aur-preflight: cannot create a temporary directory" >&2; exit 2; }
+trap 'rm -rf -- "$tmp"' EXIT
 
 # 1. The PKGBUILD must parse. This is the v3.5.2 check.
 if ! bash -n PKGBUILD 2>"$tmp/syntax"; then
     note "PKGBUILD is not sourceable, makepkg would abort before downloading anything"
     sed 's/^/    /' "$tmp/syntax" >&2
-    # Everything below reads fields out of the PKGBUILD, so stop here.
+    # Every check below reads fields out of the PKGBUILD, so stop here.
     echo "aur-preflight: FAILED" >&2
     exit 1
 fi
 
-field() { sed -n "s/^$1=//p" PKGBUILD | head -1 | sed "s/^[\"']//;s/[\"']$//"; }
-srcfield() { sed -n "s/^[[:space:]]*$1 = //p" .SRCINFO | head -1; }
+# Read the PKGBUILD the way makepkg does, in a subshell, so that ${pkgver} inside
+# a source URL is compared expanded rather than as source text. Only top-level
+# assignments run; prepare()/package() are defined, never called.
+if ! bash --noprofile --norc -c '
+        set -u
+        # shellcheck disable=SC1091
+        . ./PKGBUILD >/dev/null 2>&1 || exit 1
+        declare -p pkgname pkgver pkgrel pkgdesc source sha256sums 2>/dev/null
+    ' > "$tmp/vars" 2>/dev/null || [ ! -s "$tmp/vars" ]; then
+    note "PKGBUILD parses but does not evaluate, or declares none of pkgname/pkgver/source"
+    echo "aur-preflight: FAILED" >&2
+    exit 1
+fi
+# shellcheck disable=SC1090
+. "$tmp/vars"
 
-pkgver=$(field pkgver)
-[ -n "$pkgver" ] || note "PKGBUILD declares no pkgver"
+srcfield() { sed -n "s/^[[:space:]]*$1 = //p" .SRCINFO | head -1; }
+mapfile -t srcinfo_sources < <(sed -n 's/^[[:space:]]*source = //p' .SRCINFO)
+mapfile -t srcinfo_sums    < <(sed -n 's/^[[:space:]]*sha256sums = //p' .SRCINFO)
 
 # 2. .SRCINFO is what the AUR and every helper read. A PKGBUILD fix that never
-#    reached .SRCINFO ships the old package to users while looking fixed locally.
+#    reached it ships the old package to users while looking fixed locally.
 if command -v makepkg >/dev/null 2>&1; then
     if ! makepkg --printsrcinfo > "$tmp/srcinfo" 2>"$tmp/srcinfo.err"; then
         note "makepkg --printsrcinfo failed"
@@ -75,46 +97,84 @@ if command -v makepkg >/dev/null 2>&1; then
         diff -u .SRCINFO "$tmp/srcinfo" | sed 's/^/    /' >&2
     fi
 else
-    # Off Arch (.SRCINFO is hand-edited there), compare the fields that matter.
+    # Off Arch (.SRCINFO is hand-edited there) compare every value, not just the
+    # scalars: a checksum bumped in the PKGBUILD alone leaves users on the old
+    # digest, and equal entry counts hide it.
     for k in pkgname pkgver pkgrel pkgdesc; do
-        p=$(field "$k"); s=$(srcfield "$k")
+        p="${!k-}"; s=$(srcfield "$k")
         [ "$p" = "$s" ] || note "$k differs: PKGBUILD='$p' .SRCINFO='$s'"
     done
-    n_src=$(grep -c '^[[:space:]]*source = ' .SRCINFO)
-    n_sum=$(grep -c '^[[:space:]]*sha256sums = ' .SRCINFO)
-    [ "$n_src" -eq "$n_sum" ] || note ".SRCINFO has $n_src source lines but $n_sum sha256sums"
+    if [ "${#source[@]}" -ne "${#srcinfo_sources[@]}" ]; then
+        note "PKGBUILD has ${#source[@]} sources, .SRCINFO has ${#srcinfo_sources[@]}"
+    else
+        for i in "${!source[@]}"; do
+            [ "${source[$i]}" = "${srcinfo_sources[$i]}" ] || \
+                note "source[$i] differs:
+    PKGBUILD: ${source[$i]}
+    .SRCINFO: ${srcinfo_sources[$i]}"
+        done
+    fi
+    if [ "${#sha256sums[@]}" -ne "${#srcinfo_sums[@]}" ]; then
+        note "PKGBUILD has ${#sha256sums[@]} sha256sums, .SRCINFO has ${#srcinfo_sums[@]}"
+    else
+        for i in "${!sha256sums[@]}"; do
+            [ "${sha256sums[$i]}" = "${srcinfo_sums[$i]}" ] || \
+                note "sha256sums[$i] differs: PKGBUILD='${sha256sums[$i]}' .SRCINFO='${srcinfo_sums[$i]}'"
+        done
+    fi
 fi
+
+[ "${#source[@]}" -eq "${#sha256sums[@]}" ] || \
+    note "PKGBUILD has ${#source[@]} sources but ${#sha256sums[@]} sha256sums"
 
 # 3. A real digest on the payload. SKIP belongs to the Sigstore bundle only, which
 #    prepare() authenticates with cosign; SKIP on the .deb would pin nothing.
-first_sum=$(sed -n '/^[[:space:]]*sha256sums = /{s/^[[:space:]]*sha256sums = //p;q}' .SRCINFO)
-case "$first_sum" in
-    [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]*)
-        [ "${#first_sum}" -eq 64 ] || note "sha256sums[0] is ${#first_sum} chars, not 64: '$first_sum'" ;;
-    *) note "sha256sums[0] is '$first_sum', expected the .deb digest" ;;
-esac
+#    Match the whole value: a 64 char string with one stray character is not a
+#    digest, and makepkg would reject it after the user has downloaded 75 MB.
+first_sum="${sha256sums[0]-}"
+if [[ ! "$first_sum" =~ ^[0-9a-f]{64}$ ]]; then
+    note "sha256sums[0] is '${first_sum}', expected 64 lowercase hex characters (the .deb digest)"
+fi
 
-# 4. Both source lines in .SRCINFO are expanded, so a hand edit can leave one on
-#    the previous release: the package would then build the old .deb, or fail the
-#    hash, depending on which line was missed.
-while IFS= read -r line; do
-    case "$line" in
+# 4. Both source lines are expanded in .SRCINFO, so a hand edit can update one and
+#    miss the other, and a URL that hardcodes a version ignores the bump entirely.
+for s in "${source[@]}" "${srcinfo_sources[@]}"; do
+    case "$s" in
         *"$pkgver"*) ;;
-        *) note "source line does not carry pkgver $pkgver: ${line#*= }" ;;
+        *) note "source does not carry pkgver ${pkgver}: ${s}" ;;
     esac
-done < <(grep '^[[:space:]]*source = ' .SRCINFO)
+done
 
 # 5. A source that 404s fails the build for every user, and the release assets are
 #    named by the workflow, so a rename or a missing upload only shows up here.
-if [ "$offline" -eq 0 ] && command -v curl >/dev/null 2>&1; then
-    while IFS= read -r url; do
+# Filtered in bash rather than through sed/grep: this runs as a git hook, where a
+# missing tool must not silently produce an empty list and a green summary line.
+urls=()
+for s in "${source[@]}"; do
+    u="${s#*::}"   # drop the "renamed-file::" prefix when there is one
+    case "$u" in https://*|http://*) urls+=("$u") ;; esac
+done
+
+if [ "$offline" -eq 1 ]; then
+    echo "aur-preflight: --offline, not checking that the ${#urls[@]} sources resolve" >&2
+elif [ "${#urls[@]}" -eq 0 ]; then
+    note "no http(s) source to check, which is not what this package looks like"
+elif ! command -v curl >/dev/null 2>&1; then
+    # Fail closed: silently skipping would print a green line that means nothing.
+    note "curl is not available, cannot check that the sources resolve (pass --offline to accept that)"
+else
+    for url in "${urls[@]}"; do
         code=$(curl -sIL --retry 2 --max-time 25 -o /dev/null -w '%{http_code}' "$url" 2>/dev/null)
         [ "$code" = "200" ] || note "source does not resolve (HTTP ${code:-none}): $url"
-    done < <(sed -n 's/^[[:space:]]*source = //p' .SRCINFO | sed 's/^[^:]*:://' | grep '^https\?://')
+    done
 fi
 
 if [ "$fail" -ne 0 ]; then
     echo "aur-preflight: FAILED, refusing to publish a broken package" >&2
     exit 1
 fi
-echo "aur-preflight: PKGBUILD sourceable, .SRCINFO in sync, sources resolve"
+if [ "$offline" -eq 1 ]; then
+    echo "aur-preflight: PKGBUILD sourceable, .SRCINFO in sync, sources NOT checked (--offline)"
+else
+    echo "aur-preflight: PKGBUILD sourceable, .SRCINFO in sync, ${#urls[@]} sources resolve"
+fi

--- a/.github/scripts/aur-preflight.sh
+++ b/.github/scripts/aur-preflight.sh
@@ -52,6 +52,16 @@ fi
 fail=0
 note() { echo "aur-preflight: $*" >&2; fail=1; }
 
+# Name the missing tool rather than failing later with a message that sends the
+# reader into the PKGBUILD. curl is handled separately, further down, because
+# --offline is a legitimate way to do without it.
+for _tool in awk sed mktemp env; do
+    command -v "$_tool" >/dev/null 2>&1 || {
+        echo "aur-preflight: $_tool is required and not on PATH" >&2
+        exit 2
+    }
+done
+
 # mktemp can fail (full or read-only TMPDIR). Bail out rather than carry an empty
 # path into the trap below.
 tmp=$(mktemp -d) || { echo "aur-preflight: cannot create a temporary directory" >&2; exit 2; }
@@ -66,16 +76,37 @@ if ! bash -n PKGBUILD 2>"$tmp/syntax"; then
     exit 1
 fi
 
-# Read the PKGBUILD the way makepkg does, in a subshell, so that ${pkgver} inside
-# a source URL is compared expanded rather than as source text. Only top-level
-# assignments run; prepare()/package() are defined, never called.
-if ! bash --noprofile --norc -c '
+# ${pkgver} inside a source URL has to be compared expanded, not as source text,
+# so the values have to be evaluated rather than read with sed. Sourcing the whole
+# PKGBUILD would do it, and is what makepkg does at build time, but a preflight
+# script reads as "only checks" and must not run someone's package: a top level
+# `rm -rf ~` in a PKGBUILD you are inspecting would fire here. So slice out the
+# top level assignments first, functions and commands left behind, and evaluate
+# only those, in a subshell with an empty environment.
+awk '
+    # Continuation lines of a multi-line array, until the parentheses balance.
+    depth > 0 {
+        print
+        depth += gsub(/\(/, "(")
+        depth -= gsub(/\)/, ")")
+        next
+    }
+    # A top level assignment: name= at column zero. Anything indented belongs to a
+    # function body, and a command never matches this.
+    /^[A-Za-z_][A-Za-z0-9_]*=/ {
+        print
+        depth = gsub(/\(/, "(") - gsub(/\)/, ")")
+        next
+    }
+' PKGBUILD > "$tmp/assignments"
+
+if ! env -i "$(command -v bash)" --noprofile --norc -c '
         set -u
-        # shellcheck disable=SC1091
-        . ./PKGBUILD >/dev/null 2>&1 || exit 1
+        # shellcheck disable=SC1090
+        . "$1" >/dev/null 2>&1 || exit 1
         declare -p pkgname pkgver pkgrel pkgdesc source sha256sums 2>/dev/null
-    ' > "$tmp/vars" 2>/dev/null || [ ! -s "$tmp/vars" ]; then
-    note "PKGBUILD parses but does not evaluate, or declares none of pkgname/pkgver/source"
+    ' _ "$tmp/assignments" > "$tmp/vars" 2>/dev/null || [ ! -s "$tmp/vars" ]; then
+    note "PKGBUILD does not evaluate, or declares none of pkgname/pkgver/source/sha256sums"
     echo "aur-preflight: FAILED" >&2
     exit 1
 fi
@@ -138,10 +169,13 @@ fi
 
 # 4. Both source lines are expanded in .SRCINFO, so a hand edit can update one and
 #    miss the other, and a URL that hardcodes a version ignores the bump entirely.
+# Compare the URL alone: a "aeroftp-bin-${pkgver}.deb::" rename prefix always
+# carries the version, so checking the whole entry would pass while the download
+# URL behind it still points at the previous release.
 for s in "${source[@]}" "${srcinfo_sources[@]}"; do
-    case "$s" in
+    case "${s#*::}" in
         *"$pkgver"*) ;;
-        *) note "source does not carry pkgver ${pkgver}: ${s}" ;;
+        *) note "source URL does not carry pkgver ${pkgver}: ${s}" ;;
     esac
 done
 

--- a/.github/scripts/aur-preflight.sh
+++ b/.github/scripts/aur-preflight.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+#
+# aur-preflight.sh - refuse to publish an AUR package that cannot be built.
+#
+# Run it from the aeroftp-bin checkout, or point it at one:
+#
+#     .github/scripts/aur-preflight.sh /path/to/aeroftp-bin
+#
+# Install it as the pre-push hook of that checkout so it cannot be forgotten:
+#
+#     ln -sf /path/to/aeroftp/.github/scripts/aur-preflight.sh \
+#            /path/to/aeroftp-bin/.git/hooks/pre-push
+#
+# Why this exists: v3.5.2 was pushed with the sha256sums array closed after its
+# first element. The PKGBUILD could not be sourced at all, so makepkg died before
+# it downloaded anything and nobody could install the package for about 23 hours,
+# until v3.5.3 replaced it. A single `bash -n` would have caught it. The AUR runs
+# no CI: whatever is pushed is what every user gets, immediately.
+#
+# Checks, in order:
+#   1. PKGBUILD parses as bash
+#   2. .SRCINFO agrees with PKGBUILD (regenerated diff on Arch, field compare off it)
+#   3. sha256sums[0] is a real digest, not SKIP or a leftover placeholder
+#   4. no source line carries a version other than pkgver
+#   5. both release URLs resolve (skip with --offline)
+#
+set -uo pipefail
+
+offline=0
+repo=""
+for arg in "$@"; do
+    case "$arg" in
+        --offline) offline=1 ;;
+        *) repo="$arg" ;;
+    esac
+done
+
+if [ -n "$repo" ]; then
+    cd "$repo" || { echo "aur-preflight: cannot enter $repo" >&2; exit 2; }
+elif root=$(git rev-parse --show-toplevel 2>/dev/null); then
+    cd "$root" || exit 2
+fi
+
+[ -f PKGBUILD ] || { echo "aur-preflight: no PKGBUILD here ($PWD)" >&2; exit 2; }
+[ -f .SRCINFO ] || { echo "aur-preflight: no .SRCINFO here ($PWD)" >&2; exit 2; }
+
+fail=0
+note() { echo "aur-preflight: $*" >&2; fail=1; }
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+# 1. The PKGBUILD must parse. This is the v3.5.2 check.
+if ! bash -n PKGBUILD 2>"$tmp/syntax"; then
+    note "PKGBUILD is not sourceable, makepkg would abort before downloading anything"
+    sed 's/^/    /' "$tmp/syntax" >&2
+    # Everything below reads fields out of the PKGBUILD, so stop here.
+    echo "aur-preflight: FAILED" >&2
+    exit 1
+fi
+
+field() { sed -n "s/^$1=//p" PKGBUILD | head -1 | sed "s/^[\"']//;s/[\"']$//"; }
+srcfield() { sed -n "s/^[[:space:]]*$1 = //p" .SRCINFO | head -1; }
+
+pkgver=$(field pkgver)
+[ -n "$pkgver" ] || note "PKGBUILD declares no pkgver"
+
+# 2. .SRCINFO is what the AUR and every helper read. A PKGBUILD fix that never
+#    reached .SRCINFO ships the old package to users while looking fixed locally.
+if command -v makepkg >/dev/null 2>&1; then
+    if ! makepkg --printsrcinfo > "$tmp/srcinfo" 2>"$tmp/srcinfo.err"; then
+        note "makepkg --printsrcinfo failed"
+        sed 's/^/    /' "$tmp/srcinfo.err" >&2
+    elif ! diff -q "$tmp/srcinfo" .SRCINFO >/dev/null; then
+        note ".SRCINFO does not match PKGBUILD (regenerate: makepkg --printsrcinfo > .SRCINFO)"
+        diff -u .SRCINFO "$tmp/srcinfo" | sed 's/^/    /' >&2
+    fi
+else
+    # Off Arch (.SRCINFO is hand-edited there), compare the fields that matter.
+    for k in pkgname pkgver pkgrel pkgdesc; do
+        p=$(field "$k"); s=$(srcfield "$k")
+        [ "$p" = "$s" ] || note "$k differs: PKGBUILD='$p' .SRCINFO='$s'"
+    done
+    n_src=$(grep -c '^[[:space:]]*source = ' .SRCINFO)
+    n_sum=$(grep -c '^[[:space:]]*sha256sums = ' .SRCINFO)
+    [ "$n_src" -eq "$n_sum" ] || note ".SRCINFO has $n_src source lines but $n_sum sha256sums"
+fi
+
+# 3. A real digest on the payload. SKIP belongs to the Sigstore bundle only, which
+#    prepare() authenticates with cosign; SKIP on the .deb would pin nothing.
+first_sum=$(sed -n '/^[[:space:]]*sha256sums = /{s/^[[:space:]]*sha256sums = //p;q}' .SRCINFO)
+case "$first_sum" in
+    [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]*)
+        [ "${#first_sum}" -eq 64 ] || note "sha256sums[0] is ${#first_sum} chars, not 64: '$first_sum'" ;;
+    *) note "sha256sums[0] is '$first_sum', expected the .deb digest" ;;
+esac
+
+# 4. Both source lines in .SRCINFO are expanded, so a hand edit can leave one on
+#    the previous release: the package would then build the old .deb, or fail the
+#    hash, depending on which line was missed.
+while IFS= read -r line; do
+    case "$line" in
+        *"$pkgver"*) ;;
+        *) note "source line does not carry pkgver $pkgver: ${line#*= }" ;;
+    esac
+done < <(grep '^[[:space:]]*source = ' .SRCINFO)
+
+# 5. A source that 404s fails the build for every user, and the release assets are
+#    named by the workflow, so a rename or a missing upload only shows up here.
+if [ "$offline" -eq 0 ] && command -v curl >/dev/null 2>&1; then
+    while IFS= read -r url; do
+        code=$(curl -sIL --retry 2 --max-time 25 -o /dev/null -w '%{http_code}' "$url" 2>/dev/null)
+        [ "$code" = "200" ] || note "source does not resolve (HTTP ${code:-none}): $url"
+    done < <(sed -n 's/^[[:space:]]*source = //p' .SRCINFO | sed 's/^[^:]*:://' | grep '^https\?://')
+fi
+
+if [ "$fail" -ne 0 ]; then
+    echo "aur-preflight: FAILED, refusing to publish a broken package" >&2
+    exit 1
+fi
+echo "aur-preflight: PKGBUILD sourceable, .SRCINFO in sync, sources resolve"

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -138,7 +138,7 @@ sha256sum /tmp/AeroFTP.deb
 .github/scripts/aur-preflight.sh /path/to/aeroftp-bin
 ```
 
-It refuses the push when the `PKGBUILD` does not parse, when `.SRCINFO` disagrees with it on any value (sources and checksums compared one by one, expanded, not just the scalar fields), when `sha256sums[0]` is not a full 64 hex digest, when a source was left on the previous version, or when a release URL does not answer 200. Off Arch it evaluates the `PKGBUILD` the way `makepkg` does, so `${pkgver}` inside a URL is compared expanded.
+It refuses the push when the `PKGBUILD` does not parse, when `.SRCINFO` disagrees with it on any value (sources and checksums compared one by one, expanded, not just the scalar fields), when `sha256sums[0]` is not a full 64 hex digest, when a source was left on the previous version, or when a release URL does not answer 200. Off Arch it evaluates the `PKGBUILD` so that `${pkgver}` inside a URL is compared expanded, slicing out the top level assignments first rather than sourcing the file: a preflight reads as "only checks" and must not run a package's code.
 
 > **Install it as the pre-push hook of the AUR checkout**, once per machine, so a bad package cannot leave even in a hurry:
 >

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -138,14 +138,16 @@ sha256sum /tmp/AeroFTP.deb
 .github/scripts/aur-preflight.sh /path/to/aeroftp-bin
 ```
 
-It refuses the push when the `PKGBUILD` does not parse, when `.SRCINFO` disagrees with it, when `sha256sums[0]` is not a real digest, when a `source =` line was left on the previous version, or when either release URL does not answer 200.
+It refuses the push when the `PKGBUILD` does not parse, when `.SRCINFO` disagrees with it on any value (sources and checksums compared one by one, expanded, not just the scalar fields), when `sha256sums[0]` is not a full 64 hex digest, when a source was left on the previous version, or when a release URL does not answer 200. Off Arch it evaluates the `PKGBUILD` the way `makepkg` does, so `${pkgver}` inside a URL is compared expanded.
 
 > **Install it as the pre-push hook of the AUR checkout**, once per machine, so a bad package cannot leave even in a hurry:
 >
 > ```bash
-> ln -sf /path/to/aeroftp/.github/scripts/aur-preflight.sh \
->        /path/to/aeroftp-bin/.git/hooks/pre-push
+> ln -s /path/to/aeroftp/.github/scripts/aur-preflight.sh \
+>       /path/to/aeroftp-bin/.git/hooks/pre-push
 > ```
+>
+> `ln -s` and not `ln -sf`: if a `pre-push` hook is already there it may be doing something else, and the command should refuse rather than replace it silently. Inspect it and chain the two by hand in that case.
 
 The check earns its place: **v3.5.2 shipped a `PKGBUILD` whose `sha256sums` array was closed after its first element**, so the file could not be sourced and `makepkg` aborted before downloading anything. Nobody could install `aeroftp-bin` for about 23 hours, until v3.5.3 replaced it, and the report came from a user rather than from us. The AUR runs no CI of any kind: what is pushed is what every user gets, on their next `yay -S`, with no gate in between. `bash -n` costs nothing and catches exactly that class of break.
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -134,14 +134,22 @@ sha256sum /tmp/AeroFTP.deb
 ### 3. Verify before pushing
 
 ```bash
-# Both sources must resolve, or the package fails to build for every user
-for u in ".deb" ".deb.sigstore.json"; do
-  curl -sL -o /dev/null -w "%{http_code}\n" \
-    "https://github.com/axpdev-lab/aeroftp/releases/download/vX.Y.Z/AeroFTP_X.Y.Z_amd64${u}"
-done
+# From this repo, pointed at the AUR checkout. Add --offline to skip the URL check.
+.github/scripts/aur-preflight.sh /path/to/aeroftp-bin
 ```
 
-The cosign identity in `prepare()` pins `refs/tags/vX.Y.Z`, so it re-pins per release; confirm the bundle's certificate really carries that tag before publishing.
+It refuses the push when the `PKGBUILD` does not parse, when `.SRCINFO` disagrees with it, when `sha256sums[0]` is not a real digest, when a `source =` line was left on the previous version, or when either release URL does not answer 200.
+
+> **Install it as the pre-push hook of the AUR checkout**, once per machine, so a bad package cannot leave even in a hurry:
+>
+> ```bash
+> ln -sf /path/to/aeroftp/.github/scripts/aur-preflight.sh \
+>        /path/to/aeroftp-bin/.git/hooks/pre-push
+> ```
+
+The check earns its place: **v3.5.2 shipped a `PKGBUILD` whose `sha256sums` array was closed after its first element**, so the file could not be sourced and `makepkg` aborted before downloading anything. Nobody could install `aeroftp-bin` for about 23 hours, until v3.5.3 replaced it, and the report came from a user rather than from us. The AUR runs no CI of any kind: what is pushed is what every user gets, on their next `yay -S`, with no gate in between. `bash -n` costs nothing and catches exactly that class of break.
+
+The cosign identity in `prepare()` pins `refs/tags/vX.Y.Z`, so it re-pins per release; confirm the bundle's certificate really carries that tag before publishing. The preflight does not check the signature, only that the artifacts exist: `cosign verify-blob` runs at build time in `prepare()`.
 
 ### 4. Push to AUR
 


### PR DESCRIPTION
## Why

The AUR is the only channel we publish to that has no CI at all. A push is a publication: it reaches users on their next `yay -S` with no build, no smoke test and nothing in between. We already learned what that costs. **v3.5.2 was published with a `PKGBUILD` whose `sha256sums` array was closed after its first element**, so `makepkg` could not source the file and aborted before downloading anything. The package was uninstallable for roughly 23 hours (2026-04-16 11:39 to 2026-04-17 10:53), and the report came from a user, on the AUR comment page, rather than from us. One `bash -n` would have caught it instantly.

## What this adds

`.github/scripts/aur-preflight.sh`, run from the AUR checkout or pointed at it, checking the five things that all share one failure mode: a package that looks updated on the maintainer's machine and is broken for everybody else.

| Check | The mistake it catches |
|---|---|
| `bash -n PKGBUILD` | the v3.5.2 break: the file does not parse, so nothing can build |
| `.SRCINFO` agrees with `PKGBUILD` | a fix that never reached the file the AUR and every helper actually read |
| `sha256sums[0]` is a real 64 hex digest | `SKIP` on the payload, which would pin nothing. `SKIP` is correct only for the Sigstore bundle, authenticated by `cosign` in `prepare()` |
| every `source =` line carries `pkgver` | both are expanded in `.SRCINFO`, so a hand edit off Arch can bump one and miss the other |
| both release URLs answer 200 | a renamed or missing release asset, which 404s the build for every user |

On Arch it diffs against `makepkg --printsrcinfo`; off Arch, where `.SRCINFO` is hand-edited, it falls back to comparing the fields. `--offline` skips the network check.

`docs/RELEASE.md` step 3 now calls it in place of the inline `curl` loop, and says to install it as the pre-push hook of the AUR checkout so it cannot be skipped in a hurry.

## Verification

Every check was run against the defect it targets before it was added to the script, so none of them is a green that has never been red:

| Input | Result |
|---|---|
| live `aeroftp-bin` 4.1.7, network on | passes |
| the real v3.5.2 `PKGBUILD` | fails, `PKGBUILD is not sourceable` |
| `sha256sums[0]` set to `SKIP` | fails |
| `pkgver` bumped in `PKGBUILD` only | fails, plus both source lines flagged |
| one `source =` line left on 4.1.6 | fails |
| `.sigstore.json` asset renamed | fails, `HTTP 404` |

The hook is already installed in the local AUR checkout, and 4.1.7-1 was published through it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated pre-push validation for AUR packages.
  * Checks package files, syntax, metadata consistency, checksums, versioned sources, and release URL availability.
  * Supports offline validation and custom checkout paths.
  * Provides clear diagnostics when validation fails.

* **Documentation**
  * Updated release instructions with expanded metadata and checksum validation details.
  * Clarified preflight hook installation and handling of existing hooks.
  * Confirmed that Sigstore verification remains part of the release process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->