### PR TITLE
fix: resolve community-reported UI and scan regressions

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10705,7 +10705,7 @@ dependencies = [
  "serde_with",
  "swift-rs",
  "thiserror 2.0.19",
- "toml 1.1.3+spec-1.1.0",
+ "toml 0.9.12+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",

--- a/src-tauri/src/filesystem.rs
+++ b/src-tauri/src/filesystem.rs
@@ -1834,6 +1834,7 @@ pub struct DuplicateGroup {
 /// the total is not yet knowable.
 #[derive(Serialize, Clone)]
 pub struct DuplicateScanProgress {
+    pub scan_id: String,
     pub phase: String,
     pub files_scanned: u64,
     pub dirs_scanned: u64,
@@ -1864,6 +1865,9 @@ pub async fn find_duplicate_files(
     // <=10, text <=3, other <=100). Exposed because the right threshold is a
     // judgement about the user's own library, not a constant (discussion #347).
     distance: Option<u32>,
+    // Frontend-generated operation identity. Progress events are global Tauri
+    // events, so without this two overlapping scans interleave their counters.
+    scan_id: Option<String>,
 ) -> Result<Vec<DuplicateGroup>, String> {
     validate_path(&path)?;
 
@@ -1873,6 +1877,7 @@ pub async fn find_duplicate_files(
     }
 
     let min = min_size.unwrap_or(1);
+    let scan_id = scan_id.unwrap_or_default();
 
     let is_non_identical = mode
         .as_deref()
@@ -1924,6 +1929,7 @@ pub async fn find_duplicate_files(
             let _ = app.emit(
                 "duplicate-scan-progress",
                 DuplicateScanProgress {
+                    scan_id: scan_id.clone(),
                     phase: "walk".to_string(),
                     files_scanned: scan_count,
                     dirs_scanned,
@@ -1953,6 +1959,7 @@ pub async fn find_duplicate_files(
             let _ = app.emit(
                 "duplicate-scan-progress",
                 DuplicateScanProgress {
+                    scan_id: scan_id.clone(),
                     phase: "analyze".to_string(),
                     files_scanned,
                     dirs_scanned,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11735,6 +11735,7 @@ async fn compare_directories(
     local_path: String,
     remote_path: String,
     options: Option<CompareOptions>,
+    progress_id: Option<String>,
 ) -> Result<Vec<FileComparison>, String> {
     let mut options = options.unwrap_or_default();
     sync::apply_error_correction_excludes(&mut options);
@@ -11761,6 +11762,7 @@ async fn compare_directories(
         serde_json::json!({
             "phase": "local",
             "files_found": 0,
+            "progress_id": progress_id,
         }),
     );
 
@@ -11774,6 +11776,7 @@ async fn compare_directories(
         options.compare_checksum,
         Some(&state.cancel_flag),
         Some(&app),
+        progress_id.as_deref(),
     );
 
     let remote_future = async {
@@ -11782,10 +11785,10 @@ async fn compare_directories(
             &app,
             &mut ftp_manager,
             &remote_path,
-            &remote_path,
             &options.exclude_patterns,
             0,
             Some(&state.cancel_flag),
+            progress_id.as_deref(),
         )
         .await
     };
@@ -11812,6 +11815,7 @@ async fn compare_directories(
         serde_json::json!({
             "phase": "comparing",
             "files_found": local_files.len() + remote_files.len(),
+            "progress_id": progress_id,
         }),
     );
 
@@ -11846,6 +11850,7 @@ async fn compare_local_directories(
     left_path: String,
     right_path: String,
     options: Option<CompareOptions>,
+    progress_id: Option<String>,
 ) -> Result<Vec<FileComparison>, String> {
     let mut options = options.unwrap_or_default();
     sync::apply_error_correction_excludes(&mut options);
@@ -11864,7 +11869,7 @@ async fn compare_local_directories(
 
     let _ = app.emit(
         "sync_scan_progress",
-        serde_json::json!({ "phase": "local", "files_found": 0 }),
+        serde_json::json!({ "phase": "local", "files_found": 0, "progress_id": progress_id }),
     );
 
     // Both sides are filesystem scans; run them concurrently.
@@ -11875,6 +11880,7 @@ async fn compare_local_directories(
         options.compare_checksum,
         Some(&state.cancel_flag),
         Some(&app),
+        progress_id.as_deref(),
     );
     let right_future = get_local_files_recursive_checked(
         &right_path,
@@ -11883,6 +11889,7 @@ async fn compare_local_directories(
         options.compare_checksum,
         Some(&state.cancel_flag),
         Some(&app),
+        progress_id.as_deref(),
     );
 
     let (left_result, right_result) = tokio::join!(left_future, right_future);
@@ -11901,6 +11908,7 @@ async fn compare_local_directories(
         serde_json::json!({
             "phase": "comparing",
             "files_found": left_files.len() + right_files.len(),
+            "progress_id": progress_id,
         }),
     );
 
@@ -12029,6 +12037,7 @@ pub async fn get_local_files_recursive_with_progress(
         compare_checksum,
         cancel_flag,
         app,
+        None,
     )
     .await
     .map(|(files, _)| files)
@@ -12048,6 +12057,7 @@ pub async fn get_local_files_recursive_checked(
     compare_checksum: bool,
     cancel_flag: Option<&std::sync::atomic::AtomicBool>,
     app: Option<&AppHandle>,
+    progress_id: Option<&str>,
 ) -> Result<
     (
         HashMap<String, FileInfo>,
@@ -12106,7 +12116,7 @@ pub async fn get_local_files_recursive_checked(
             {
                 let _ = handle.emit(
                     "sync_scan_progress",
-                    local_scan_progress_payload(count, dirs_found, bytes_found),
+                    local_scan_progress_payload_scoped(count, dirs_found, bytes_found, progress_id),
                 );
                 last_progress_emit = now;
                 last_progress_count = count;
@@ -12229,7 +12239,7 @@ pub async fn get_local_files_recursive_checked(
     if let Some(handle) = app {
         let _ = handle.emit(
             "sync_scan_progress",
-            local_scan_progress_payload(files.len(), dirs_found, bytes_found),
+            local_scan_progress_payload_scoped(files.len(), dirs_found, bytes_found, progress_id),
         );
     }
 
@@ -12244,11 +12254,21 @@ pub fn local_scan_progress_payload(
     dirs_found: usize,
     bytes_found: u64,
 ) -> serde_json::Value {
+    local_scan_progress_payload_scoped(files_found, dirs_found, bytes_found, None)
+}
+
+fn local_scan_progress_payload_scoped(
+    files_found: usize,
+    dirs_found: usize,
+    bytes_found: u64,
+    progress_id: Option<&str>,
+) -> serde_json::Value {
     serde_json::json!({
         "phase": "local",
         "files_found": files_found,
         "dirs_found": dirs_found,
         "bytes_found": bytes_found,
+        "progress_id": progress_id,
     })
 }
 
@@ -12451,10 +12471,10 @@ async fn get_remote_files_recursive_with_progress(
     app: &AppHandle,
     ftp_manager: &mut ftp::FtpManager,
     base_path: &str,
-    _current_path: &str,
     exclude_patterns: &[String],
     local_count: usize,
     cancel_flag: Option<&std::sync::atomic::AtomicBool>,
+    progress_id: Option<&str>,
 ) -> Result<
     (
         HashMap<String, FileInfo>,
@@ -12585,6 +12605,7 @@ async fn get_remote_files_recursive_with_progress(
                 "files_found": local_count + files.len(),
                 "dirs_found": remote_dirs_found,
                 "bytes_found": remote_bytes_found,
+                "progress_id": progress_id,
             }),
         );
     }
@@ -22085,7 +22106,7 @@ mod scan_completeness_gate_tests {
         HashMap<String, FileInfo>,
         crate::sync_core::ScanCompleteness,
     ) {
-        get_local_files_recursive_checked(root, root, &[], false, None, None)
+        get_local_files_recursive_checked(root, root, &[], false, None, None, None)
             .await
             .expect("walk should not hard-error")
     }
@@ -22152,6 +22173,7 @@ mod scan_completeness_gate_tests {
             &[],
             false,
             Some(&cancel),
+            None,
             None,
         )
         .await

--- a/src-tauri/src/provider_commands.rs
+++ b/src-tauri/src/provider_commands.rs
@@ -6437,6 +6437,8 @@ pub async fn provider_remove_permission(
 /// unchanged.
 struct ScanProgressEmitter {
     app: AppHandle,
+    progress_id: Option<String>,
+    base_count: usize,
 }
 
 impl crate::transfer_dag::DagObserver for ScanProgressEmitter {
@@ -6444,7 +6446,8 @@ impl crate::transfer_dag::DagObserver for ScanProgressEmitter {
         let _ = self.app.emit(
             "sync_scan_progress",
             serde_json::json!({
-                "phase": "remote", "files_found": scanned,
+                "phase": "remote", "files_found": self.base_count + scanned,
+                "progress_id": self.progress_id.as_deref(),
             }),
         );
     }
@@ -6604,6 +6607,7 @@ pub async fn provider_compare_directories(
     crypt_vault_id: Option<String>,
     crypt_kind: Option<String>,
     options: Option<crate::sync::CompareOptions>,
+    progress_id: Option<String>,
 ) -> Result<Vec<crate::sync::FileComparison>, String> {
     use crate::sync::{
         build_comparison_results_with_index, load_sync_index, should_exclude, FileInfo,
@@ -6638,6 +6642,7 @@ pub async fn provider_compare_directories(
         "sync_scan_progress",
         serde_json::json!({
             "phase": "local", "files_found": 0,
+            "progress_id": progress_id,
         }),
     );
 
@@ -6651,6 +6656,7 @@ pub async fn provider_compare_directories(
         options.compare_checksum,
         Some(&state.cancel_flag),
         Some(&app),
+        progress_id.as_deref(),
     )
     .await
     .map_err(|e| format!("Failed to scan local directory: {}", e))?;
@@ -6664,6 +6670,7 @@ pub async fn provider_compare_directories(
         "sync_scan_progress",
         serde_json::json!({
             "phase": "remote", "files_found": local_files.len(),
+            "progress_id": progress_id,
         }),
     );
 
@@ -6712,7 +6719,11 @@ pub async fn provider_compare_directories(
             disable_recursive_fastpath: crypt_compare_active,
             ..Default::default()
         };
-        let scan_observer = ScanProgressEmitter { app: app.clone() };
+        let scan_observer = ScanProgressEmitter {
+            app: app.clone(),
+            progress_id: progress_id.clone(),
+            base_count: local_files.len(),
+        };
         let (remote_entries, remote_scan) = scan_remote_tree_with_provider_lock_checked(
             state.provider.clone(),
             &remote_path,
@@ -6794,6 +6805,7 @@ pub async fn provider_compare_directories(
                 "phase": "remote",
                 "files_found": local_files.len() + remote_files.len(),
                 "bytes_found": remote_files.values().map(|f| f.size).sum::<u64>(),
+                "progress_id": progress_id,
             }),
         );
     } else {
@@ -6936,6 +6948,7 @@ pub async fn provider_compare_directories(
                     "files_found": local_files.len() + remote_files.len(),
                     "dirs_found": remote_dirs_found,
                     "bytes_found": remote_bytes_found,
+                    "progress_id": progress_id,
                 }),
             );
         }
@@ -7044,6 +7057,7 @@ pub async fn provider_compare_directories(
         serde_json::json!({
             "phase": "comparing",
             "files_found": local_files.len() + remote_files.len(),
+            "progress_id": progress_id,
         }),
     );
 

--- a/src-tauri/src/rclone_crypt.rs
+++ b/src-tauri/src/rclone_crypt.rs
@@ -1484,6 +1484,22 @@ mod tests {
     }
 
     #[test]
+    fn golden_rclone_174_standard_filenames_with_omitted_password2() {
+        // Generated with rclone v1.74.3 and an omitted/empty password2. This is
+        // the exact #600 setup: rclone substitutes its public default salt;
+        // AeroFTP must do the same or every name fails with PKCS#7 padding.
+        let (name_key, _, name_tweak) = derive_keys_with_tweak("triage-password-600", "").unwrap();
+        assert_eq!(
+            encrypt_name(&name_key, &name_tweak, "folder").unwrap(),
+            "785v69hnpanb9p84bhrlki9lp0"
+        );
+        assert_eq!(
+            encrypt_name(&name_key, &name_tweak, "file.txt").unwrap(),
+            "h5p2oibs3erqnaspobsargglqs"
+        );
+    }
+
+    #[test]
     fn name_decrypt_rejects_invalid_base32() {
         let key = [0u8; 32];
         let iv = [0u8; 16];

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -465,7 +465,7 @@ import { useTranslation } from './i18n';
 
 // Components
 import { ConfirmDialog, InputDialog, ArchivePasswordDialog, SyncNavDialog, PropertiesDialog, FileProperties, ChecksumCapability, MultiFilePropertiesDialog, MultiFileProperties, MasterPasswordSetupDialog } from './components/Dialogs';
-import { TransferToastContainer, dispatchTransferToast, reopenTransferToast } from './components/Transfer/TransferToastContainer';
+import { TransferToastContainer, dispatchTransferToast, toggleTransferToast } from './components/Transfer/TransferToastContainer';
 import { runExtractWithToast } from './utils/extractToast';
 import { archiveStem, dispatchGeneralExtract, isWrongPasswordError, resolveUniqueExtractDir } from './utils/extractOrchestrator';
 import { formatExtractDetails, formatCompressDetails } from './utils/archiveSizeReport';
@@ -10638,6 +10638,7 @@ const App: React.FC = () => {
     // Bump the compare token: any recursive scan still in flight from a
     // previous open is now stale and will discard its own result.
     const mySeq = ++aeroSyncCompareSeqRef.current;
+    const scanProgressId = `aerosync-${Date.now()}-${mySeq}`;
 
     const toCompareEntry = (item: { name: string; is_dir: boolean; size: number | null; modified: string | null }): CompareInputEntry => {
       const mtimeMs = (() => {
@@ -10669,6 +10670,7 @@ const App: React.FC = () => {
             ? null
             : compareEntries(localFiles.map(toCompareEntry), localFiles2.map(toCompareEntry)),
           compareLoading: canRecurse,
+          scanProgressId: canRecurse ? scanProgressId : undefined,
           leftLabel: leftPath || 'Local',
           rightLabel: rightPath || currentLocalPath || 'Local (right)',
           pairKind: 'local-local',
@@ -10697,6 +10699,7 @@ const App: React.FC = () => {
                 ],
                 direction: 'bidirectional',
               },
+              progressId: scanProgressId,
             });
             // Both sides are local: local_info = left, remote_info = right.
             resolved = adaptFileComparisons(comparisons, true);
@@ -10778,6 +10781,7 @@ const App: React.FC = () => {
         context: {
           compareResult: null,
           compareLoading: true,
+          scanProgressId,
           leftLabel: leftLocal ? (currentLocalPath || 'Local') : remoteLabel,
           rightLabel: leftLocal ? remoteLabel : (currentLocalPath || 'Local'),
           pairKind: leftLocal ? 'local-remote' : 'remote-local',
@@ -10813,6 +10817,7 @@ const App: React.FC = () => {
               ],
               direction: 'bidirectional',
             },
+            progressId: scanProgressId,
           };
           const comparisons = await invoke<FileComparison[]>(
             isProviderConn ? 'provider_compare_directories' : 'compare_directories',
@@ -19008,7 +19013,7 @@ const App: React.FC = () => {
             transferQueueCount={transferQueue.items.length}
             onToggleTransferQueue={transferQueue.toggle}
             transferToastActive={hasActiveTransfer || transferQueue.hasActiveTransfers}
-            onReopenTransferToast={reopenTransferToast}
+            onReopenTransferToast={toggleTransferToast}
             showActivityLog={showActivityLog}
             activityLogCount={activityLogFilteredCount}
             onToggleActivityLog={() => setShowActivityLog(!showActivityLog)}

--- a/src/components/AeroSync/AeroSyncDialog.tsx
+++ b/src/components/AeroSync/AeroSyncDialog.tsx
@@ -23,6 +23,7 @@ import { MultiPathEditor } from '../Sync/MultiPathEditor';
 import { RollbackDialog } from '../Sync/RollbackDialog';
 import { useTransferCapabilities } from '../Sync/useTransferCapabilities';
 import { TabStateStoreContext, createTabStateStore } from './tabStateStore';
+import { buildAeroSyncTabStatePatch, type ImportedSyncSettings } from '../../utils/syncTemplateApply';
 import type { AeroSyncDialogProps, AeroSyncTab } from './types';
 
 const TAB_ORDER: AeroSyncTab[] = ['compare', 'plan', 'sync'];
@@ -71,6 +72,14 @@ export const AeroSyncDialog: React.FC<AeroSyncDialogProps> = ({
     // a side effect in a place where side effects belong. A first-ever open sees
     // a fresh store anyway.
     const tabState = React.useRef(createTabStateStore()).current;
+    const applyImportedSettings = React.useCallback((settings: ImportedSyncSettings) => {
+        const patch = buildAeroSyncTabStatePatch(settings, context.pairKind);
+        Object.entries(patch).forEach(([key, value]) => tabState.set(key, value));
+        setShowTemplates(false);
+        // Plan summarizes the imported direction/preset. Sync is populated in
+        // the same store and shows the imported paths when the user opens it.
+        setActiveTab('plan');
+    }, [context.pairKind, tabState]);
     React.useEffect(() => {
         if (!isOpen) tabState.reset();
     }, [isOpen, tabState]);
@@ -254,6 +263,7 @@ export const AeroSyncDialog: React.FC<AeroSyncDialogProps> = ({
                         <CompareTabContent
                             result={context.compareResult}
                             loading={context.compareLoading}
+                            scanProgressId={context.scanProgressId}
                             leftLabel={context.leftLabel}
                             rightLabel={context.rightLabel}
                             pairKind={context.pairKind}
@@ -298,6 +308,7 @@ export const AeroSyncDialog: React.FC<AeroSyncDialogProps> = ({
                         remotePath={remotePath}
                         serverProfileName={serverProfileName}
                         excludePatterns={excludePatterns}
+                        onApplyImport={applyImportedSettings}
                     />
                     <MultiPathEditor
                         isOpen={showMultiPath}

--- a/src/components/AeroSync/CompareTabContent.tsx
+++ b/src/components/AeroSync/CompareTabContent.tsx
@@ -35,6 +35,7 @@ interface CompareTabContentProps {
     result: CompareResult | null;
     /** GAP-5: true while the recursive connected-remote scan is running. */
     loading?: boolean;
+    scanProgressId?: string;
     leftLabel: string;
     rightLabel: string;
     pairKind?: string | null;
@@ -217,6 +218,7 @@ const BucketSection: React.FC<BucketSectionProps> = ({ bucket, entries, bytes, i
 export const CompareTabContent: React.FC<CompareTabContentProps> = ({
     result,
     loading,
+    scanProgressId,
     leftLabel,
     rightLabel,
     pairKind,
@@ -227,7 +229,7 @@ export const CompareTabContent: React.FC<CompareTabContentProps> = ({
 }) => {
     const t = useTranslation();
     // Live counters for the scan the spinner below used to hide entirely.
-    const { totals: scanTotals, elapsedMs: scanElapsedMs } = useScanProgress(!!loading && !result);
+    const { totals: scanTotals, elapsedMs: scanElapsedMs } = useScanProgress(!!loading && !result, scanProgressId);
 
     // Hooks must run unconditionally: the recursive connected-remote scan
     // (GAP-5) flips `result` from null to a value while this component stays

--- a/src/components/AeroSync/tabStateStore.test.ts
+++ b/src/components/AeroSync/tabStateStore.test.ts
@@ -51,4 +51,14 @@ describe('createTabStateStore', () => {
     expect(store.get('plan.source', '')).toBe('/plan');
     expect(store.get('sync.source', '')).toBe('/sync');
   });
+
+  it('notifies a mounted tab when a dialog-level import writes its key', () => {
+    const store = createTabStateStore();
+    const seen: unknown[] = [];
+    const unsubscribe = store.subscribe('plan.preset', value => seen.push(value));
+    store.set('plan.preset', 'bisync');
+    unsubscribe();
+    store.set('plan.preset', 'mirror');
+    expect(seen).toEqual(['bisync']);
+  });
 });

--- a/src/components/AeroSync/tabStateStore.ts
+++ b/src/components/AeroSync/tabStateStore.ts
@@ -20,20 +20,32 @@ export interface TabStateStore {
   get<T>(key: string, fallback: T): T;
   set(key: string, value: unknown): void;
   has(key: string): boolean;
+  subscribe(key: string, listener: (value: unknown) => void): () => void;
   reset(): void;
 }
 
 export const createTabStateStore = (): TabStateStore => {
   const values = new Map<string, unknown>();
+  const listeners = new Map<string, Set<(value: unknown) => void>>();
   return {
     get<T>(key: string, fallback: T): T {
       return values.has(key) ? (values.get(key) as T) : fallback;
     },
     set(key: string, value: unknown): void {
       values.set(key, value);
+      listeners.get(key)?.forEach((listener) => listener(value));
     },
     has(key: string): boolean {
       return values.has(key);
+    },
+    subscribe(key: string, listener: (value: unknown) => void): () => void {
+      const keyListeners = listeners.get(key) ?? new Set<(value: unknown) => void>();
+      keyListeners.add(listener);
+      listeners.set(key, keyListeners);
+      return () => {
+        keyListeners.delete(listener);
+        if (keyListeners.size === 0) listeners.delete(key);
+      };
     },
     reset(): void {
       values.clear();
@@ -59,13 +71,27 @@ export function useStickyState<T>(
     const fallback = typeof initial === 'function' ? (initial as () => T)() : initial;
     return store ? store.get<T>(key, fallback) : fallback;
   });
+  const valueRef = React.useRef(value);
+  React.useEffect(() => { valueRef.current = value; }, [value]);
+
+  // Imports and other dialog-level actions write the store while a tab may be
+  // mounted. Subscribe so its visible controls change immediately rather than
+  // only after an unmount/remount cycle (#514).
+  React.useEffect(() => {
+    if (!store) return;
+    return store.subscribe(key, (next) => {
+      valueRef.current = next as T;
+      setValue(next as T);
+    });
+  }, [store, key]);
 
   const set = React.useCallback<React.Dispatch<React.SetStateAction<T>>>((next) => {
-    setValue((prev) => {
-      const resolved = typeof next === 'function' ? (next as (p: T) => T)(prev) : next;
-      store?.set(key, resolved);
-      return resolved;
-    });
+    const resolved = typeof next === 'function'
+      ? (next as (p: T) => T)(valueRef.current)
+      : next;
+    valueRef.current = resolved;
+    setValue(resolved);
+    store?.set(key, resolved);
   }, [store, key]);
 
   return [value, set];

--- a/src/components/AeroSync/types.ts
+++ b/src/components/AeroSync/types.ts
@@ -77,6 +77,8 @@ export interface AeroSyncContext {
      * render a scanning placeholder instead of the empty-state hint.
      */
     compareLoading?: boolean;
+    /** Identity of the backend compare whose global progress events belong to this dialog. */
+    scanProgressId?: string;
     /**
      * GAP-6: an interrupted connected-remote sync journal for this path
      * pair, if one exists. When set, the dialog surfaces a resume banner.

--- a/src/components/ConnectionScreen.tsx
+++ b/src/components/ConnectionScreen.tsx
@@ -6535,15 +6535,24 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                                         )}
                                         <div>
                                             {renderUsernameLabel()}
+                                            <div className="relative">
                                                 <input
                                                     type="text"
                                                     value={connectionParams.username}
                                                     onChange={(e) => onConnectionParamsChange({ ...connectionParams, username: e.target.value })}
-                                                    className="w-full px-4 py-2.5 bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-sm"
+                                                    className={`w-full px-4 py-2.5 ${isFilenDesktopBridge ? 'pr-12' : ''} bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-sm`}
                                                     placeholder={getUsernamePlaceholder()}
                                                     maxLength={isFilenDesktopBridge ? FILEN_BRIDGE_MAX_LENGTH : undefined}
                                                     aria-invalid={!!filenBridgeCredentialIssue}
                                                 />
+                                                {isFilenDesktopBridge && (
+                                                    <InlinePasswordGenerator
+                                                        preset="compatible"
+                                                        onGenerated={(value) => onConnectionParamsChange({ ...connectionParams, username: value })}
+                                                        className="absolute right-3 top-1/2 -translate-y-1/2"
+                                                    />
+                                                )}
+                                            </div>
                                         </div>
                                         {/* Password: not applicable to an AeroShare friend (peer carries
                                             no password; the binding rides in options.peer*). */}

--- a/src/components/DuplicateFinderDialog.tsx
+++ b/src/components/DuplicateFinderDialog.tsx
@@ -31,6 +31,7 @@ const isPreviewableImage = (name: string): boolean => PREVIEWABLE_IMAGE.test(nam
 
 /** Payload of the backend's `duplicate-scan-progress` event (filesystem.rs). */
 interface DuplicateScanProgress {
+  scan_id: string;
   phase: 'walk' | 'analyze';
   files_scanned: number;
   dirs_scanned: number;
@@ -234,6 +235,8 @@ export const DuplicateFinderDialog: React.FC<DuplicateFinderDialogProps> = ({
   // to those dependencies would turn a dropdown into a full filesystem walk.
   // The ref gives Retry the policy in force now without that.
   const keepPolicyRef = useRef(keepPolicy);
+  const scanSequenceRef = useRef(0);
+  const activeScanIdRef = useRef<string | null>(null);
   useEffect(() => {
     keepPolicyRef.current = keepPolicy;
   }, [keepPolicy]);
@@ -246,6 +249,8 @@ export const DuplicateFinderDialog: React.FC<DuplicateFinderDialogProps> = ({
 
   // Scan for duplicates when the dialog opens
   const scan = useCallback(async () => {
+    const scanId = `duplicate-${Date.now()}-${++scanSequenceRef.current}`;
+    activeScanIdRef.current = scanId;
     setIsScanning(true);
     setError(null);
     setGroups([]);
@@ -259,7 +264,9 @@ export const DuplicateFinderDialog: React.FC<DuplicateFinderDialogProps> = ({
         mode: mode,
         // Only meaningful for the fuzzy engine; null keeps its per-modality defaults.
         distance: mode === 'non-identical' ? appliedThreshold : null,
+        scanId,
       });
+      if (activeScanIdRef.current !== scanId) return;
       setGroups(result);
 
       if (mode === 'exact') {
@@ -273,9 +280,10 @@ export const DuplicateFinderDialog: React.FC<DuplicateFinderDialogProps> = ({
         setSelectedPaths(new Set());
       }
     } catch (err) {
+      if (activeScanIdRef.current !== scanId) return;
       setError(err instanceof Error ? err.message : String(err));
     } finally {
-      setIsScanning(false);
+      if (activeScanIdRef.current === scanId) setIsScanning(false);
     }
   }, [scanPath, mode, appliedThreshold]);
 
@@ -283,6 +291,7 @@ export const DuplicateFinderDialog: React.FC<DuplicateFinderDialogProps> = ({
     if (isOpen) {
       scan();
     } else {
+      activeScanIdRef.current = null;
       // Reset state when dialog closes
       setGroups([]);
       setSelectedPaths(new Set());
@@ -301,6 +310,7 @@ export const DuplicateFinderDialog: React.FC<DuplicateFinderDialogProps> = ({
     let unlisten: UnlistenFn | null = null;
     let cancelled = false;
     listen<DuplicateScanProgress>('duplicate-scan-progress', (e) => {
+      if (e.payload.scan_id !== activeScanIdRef.current) return;
       setProgress(e.payload);
     }).then((fn) => {
       if (cancelled) fn();

--- a/src/components/IntroHub/MyServersPanel.tsx
+++ b/src/components/IntroHub/MyServersPanel.tsx
@@ -780,6 +780,13 @@ export function MyServersPanel({
         }
     }, [dragIdx]);
 
+    // Visible list for the native drag handlers (filteredServers is declared
+    // later). The source is also pinned by id: React can re-render this table
+    // during a drag when health/quota data arrives, and a render-time index can
+    // then identify a different row (#453).
+    const visibleListRef = useRef<ServerProfile[]>([]);
+    const dragServerIdRef = useRef<string | null>(null);
+
     // Drag handlers used to be higher-order functions (`(idx) => (e) => ...`),
     // which produced a fresh closure per card per render and silently
     // defeated the `React.memo()` on `ServerCard` and `MyServersTableRow`.
@@ -787,9 +794,15 @@ export function MyServersPanel({
     // a stable reference and the children rebind to their own row index
     // internally via `useCallback`. See issue #221.
     const handleDragStart = useCallback((idx: number, e: React.DragEvent) => {
+        const sourceId = visibleListRef.current[idx]?.id;
+        if (!sourceId) {
+            e.preventDefault();
+            return;
+        }
+        dragServerIdRef.current = sourceId;
         setDragIdx(idx);
         e.dataTransfer.effectAllowed = 'move';
-        e.dataTransfer.setData('text/plain', idx.toString());
+        e.dataTransfer.setData('text/plain', sourceId);
     }, []);
 
     const handleDragEnter = useCallback((idx: number, e: React.DragEvent) => {
@@ -806,15 +819,15 @@ export function MyServersPanel({
         setOverIdx(idx);
     }, [maybeAutoScrollWhileDrag]);
 
-    // Visible list for the drop handler (filteredServers is declared later).
-    // Ref keeps the callback stable and avoids a temporal dead zone on the memo.
-    const visibleListRef = useRef<ServerProfile[]>([]);
-
     const handleDrop = useCallback((idx: number, e: React.DragEvent) => {
         e.preventDefault();
-        if (dragIdx === null) { setDragIdx(null); setOverIdx(null); return; }
         const visible = visibleListRef.current;
-        if (visible.length === 0) { setDragIdx(null); setOverIdx(null); return; }
+        if (visible.length === 0) { dragServerIdRef.current = null; setDragIdx(null); setOverIdx(null); return; }
+        let transferredId = '';
+        try { transferredId = e.dataTransfer.getData('text/plain'); } catch { /* WebKit fallback below */ }
+        const sourceId = dragServerIdRef.current || transferredId;
+        const fromVisible = visible.findIndex((server) => server.id === sourceId);
+        if (fromVisible < 0) { dragServerIdRef.current = null; setDragIdx(null); setOverIdx(null); return; }
 
         // Drop ON a row inherits that row's visible index. Top/bottom sentinels
         // pin the ends of the visible list (append uses length as "after last").
@@ -823,21 +836,24 @@ export function MyServersPanel({
             : idx === DRAG_SENTINEL_BOTTOM
                 ? visible.length
                 : idx;
-        if (dragIdx === rawTarget) { setDragIdx(null); setOverIdx(null); return; }
+        if (fromVisible === rawTarget) { dragServerIdRef.current = null; setDragIdx(null); setOverIdx(null); return; }
 
-        const updated = reorderVisibleInFull(servers, visible, dragIdx, rawTarget);
+        const updated = reorderVisibleInFull(servers, visible, fromVisible, rawTarget);
         if (updated.every((s, i) => s.id === servers[i]?.id)) {
+            dragServerIdRef.current = null;
             setDragIdx(null);
             setOverIdx(null);
             return;
         }
         setServers(updated);
         storeSavedServerProfiles(updated).catch(() => {});
+        dragServerIdRef.current = null;
         setDragIdx(null);
         setOverIdx(null);
-    }, [dragIdx, servers]);
+    }, [servers]);
 
     const handleDragEnd = useCallback(() => {
+        dragServerIdRef.current = null;
         setDragIdx(null);
         setOverIdx(null);
     }, []);

--- a/src/components/PasswordForgeTab.tsx
+++ b/src/components/PasswordForgeTab.tsx
@@ -116,8 +116,8 @@ export const PasswordForgeTab: React.FC = () => {
                 <div className="space-y-4">
                     <div>
                         <label className="mb-1.5 block text-xs font-medium text-gray-500 dark:text-gray-400">{t('cyberTools.pwdPresets')}</label>
-                        <div className="grid grid-cols-3 gap-1.5">
-                            {(['balanced', 'maximum', 'compatible'] as const).map(preset => (
+                        <div className="grid grid-cols-2 gap-1.5">
+                            {(['balanced', 'maximum'] as const).map(preset => (
                                 <button key={preset} type="button" onClick={() => applyPreset(preset)} className={`rounded-md border px-2 py-2 text-xs font-medium transition-all ${activePreset === preset ? 'border-cyan-500 bg-cyan-500/10 text-cyan-700 dark:text-cyan-300' : 'border-gray-200 text-gray-600 hover:border-cyan-300 dark:border-gray-700 dark:text-gray-300'}`}>
                                     {t(`cyberTools.pwdPreset${preset[0].toUpperCase()}${preset.slice(1)}`)}
                                 </button>

--- a/src/components/SpeedTestDialog.tsx
+++ b/src/components/SpeedTestDialog.tsx
@@ -49,6 +49,7 @@ import {
     rankOutcomes,
     singleResultAsOutcome,
     SPEEDTEST_SIZES,
+    speedTestServerName,
     supportsSpeedTest,
 } from '../utils/speedTest';
 import { ServerProfile } from '../types';
@@ -364,14 +365,14 @@ export const SpeedTestDialog: React.FC<SpeedTestDialogProps> = ({
                     const testId = genTestId();
                     compareTestIdsRef.current.set(testId, {
                         serverId: server.id,
-                        serverName: server.name || server.host,
+                        serverName: speedTestServerName(server),
                         protocol: server.protocol || 'ftp',
                     });
                     return {
                         connection,
                         size_bytes: effectiveSize,
                         remote_dir: server.initialPath || '/',
-                        server_name: server.name || server.host,
+                        server_name: speedTestServerName(server),
                         test_id: testId,
                         expert_confirmed: sizeRequiresConfirm && expertConfirmed,
                         verify_integrity: verifyIntegrity,

--- a/src/components/Sync/SyncTemplateDialog.tsx
+++ b/src/components/Sync/SyncTemplateDialog.tsx
@@ -24,6 +24,12 @@ import {
 } from '../../types';
 import { useTranslation } from '../../i18n';
 import { useDraggableModal } from '../../hooks/useDraggableModal';
+import {
+    settingsFromAerosyncScript,
+    settingsFromLegacyScript,
+    settingsFromTemplate,
+    type ImportedSyncSettings,
+} from '../../utils/syncTemplateApply';
 
 interface SyncTemplateDialogProps {
     isOpen: boolean;
@@ -38,6 +44,8 @@ interface SyncTemplateDialogProps {
      */
     serverProfileName: string;
     excludePatterns: string[];
+    /** Apply imported values to the live AeroSync Plan + Sync tab controls. */
+    onApplyImport: (settings: ImportedSyncSettings) => void;
 }
 
 type ExportFormat = 'aerosync' | 'aeroftp-script' | 'bash' | 'pwsh';
@@ -57,6 +65,7 @@ export const SyncTemplateDialog: React.FC<SyncTemplateDialogProps> = ({
     remotePath,
     serverProfileName,
     excludePatterns,
+    onApplyImport,
 }) => {
     const t = useTranslation();
     const modalDrag = useDraggableModal();
@@ -592,6 +601,14 @@ export const SyncTemplateDialog: React.FC<SyncTemplateDialogProps> = ({
                             {importPreview.exclude_patterns.length > 0 && (
                                 <div><strong>Excludes:</strong> {importPreview.exclude_patterns.join(', ')}</div>
                             )}
+                            <div className="pt-2">
+                                <button
+                                    className="px-3 py-1.5 rounded-lg bg-purple-500 text-white text-xs font-medium hover:bg-purple-600"
+                                    onClick={() => onApplyImport(settingsFromTemplate(importPreview))}
+                                >
+                                    {t('common.apply')}
+                                </button>
+                            </div>
                         </div>
                     )}
 
@@ -652,9 +669,15 @@ export const SyncTemplateDialog: React.FC<SyncTemplateDialogProps> = ({
                                     ))}
                                 </ul>
                             )}
-                            <div className="pt-2">
+                            <div className="flex gap-2 pt-2">
                                 <button
-                                    className="px-3 py-1.5 rounded-lg bg-purple-500 text-white text-xs font-medium hover:bg-purple-600 disabled:opacity-50"
+                                    className="px-3 py-1.5 rounded-lg bg-purple-500 text-white text-xs font-medium hover:bg-purple-600"
+                                    onClick={() => onApplyImport(settingsFromAerosyncScript(importedAerosyncScript))}
+                                >
+                                    {t('common.apply')}
+                                </button>
+                                <button
+                                    className="px-3 py-1.5 rounded-lg border border-purple-500 text-purple-500 text-xs font-medium hover:bg-purple-500/10 disabled:opacity-50"
                                     onClick={applyImportedAerosyncScript}
                                     disabled={applying}
                                 >
@@ -686,6 +709,14 @@ export const SyncTemplateDialog: React.FC<SyncTemplateDialogProps> = ({
                             {importedScript.retries != null && (
                                 <div><strong>Retries:</strong> {importedScript.retries}{importedScript.retries_sleep ? ` × ${importedScript.retries_sleep}` : ''}</div>
                             )}
+                            <div className="pt-2">
+                                <button
+                                    className="px-3 py-1.5 rounded-lg bg-purple-500 text-white text-xs font-medium hover:bg-purple-600"
+                                    onClick={() => onApplyImport(settingsFromLegacyScript(importedScript))}
+                                >
+                                    {t('common.apply')}
+                                </button>
+                            </div>
                         </div>
                     )}
 

--- a/src/components/Transfer/TransferToastContainer.tsx
+++ b/src/components/Transfer/TransferToastContainer.tsx
@@ -19,6 +19,7 @@ import { MinimizedTransferIndicator, ProgressCard, TransferToastState } from './
 
 /** Custom event name for transfer progress updates */
 export const TRANSFER_TOAST_EVENT = 'transfer-toast-update';
+export const TRANSFER_TOAST_TOGGLE_EVENT = 'transfer-toast-toggle';
 let latestTransferToastState: TransferToastState | null = null;
 let activeTransferToastId: string | null = null;
 let dismissedTransferToastId: string | null = null;
@@ -52,6 +53,13 @@ export function reopenTransferToast(): void {
     if (!latestTransferToastState) return;
     dismissedTransferToastId = null;
     window.dispatchEvent(new CustomEvent(TRANSFER_TOAST_EVENT, { detail: latestTransferToastState }));
+}
+
+/** Toggle the compact/full AeroProgress surface for the active transfer. */
+export function toggleTransferToast(): void {
+    if (!latestTransferToastState) return;
+    dismissedTransferToastId = null;
+    window.dispatchEvent(new CustomEvent(TRANSFER_TOAST_TOGGLE_EVENT));
 }
 
 interface TransferToastContainerProps {
@@ -90,6 +98,17 @@ export const TransferToastContainer: React.FC<TransferToastContainerProps> = ({ 
         };
         window.addEventListener(TRANSFER_TOAST_EVENT, handler);
         return () => window.removeEventListener(TRANSFER_TOAST_EVENT, handler);
+    }, []);
+
+    // The status-bar Progress chip is the peer of the Queue chip: repeated
+    // clicks collapse and restore its own window instead of being a one-way
+    // "reopen" action (#364).
+    useEffect(() => {
+        const toggle = () => {
+            if (latestTransferToastState) setMinimized((value) => !value);
+        };
+        window.addEventListener(TRANSFER_TOAST_TOGGLE_EVENT, toggle);
+        return () => window.removeEventListener(TRANSFER_TOAST_TOGGLE_EVENT, toggle);
     }, []);
 
     // Stuck detection: auto-close if no updates for 30 seconds

--- a/src/components/Transfer/index.tsx
+++ b/src/components/Transfer/index.tsx
@@ -230,10 +230,46 @@ export const ProgressCard: React.FC<ProgressCardProps> = ({ transfer, onCancel, 
         // #364: anchor bottom-LEFT (was centered) so this card never overlaps
         // the bottom-right Transfer Queue panel (fixed bottom-12 right-6 w-[33rem]).
         <div
-            className={`fixed bottom-12 left-6 z-40 rounded-lg border px-4 py-3 w-[30rem] max-w-[calc(100vw-2rem)] text-xs ${styles.container}`}
+            className={`fixed bottom-12 left-6 z-40 overflow-hidden rounded-lg border w-[30rem] max-w-[calc(100vw-2rem)] text-xs ${styles.container}`}
             style={{ isolation: 'isolate', contain: 'layout paint' }}
         >
-            <div className="flex items-start gap-3">
+            <div
+                className="flex cursor-pointer items-center justify-between gap-3 border-b border-gray-200 bg-gray-100 px-3 py-2 dark:border-gray-700 dark:bg-gray-800"
+                onClick={onMinimize}
+                title={t('ui.minimize')}
+            >
+                <span className={`min-w-0 truncate font-semibold ${styles.title}`} title={summary.path || summary.filename}>
+                    {t('transfer.progress')} · {displayName}
+                </span>
+                <div className="flex shrink-0 items-center gap-0.5" onClick={(event) => event.stopPropagation()}>
+                    <span className={`mr-1 text-base font-semibold tabular-nums ${styles.title}`}>
+                        {isIndeterminate ? '...' : `${headerPct}%`}
+                    </span>
+                    {onOpenPanel && (
+                        <button onClick={onOpenPanel} className={`p-1 rounded-md transition-opacity opacity-60 hover:opacity-100 ${styles.title}`} title={t('transfer.queue')} aria-label={t('transfer.queue')}>
+                            <Maximize2 size={13} />
+                        </button>
+                    )}
+                    {isTransferring ? (
+                        <span className={`p-1 ${styles.subtitle}`} title={t('ui.locked')}>
+                            <Lock size={13} />
+                        </span>
+                    ) : (
+                        <button onClick={onCancel} className={`p-1 rounded-full transition-colors ${styles.cancel}`} title={t('ui.dismiss')}>
+                            <X size={14} />
+                        </button>
+                    )}
+                    <button
+                        onClick={onMinimize}
+                        className={`p-1 rounded-md transition-opacity opacity-60 hover:opacity-100 ${styles.title}`}
+                        title={t('ui.minimize')}
+                        aria-label={t('ui.minimize')}
+                    >
+                        <Minus size={14} />
+                    </button>
+                </div>
+            </div>
+            <div className="flex items-start gap-3 px-4 py-3">
                 <div className={`mt-0.5 rounded-lg p-2 ${styles.panel} ${isUpload && !isFolderTransfer ? 'animate-pulse' : ''}`}>
                     {isFolderTransfer
                         ? <Folder size={18} className={isUpload ? 'text-cyan-400' : 'text-orange-400'} />
@@ -254,38 +290,6 @@ export const ProgressCard: React.FC<ProgressCardProps> = ({ transfer, onCancel, 
                                     <span className={`rounded-md px-1.5 py-0.5 ${styles.badgeMuted}`}>{summary.transferred}/{summary.total} files</span>
                                 )}
                             </div>
-                        </div>
-                        <div className="flex items-center gap-0.5 shrink-0">
-                            <span className={`text-base font-semibold tabular-nums mr-1 ${styles.title}`}>
-                                {isIndeterminate ? '...' : `${headerPct}%`}
-                            </span>
-                            {onOpenPanel && (
-                                <button onClick={onOpenPanel} className={`p-1 rounded-md transition-opacity opacity-60 hover:opacity-100 ${styles.title}`} title={t('transfer.queue')} aria-label={t('transfer.queue')}>
-                                    <Maximize2 size={13} />
-                                </button>
-                            )}
-                            {/* Locked during transfer (no full dismiss until 100%):
-                                only minimize is allowed, so an in-flight transfer
-                                can never be lost. The close button returns at 100%. */}
-                            {isTransferring ? (
-                                <span className={`p-1 ${styles.subtitle}`} title={t('ui.locked')}>
-                                    <Lock size={13} />
-                                </span>
-                            ) : (
-                                <button onClick={onCancel} className={`p-1 rounded-full transition-colors ${styles.cancel}`} title={t('ui.dismiss')}>
-                                    <X size={14} />
-                                </button>
-                            )}
-                            {/* Last in the row: the top-right corner is Minimize in
-                                both transfer windows, so the two read the same (#364). */}
-                            <button
-                                onClick={onMinimize}
-                                className={`p-1 rounded-md transition-opacity opacity-60 hover:opacity-100 ${styles.title}`}
-                                title={t('ui.minimize')}
-                                aria-label={t('ui.minimize')}
-                            >
-                                <Minus size={14} />
-                            </button>
                         </div>
                     </div>
 
@@ -503,4 +507,3 @@ function getToastStyles(theme: string) {
             };
     }
 }
-

--- a/src/components/Trash/TrashTable.tsx
+++ b/src/components/Trash/TrashTable.tsx
@@ -16,10 +16,13 @@
 //     losing what is already selected, and a rubber-band drag selects an area.
 
 import * as React from 'react';
-import { CheckSquare, File, Folder, Square, ChevronUp, ChevronDown } from 'lucide-react';
+import { CheckSquare, File, Folder, Square, ChevronUp, ChevronDown, Settings2 } from 'lucide-react';
 import { formatSize, formatDate } from '../../utils/formatters';
 import { useMarqueeSelection } from '../../hooks/useMarqueeSelection';
 import { useTranslation } from '../../i18n';
+import { useTableColumns, type TableColumnDef, type TableColAlign } from '../../hooks/useTableColumns';
+import { TableColumnsManager } from '../ui/TableColumnsManager';
+import { TableColResizer } from '../ui/TableColResizer';
 import {
     nextTrashSort,
     selectionAfterRowClick,
@@ -58,21 +61,22 @@ interface TrashTableProps {
     showTypeColumn?: boolean;
 }
 
-const HEADERS: { key: TrashSortKey; labelKey: string; fallback: string; className: string }[] = [
+const TRASH_COLUMNS: TableColumnDef<TrashSortKey>[] = [
     // settings.columnType is the file-list column header of the same name,
     // already translated everywhere; no 47th copy of the word "Type".
-    { key: 'type', labelKey: 'settings.columnType', fallback: 'Type', className: 'w-10' },
-    { key: 'name', labelKey: 'common.name', fallback: 'Name', className: '' },
-    { key: 'size', labelKey: 'common.size', fallback: 'Size', className: 'w-20 text-right' },
-    {
-        key: 'deletedAt',
-        labelKey: 'contextMenu.trashDeletedDate',
-        fallback: 'Deleted',
-        // Wide enough for a full date and time on one line, and never wrapped:
-        // the Name column gives up the width, which it has to spare.
-        className: 'w-48 whitespace-nowrap',
-    },
+    { id: 'type', labelKey: 'settings.columnType', sortable: true, defaultVisible: true, defaultWidth: 64, minWidth: 48, defaultAlign: 'center' },
+    { id: 'name', labelKey: 'common.name', sortable: true, defaultVisible: true, defaultWidth: 300, minWidth: 120, defaultAlign: 'left' },
+    { id: 'size', labelKey: 'common.size', sortable: true, defaultVisible: true, defaultWidth: 100, minWidth: 72, defaultAlign: 'right' },
+    { id: 'deletedAt', labelKey: 'contextMenu.trashDeletedDate', sortable: true, defaultVisible: true, defaultWidth: 190, minWidth: 130, defaultAlign: 'left' },
 ];
+
+const alignClass = (align: TableColAlign): string => align === 'right'
+    ? 'text-right'
+    : align === 'center' ? 'text-center' : 'text-left';
+
+const justifyClass = (align: TableColAlign): string => align === 'right'
+    ? 'justify-end'
+    : align === 'center' ? 'justify-center' : 'justify-start';
 
 const NO_SELECTION: Set<string> = new Set();
 
@@ -88,11 +92,38 @@ export const TrashTable: React.FC<TrashTableProps> = ({
     const t = useTranslation();
     const selectable = !!setSelected;
     const selection = selected ?? NO_SELECTION;
-    const [sort, setSort] = React.useState<TrashSort | null>(null);
     const anchorRef = React.useRef<number | null>(null);
     const containerRef = React.useRef<HTMLDivElement | null>(null);
+    const managerRef = React.useRef<HTMLDivElement | null>(null);
+    const [showManager, setShowManager] = React.useState(false);
+    const columns = useTableColumns({ columns: TRASH_COLUMNS, storageKey: 'trash_table' });
+    const visibleColumns = React.useMemo(
+        () => columns.orderedVisibleColumns.filter((column) => showTypeColumn || column.id !== 'type'),
+        [columns.orderedVisibleColumns, showTypeColumn],
+    );
+    const [liveWidths, setLiveWidths] = React.useState(columns.config.widths);
+    React.useEffect(() => setLiveWidths(columns.config.widths), [columns.config.widths]);
+    const sort: TrashSort | null = columns.config.sort
+        ? { key: columns.config.sort.colId, direction: columns.config.sort.dir }
+        : null;
 
     const ordered = React.useMemo(() => sortTrashRows(rows, sort), [rows, sort]);
+
+    React.useEffect(() => {
+        if (!showManager) return;
+        const closeOutside = (event: MouseEvent) => {
+            if (!managerRef.current?.contains(event.target as Node)) setShowManager(false);
+        };
+        const closeOnEscape = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') setShowManager(false);
+        };
+        document.addEventListener('mousedown', closeOutside);
+        document.addEventListener('keydown', closeOnEscape);
+        return () => {
+            document.removeEventListener('mousedown', closeOutside);
+            document.removeEventListener('keydown', closeOnEscape);
+        };
+    }, [showManager]);
 
     // Rubber band. The hook keys items by `data-file-name`, which here carries
     // the row id, so the set it produces is the same set the checkboxes use.
@@ -126,14 +157,45 @@ export const TrashTable: React.FC<TrashTableProps> = ({
             : <ChevronDown size={11} className="inline-block ml-0.5 -mt-px" />;
     };
 
+    const renderCoreCell = (row: TrashRow, key: TrashSortKey) => {
+        switch (key) {
+            case 'type':
+                return row.isDir
+                    ? <Folder size={13} className="inline-block text-yellow-500" />
+                    : <File size={13} className="inline-block text-gray-500 dark:text-gray-500" />;
+            case 'name':
+                return <span className="block truncate text-gray-900 dark:text-gray-100">{row.name}</span>;
+            case 'size':
+                return <span className="tabular-nums text-gray-600 dark:text-gray-400">{row.isDir || row.size == null ? '-' : formatSize(row.size)}</span>;
+            case 'deletedAt':
+                return <span className="whitespace-nowrap tabular-nums text-gray-500 dark:text-gray-500">{row.deletedAtLabel ?? (row.deletedAt ? formatDate(row.deletedAt) : '-')}</span>;
+            default:
+                return null;
+        }
+    };
+
+    const tableMinWidth = (selectable ? 32 : 0)
+        + visibleColumns.reduce((sum, column) => sum + liveWidths[column.id], 0)
+        + extraColumns.length * 120
+        + 40;
+
     return (
-        <div ref={containerRef} className="relative h-full min-h-0 overflow-y-auto" onMouseDown={marquee.onMouseDown}>
-            <table className="w-full text-xs select-none">
+        <div ref={containerRef} className="relative h-full min-h-0 overflow-auto" onMouseDown={marquee.onMouseDown}>
+            <table className="w-full table-fixed text-xs select-none" style={{ minWidth: `${tableMinWidth}px` }}>
+                <colgroup>
+                    {selectable && <col style={{ width: '32px' }} />}
+                    {visibleColumns.map((column) => <col key={column.id} style={{ width: `${liveWidths[column.id]}px` }} />)}
+                    {extraColumns.map((column) => <col key={column.key} />)}
+                    <col style={{ width: '40px' }} />
+                </colgroup>
                 <thead className="sticky top-0 z-10 bg-gray-50 dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
                     <tr className="text-left text-gray-500 dark:text-gray-500">
                         {selectable && <th className="w-8 px-2 py-1.5" />}
-                        {HEADERS.filter((h) => showTypeColumn || h.key !== 'type').map(({ key, labelKey, fallback, className }) => (
-                            <th key={key} className={`px-2 py-1.5 ${className}`}>
+                        {visibleColumns.map((column) => {
+                            const key = column.id;
+                            const alignment = columns.resolveAlign(key);
+                            return (
+                            <th key={key} className={`relative px-2 py-1.5 whitespace-nowrap ${alignClass(alignment)}`}>
                                 <button
                                     type="button"
                                     onClick={() => {
@@ -141,21 +203,56 @@ export const TrashTable: React.FC<TrashTableProps> = ({
                                         // order; a sort gives that index to a
                                         // different row, so start a new range.
                                         anchorRef.current = null;
-                                        setSort((cur) => nextTrashSort(cur, key));
+                                        const next = nextTrashSort(sort, key);
+                                        columns.setSort(next ? { colId: next.key, dir: next.direction } : null);
                                     }}
-                                    className="inline-flex items-center hover:text-gray-700 dark:hover:text-gray-300"
-                                    aria-label={t(labelKey) || fallback}
+                                    className={`flex w-full items-center hover:text-gray-700 dark:hover:text-gray-300 ${justifyClass(alignment)}`}
+                                    aria-label={t(column.labelKey)}
                                 >
-                                    {t(labelKey) || fallback}
+                                    {t(column.labelKey)}
                                     {sortIndicator(key)}
                                 </button>
+                                <TableColResizer
+                                    currentWidth={liveWidths[key]}
+                                    minWidth={column.minWidth}
+                                    onResize={(width) => setLiveWidths((current) => ({ ...current, [key]: width }))}
+                                    onResizeEnd={(width) => columns.setWidth(key, width)}
+                                    title={t('table.dragToResize')}
+                                />
                             </th>
-                        ))}
+                            );
+                        })}
                         {extraColumns.map((col) => (
                             <th key={col.key} className={`px-2 py-1.5 ${col.className ?? ''}`}>
                                 {col.header}
                             </th>
                         ))}
+                        <th className="px-1 py-1.5 text-right">
+                            <div ref={managerRef} className="relative inline-block">
+                                <button
+                                    type="button"
+                                    onClick={(event) => { event.stopPropagation(); setShowManager((value) => !value); }}
+                                    className="rounded p-1 text-gray-400 hover:bg-gray-200 hover:text-gray-700 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+                                    title={t('table.manageColumns')}
+                                    aria-label={t('table.manageColumns')}
+                                >
+                                    <Settings2 size={13} />
+                                </button>
+                                {showManager && (
+                                    <TableColumnsManager
+                                        columns={TRASH_COLUMNS}
+                                        visibility={columns.config.visibility}
+                                        orderedAllColumns={columns.orderedAllColumns}
+                                        onSetVisible={columns.setVisible}
+                                        onSetOrder={columns.setOrder}
+                                        onReset={() => { columns.reset(); setShowManager(false); }}
+                                        onClose={() => setShowManager(false)}
+                                        resolveAlign={columns.resolveAlign}
+                                        onSetAlign={columns.setAlign}
+                                    />
+                                )}
+                            </div>
+                        </th>
                     </tr>
                 </thead>
                 <tbody>
@@ -181,32 +278,17 @@ export const TrashTable: React.FC<TrashTableProps> = ({
                                         )}
                                     </td>
                                 )}
-                                {showTypeColumn && (
-                                    <td className="px-2 py-1.5 text-center">
-                                        {row.isDir ? (
-                                            <Folder size={13} className="inline-block text-yellow-500" />
-                                        ) : (
-                                            <File size={13} className="inline-block text-gray-500 dark:text-gray-500" />
-                                        )}
+                                {visibleColumns.map((column) => (
+                                    <td key={column.id} className={`px-2 py-1.5 ${alignClass(columns.resolveAlign(column.id))}`}>
+                                        {renderCoreCell(row, column.id)}
                                     </td>
-                                )}
-                                <td className="px-2 py-1.5">
-                                    <span className="block truncate text-gray-900 dark:text-gray-100">{row.name}</span>
-                                </td>
-                                <td className="px-2 py-1.5 text-right text-gray-600 dark:text-gray-400 tabular-nums">
-                                    {/* Null is not zero: a folder, an S3 delete marker and a
-                                        FileLu row have no size to show, and sortTrashRows
-                                        already treats them that way. */}
-                                    {row.isDir || row.size == null ? '-' : formatSize(row.size)}
-                                </td>
-                                <td className="px-2 py-1.5 whitespace-nowrap text-gray-500 dark:text-gray-500 tabular-nums">
-                                    {row.deletedAtLabel ?? (row.deletedAt ? formatDate(row.deletedAt) : '-')}
-                                </td>
+                                ))}
                                 {extraColumns.map((col) => (
                                     <td key={col.key} className={`px-2 py-1.5 ${col.className ?? ''}`}>
                                         {col.render(row)}
                                     </td>
                                 ))}
+                                <td />
                             </tr>
                         );
                     })}

--- a/src/hooks/useScanProgress.ts
+++ b/src/hooks/useScanProgress.ts
@@ -16,6 +16,7 @@ import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 /** One `sync_scan_progress` tick. `dirs_found`/`bytes_found` are absent from
  *  the DAG-observer emitter, which only knows how many entries it has seen. */
 export interface ScanProgressEvent {
+    progress_id?: string;
     phase: 'local' | 'remote' | 'comparing';
     files_found?: number;
     dirs_found?: number;
@@ -82,7 +83,7 @@ export function scanProgressTotals(state: ScanProgressState): ScanProgressSide {
  * Subscribe while `active`, and keep a clock running alongside. Returns the
  * folded state, the totals, and how long the scan has been going.
  */
-export function useScanProgress(active: boolean) {
+export function useScanProgress(active: boolean, progressId?: string) {
     const [state, setState] = useState<ScanProgressState>(EMPTY_SCAN_PROGRESS);
     const [elapsedMs, setElapsedMs] = useState(0);
     const startedAt = useRef<number>(0);
@@ -96,6 +97,7 @@ export function useScanProgress(active: boolean) {
         let unlisten: UnlistenFn | null = null;
         let cancelled = false;
         listen<ScanProgressEvent>('sync_scan_progress', (e) => {
+            if (progressId && e.payload.progress_id !== progressId) return;
             setState((prev) => reduceScanProgress(prev, e.payload));
         }).then((fn) => {
             if (cancelled) fn();
@@ -108,7 +110,7 @@ export function useScanProgress(active: boolean) {
             if (unlisten) unlisten();
             clearInterval(clock);
         };
-    }, [active]);
+    }, [active, progressId]);
 
     return { progress: state, totals: scanProgressTotals(state), elapsedMs };
 }

--- a/src/utils/passwordForge.test.ts
+++ b/src/utils/passwordForge.test.ts
@@ -10,7 +10,7 @@ import {
 } from './passwordForge';
 
 describe('passwordForge', () => {
-    it('defines a compatible 32 preset that satisfies the Filen bridge restrictions', () => {
+    it('keeps the internal Filen bridge generator at the longest accepted length', () => {
         const preset = PASSWORD_PRESETS.compatible;
         expect(preset.length).toBe(FILEN_BRIDGE_MAX_LENGTH);
         expect([...preset.customCharacters].some(char => FILEN_BRIDGE_REJECTED_CHARACTERS.includes(char))).toBe(false);

--- a/src/utils/speedTest.test.ts
+++ b/src/utils/speedTest.test.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it } from 'vitest';
+import type { ServerProfile } from '../types';
+import { speedTestServerName } from './speedTest';
+
+const profile = (partial: Partial<ServerProfile>): ServerProfile => ({
+    id: 'test',
+    name: 'Test',
+    host: 'example.test',
+    username: '',
+    ...partial,
+} as ServerProfile);
+
+describe('speedTestServerName', () => {
+    it('uses one pCloud Drive label for OAuth and WebDAV defaults', () => {
+        expect(speedTestServerName(profile({ name: 'pCloud', protocol: 'pcloud' }))).toBe('pCloud Drive');
+        expect(speedTestServerName(profile({ name: 'pCloud Drive (WebDAV)', protocol: 'webdav', providerId: 'pcloud-webdav' }))).toBe('pCloud Drive');
+    });
+
+    it('preserves a user-supplied profile name', () => {
+        expect(speedTestServerName(profile({ name: 'Photos EU', protocol: 'pcloud' }))).toBe('Photos EU');
+    });
+});

--- a/src/utils/speedTest.ts
+++ b/src/utils/speedTest.ts
@@ -23,6 +23,23 @@ export function supportsSpeedTest(server: ServerProfile): boolean {
     return (SPEEDTEST_SUPPORTED_PROTOCOLS as readonly string[]).includes(server.protocol || 'ftp');
 }
 
+/**
+ * Keep provider-supplied default profile names stable across connection modes.
+ * Custom profile labels remain untouched: only the historical pCloud defaults
+ * are canonicalized, so OAuth and WebDAV compare as the same service (#368).
+ */
+export function speedTestServerName(server: ServerProfile): string {
+    const fallback = server.name || server.host || '?';
+    const isPcloud = server.protocol === 'pcloud' || server.providerId?.startsWith('pcloud-');
+    if (!isPcloud) return fallback;
+    const normalized = fallback.trim().toLowerCase();
+    return normalized === 'pcloud'
+        || normalized === 'pcloud drive'
+        || normalized === 'pcloud drive (webdav)'
+        ? 'pCloud Drive'
+        : fallback;
+}
+
 export function formatBytes(bytes: number): string {
     if (bytes >= 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
     if (bytes >= 1024 * 1024) return `${Math.round(bytes / (1024 * 1024))} MB`;

--- a/src/utils/syncTemplateApply.test.ts
+++ b/src/utils/syncTemplateApply.test.ts
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it } from 'vitest';
+import {
+    buildAeroSyncTabStatePatch,
+    settingsFromAerosyncScript,
+    settingsFromLegacyScript,
+    settingsFromTemplate,
+} from './syncTemplateApply';
+import type { AerosyncImportScriptResult, SyncScriptMeta, SyncTemplate } from '../types';
+
+describe('AeroSync template import application', () => {
+    it('maps a canonical script into Plan and Sync controls', () => {
+        const imported = {
+            profile: {
+                local_path: '/photos', remote_path: '/backup', dry_run: true,
+                conflict_mode: 'rename', track_renames: false, skip_matching: false,
+                resync: false, watch: false, connect_profile: 'Cloud', connect_url: null,
+                profile: {
+                    id: 'backup', name: 'Backup', builtin: false,
+                    direction: 'local_to_remote', compare_timestamp: true,
+                    compare_size: true, compare_checksum: false,
+                    exclude_patterns: ['*.tmp'], verify_policy: 'full',
+                    delete_orphans: true, parallel_streams: 7,
+                    compression_mode: 'on',
+                    retry_policy: { max_retries: 3, base_delay_ms: 1, max_delay_ms: 2, timeout_ms: 3, backoff_multiplier: 2 },
+                },
+            },
+            unmapped_fields: [], warnings: [], canonical_path: '/x', resolved_from_wrapper: false,
+        } as AerosyncImportScriptResult;
+        const patch = buildAeroSyncTabStatePatch(settingsFromAerosyncScript(imported), 'remote-local');
+        expect(patch).toMatchObject({
+            'sync.source': '/photos',
+            'sync.destination': '/backup',
+            'sync.exclude': '*.tmp',
+            'sync.dryRun': true,
+            'plan.preset': 'mirror',
+            'plan.direction': 'right-to-left',
+            'plan.conflictPolicy': 'rename',
+            'plan.verifyPolicy': 'full_checksum',
+            'plan.parallelStreams': 7,
+            'plan.compressionMode': 'on',
+        });
+    });
+
+    it('maps an .aerosync template into live paths and comparison settings', () => {
+        const template: SyncTemplate = {
+            schema_version: 1,
+            name: 'Pull',
+            description: '',
+            created_by: 'test',
+            path_patterns: [{ local: '/local', remote: '/remote' }],
+            profile: {
+                direction: 'remote_to_local',
+                compare_timestamp: false,
+                compare_size: true,
+                compare_checksum: false,
+                delete_orphans: false,
+                parallel_streams: 3,
+                compression_mode: 'auto',
+            },
+            exclude_patterns: ['cache/**', '*.part'],
+            schedule: null,
+        };
+        const patch = buildAeroSyncTabStatePatch(settingsFromTemplate(template), 'local-remote');
+        expect(patch).toMatchObject({
+            'sync.source': '/local',
+            'sync.destination': '/remote',
+            'sync.exclude': 'cache/**, *.part',
+            'plan.preset': 'backup',
+            'plan.direction': 'right-to-left',
+            'plan.verifyPolicy': 'size_only',
+            'plan.parallelStreams': 3,
+            'plan.compressionMode': 'auto',
+        });
+    });
+
+    it('maps a legacy wrapper import without inventing absent runtime knobs', () => {
+        const legacy: SyncScriptMeta = {
+            schema: 1,
+            profile_id: 'legacy',
+            profile_name: 'Legacy',
+            local_path: '/from',
+            remote_path: '/to',
+            direction: 'bidirectional',
+            delete_orphans: true,
+            exclude_patterns: [],
+            retries: null,
+            retries_sleep: null,
+        };
+        const patch = buildAeroSyncTabStatePatch(settingsFromLegacyScript(legacy), 'local-local');
+        expect(patch).toEqual({
+            'sync.source': '/from',
+            'sync.destination': '/to',
+            'sync.exclude': '',
+            'plan.preset': 'bisync',
+            'plan.direction': 'left-to-right',
+        });
+    });
+});

--- a/src/utils/syncTemplateApply.ts
+++ b/src/utils/syncTemplateApply.ts
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import type {
+    AerosyncImportScriptResult,
+    CompressionMode,
+    SyncDirection,
+    SyncScriptMeta,
+    SyncTemplate,
+    VerifyPolicy,
+} from '../types';
+import type { AeroSyncPairKind, AeroSyncVerifyPolicy } from '../components/AeroSync/types';
+import type { ConflictPolicy, PresetDirection, SyncPreset } from './syncPresets';
+
+export interface ImportedSyncSettings {
+    localPath: string;
+    remotePath: string;
+    direction: SyncDirection;
+    deleteOrphans: boolean;
+    excludePatterns: string[];
+    parallelStreams?: number;
+    compressionMode?: CompressionMode;
+    verifyPolicy?: VerifyPolicy;
+    dryRun?: boolean;
+    conflictMode?: string | null;
+}
+
+export type AeroSyncTabStatePatch = Record<string, unknown>;
+
+export function settingsFromTemplate(template: SyncTemplate): ImportedSyncSettings {
+    const paths = template.path_patterns[0];
+    return {
+        localPath: paths?.local || '',
+        remotePath: paths?.remote || '',
+        direction: template.profile.direction,
+        deleteOrphans: template.profile.delete_orphans,
+        excludePatterns: template.exclude_patterns,
+        parallelStreams: template.profile.parallel_streams,
+        compressionMode: template.profile.compression_mode,
+        verifyPolicy: template.profile.compare_checksum
+            ? 'full'
+            : template.profile.compare_timestamp
+                ? 'size_and_mtime'
+                : 'size_only',
+    };
+}
+
+export function settingsFromLegacyScript(script: SyncScriptMeta): ImportedSyncSettings {
+    return {
+        localPath: script.local_path,
+        remotePath: script.remote_path,
+        direction: script.direction,
+        deleteOrphans: script.delete_orphans,
+        excludePatterns: script.exclude_patterns,
+    };
+}
+
+export function settingsFromAerosyncScript(script: AerosyncImportScriptResult): ImportedSyncSettings {
+    const imported = script.profile;
+    return {
+        localPath: imported.local_path,
+        remotePath: imported.remote_path,
+        direction: imported.profile.direction,
+        deleteOrphans: imported.profile.delete_orphans,
+        excludePatterns: imported.profile.exclude_patterns,
+        parallelStreams: imported.profile.parallel_streams,
+        compressionMode: imported.profile.compression_mode,
+        verifyPolicy: imported.profile.verify_policy,
+        dryRun: imported.dry_run,
+        conflictMode: imported.conflict_mode,
+    };
+}
+
+function planDirection(direction: SyncDirection, pairKind: AeroSyncPairKind | null): PresetDirection {
+    const localIsLeft = pairKind !== 'remote-local';
+    if (direction === 'remote_to_local') return localIsLeft ? 'right-to-left' : 'left-to-right';
+    return localIsLeft ? 'left-to-right' : 'right-to-left';
+}
+
+function planPreset(settings: ImportedSyncSettings): SyncPreset {
+    if (settings.direction === 'bidirectional') return 'bisync';
+    return settings.deleteOrphans ? 'mirror' : 'backup';
+}
+
+function planVerify(value: VerifyPolicy | undefined): AeroSyncVerifyPolicy | undefined {
+    return value === 'full' ? 'full_checksum' : value;
+}
+
+function planConflict(value: string | null | undefined): ConflictPolicy | undefined {
+    switch (value) {
+        case 'newer': return 'newer-wins';
+        case 'older': return 'older-wins';
+        case 'larger': return 'larger-wins';
+        case 'smaller': return 'smaller-wins';
+        case 'rename':
+        case 'keep_both': return 'rename';
+        case 'skip': return 'skip';
+        default: return undefined;
+    }
+}
+
+/** Convert every import format into the controls owned by AeroSync's tabs. */
+export function buildAeroSyncTabStatePatch(
+    settings: ImportedSyncSettings,
+    pairKind: AeroSyncPairKind | null,
+): AeroSyncTabStatePatch {
+    const patch: AeroSyncTabStatePatch = {
+        'sync.source': settings.localPath,
+        'sync.destination': settings.remotePath,
+        'sync.exclude': settings.excludePatterns.join(', '),
+        'plan.preset': planPreset(settings),
+        'plan.direction': planDirection(settings.direction, pairKind),
+    };
+    if (settings.parallelStreams != null) patch['plan.parallelStreams'] = settings.parallelStreams;
+    if (settings.compressionMode != null) patch['plan.compressionMode'] = settings.compressionMode;
+    const verify = planVerify(settings.verifyPolicy);
+    if (verify) patch['plan.verifyPolicy'] = verify;
+    if (settings.dryRun != null) patch['sync.dryRun'] = settings.dryRun;
+    const conflict = planConflict(settings.conflictMode);
+    if (conflict) patch['plan.conflictPolicy'] = conflict;
+    return patch;
+}


### PR DESCRIPTION
## Summary

This resolves the August community triage batch with definitive fixes across table behavior, overlapping scans, template import, credential generation, transfer UI, and server-card drag and drop.

- make Trash use the shared persistent column model, including ordering, visibility, width, alignment, sorting, resizing, and horizontal overflow
- scope Duplicate Finder and AeroSync progress/results to per-operation IDs so stale concurrent scans cannot overwrite current state
- apply AeroSync templates to the live form for canonical and legacy formats
- make the transfer progress header clickable and let the Progress chip toggle minimized state
- generate provider-safe Filen S3/WebDAV credentials from both relevant fields and remove the misleading Compatible 32 preset from the UI
- preserve custom speed-test names while canonicalizing default pCloud labels
- resolve My Servers drag/drop by stable profile ID instead of mutable visible indexes
- pin rclone crypt compatibility with a golden rclone v1.74.3 omitted-password2 regression test
- keep the current raw Argon2 salt derivation and existing Filen API-key guidance after compatibility and documentation review

## References

- #609, #600, #514
- #364, #368, #453
- discussions #347, #276, #266, #369

## Verification

- `npm run ci:pre-push`
  - security regression suite: pass
  - frontend: 85 files, 748 tests passed
  - TypeScript: pass
  - i18n: 46/46 locales, 0 errors, 0 placeholders
  - Clippy all targets with warnings denied: pass
  - Rust library: 3478 passed, 0 failed, 20 ignored
  - Rust CLI: 502 passed, 0 failed
  - integration/doc tests: pass
  - cargo audit: 1187 dependencies scanned, pass
- production frontend build: pass
- real dev GUI verification: Trash/credential/progress/scan flows exercised successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Import sync templates and scripts directly into AeroSync settings.
  - Customize Trash columns, including visibility, order, sizing, and sorting.
  - Toggle transfer progress panels between minimized and expanded views.
  - Generate compatible usernames in Filen Desktop connections.

- **Bug Fixes**
  - Prevent stale duplicate-scan results and progress from updating the dialog.
  - Improve scan progress tracking during directory comparisons.
  - Fix server reordering after filtering or list changes.
  - Standardize pCloud names in speed-test results.
  - Remove the unsupported “compatible” password preset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->