### PR TITLE
chore(deps): ignore isolated RustCrypto AEAD 0.12-line bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -78,13 +78,27 @@ updates:
       # which depends on num-bigint-dig 0.8. Unblock when rsa 0.10 stable.
       - dependency-name: "num-bigint-dig"
         versions: [">=0.9.0"]
-      # aes 0.9 is a breaking RustCrypto block-cipher bump. aes-gcm 0.10,
-      # aes-kw 0.2, aes-siv 0.7 and aes-gcm-siv 0.11 (AeroVault v3) all
-      # still depend on aes 0.8; taking aes 0.9 directly forks the cipher
-      # crate and breaks the AEAD wrappers. Unblock when aes-gcm/aes-kw/
-      # aes-siv/aes-gcm-siv ship releases built on aes 0.9.
+      # aes 0.9 is a breaking RustCrypto block-cipher bump. Direct
+      # `aes-gcm-siv` 0.11, `aes-kw` 0.2, `aes-siv` 0.7 and
+      # `chacha20poly1305` 0.10 (AeroVault v3 / aerocrypt) still depend
+      # on aes 0.8 / aead 0.5; taking aes 0.9 (or any one wrapper) in
+      # isolation forks the trait crates. russh already pulls aes 0.9 as
+      # a *separate* copy — that is fine; a direct bump is not.
+      # Upstream now has aes-gcm 0.11 / aes-kw 0.3 / aes-siv 0.8 /
+      # aes-gcm-siv 0.12 / chacha20poly1305 0.11 on aes 0.9, but
+      # aerovault 0.6.3 still requires the 0.11/0.2/0.7/0.10 line and
+      # aerocrypt still uses `aead::{Aead, Payload}`. Unblock the
+      # wrappers together when aerovault ships a matching release.
       - dependency-name: "aes"
         versions: [">=0.9.0"]
+      - dependency-name: "aes-gcm-siv"
+        versions: [">=0.12.0"]
+      - dependency-name: "aes-kw"
+        versions: [">=0.3.0"]
+      - dependency-name: "aes-siv"
+        versions: [">=0.8.0"]
+      - dependency-name: "chacha20poly1305"
+        versions: [">=0.11.0"]
 
   # npm dependencies
   - package-ecosystem: "npm"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -85,12 +85,17 @@ updates:
       # isolation forks the trait crates. russh already pulls aes 0.9 as
       # a *separate* copy — that is fine; a direct bump is not.
       # Upstream now has aes-gcm 0.11 / aes-kw 0.3 / aes-siv 0.8 /
-      # aes-gcm-siv 0.12 / chacha20poly1305 0.11 on aes 0.9, but
-      # aerovault 0.6.3 still requires the 0.11/0.2/0.7/0.10 line and
-      # aerocrypt still uses `aead::{Aead, Payload}`. Unblock the
-      # wrappers together when aerovault ships a matching release.
+      # aes-gcm-siv 0.12 on aes 0.9. chacha20poly1305 0.11 is the same
+      # aead 0.6 cohort (chacha20 0.10 / cipher 0.5 / poly1305 0.9), not
+      # an aes 0.9 crate. aerovault 0.6.3 still requires the
+      # 0.11/0.2/0.7/0.10 line, noq-proto still needs aes-gcm =0.10.3,
+      # and aerocrypt still uses `aead::{Aead, Payload}`. Unblock the
+      # wrappers together when aerovault (and noq-proto for aes-gcm)
+      # ship matching releases.
       - dependency-name: "aes"
         versions: [">=0.9.0"]
+      - dependency-name: "aes-gcm"
+        versions: [">=0.11.0"]
       - dependency-name: "aes-gcm-siv"
         versions: [">=0.12.0"]
       - dependency-name: "aes-kw"


### PR DESCRIPTION
Related to Dependabot #589 (closed, not merge-safe).

`aes-gcm-siv` 0.12 is a breaking 0.x bump (`aead` 0.6, `aes` 0.9, `AeadInOut`). Our pins and `aerovault` 0.6.3 are still on the 0.11 / `aes-kw` 0.2 / `aes-siv` 0.7 / `chacha20poly1305` 0.10 line. Taking any one wrapper in isolation forks the AEAD traits.

This adds Dependabot ignores for those wrappers so Monday does not reopen them one crate at a time. Unblock together when aerovault ships a matching release and aerocrypt moves with it.

No runtime change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency update restrictions for select encryption libraries, including additional AES-related versions.
  * Clarified compatibility requirements across supported encryption components and documented separate version constraints.
  * Improved maintenance guidance to help prevent incompatible updates from being introduced automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->