### PR TITLE
fix(introhub): reorder Add Service form tabs and share catalog glyphs

### DIFF
--- a/src/components/IntroHub/CatalogTable.tsx
+++ b/src/components/IntroHub/CatalogTable.tsx
@@ -11,11 +11,11 @@
 
 import * as React from 'react';
 import { useMemo, useState, useRef, useCallback } from 'react';
-import { Search, Columns3, ChevronUp, ChevronDown, ChevronsUpDown, Globe, ExternalLink, Braces, KeyRound, Server, Database, Boxes, TerminalSquare, ShieldCheck, CreditCard } from 'lucide-react';
+import { Search, Columns3, ChevronUp, ChevronDown, ChevronsUpDown, Globe, ExternalLink, CreditCard } from 'lucide-react';
 import { ProviderType } from '../../types';
 import { CatalogCategoryId } from '../../types/catalog';
-import { PROVIDER_LOGOS, S3BucketLogo } from '../ProviderLogos';
-import type { CatalogProtocol } from '../providerCatalog';
+import { PROVIDER_LOGOS } from '../ProviderLogos';
+import { methodIcon } from '../connectionMethodIcons';
 import { CountryFlag } from '../CountryFlag';
 import { useTranslation } from '../../i18n';
 import { middleClickOpen } from '../../utils/middleClick';
@@ -106,21 +106,9 @@ function HealthDot({ status, enabled }: { status: HealthStatus; enabled: boolean
 
 // Per-connection-method glyph (issue #270, Ehud): a tiny inline icon before
 // the badge label so an S3 object-storage bucket reads differently from a
-// generic REST API at a glance. Keyed by the closed `CatalogProtocol` enum;
-// inherits the badge text colour via `currentColor`.
-const PROTOCOL_GLYPHS: Record<CatalogProtocol, React.ReactNode> = {
-    S3: <S3BucketLogo size={11} />,
-    API: <Braces size={11} />,
-    OAuth: <KeyRound size={11} />,
-    WebDAV: <Globe size={11} />,
-    Swift: <Boxes size={11} />,
-    Blob: <Database size={11} />,
-    FTP: <Server size={11} />,
-    FTPS: <ShieldCheck size={11} />,
-    SFTP: <ShieldCheck size={11} />,
-    MEGAcmd: <TerminalSquare size={11} />,
-};
-
+// generic REST API at a glance. The shape comes from the shared
+// `connectionMethodIcons` map (#347), the same glyph a method carries in the
+// Quick Connect tabs and the My Servers table, tinted here via `currentColor`.
 function ProtocolBadge({ p, paid, onSelect }: { p: CatalogProtocolRef; paid: boolean; onSelect: (openInBackground?: boolean) => void }) {
     return (
         <button
@@ -137,7 +125,7 @@ function ProtocolBadge({ p, paid, onSelect }: { p: CatalogProtocolRef; paid: boo
                     : 'bg-blue-100 text-blue-700 hover:bg-blue-200 dark:bg-blue-900/40 dark:text-blue-300 dark:hover:bg-blue-900/60'
             }`}
         >
-            <span className="flex-shrink-0 opacity-80">{PROTOCOL_GLYPHS[p.label]}</span>
+            <span className="flex-shrink-0 opacity-80">{methodIcon(p.label, { size: 11 })}</span>
             {p.labelOverride ?? p.label}
         </button>
     );

--- a/src/components/IntroHub/IntroHub.tsx
+++ b/src/components/IntroHub/IntroHub.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { ConnectionParams, ServerProfile } from '../../types';
 import { IntroHubHeader, FormTab } from './IntroHubHeader';
+import { applyFormTabReorder } from './formTabReorder';
 import { MyServersPanel } from './MyServersPanel';
 import { DiscoverPanel } from './DiscoverPanel';
 import { PortableIsolationBanner } from './PortableIsolationBanner';
@@ -291,6 +292,13 @@ export function IntroHub(props: IntroHubProps) {
         setActiveTab('my-servers');
     }, []);
 
+    // Drag-to-reorder form tabs (Ehud #347). The header's FormTab type does
+    // not carry connectionParams, so map the reordered ids back onto the
+    // current FormTabState objects.
+    const handleReorderFormTabs = useCallback((reordered: FormTab[]) => {
+        setFormTabs(prev => applyFormTabReorder(prev, reordered));
+    }, []);
+
     // Update form tab's connectionParams + derive dynamic tab label from server field.
     // When protocol changes (FTP↔SFTP switch), also update editingProfile so the
     // remounted ConnectionScreen initializes with the correct protocol.
@@ -404,6 +412,7 @@ export function IntroHub(props: IntroHubProps) {
                 formTabs={formTabs}
                 onCloseFormTab={handleCloseFormTab}
                 onCloseAllFormTabs={handleCloseAllFormTabs}
+                onReorderFormTabs={handleReorderFormTabs}
                 hasExistingSessions={hasExistingSessions}
                 sessionCount={sessionCount}
                 onSkipToFileManager={onSkipToFileManager}

--- a/src/components/IntroHub/IntroHubHeader.tsx
+++ b/src/components/IntroHub/IntroHubHeader.tsx
@@ -5,6 +5,7 @@ import { ProtocolIcon } from '../ProtocolSelector';
 import { PROVIDER_LOGOS } from '../ProviderLogos';
 import { useTranslation } from '../../i18n';
 import { middleClickClose } from '../../utils/middleClick';
+import { reorderInheritingIndex } from '../../utils/reorderByIndex';
 import type { ServerProfile, ProviderType } from '../../types';
 
 export type IntroHubTab = 'my-servers' | 'discover';
@@ -24,6 +25,9 @@ interface IntroHubHeaderProps {
     formTabs: FormTab[];
     onCloseFormTab: (tabId: string) => void;
     onCloseAllFormTabs?: () => void;
+    /** Drag-to-reorder the form tabs (Ehud #347). Called with the reordered
+     *  array after a drop. When omitted the tabs are not draggable. */
+    onReorderFormTabs?: (tabs: FormTab[]) => void;
     hasExistingSessions?: boolean;
     /** Number of open session tabs, shown as a count chip inside the
      *  "Active Sessions" button. Issue #128-C. */
@@ -58,6 +62,7 @@ export function IntroHubHeader({
     formTabs,
     onCloseFormTab,
     onCloseAllFormTabs,
+    onReorderFormTabs,
     hasExistingSessions,
     sessionCount = 0,
     onSkipToFileManager,
@@ -72,6 +77,44 @@ export function IntroHubHeader({
     const t = useTranslation();
     const [ctxMenu, setCtxMenu] = React.useState<{ x: number; y: number; tabId: string } | null>(null);
     const ctxMenuRef = React.useRef<HTMLDivElement | null>(null);
+
+    // HTML5 DnD for form tabs (Ehud #347): inherit-slot reorder, same helper
+    // as My Servers (#453). Disabled unless the parent passed a callback and
+    // there is more than one tab to move.
+    const [dragIdx, setDragIdx] = React.useState<number | null>(null);
+    const [overIdx, setOverIdx] = React.useState<number | null>(null);
+    const dragNodeRef = React.useRef<HTMLDivElement | null>(null);
+    const canReorder = !!onReorderFormTabs && formTabs.length > 1;
+
+    const handleTabDragStart = (e: React.DragEvent<HTMLDivElement>, idx: number) => {
+        setDragIdx(idx);
+        dragNodeRef.current = e.currentTarget;
+        e.dataTransfer.effectAllowed = 'move';
+        e.dataTransfer.setData('application/x-introhub-form-tab', String(idx));
+        requestAnimationFrame(() => {
+            if (dragNodeRef.current) dragNodeRef.current.style.opacity = '0.4';
+        });
+    };
+
+    const handleTabDragOver = (e: React.DragEvent<HTMLDivElement>, idx: number) => {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'move';
+        if (dragIdx === null || idx === dragIdx) return;
+        setOverIdx(idx);
+    };
+
+    const handleTabDrop = (e: React.DragEvent<HTMLDivElement>, idx: number) => {
+        e.preventDefault();
+        if (dragIdx === null || dragIdx === idx || !onReorderFormTabs) return;
+        onReorderFormTabs(reorderInheritingIndex(formTabs, dragIdx, idx));
+    };
+
+    const handleTabDragEnd = () => {
+        if (dragNodeRef.current) dragNodeRef.current.style.opacity = '1';
+        dragNodeRef.current = null;
+        setDragIdx(null);
+        setOverIdx(null);
+    };
 
     // Close context menu on outside click (same pattern as SessionTabs)
     React.useEffect(() => {
@@ -115,13 +158,20 @@ export function IntroHubHeader({
             {formTabs.length > 0 && (
                 <>
                     <div className="w-px h-5 bg-gray-300 dark:bg-gray-600 mx-1 shrink-0" />
-                    {formTabs.map((ft) => (
+                    {formTabs.map((ft, idx) => (
                         <div
                             key={ft.id}
+                            draggable={canReorder}
+                            onDragStart={canReorder ? (e) => handleTabDragStart(e, idx) : undefined}
+                            onDragOver={canReorder ? (e) => handleTabDragOver(e, idx) : undefined}
+                            onDrop={canReorder ? (e) => handleTabDrop(e, idx) : undefined}
+                            onDragEnd={canReorder ? handleTabDragEnd : undefined}
                             className={`group flex items-center gap-1.5 pl-2.5 pr-1.5 py-1.5 rounded-lg text-sm transition-all min-w-0 cursor-pointer ${
                                 activeTab === ft.id
                                     ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 border border-blue-200 dark:border-blue-500/30 shadow-[0_1px_3px_rgba(0,0,0,0.08)] dark:shadow-[0_1px_3px_rgba(0,0,0,0.3)]'
                                     : 'text-gray-500 dark:text-gray-400 border border-transparent hover:bg-gray-100 dark:hover:bg-gray-700/50 hover:border-gray-200 dark:hover:border-gray-600/50 hover:shadow-[0_1px_3px_rgba(0,0,0,0.08)] dark:hover:shadow-[0_1px_3px_rgba(0,0,0,0.3)]'
+                            } ${dragIdx === idx ? 'scale-95' : ''} ${
+                                overIdx === idx && dragIdx !== null && dragIdx !== idx ? 'border-l-2 border-blue-500' : ''
                             }`}
                             onClick={() => onTabChange(ft.id)}
                             // Middle click closes the tab (Ehud #274), on the ✖ and

--- a/src/components/IntroHub/formTabReorder.test.ts
+++ b/src/components/IntroHub/formTabReorder.test.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+import { describe, it, expect } from 'vitest';
+import { reorderInheritingIndex } from '../../utils/reorderByIndex';
+import { applyFormTabReorder } from './formTabReorder';
+import headerRaw from './IntroHubHeader.tsx?raw';
+import hubRaw from './IntroHub.tsx?raw';
+
+describe('applyFormTabReorder', () => {
+    it('keeps connectionParams on the same tab id after a 0<->1 swap', () => {
+        const current = [
+            { id: 'ftp', connectionParams: { server: 'ftp.example' }, extra: 'keep-a' },
+            { id: 's3', connectionParams: { server: 's3.example' }, extra: 'keep-b' },
+        ];
+        // Header FormTab values have ids (and labels) but not connectionParams.
+        const headerView = current.map(({ id }) => ({ id }));
+        const reordered = reorderInheritingIndex(headerView, 0, 1);
+        const next = applyFormTabReorder(current, reordered);
+
+        expect(next.map((t) => t.id)).toEqual(['s3', 'ftp']);
+        expect(next[0].connectionParams).toBe(current[1].connectionParams);
+        expect(next[0].extra).toBe('keep-b');
+        expect(next[1].connectionParams).toBe(current[0].connectionParams);
+        expect(next[1].extra).toBe('keep-a');
+    });
+});
+
+describe('IntroHubHeader form-tab drag (#347)', () => {
+    it('wires HTML5 DnD through reorderInheritingIndex when more than one tab is open', () => {
+        expect(headerRaw).toContain('draggable={canReorder}');
+        expect(headerRaw).toContain('reorderInheritingIndex');
+        expect(headerRaw).toContain('application/x-introhub-form-tab');
+    });
+
+    it('maps the header order back through applyFormTabReorder', () => {
+        expect(hubRaw).toContain('applyFormTabReorder');
+        expect(hubRaw).toContain('onReorderFormTabs={handleReorderFormTabs}');
+    });
+});

--- a/src/components/IntroHub/formTabReorder.ts
+++ b/src/components/IntroHub/formTabReorder.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+/**
+ * Map a reordered FormTab id sequence back onto the full form-tab state.
+ *
+ * The header's FormTab type does not carry connectionParams. Storing the
+ * array it hands back would drop typed fields; lookup by id keeps them
+ * attached to the same tab after a drag.
+ */
+export function applyFormTabReorder<T extends { id: string }>(
+    current: readonly T[],
+    reordered: readonly { id: string }[],
+): T[] {
+    const byId = new Map(current.map((ft) => [ft.id, ft]));
+    return reordered.map((ft) => byId.get(ft.id)).filter((ft): ft is T => !!ft);
+}

--- a/src/components/connectionMethodIcons.test.ts
+++ b/src/components/connectionMethodIcons.test.ts
@@ -2,9 +2,11 @@
 // Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
 
 import { describe, it, expect } from 'vitest';
-import { CONNECTION_METHOD_GLYPH } from './connectionMethodIcons';
+import { Boxes, Braces, Cloud, Container, Database, KeyRound, Server, TerminalSquare } from 'lucide-react';
+import { CONNECTION_METHOD_GLYPH, methodIcon } from './connectionMethodIcons';
 import modeGroupsRaw from './providerModeGroups.tsx?raw';
 import myServersRaw from './IntroHub/MyServersTable.tsx?raw';
+import catalogTableRaw from './IntroHub/CatalogTable.tsx?raw';
 
 /**
  * The icons for connection methods were assigned by hand at each site, so they
@@ -57,5 +59,39 @@ describe('one glyph per connection method (#347)', () => {
                 `My Servers still hand-picks an icon for ${method}`,
             ).toContain(`${method}: methodIcon('${method}'`);
         }
+
+        // CatalogTable used to keep a private PROTOCOL_GLYPHS map, so S3/OAuth
+        // /FTP/SFTP disagreed with the two surfaces above. One map, or it
+        // drifts again.
+        expect(catalogTableRaw).toContain('methodIcon(');
+        expect(catalogTableRaw).not.toContain('PROTOCOL_GLYPHS');
+    });
+
+    it('keeps the shipped #567 shapes', () => {
+        // CatalogTable's leftover private map drew a bucket for S3, KeyRound
+        // for OAuth, ShieldCheck for FTPS/SFTP. Unifying through methodIcon
+        // must not quietly rewrite the assignments already on main.
+        expect(CONNECTION_METHOD_GLYPH.OAuth).toBe(Cloud);
+        expect(CONNECTION_METHOD_GLYPH.API).toBe(Braces);
+        expect(CONNECTION_METHOD_GLYPH.S3).toBe(Database);
+        expect(CONNECTION_METHOD_GLYPH.FTP).toBe(Server);
+        expect(CONNECTION_METHOD_GLYPH.SFTP).toBe(KeyRound);
+    });
+
+    it('covers the catalog methods CatalogTable used to keep privately', () => {
+        for (const method of ['Swift', 'Blob', 'MEGAcmd'] as const) {
+            expect(
+                CONNECTION_METHOD_GLYPH,
+                `${method} is still missing from the shared map`,
+            ).toHaveProperty(method);
+            expect(methodIcon(method, { size: 11 }), `${method} still renders null`).not.toBeNull();
+        }
+        expect(CONNECTION_METHOD_GLYPH.Swift).toBe(Boxes);
+        expect(CONNECTION_METHOD_GLYPH.Blob).toBe(Container);
+        expect(CONNECTION_METHOD_GLYPH.MEGAcmd).toBe(TerminalSquare);
+        // Fail-first: Blob = Database exploded unique-shape with
+        // "Blob draws the same glyph as S3". Container is the non-colliding
+        // pick; S3 stays Database.
+        expect(CONNECTION_METHOD_GLYPH.Blob).not.toBe(CONNECTION_METHOD_GLYPH.S3);
     });
 });

--- a/src/components/connectionMethodIcons.tsx
+++ b/src/components/connectionMethodIcons.tsx
@@ -25,8 +25,19 @@
  *   - A native API is `Braces`. It cannot keep `Database` (that is S3) or
  *     `Cloud` (that is OAuth), and `Key`/`KeyRound` reads as SFTP. Curly braces
  *     say "this provider's own JSON API" without borrowing anyone's meaning.
+ *     Ehud confirmed `{ }` on 11 Aug (#347).
  *   - S3 keeps `Database`, the reading three of the four surfaces already had;
- *     Filen's `Layers` was the outlier.
+ *     Filen's `Layers` was the outlier. Ehud's later bucket suggestion is
+ *     noted, not applied: remapping S3 would change a shipped #567 shape.
+ *
+ * CatalogTable still kept a private map for three catalog labels the shared
+ * map did not know, so those join here without touching the #567 assignments:
+ *
+ *   - Swift is `Boxes` (the leftover CatalogTable pick).
+ *   - MEGAcmd is `TerminalSquare` (`>_` in a square, Ehud 11 Aug).
+ *   - Blob cannot reuse `Database` (that is S3; unique-shape fails with
+ *     "Blob draws the same glyph as S3"). Azure Blob is organised in
+ *     containers, so it draws lucide `Container`.
  *
  * Colours stay per-surface: the table tints its glyphs to match its badge
  * palette, the Quick Connect tabs tint on the active state. Only the shape is
@@ -34,13 +45,16 @@
  */
 import * as React from 'react';
 import {
+    Boxes,
     Braces,
     Cloud,
+    Container,
     Database,
     Globe,
     KeyRound,
     Server,
     Shield,
+    TerminalSquare,
     type LucideIcon,
 } from 'lucide-react';
 
@@ -54,7 +68,10 @@ export type ConnectionMethod =
     | 'FTPS'
     | 'SFTP'
     | 'E2E'
-    | 'Crypt';
+    | 'Crypt'
+    | 'Swift'
+    | 'Blob'
+    | 'MEGAcmd';
 
 /** The lucide component for a method, so each caller picks its own size/colour. */
 export const CONNECTION_METHOD_GLYPH: Record<ConnectionMethod, LucideIcon> = {
@@ -67,6 +84,9 @@ export const CONNECTION_METHOD_GLYPH: Record<ConnectionMethod, LucideIcon> = {
     SFTP: KeyRound,
     E2E: Shield,
     Crypt: Shield,
+    Swift: Boxes,
+    Blob: Container,
+    MEGAcmd: TerminalSquare,
 };
 
 /**

--- a/src/components/providerCatalog.ts
+++ b/src/components/providerCatalog.ts
@@ -50,9 +50,9 @@ export type CatalogProtocol =
 
 /** One connection method for a company, with its Quick Connect target. */
 export interface CatalogProtocolRef {
-    /** Badge glyph key into `PROTOCOL_GLYPHS` — must stay a member of the closed
-     *  `CatalogProtocol` enum. Display text prefers `labelOverride` when set
-     *  (GUI badges, CLI catalog, providers markdown). */
+    /** Badge glyph key into `methodIcon` / `CONNECTION_METHOD_GLYPH`. Must stay
+     *  a member of the closed `CatalogProtocol` enum. Display text prefers
+     *  `labelOverride` when set (GUI badges, CLI catalog, providers markdown). */
     label: CatalogProtocol;
     /** Display override when the branded product name differs from the wire
      *  protocol: e.g. MEGA's paid S3 object storage is "S4" and FileLu's is "S5",


### PR DESCRIPTION
Two leftover IntroHub items from Ehud on [#347](https://github.com/axpdev-lab/aeroftp/discussions/347): drag-to-reorder of Add Service form tabs ([17859138](https://github.com/axpdev-lab/aeroftp/discussions/347#discussioncomment-17859138)), and CatalogTable badges going through the shared `methodIcon` map ([17859082](https://github.com/axpdev-lab/aeroftp/discussions/347#discussioncomment-17859082)).

Please merge with a merge commit, not squash. Two commits, two concerns.

## 1. Form-tab drag (`6a78daa20`)

The chips that open from Add Service sat in creation order. They now use the same HTML5 DnD and inherit-slot helper as My Servers (`reorderInheritingIndex`, not the SessionTabs splice). The header's `FormTab[]` does not carry `connectionParams`, so `applyFormTabReorder` maps the reordered ids back onto the current `FormTabState[]`.

Fail-first: a helper that stored the header array as-is failed with `expected undefined to be { server: 's3.example' }`. That is the loss the map-by-id exists to prevent.

Live (Linux 2, `tauri dev`, inspector): opened custom FTP and SFTP, typed `ftp.example` and `sftp.example`, swapped the chips, then clicking each chip still showed that host.

## 2. CatalogTable glyphs (`bb5a53c88`)

CatalogTable kept a private `PROTOCOL_GLYPHS` map, so S3/OAuth/FTP/SFTP disagreed with My Servers and Quick Connect. Badges now call `methodIcon(p.label, { size: 11 })`. Swift (`Boxes`), Blob (`Container`) and MEGAcmd (`TerminalSquare`) join the shared map.

Shipped #567 shapes are unchanged: OAuth `Cloud`, S3 `Database`, FTP `Server`, SFTP `KeyRound`, API `Braces` (Ehud confirmed `{ }` on 11 Aug). MEGAcmd is `>_` in a square (`TerminalSquare`). Ehud's bucket-for-S3 suggestion is noted, not applied.

Fail-first: Blob = `Database` exploded unique-shape with `Blob draws the same glyph as S3`. Azure Blob is organised in containers, so Blob draws lucide `Container`. The official OAuth mark (CC BY-SA 3.0) is not introduced here.

Live (table view of Add Service): 51 catalog rows, 65 protocol badges, every badge had an `<svg>`. S3 18, OAuth 8, FTP 1, SFTP 2, Swift 1, Blob 1, MEGAcmd 1, API 17, WebDAV 16. Empty: 0.

Unification side-effect (the point of one map): CatalogTable S3 now draws `Database` (was `S3BucketLogo`); OAuth `Cloud` (was `KeyRound`); FTPS `Server` (was `ShieldCheck`); SFTP `KeyRound` (was `ShieldCheck`).

## Out of scope

DiscoverPanel / `CUSTOM_PROFILES` is PR #622. EC vs ECC naming is PR #621. Do not remap the #567 glyphs in this PR.

## Gates

`npm run ci:pre-push` exit 0 on Linux 2: security regression, vitest 86/753, `tsc --noEmit`, i18n:validate 46/46, clippy `-D warnings`, cargo test, cargo audit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added drag-and-drop reordering for form tabs while preserving each tab’s settings and associated data.
  * Added shared connection-method icons for Swift, Azure Blob, and MEGAcmd.
* **Improvements**
  * Standardized connection icons across catalog views for consistent display.
  * Added visual feedback while reordering tabs.
* **Bug Fixes**
  * Improved tab reordering reliability by ignoring unknown tab identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->