### PR TITLE
fix(intro-hub): CUSTOM / GENERIC SERVERS gets the shared badge order and its own method glyphs

### DIFF
--- a/src/components/IntroHub/DiscoverPanel.tsx
+++ b/src/components/IntroHub/DiscoverPanel.tsx
@@ -19,7 +19,7 @@ import { useDiscoverHealthCheck } from '../../hooks/useDiscoverHealthCheck';
 import { openUrl } from '../../utils/openUrl';
 import { middleClickOpen } from '../../utils/middleClick';
 import { CatalogTable, loadTierFilter, persistTierFilter, TIER_FILTERS, type TierFilter } from './CatalogTable';
-import { PROVIDER_CATALOG, companyInCategory, companyTierInCategory, isDevOnlyProvider } from '../providerCatalog';
+import { PROVIDER_CATALOG, companyInCategory, companyTierInCategory, isDevOnlyProvider, protocolBadgeRank } from '../providerCatalog';
 
 /** All category sidebar entries share these keys; 'all' is a virtual category. */
 type DiscoverCategoryId = CatalogCategoryId | 'all';
@@ -60,12 +60,22 @@ function resolveCompanyHealthUrl(c: CatalogCompany): string | undefined {
  *  and nothing shows in the cloud / media / developer tabs. Azure Blob is
  *  dropped here since it is a first-class Object Storage provider with its own
  *  row. */
-const CUSTOM_PROFILES: { labelKey: string; protocol: ProviderType; providerId?: string; categories: CatalogCategoryId[] }[] = [
+const CUSTOM_PROFILE_ENTRIES: { labelKey: string; protocol: ProviderType; providerId?: string; categories: CatalogCategoryId[] }[] = [
     { labelKey: 'introHub.list.customFtp', protocol: 'ftp', categories: ['protocols'] },
     { labelKey: 'introHub.list.customSftp', protocol: 'sftp', categories: ['protocols'] },
     { labelKey: 'introHub.list.customS3', protocol: 's3', providerId: 'custom-s3', categories: ['object-storage'] },
     { labelKey: 'introHub.list.customWebdav', protocol: 'webdav', providerId: 'custom-webdav', categories: ['webdav'] },
 ];
+
+/** The strip in the one presentation order, rather than in however the array
+ *  above happens to be authored. It used to render `FTP, SFTP, S3, WebDAV`,
+ *  a third hand-written opinion of the sequence the Add Service badges and the
+ *  Quick Connect tabs were unified on in v4.1.7 (Ehud, #347). Sorting by the
+ *  shared rank rather than reordering the literal means adding an entry cannot
+ *  reintroduce the drift. */
+export const CUSTOM_PROFILES = [...CUSTOM_PROFILE_ENTRIES].sort(
+    (a, b) => protocolBadgeRank(a.protocol) - protocolBadgeRank(b.protocol),
+);
 
 const CATEGORY_ICONS: Record<string, React.ReactNode> = {
     Server: <Server size={16} />,

--- a/src/components/IntroHub/DiscoverPanel.tsx
+++ b/src/components/IntroHub/DiscoverPanel.tsx
@@ -18,6 +18,7 @@ import { useIntroHubIconSize } from '../../hooks/useIntroHubIconSize';
 import { useDiscoverHealthCheck } from '../../hooks/useDiscoverHealthCheck';
 import { openUrl } from '../../utils/openUrl';
 import { middleClickOpen } from '../../utils/middleClick';
+import { methodIcon, type ConnectionMethod } from '../connectionMethodIcons';
 import { CatalogTable, loadTierFilter, persistTierFilter, TIER_FILTERS, type TierFilter } from './CatalogTable';
 import { PROVIDER_CATALOG, companyInCategory, companyTierInCategory, isDevOnlyProvider, protocolBadgeRank } from '../providerCatalog';
 
@@ -60,11 +61,11 @@ function resolveCompanyHealthUrl(c: CatalogCompany): string | undefined {
  *  and nothing shows in the cloud / media / developer tabs. Azure Blob is
  *  dropped here since it is a first-class Object Storage provider with its own
  *  row. */
-const CUSTOM_PROFILE_ENTRIES: { labelKey: string; protocol: ProviderType; providerId?: string; categories: CatalogCategoryId[] }[] = [
-    { labelKey: 'introHub.list.customFtp', protocol: 'ftp', categories: ['protocols'] },
-    { labelKey: 'introHub.list.customSftp', protocol: 'sftp', categories: ['protocols'] },
-    { labelKey: 'introHub.list.customS3', protocol: 's3', providerId: 'custom-s3', categories: ['object-storage'] },
-    { labelKey: 'introHub.list.customWebdav', protocol: 'webdav', providerId: 'custom-webdav', categories: ['webdav'] },
+const CUSTOM_PROFILE_ENTRIES: { labelKey: string; protocol: ProviderType; method: ConnectionMethod; providerId?: string; categories: CatalogCategoryId[] }[] = [
+    { labelKey: 'introHub.list.customFtp', protocol: 'ftp', method: 'FTP', categories: ['protocols'] },
+    { labelKey: 'introHub.list.customSftp', protocol: 'sftp', method: 'SFTP', categories: ['protocols'] },
+    { labelKey: 'introHub.list.customS3', protocol: 's3', method: 'S3', providerId: 'custom-s3', categories: ['object-storage'] },
+    { labelKey: 'introHub.list.customWebdav', protocol: 'webdav', method: 'WebDAV', providerId: 'custom-webdav', categories: ['webdav'] },
 ];
 
 /** The strip in the one presentation order, rather than in however the array
@@ -714,7 +715,7 @@ export function DiscoverPanel({ onSelectProvider, query, onQueryChange }: Discov
                                         {...middleClickOpen(() => onSelectProvider(p.protocol, p.providerId, undefined, true))}
                                         className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-200 hover:border-blue-300 dark:hover:border-blue-500/40 hover:bg-gray-50 dark:hover:bg-gray-750 transition-colors"
                                     >
-                                        <Server size={12} className="text-gray-400" />
+                                        <span className="text-gray-400">{methodIcon(p.method, { size: 12 })}</span>
                                         {t(p.labelKey)}
                                     </button>
                                 ))}

--- a/src/components/IntroHub/customProfilesOrder.test.ts
+++ b/src/components/IntroHub/customProfilesOrder.test.ts
@@ -4,6 +4,7 @@
 import { describe, it, expect } from 'vitest';
 import { CUSTOM_PROFILES } from './DiscoverPanel';
 import { protocolBadgeRank, PROTOCOL_BADGE_ORDER } from '../providerCatalog';
+import { CONNECTION_METHOD_GLYPH } from '../connectionMethodIcons';
 
 /**
  * One presentation order for connection methods, everywhere they are listed
@@ -32,5 +33,26 @@ describe('CUSTOM / GENERIC SERVERS follow the one badge order (#347)', () => {
         for (const p of CUSTOM_PROFILES) {
             expect(PROTOCOL_BADGE_ORDER).toContain(p.protocol);
         }
+    });
+
+    it('draws each entry with its own method glyph, not one symbol for all', () => {
+        // The strip used to render a single `Server` icon for every entry, which
+        // is the same report's second half: "All protocols share the same generic
+        // symbol in CUSTOM / GENERIC SERVERS". Distinct methods must not collapse
+        // onto one glyph component.
+        const glyphs = CUSTOM_PROFILES.map(p => CONNECTION_METHOD_GLYPH[p.method]);
+        expect(glyphs.every(Boolean)).toBe(true);
+        expect(new Set(glyphs).size).toBeGreaterThan(1);
+    });
+
+    it('names the method each entry actually speaks', () => {
+        // A wrong-but-present glyph is worse than the generic one, so pin the
+        // pairing rather than only that a glyph exists.
+        expect(CUSTOM_PROFILES.map(p => [p.protocol, p.method])).toEqual([
+            ['webdav', 'WebDAV'],
+            ['sftp', 'SFTP'],
+            ['ftp', 'FTP'],
+            ['s3', 'S3'],
+        ]);
     });
 });

--- a/src/components/IntroHub/customProfilesOrder.test.ts
+++ b/src/components/IntroHub/customProfilesOrder.test.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+import { describe, it, expect } from 'vitest';
+import { CUSTOM_PROFILES } from './DiscoverPanel';
+import { protocolBadgeRank, PROTOCOL_BADGE_ORDER } from '../providerCatalog';
+
+/**
+ * One presentation order for connection methods, everywhere they are listed
+ * (Ehud, #347). v4.1.7 unified the Add Service badges with the Quick Connect
+ * tabs, but the CUSTOM / GENERIC SERVERS strip under the table kept a third
+ * opinion: it rendered its array in the order it happened to be authored,
+ * `FTP, SFTP, S3, WebDAV`, which is not the agreed sequence.
+ *
+ * The array is now sorted by the shared rank, so this fails if someone
+ * reintroduces a hand-kept order or adds an entry at the wrong rank.
+ */
+describe('CUSTOM / GENERIC SERVERS follow the one badge order (#347)', () => {
+    it('is sorted by the shared protocol rank', () => {
+        const ranks = CUSTOM_PROFILES.map(p => protocolBadgeRank(p.protocol));
+        expect(ranks).toEqual([...ranks].sort((a, b) => a - b));
+    });
+
+    it('reads WebDAV, SFTP, FTP, S3, the sequence the badges already use', () => {
+        // Spelled out rather than derived, so a change to the shared order has
+        // to be made deliberately here too instead of passing silently.
+        expect(CUSTOM_PROFILES.map(p => p.protocol)).toEqual(['webdav', 'sftp', 'ftp', 's3']);
+    });
+
+    it('ranks every entry it lists, so none of them sorts as a native API', () => {
+        // An unranked protocol gets -1 and would jump to the front of the strip.
+        for (const p of CUSTOM_PROFILES) {
+            expect(PROTOCOL_BADGE_ORDER).toContain(p.protocol);
+        }
+    });
+});


### PR DESCRIPTION
Closes both halves of the CUSTOM / GENERIC SERVERS report on #347: the ordering follow-up ([17978401](https://github.com/axpdev-lab/aeroftp/discussions/347#discussioncomment-17978401)) and the shared-symbol complaint ([17859082](https://github.com/axpdev-lab/aeroftp/discussions/347#discussioncomment-17859082)). Both replies had been sitting unanswered since 11 August.

## 1. The order

v4.1.7 unified the Add Service badges with the Quick Connect tabs on one presentation order, `webdav, sftp, ftps, ftp, s3`, exported as `PROTOCOL_BADGE_ORDER` precisely so the two could not drift apart again. Ehud replied: "Thanks, but the CUSTOM / GENERIC SERVERS are still not in that order."

He is right, and it is the same defect rather than a leftover of it. `CUSTOM_PROFILES` never consulted the rank; it rendered in the order the array happened to be authored, `FTP, SFTP, S3, WebDAV`. A third hand-written opinion of the sequence, one screen below the two that had just been made to agree.

It sorts by `protocolBadgeRank` now, rather than being reordered by hand. Reordering the literal fixes today's display and leaves the next entry free to land anywhere; sorting means an entry appended at the bottom still appears in the right place.

## 2. The icons

"All protocols share the same generic symbol in CUSTOM / GENERIC SERVERS at the bottom of the table view of the Add Service page."

Also right: the strip drew one `Server` icon for all four entries, so FTP, SFTP, S3 and WebDAV were visually identical in the one place whose whole job is telling them apart.

Nothing new was needed. `ConnectionMethod`, `CONNECTION_METHOD_GLYPH` and `methodIcon` already exist on `main` and already serve the badges elsewhere; the strip simply never used them. Each entry now carries its method and draws that method's glyph, so the symbols stay in agreement with the rest of the UI by construction instead of being chosen again here.

## The tests

`customProfilesOrder.test.ts` pins the order against the shared rank, spells out the expected sequence so a change to the shared order has to be deliberate here too, checks every entry is ranked (an unranked protocol scores -1 and would jump to the front as if it were a native API), and pins the glyph pairing rather than only the presence of a glyph, since a wrong symbol is worse than the generic one it replaces.

Every assertion was run against the defective code first. The ordering ones fail with exactly the order reported:

```
AssertionError: expected [ 'ftp', 'sftp', 's3', 'webdav' ] to deeply equal [ 'webdav', 'sftp', 'ftp', 's3' ]
```

and collapsing every entry onto one method fails both glyph assertions:

```
AssertionError: expected 1 to be greater than 1
AssertionError: expected [ [ 'webdav', 'FTP' ], …(3) ] to deeply equal [ [ 'webdav', 'WebDAV' ], …(3) ]
```

## On the overlap with `fix/introhub-347`

That parked branch (`c4897aa7d`, no PR, 11 days idle, 10 commits behind `main`) changes the same block, and an earlier comment here proposed resolving that at merge time. Folding the icons in instead is the better answer, so that comment is superseded: with both halves here the two no longer disagree about this block at all, and the resolution when that branch is revived is simply to drop its `CUSTOM_PROFILES` hunk.

What that branch keeps is the work that is genuinely its own and is not touched here: the Add Service form-tab reorder, and the icon changes in `IntroHubHeader`, `CatalogTable`, `discoverData` and the shared glyph map itself.

## Verification

`tsc --noEmit` clean. Full `vitest run` green: 86 files, 753 tests.
