### PR TITLE
chore(deps): ignore globset >=0.4.20 until MSRV 1.88

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -104,6 +104,11 @@ updates:
         versions: [">=0.8.0"]
       - dependency-name: "chacha20poly1305"
         versions: [">=0.11.0"]
+      # globset 0.4.20 declares rust-version 1.88; we still advertise
+      # 1.85.0. Unblock when the AeroFTP MSRV moves, or globset ships
+      # a 0.4.x that stays on 1.85.
+      - dependency-name: "globset"
+        versions: [">=0.4.20"]
 
   # npm dependencies
   - package-ecosystem: "npm"


### PR DESCRIPTION
Related to Dependabot #602 (closed).

`globset` 0.4.20 sets `rust-version = 1.88`. We still advertise `rust-version = \"1.85.0\"` in `src-tauri/Cargo.toml`. CI is on 1.97 so the bump looked green; taking it would still lie about MSRV.

Ignore `>=0.4.20` until we bump the AeroFTP MSRV or globset ships a 0.4.x that stays on 1.85.

No runtime change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an update safeguard to maintain compatibility with the project’s supported Rust version.
  * Documented when newer versions can be enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->