### PR TITLE
fix(export): keep rclone zoho and crypt remotes listable

### DIFF
--- a/src-tauri/src/bridge_commands.rs
+++ b/src-tauri/src/bridge_commands.rs
@@ -757,14 +757,33 @@ pub fn inject_rclone_onedrive_export_options(
     }
 }
 
+/// A Zoho folder/workspace id stored as `initialPath`. AeroFTP persists
+/// those with a leading slash (`/fmip…`); rclone's `root_folder_id` does
+/// not. One leading slash is stripped, then any remaining `/` means this
+/// is a real path, not an id.
+fn zoho_folder_id_from_initial_path(initial_path: Option<&str>) -> Option<String> {
+    let s = initial_path?.trim();
+    if s.is_empty() || s == "/" {
+        return None;
+    }
+    let s = s.strip_prefix('/').unwrap_or(s);
+    if s.is_empty() || s.contains('/') {
+        None
+    } else {
+        Some(s.to_string())
+    }
+}
+
 /// Inject Zoho WorkDrive fields rclone's `zoho` backend needs that do not
-/// travel with the OAuth token: `root_folder_id` (the workspace / team
-/// folder the profile is pinned to). The region is injected next to the
-/// token by [`inject_rclone_oauth_export_options`].
+/// travel with the OAuth token: `root_folder_id` (the workspace /
+/// privatespace the profile is pinned to). The region is injected next to
+/// the token by [`inject_rclone_oauth_export_options`].
 ///
-/// Sources, first non-empty wins: `options.root_folder_id` / `team_id` /
-/// `workspace_id` (any camel/snake spelling the profile may already carry),
-/// then `initial_path` when it is a Zoho id rather than a slash-path.
+/// Sources, first non-empty wins: `options.root_folder_id` /
+/// `privatespace_id` / `workspace_id` (camel or snake), then `initial_path`
+/// when it is a Zoho id rather than a slash-path. Team ids are not folder
+/// ids: rclone lists `GET /files/{root}/files`, and a team id reproduces
+/// F6016, so they are never copied here.
 pub fn inject_rclone_zoho_export_options(
     options: &mut Option<Value>,
     protocol: &str,
@@ -791,8 +810,8 @@ pub fn inject_rclone_zoho_export_options(
     let from_opts = [
         "root_folder_id",
         "rootFolderId",
-        "team_id",
-        "teamId",
+        "privatespace_id",
+        "privatespaceId",
         "workspace_id",
         "workspaceId",
     ]
@@ -804,11 +823,7 @@ pub fn inject_rclone_zoho_export_options(
             .filter(|s| !s.is_empty())
             .map(str::to_string)
     });
-    let from_path = initial_path
-        .map(str::trim)
-        .filter(|s| !s.is_empty() && *s != "/" && !s.contains('/'))
-        .map(str::to_string);
-    if let Some(id) = from_opts.or(from_path) {
+    if let Some(id) = from_opts.or_else(|| zoho_folder_id_from_initial_path(initial_path)) {
         opts.insert("root_folder_id".into(), Value::String(id));
     }
 }
@@ -846,16 +861,27 @@ pub async fn ensure_zoho_rclone_root_folder(options: &mut Option<Value>, profile
     if client_id.is_empty() {
         return;
     }
-    let Some(root) =
+    // The provider client used for file transfer allows a 1800s read
+    // timeout. Discovery is a handful of JSON calls; without a bound, a
+    // stuck Zoho API stalls the entire export (CLI and GUI share this
+    // helper) for every Zoho profile. 45s covers four sequential round
+    // trips on a slow link without approaching transfer-scale waits.
+    let discovery =
         crate::providers::zoho_workdrive::ZohoWorkdriveProvider::rclone_root_folder_id_for_export(
             profile_id,
             &client_id,
             &client_secret,
             &region,
-        )
-        .await
-    else {
-        return;
+        );
+    let root = match tokio::time::timeout(std::time::Duration::from_secs(45), discovery).await {
+        Ok(Some(root)) => root,
+        Ok(None) => return,
+        Err(_) => {
+            log::warn!(
+                "rclone export: Zoho root_folder_id discovery timed out for profile {profile_id}"
+            );
+            return;
+        }
     };
     if !matches!(options, Some(Value::Object(_))) {
         *options = Some(Value::Object(serde_json::Map::new()));
@@ -1227,6 +1253,76 @@ mod tests {
         // Jottacloud has no OAuth app at all (personal login token).
         assert_eq!(oauth_client_cred_key("jottacloud"), None);
         assert_eq!(oauth_client_cred_key("ftp"), None);
+    }
+
+    #[test]
+    fn zoho_folder_id_from_initial_path_strips_one_leading_slash() {
+        assert_eq!(
+            zoho_folder_id_from_initial_path(Some("/fmip966f979e195e64ec78e6846976861eed5"))
+                .as_deref(),
+            Some("fmip966f979e195e64ec78e6846976861eed5")
+        );
+        assert_eq!(
+            zoho_folder_id_from_initial_path(Some("fmip966f979e195e64ec78e6846976861eed5"))
+                .as_deref(),
+            Some("fmip966f979e195e64ec78e6846976861eed5")
+        );
+        assert_eq!(zoho_folder_id_from_initial_path(Some("/")), None);
+        assert_eq!(zoho_folder_id_from_initial_path(Some("")), None);
+        assert_eq!(zoho_folder_id_from_initial_path(None), None);
+        // A real path, not a folder id.
+        assert_eq!(
+            zoho_folder_id_from_initial_path(Some("/My Folders/docs")),
+            None
+        );
+        assert_eq!(
+            zoho_folder_id_from_initial_path(Some("My Folders/docs")),
+            None
+        );
+    }
+
+    #[test]
+    fn inject_zoho_export_uses_slash_prefixed_path_and_ignores_team_id() {
+        let mut opts = Some(serde_json::json!({
+            "team_id": "team-not-a-folder",
+            "teamId": "team-camel-not-a-folder",
+        }));
+        inject_rclone_zoho_export_options(
+            &mut opts,
+            "zohoworkdrive",
+            Some("/fmip966f979e195e64ec78e6846976861eed5"),
+        );
+        assert_eq!(
+            opts.as_ref()
+                .and_then(|o| o.get("root_folder_id"))
+                .and_then(|v| v.as_str()),
+            Some("fmip966f979e195e64ec78e6846976861eed5"),
+            "leading-slash initialPath is the pinned folder id: {opts:?}"
+        );
+
+        let mut opts = Some(serde_json::json!({
+            "team_id": "team-not-a-folder",
+            "workspace_id": "ws-is-a-folder",
+        }));
+        inject_rclone_zoho_export_options(&mut opts, "zohoworkdrive", None);
+        assert_eq!(
+            opts.as_ref()
+                .and_then(|o| o.get("root_folder_id"))
+                .and_then(|v| v.as_str()),
+            Some("ws-is-a-folder"),
+            "workspace id is a valid rclone root, team id is not: {opts:?}"
+        );
+
+        let mut opts = Some(serde_json::json!({ "team_id": "team-only" }));
+        inject_rclone_zoho_export_options(&mut opts, "zohoworkdrive", None);
+        assert!(
+            opts.as_ref()
+                .and_then(|o| o.get("root_folder_id"))
+                .and_then(|v| v.as_str())
+                .map(|s| s.trim().is_empty())
+                .unwrap_or(true),
+            "team id must not become root_folder_id: {opts:?}"
+        );
     }
 
     fn server_count(v: &Value) -> usize {

--- a/src-tauri/src/providers/zoho_workdrive.rs
+++ b/src-tauri/src/providers/zoho_workdrive.rs
@@ -552,6 +552,31 @@ pub struct ZohoWorkdriveProvider {
     profile_id: String,
 }
 
+/// Pick rclone's `root_folder_id` from a completed `discover_team`.
+///
+/// rclone lists `GET /files/{root}/files`. The privatespace (My Folders)
+/// id is that root. `discover_team`'s last fallback stores the *team* id
+/// in `current_folder_id`; using it reproduces F6016, the failure this
+/// helper exists to prevent. A `current_folder_id` that is not the team
+/// id is a real folder and is kept.
+fn rclone_root_folder_id_from_discovery(
+    privatespace_id: Option<&str>,
+    current_folder_id: &str,
+    team_id: Option<&str>,
+) -> Option<String> {
+    if let Some(id) = privatespace_id.map(str::trim).filter(|s| !s.is_empty()) {
+        return Some(id.to_string());
+    }
+    let current = current_folder_id.trim();
+    if current.is_empty() {
+        return None;
+    }
+    if team_id.map(str::trim) == Some(current) {
+        return None;
+    }
+    Some(current.to_string())
+}
+
 impl ZohoWorkdriveProvider {
     pub fn new(config: ZohoWorkdriveConfig) -> Self {
         // Build HTTP client with default Accept header required by Zoho JSON:API
@@ -606,17 +631,11 @@ impl ZohoWorkdriveProvider {
         if provider.discover_team().await.is_err() {
             return None;
         }
-        provider
-            .privatespace_id
-            .filter(|s| !s.is_empty())
-            .or_else(|| {
-                let id = provider.current_folder_id.trim();
-                if id.is_empty() {
-                    None
-                } else {
-                    Some(id.to_string())
-                }
-            })
+        rclone_root_folder_id_from_discovery(
+            provider.privatespace_id.as_deref(),
+            &provider.current_folder_id,
+            provider.team_id.as_deref(),
+        )
     }
 
     /// Get OAuth config for token operations
@@ -3699,6 +3718,37 @@ mod tests {
         );
         assert_eq!(parse_privatespace_id(""), None);
         assert_eq!(parse_privatespace_id("not json"), None);
+    }
+
+    #[test]
+    fn rclone_root_folder_id_from_discovery_rejects_team_id_fallback() {
+        assert_eq!(
+            rclone_root_folder_id_from_discovery(
+                Some("fmip966f979e195e64ec78e6846976861eed5"),
+                "team-id",
+                Some("team-id"),
+            )
+            .as_deref(),
+            Some("fmip966f979e195e64ec78e6846976861eed5")
+        );
+        assert_eq!(
+            rclone_root_folder_id_from_discovery(None, "team-id", Some("team-id")),
+            None,
+            "team id is not a folder id"
+        );
+        assert_eq!(
+            rclone_root_folder_id_from_discovery(None, "  ", Some("team-id")),
+            None
+        );
+        assert_eq!(
+            rclone_root_folder_id_from_discovery(None, "folder-not-team", Some("team-id"))
+                .as_deref(),
+            Some("folder-not-team")
+        );
+        assert_eq!(
+            rclone_root_folder_id_from_discovery(Some(""), "", None),
+            None
+        );
     }
 
     #[test]

--- a/src-tauri/src/rclone_import.rs
+++ b/src-tauri/src/rclone_import.rs
@@ -876,13 +876,22 @@ fn map_remote(name: &str, remote: &RcloneRemote) -> Option<MappedProfile> {
 }
 
 /// Map AeroFTP's Zoho region slug to rclone's `zoho` backend `region`.
-/// rclone documents `com`, `eu`, `in`, `jp`, `com.cn`, `com.au`.
-fn zoho_region_to_rclone(region: &str) -> String {
+///
+/// rclone interpolates the value as the TLD in `https://accounts.zoho.{region}`
+/// (see `setupRegion` in rclone's zoho backend). Documented examples are
+/// `com` / `eu` / `in` / `jp` / `com.cn` / `com.au`. `uk`, `sa`, and `ae`
+/// fit the same template and are real Zoho data centres, so they are
+/// emitted. Canada lives at `zohocloud.ca`, which that template cannot
+/// express: return `None` rather than a host rclone will never reach.
+/// Unknown slugs are also `None` so we never write `region = garbage`.
+fn zoho_region_to_rclone(region: &str) -> Option<String> {
     match region.trim().to_ascii_lowercase().as_str() {
-        "" | "us" | "com" => "com".into(),
-        "au" | "com.au" => "com.au".into(),
-        "cn" | "com.cn" => "com.cn".into(),
-        other => other.to_string(),
+        "" | "us" | "com" => Some("com".into()),
+        "au" | "com.au" => Some("com.au".into()),
+        "cn" | "com.cn" => Some("com.cn".into()),
+        "eu" | "in" | "jp" | "uk" | "sa" | "ae" => Some(region.trim().to_ascii_lowercase()),
+        // `ca` / `zohocloud.ca`: rclone would build accounts.zoho.ca.
+        _ => None,
     }
 }
 
@@ -1382,6 +1391,43 @@ fn crypt_export_remote_target(base_name: &str, options: &serde_json::Value) -> S
     }
 }
 
+/// rclone's s3 backend has no `bucket` key. A pinned bucket is exported as
+/// an `alias` remote `<base>-<bucket>` whose path is `<base>:<bucket>`, so
+/// keys stay bucket-relative (the way AeroFTP writes them). A crypt overlay
+/// on that profile must wrap the alias, not the raw s3 remote: wrapping
+/// `minio:/vault` makes rclone look for a bucket named `vault`.
+fn s3_pinned_bucket(options: Option<&serde_json::Value>) -> Option<&str> {
+    options
+        .and_then(|o| o.get("bucket"))
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+}
+
+fn s3_bucket_alias_name(remote_name: &str, bucket: &str) -> Option<String> {
+    let alias = sanitize_rclone_remote_name(&format!("{remote_name}-{bucket}"));
+    if alias.is_empty() || alias == remote_name {
+        None
+    } else {
+        Some(alias)
+    }
+}
+
+fn crypt_export_base_name(
+    proto: &str,
+    remote_name: &str,
+    options: Option<&serde_json::Value>,
+) -> String {
+    if proto == "s3" {
+        if let Some(bucket) = s3_pinned_bucket(options) {
+            if let Some(alias) = s3_bucket_alias_name(remote_name, bucket) {
+                return alias;
+            }
+        }
+    }
+    remote_name.to_string()
+}
+
 fn crypt_section_name(base_name: &str, options: &serde_json::Value) -> String {
     let requested = options
         .get("rcloneCryptOverlayName")
@@ -1511,6 +1557,25 @@ pub fn export_rclone(
             ));
         }
 
+        // rclone's zoho backend interpolates `region` as the TLD in
+        // accounts.zoho.{region}. Skip profiles whose AeroFTP slug cannot
+        // be expressed that way (Canada's zohocloud.ca, unknown garbage)
+        // rather than writing a remote rclone will never reach.
+        if proto == "zohoworkdrive" {
+            let region = options
+                .and_then(|o| o.get("region"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("us");
+            if zoho_region_to_rclone(region).is_none() {
+                output.push_str(&format!(
+                    "# skipped Zoho profile '{}': rclone's zoho backend cannot address region '{}'\n\n",
+                    remote_name,
+                    region.replace(['\n', '\r'], " ")
+                ));
+                continue;
+            }
+        }
+
         output.push_str(&format!("[{}]\n", remote_name));
 
         match proto {
@@ -1630,10 +1695,8 @@ pub fn export_rclone(
                     {
                         endpoint_from_opts = Some(endpoint.to_string());
                     }
-                    if let Some(b) = opts.get("bucket").and_then(|v| v.as_str()) {
-                        if !b.trim().is_empty() {
-                            pinned_bucket = Some(b.trim().to_string());
-                        }
+                    if let Some(b) = s3_pinned_bucket(options) {
+                        pinned_bucket = Some(b.to_string());
                     }
                     // verify_cert is stored as a bool by the GUI but may arrive
                     // as the string "false" through normalization; honour both.
@@ -1707,9 +1770,7 @@ pub fn export_rclone(
                 // alias addresses objects bucket-relative, identical to how
                 // the AeroFTP S3 client writes keys (drop-in for crypt/sync).
                 if let Some(bucket) = pinned_bucket {
-                    let alias_name =
-                        sanitize_rclone_remote_name(&format!("{}-{}", remote_name, bucket));
-                    if !alias_name.is_empty() && alias_name != remote_name {
+                    if let Some(alias_name) = s3_bucket_alias_name(&remote_name, &bucket) {
                         output.push_str(&format!(
                             "\n# Bucket-relative view of '{}' (bucket '{}').\n\
                              # AeroFTP writes keys at bucket root; address them\n\
@@ -2052,16 +2113,16 @@ pub fn export_rclone(
                 // rclone's backend type is `zoho`. Region uses TLD slugs
                 // (`com` for US / Global, `com.au` for Australia). AeroFTP
                 // stores `us` / `au` (and the other data-centre slugs that
-                // match rclone already). Map only the ones that diverge.
+                // match rclone already). Unmappable regions were skipped
+                // before the section header; unwrap is then a mapped TLD.
                 output.push_str("type = zoho\n");
                 let region = options
                     .and_then(|o| o.get("region"))
                     .and_then(|v| v.as_str())
                     .unwrap_or("us");
-                output.push_str(&format!(
-                    "region = {}\n",
-                    ini_value(&zoho_region_to_rclone(region))
-                ));
+                let rclone_region =
+                    zoho_region_to_rclone(region).expect("zohoworkdrive region preflighted");
+                output.push_str(&format!("region = {}\n", ini_value(&rclone_region)));
                 if let Some(folder) = options
                     .and_then(|o| o.get("root_folder_id"))
                     .and_then(|v| v.as_str())
@@ -2100,7 +2161,8 @@ pub fn export_rclone(
         // Rclone Crypt is a second remote wrapping this one. The overlay
         // path is always at or below the server's remote path, so
         // `remote = <base>:<path>` is derived rather than guessed.
-        if append_crypt_remote_section(&mut output, &remote_name, options) {
+        let crypt_base = crypt_export_base_name(proto, &remote_name, options);
+        if append_crypt_remote_section(&mut output, &crypt_base, options) {
             exported += 1;
         }
     }
@@ -3044,10 +3106,15 @@ api_key = 4BVmu-SCRQai2-0-hucKgbeyzH6-uqexma-skpRs4Kk
 
     #[test]
     fn test_zoho_region_maps_between_aeroftp_and_rclone() {
-        assert_eq!(zoho_region_to_rclone("us"), "com");
-        assert_eq!(zoho_region_to_rclone("au"), "com.au");
-        assert_eq!(zoho_region_to_rclone("cn"), "com.cn");
-        assert_eq!(zoho_region_to_rclone("eu"), "eu");
+        assert_eq!(zoho_region_to_rclone("us").as_deref(), Some("com"));
+        assert_eq!(zoho_region_to_rclone("au").as_deref(), Some("com.au"));
+        assert_eq!(zoho_region_to_rclone("cn").as_deref(), Some("com.cn"));
+        assert_eq!(zoho_region_to_rclone("eu").as_deref(), Some("eu"));
+        assert_eq!(zoho_region_to_rclone("uk").as_deref(), Some("uk"));
+        assert_eq!(zoho_region_to_rclone("sa").as_deref(), Some("sa"));
+        assert_eq!(zoho_region_to_rclone("ae").as_deref(), Some("ae"));
+        assert_eq!(zoho_region_to_rclone("ca"), None);
+        assert_eq!(zoho_region_to_rclone("not-a-dc"), None);
         assert_eq!(zoho_region_from_rclone("com"), "us");
         assert_eq!(zoho_region_from_rclone("com.au"), "au");
         assert_eq!(zoho_region_from_rclone("eu"), "eu");
@@ -3148,6 +3215,35 @@ api_key = 4BVmu-SCRQai2-0-hucKgbeyzH6-uqexma-skpRs4Kk
         assert!(
             !conf.contains("region = us"),
             "must not emit AeroFTP slug:\n{conf}"
+        );
+    }
+
+    #[test]
+    fn test_export_rclone_zoho_skips_region_rclone_cannot_address() {
+        let servers = vec![RcloneExportServer {
+            name: "zoho-ca".to_string(),
+            host: "workdrive.zohocloud.ca".to_string(),
+            port: 443,
+            username: "me@example.com".to_string(),
+            protocol: Some("zohoworkdrive".to_string()),
+            options: Some(serde_json::json!({ "region": "ca" })),
+            provider_id: Some("zoho-workdrive".to_string()),
+        }];
+        let tmp = std::env::temp_dir().join("aeroftp-test-export-zoho-ca.conf");
+        let n = export_rclone(&servers, &HashMap::new(), &tmp).expect("export");
+        let conf = std::fs::read_to_string(&tmp).expect("read");
+        std::fs::remove_file(&tmp).ok();
+        assert_eq!(
+            n, 0,
+            "unusable zoho remote must not count as exported:\n{conf}"
+        );
+        assert!(
+            !conf.contains("[zoho-ca]"),
+            "must not emit a section rclone cannot reach:\n{conf}"
+        );
+        assert!(
+            conf.contains("skipped Zoho profile 'zoho-ca'"),
+            "skip must be explained:\n{conf}"
         );
     }
 
@@ -3275,6 +3371,45 @@ token = {\"access_token\":\"acc\",\"token_type\":\"Zoho-oauthtoken\",\"refresh_t
             .lines()
             .any(|l| l.trim_start().starts_with("password ="));
         assert!(!has_pw_line, "must not emit password =:\n{conf}");
+    }
+
+    #[test]
+    fn test_export_rclone_s3_crypt_wraps_bucket_alias() {
+        let servers = vec![RcloneExportServer {
+            name: "minio".to_string(),
+            host: "s3.lab.example.test".to_string(),
+            port: 443,
+            username: "AKIAEXAMPLE".to_string(),
+            protocol: Some("s3".to_string()),
+            options: Some(serde_json::json!({
+                "region": "us-east-1",
+                "endpoint": "https://s3.lab.example.test",
+                "bucket": "aeroftp-test",
+                "rcloneCryptEnabled": true,
+                "rcloneCryptOverlayScope": "/vault",
+                "rcloneCryptPassword": "topsecret",
+            })),
+            provider_id: Some("minio".to_string()),
+        }];
+        let mut passwords = HashMap::new();
+        passwords.insert("minio".to_string(), "s3secret".to_string());
+        let tmp = std::env::temp_dir().join("aeroftp-test-export-s3-crypt-alias.conf");
+        let n = export_rclone(&servers, &passwords, &tmp).expect("export");
+        let conf = std::fs::read_to_string(&tmp).expect("read");
+        std::fs::remove_file(&tmp).ok();
+        assert!(n >= 2, "s3 + alias + crypt: {n}\n{conf}");
+        assert!(
+            conf.contains("[minio-aeroftp-test]"),
+            "bucket alias:\n{conf}"
+        );
+        assert!(
+            conf.contains("remote = minio-aeroftp-test:/vault"),
+            "crypt must wrap the bucket alias, not minio:/vault:\n{conf}"
+        );
+        assert!(
+            !conf.contains("remote = minio:/vault"),
+            "must not point crypt at a bucket named vault:\n{conf}"
+        );
     }
 
     /// #128-D: pCloud's rclone `hostname` must be a real API host, not the


### PR DESCRIPTION
Follow-up to #596. Five CodeRabbit findings on that PR, verified against the code and against rclone's zoho backend (`setupRegion` interpolates `region` as the TLD in `accounts.zoho.{region}`).

**Zoho `root_folder_id`**
- AeroFTP persists folder ids as `initialPath` with a leading slash (`/fmip…`). The no-slash filter dropped them, so export fell through to live discovery (or to a team id). One leading slash is stripped; remaining slashes still mean "this is a path, not an id".
- Team ids are not folder ids. rclone lists `GET /files/{root}/files`; a team id is F6016. Inject copies privatespace/workspace ids only. Discovery no longer returns `current_folder_id` when it is the team-id fallback from `discover_team`.

**Discovery bound**
- CLI and GUI share `ensure_zoho_rclone_root_folder`. The provider client used for file transfer allows a 1800s read timeout; discovery is a handful of JSON calls. A 45s cap on the shared helper stops a stuck Zoho API from stalling the whole export.

**Region**
- rclone does not whitelist regions; it interpolates the TLD. `uk` / `sa` / `ae` fit that template and are real Zoho DCs, so they are emitted. Canada lives at `zohocloud.ca`, which `accounts.zoho.{region}` cannot express, and unknown slugs are garbage: those profiles are skipped with a comment instead of writing a host rclone will never reach.

**S3 crypt overlay**
- A pinned bucket already exports as an alias (`minio-aeroftp-test` -> `minio:aeroftp-test`) because rclone's s3 backend has no `bucket` key. Crypt now wraps that alias, so overlay `/vault` becomes `remote = minio-aeroftp-test:/vault` rather than `minio:/vault` (a bucket named vault).

Tracker #575. Refs #596, #347.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Zoho WorkDrive exports by selecting valid root folders and rejecting invalid or unsupported folder identifiers.
  * Normalized initial paths and prevented empty or nested paths from producing incorrect exports.
  * Added a timeout for Zoho root-folder discovery to prevent indefinite waiting.
  * Improved region validation and skipped unsupported Zoho regions during export.
  * Improved S3 bucket alias handling, including encrypted bucket configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->