### PR TITLE
fix: option-key aliases, Swift dot-path listings, and Swift tab logos

### DIFF
--- a/src-tauri/src/agent_session.rs
+++ b/src-tauri/src/agent_session.rs
@@ -45,58 +45,22 @@ pub struct ProfileSummary {
     pub extras: HashMap<String, String>,
 }
 
-/// Convert camelCase JSON keys (the desktop frontend's `ProviderOptions`
-/// shape) into the snake_case keys the Rust `ProviderConfig.extra`
-/// builders expect. Pure ASCII: non-alpha chars are preserved as-is.
-/// Mechanical camelCase to snake_case, NOT the canonical option-key mapping.
-///
-/// `profile_loader::normalize_profile_option_key` is the table that knows the
-/// aliases where the two spellings are not a mechanical transform of each other
-/// (`webdavScheme` becomes `tls_mode`, `allowCleartextStorage` becomes
-/// `allow_cleartext_storage_endpoint`, the STS set). This function does not
-/// consult it, so any option in that table arrives here under the wrong key.
-///
-/// That is currently harmless because the protocols this path can connect are
-/// FTP, FTPS, SFTP, WebDAV, S3, GitHub and GitLab (`resolve_provider_type`), and
-/// none of them reads an aliased key. It is a live trap for the next one that
-/// does: unifying the two is tracked rather than done here, because changing what
-/// this returns would also change the keys the current callers already receive.
-fn camel_to_snake(s: &str) -> String {
-    let mut out = String::with_capacity(s.len() + 4);
-    for (i, ch) in s.chars().enumerate() {
-        if ch.is_ascii_uppercase() {
-            if i > 0 {
-                out.push('_');
-            }
-            out.push(ch.to_ascii_lowercase());
-        } else {
-            out.push(ch);
-        }
-    }
-    out
-}
-
 /// Flatten the profile's `options` JSON object into the snake_case
 /// string map providers consume via `ProviderConfig.extra`. Skips
 /// `null` and any non-scalar values; arrays/objects don't currently
 /// have a representation in the `extra` map and would silently confuse
 /// the provider if forwarded.
+///
+/// Keys go through `profile_loader::insert_profile_option`, the same
+/// canonicalizer CLI and MCP use, so aliases (`webdavScheme` →
+/// `tls_mode`) are not dropped the way a local camelCase rewrite did.
 fn flatten_options(options: Option<&Value>) -> HashMap<String, String> {
     let mut out = HashMap::new();
     let Some(obj) = options.and_then(|v| v.as_object()) else {
         return out;
     };
     for (k, v) in obj {
-        let key = camel_to_snake(k);
-        let value = match v {
-            Value::String(s) => s.clone(),
-            Value::Bool(b) => b.to_string(),
-            Value::Number(n) => n.to_string(),
-            // Skip nulls / arrays / nested objects: the legacy
-            // builders never accepted those shapes either.
-            _ => continue,
-        };
-        out.insert(key, value);
+        crate::profile_loader::insert_profile_option(&mut out, k, v);
     }
     out
 }
@@ -1481,13 +1445,28 @@ mod tests {
     }
 
     #[test]
-    fn camel_to_snake_handles_typical_keys() {
-        assert_eq!(camel_to_snake("bucket"), "bucket");
-        assert_eq!(camel_to_snake("tlsMode"), "tls_mode");
-        assert_eq!(camel_to_snake("verifyCert"), "verify_cert");
-        assert_eq!(camel_to_snake("privateKeyPath"), "private_key_path");
-        assert_eq!(camel_to_snake("trustUnknownHosts"), "trust_unknown_hosts");
-        assert_eq!(camel_to_snake("sseKmsKeyId"), "sse_kms_key_id");
+    fn flatten_options_uses_canonical_aliases() {
+        let v = json!({
+            "webdavScheme": "https",
+            "allowCleartextStorage": true,
+            "pcloudRegion": "eu",
+            "privateKeyPath": "/tmp/id",
+            "trustUnknownHosts": false,
+            "sseKmsKeyId": "kms-1",
+        });
+        let m = flatten_options(Some(&v));
+        assert_eq!(m.get("tls_mode"), Some(&"https".to_string()));
+        assert_eq!(
+            m.get("allow_cleartext_storage_endpoint"),
+            Some(&"true".to_string())
+        );
+        assert_eq!(m.get("region"), Some(&"eu".to_string()));
+        assert_eq!(m.get("private_key_path"), Some(&"/tmp/id".to_string()));
+        assert_eq!(m.get("trust_unknown_hosts"), Some(&"false".to_string()));
+        assert_eq!(m.get("sse_kms_key_id"), Some(&"kms-1".to_string()));
+        assert!(!m.contains_key("webdav_scheme"));
+        assert!(!m.contains_key("allow_cleartext_storage"));
+        assert!(!m.contains_key("pcloud_region"));
     }
 
     #[test]

--- a/src-tauri/src/ai_tools.rs
+++ b/src-tauri/src/ai_tools.rs
@@ -1716,6 +1716,9 @@ pub(crate) fn find_server_by_name_or_id(
 }
 
 /// Load provider-specific extra options from the full server profile in vault.
+/// Keys go through `profile_loader::insert_profile_option`, the same
+/// canonicalizer CLI and MCP use. A local alias table here used to miss
+/// `webdavScheme`, `allowCleartextStorage` and the STS set.
 fn load_provider_extra_options(
     server_id: &str,
 ) -> Result<std::collections::HashMap<String, String>, String> {
@@ -1733,28 +1736,7 @@ fn load_provider_extra_options(
     {
         if let Some(options) = profile.get("options").and_then(|v| v.as_object()) {
             for (k, v) in options {
-                let key = match k.as_str() {
-                    "tlsMode" => "tls_mode",
-                    "verifyCert" => "verify_cert",
-                    "pathStyle" => "path_style",
-                    "private_key_path" => "private_key_path",
-                    "key_passphrase" => "key_passphrase",
-                    "accountName" => "account_name",
-                    "accessKey" => "access_key",
-                    "sasToken" => "sas_token",
-                    "pcloudRegion" | "region" => "region",
-                    "two_factor_code" => "two_factor_code",
-                    "drive_id" => "drive_id",
-                    "trust_unknown_hosts" => "trust_unknown_hosts",
-                    other => other,
-                };
-                if let Some(s) = v.as_str() {
-                    extra.insert(key.to_string(), s.to_string());
-                } else if let Some(b) = v.as_bool() {
-                    extra.insert(key.to_string(), b.to_string());
-                } else if let Some(n) = v.as_u64() {
-                    extra.insert(key.to_string(), n.to_string());
-                }
+                crate::profile_loader::insert_profile_option(&mut extra, k, v);
             }
         }
     }
@@ -2116,5 +2098,45 @@ mod approval_tests {
         assert!(verify
             .iter()
             .any(|d| d.contains("cargo-check") && d.contains("vitest")));
+    }
+}
+
+#[cfg(test)]
+mod extra_options_tests {
+    use crate::profile_loader::insert_profile_option;
+    use serde_json::json;
+    use std::collections::HashMap;
+
+    #[test]
+    fn extra_options_use_canonical_aliases() {
+        let options = json!({
+            "webdavScheme": "http",
+            "allowCleartextStorage": true,
+            "pcloudRegion": "eu",
+            "privateKeyPath": "/tmp/id",
+            "drive_id": "123",
+            "sessionToken": "tok",
+        });
+        let mut extra = HashMap::new();
+        for (k, v) in options.as_object().unwrap() {
+            insert_profile_option(&mut extra, k, v);
+        }
+        assert_eq!(extra.get("tls_mode").map(String::as_str), Some("http"));
+        assert_eq!(
+            extra
+                .get("allow_cleartext_storage_endpoint")
+                .map(String::as_str),
+            Some("true")
+        );
+        assert_eq!(extra.get("region").map(String::as_str), Some("eu"));
+        assert_eq!(
+            extra.get("private_key_path").map(String::as_str),
+            Some("/tmp/id")
+        );
+        assert_eq!(extra.get("drive_id").map(String::as_str), Some("123"));
+        assert_eq!(extra.get("session_token").map(String::as_str), Some("tok"));
+        assert!(!extra.contains_key("webdav_scheme"));
+        assert!(!extra.contains_key("pcloud_region"));
+        assert!(!extra.contains_key("allow_cleartext_storage"));
     }
 }

--- a/src-tauri/src/profile_loader.rs
+++ b/src-tauri/src/profile_loader.rs
@@ -55,6 +55,46 @@ pub fn normalize_profile_option_key(key: &str) -> &str {
     }
 }
 
+/// Mechanical camelCase to snake_case. Pure ASCII: non-alpha chars are
+/// preserved as-is. Already-snake keys pass through unchanged.
+fn camel_to_snake_case(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 4);
+    for (i, ch) in s.chars().enumerate() {
+        if ch.is_ascii_uppercase() {
+            if i > 0 {
+                out.push('_');
+            }
+            out.push(ch.to_ascii_lowercase());
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+/// Canonical option key for `ProviderConfig.extra`.
+///
+/// The alias table runs first, because some GUI keys are not a mechanical
+/// transform of the provider key (`webdavScheme` is `tls_mode`,
+/// `allowCleartextStorage` is `allow_cleartext_storage_endpoint`,
+/// `pcloudRegion` is `region`). Keys the table does not know are then
+/// converted from camelCase to snake_case, so a GUI-shaped
+/// `privateKeyPath` still lands as `private_key_path`. Already-snake keys
+/// pass through unchanged.
+///
+/// Agent session, AI tools, CLI and MCP all go through here. Two of those
+/// used to have their own tables and knew none of the aliases, so a
+/// saved WebDAV `webdavScheme` or Swift `allowCleartextStorage` arrived
+/// under the wrong key and the provider ignored it.
+pub fn canonicalize_profile_option_key(key: &str) -> String {
+    let aliased = normalize_profile_option_key(key);
+    if aliased != key {
+        aliased.to_string()
+    } else {
+        camel_to_snake_case(key)
+    }
+}
+
 /// Insert a single profile option into the `extra` map after normalizing the
 /// key and serializing primitive JSON values to strings.
 pub fn insert_profile_option(
@@ -62,7 +102,7 @@ pub fn insert_profile_option(
     key: &str,
     value: &serde_json::Value,
 ) {
-    let normalized_key = normalize_profile_option_key(key).to_string();
+    let normalized_key = canonicalize_profile_option_key(key);
 
     if let Some(string_value) = value.as_str() {
         extra.insert(normalized_key, string_value.to_string());
@@ -327,6 +367,80 @@ mod tests {
             normalize_profile_option_key("private_key_path"),
             "private_key_path"
         );
+        // Mechanical conversion is canonicalize's job, not the alias table's.
+        assert_eq!(
+            normalize_profile_option_key("privateKeyPath"),
+            "privateKeyPath"
+        );
+    }
+
+    #[test]
+    fn canonicalize_aliases_then_mechanical_camel_case() {
+        assert_eq!(canonicalize_profile_option_key("webdavScheme"), "tls_mode");
+        assert_eq!(
+            canonicalize_profile_option_key("allowCleartextStorage"),
+            "allow_cleartext_storage_endpoint"
+        );
+        assert_eq!(canonicalize_profile_option_key("pcloudRegion"), "region");
+        assert_eq!(
+            canonicalize_profile_option_key("sessionToken"),
+            "session_token"
+        );
+        assert_eq!(canonicalize_profile_option_key("roleArn"), "role_arn");
+        assert_eq!(
+            canonicalize_profile_option_key("privateKeyPath"),
+            "private_key_path"
+        );
+        assert_eq!(
+            canonicalize_profile_option_key("trustUnknownHosts"),
+            "trust_unknown_hosts"
+        );
+        assert_eq!(
+            canonicalize_profile_option_key("sseKmsKeyId"),
+            "sse_kms_key_id"
+        );
+        assert_eq!(canonicalize_profile_option_key("bucket"), "bucket");
+        assert_eq!(
+            canonicalize_profile_option_key("private_key_path"),
+            "private_key_path"
+        );
+        assert_eq!(canonicalize_profile_option_key("drive_id"), "drive_id");
+        // A mechanical rewrite of the alias would be the wrong provider key.
+        assert_ne!(
+            canonicalize_profile_option_key("webdavScheme"),
+            "webdav_scheme"
+        );
+        assert_ne!(
+            canonicalize_profile_option_key("allowCleartextStorage"),
+            "allow_cleartext_storage"
+        );
+        assert_ne!(
+            canonicalize_profile_option_key("pcloudRegion"),
+            "pcloud_region"
+        );
+    }
+
+    #[test]
+    fn insert_profile_option_maps_non_alias_camel_case() {
+        let mut extra = HashMap::new();
+        insert_profile_option(&mut extra, "privateKeyPath", &json!("/tmp/id"));
+        insert_profile_option(&mut extra, "webdavScheme", &json!("https"));
+        insert_profile_option(&mut extra, "allowCleartextStorage", &json!(true));
+        assert_eq!(
+            extra.get("private_key_path").map(String::as_str),
+            Some("/tmp/id")
+        );
+        assert_eq!(extra.get("tls_mode").map(String::as_str), Some("https"));
+        assert_eq!(
+            extra
+                .get("allow_cleartext_storage_endpoint")
+                .map(String::as_str),
+            Some("true")
+        );
+        assert!(!extra.contains_key("webdavScheme"));
+        assert!(!extra.contains_key("webdav_scheme"));
+        assert!(!extra.contains_key("allowCleartextStorage"));
+        assert!(!extra.contains_key("allow_cleartext_storage"));
     }
 
     #[test]

--- a/src-tauri/src/providers/swift.rs
+++ b/src-tauri/src/providers/swift.rs
@@ -734,10 +734,16 @@ impl SwiftProvider {
     /// the first listing after connecting sent `./` and every Swift account
     /// looked empty in the app while the CLI, which passes `/`, worked.
     fn normalize_path(path: &str) -> String {
+        // Leading and trailing slashes are framing and go, exactly as the
+        // original trim did. Repeated slashes INSIDE the path do not: a Swift
+        // object name is an opaque key, so `a//b` and `a/b` name two different
+        // objects and collapsing them would point rename, copy and delete at
+        // the wrong one. Only `.` and `..` are resolved, because the GUI opens
+        // a session on `.` and a relative segment has no meaning to the server.
         let mut segments: Vec<&str> = Vec::new();
-        for segment in path.split('/') {
+        for segment in path.trim_matches('/').split('/') {
             match segment {
-                "" | "." => {}
+                "." => {}
                 ".." => {
                     segments.pop();
                 }
@@ -1702,6 +1708,25 @@ mod tests {
         assert_eq!(SwiftProvider::normalize_path("foo"), "foo");
         assert_eq!(SwiftProvider::normalize_path("/foo/bar/"), "foo/bar");
         assert_eq!(SwiftProvider::normalize_path("/a/b/c"), "a/b/c");
+    }
+
+    /// A Swift object name is an opaque key, so a repeated slash inside it is
+    /// part of the name and not punctuation to tidy away. The first cut of the
+    /// dot-path fix dropped every empty segment, which silently turned `a//b`
+    /// into `a/b`: listing kept the server's name while rename, copy and delete
+    /// went through the normalizer and addressed a different object. Raised by
+    /// CodeRabbit on the pull request that introduced it.
+    #[test]
+    fn normalize_path_keeps_repeated_slashes_inside_the_name() {
+        assert_eq!(SwiftProvider::normalize_path("a//b"), "a//b");
+        assert_eq!(SwiftProvider::normalize_path("/a//b/"), "a//b");
+        assert_eq!(
+            SwiftProvider::normalize_path("dir//sub///file.txt"),
+            "dir//sub///file.txt"
+        );
+        // Framing still goes, and the dot segments still resolve around them.
+        assert_eq!(SwiftProvider::normalize_path("//a//b//"), "a//b");
+        assert_eq!(SwiftProvider::normalize_path("a//./b"), "a//b");
     }
 
     #[test]

--- a/src-tauri/src/providers/swift.rs
+++ b/src-tauri/src/providers/swift.rs
@@ -723,8 +723,28 @@ impl SwiftProvider {
         }
     }
 
+    /// Swift object keys are flat, so a path is only ever a prefix. This turns
+    /// a UI path into that prefix, and the segment walk is the point: without
+    /// it, `.` survives as a literal segment and the listing asks the server
+    /// for the objects starting with `./`, which are none. The server answers
+    /// 200 with an empty array, so the panel shows an empty container with no
+    /// error at all, which is exactly how this hid.
+    ///
+    /// The GUI reaches it: `provider_list_files` defaults its path to `"."`, so
+    /// the first listing after connecting sent `./` and every Swift account
+    /// looked empty in the app while the CLI, which passes `/`, worked.
     fn normalize_path(path: &str) -> String {
-        path.trim_matches('/').to_string()
+        let mut segments: Vec<&str> = Vec::new();
+        for segment in path.split('/') {
+            match segment {
+                "" | "." => {}
+                ".." => {
+                    segments.pop();
+                }
+                other => segments.push(other),
+            }
+        }
+        segments.join("/")
     }
 
     // ─── Request with 401 retry ────────────────────────────────
@@ -1644,6 +1664,35 @@ mod tests {
             verify_cert: true,
             allow_cleartext_storage_endpoint: true,
         })
+    }
+
+    #[test]
+    /// The GUI's default listing path is `"."`, not `"/"`, and Swift turned that
+    /// into the prefix `./`, which matches no object. The container listed as
+    /// empty in the app with a 200 and no error, while the CLI (which passes
+    /// `/`) listed it correctly. Live-reproduced against Blomp: `ls /` returned
+    /// ten entries and `ls .` returned zero.
+    #[test]
+    fn a_dot_path_is_the_container_root_like_a_slash() {
+        assert_eq!(SwiftProvider::normalize_path("."), "");
+        assert_eq!(SwiftProvider::normalize_path("./"), "");
+        assert_eq!(SwiftProvider::normalize_path("/."), "");
+        assert_eq!(
+            SwiftProvider::normalize_path("."),
+            SwiftProvider::normalize_path("/"),
+            "the GUI default and the CLI default must address the same place"
+        );
+        // A dot inside a path is a segment to drop, not part of a name.
+        assert_eq!(SwiftProvider::normalize_path("foo/./bar"), "foo/bar");
+        // And `..` walks up rather than surviving into a prefix the server
+        // would match literally.
+        assert_eq!(SwiftProvider::normalize_path("foo/../bar"), "bar");
+        assert_eq!(SwiftProvider::normalize_path("/foo/bar/../"), "foo");
+        // A leading `..` cannot escape the container: there is nothing above it.
+        assert_eq!(SwiftProvider::normalize_path("../secrets"), "secrets");
+        // A file whose name merely contains a dot is untouched.
+        assert_eq!(SwiftProvider::normalize_path("/a.txt"), "a.txt");
+        assert_eq!(SwiftProvider::normalize_path("dir/.hidden"), "dir/.hidden");
     }
 
     #[test]

--- a/src-tauri/src/providers/swift.rs
+++ b/src-tauri/src/providers/swift.rs
@@ -1666,7 +1666,6 @@ mod tests {
         })
     }
 
-    #[test]
     /// The GUI's default listing path is `"."`, not `"/"`, and Swift turned that
     /// into the prefix `./`, which matches no object. The container listed as
     /// empty in the app with a 200 and no error, while the CLI (which passes

--- a/src/components/SessionTabs.tsx
+++ b/src/components/SessionTabs.tsx
@@ -58,9 +58,27 @@ const createStatusConfig = (t: (key: string) => string): Record<SessionStatus, {
     disconnected: { icon: <Server size={12} />, color: 'text-gray-400', title: t('ui.session.disconnected') },
 });
 
-// Check if protocol is a provider (not standard FTP)
-const isProviderProtocol = (protocol: ProviderType | undefined): boolean => {
-    return protocol !== undefined && ['s3', 'webdav', 'googledrive', 'dropbox', 'onedrive', 'mega', 'sftp', 'box', 'pcloud', 'azure', 'filen', 'fourshared', 'zohoworkdrive', 'internxt', 'kdrive', 'jottacloud', 'drime', 'filelu', 'koofr', 'opendrive', 'yandexdisk', 'github', 'gitlab', 'immich', 'imagekit', 'uploadcare', 'cloudinary', 'backblaze'].includes(protocol);
+/**
+ * Everything except plain FTP is a "provider" for icon purposes.
+ *
+ * This used to be an allowlist of protocol names, and it drifted: `swift`,
+ * `googlephotos`, `aerocloud` and `peer` were in `ProviderType` and never in
+ * the list. Only `swift` was reachable, and it was the one that showed: a
+ * connected Blomp session drew the generic Wifi glyph even though the PNG, the
+ * `BlompLogo` component and the `PROVIDER_LOGOS['blomp']` entry all existed and
+ * were correct. The other three have no registry entry, so nothing could reach
+ * them; they were latent, not broken. Nothing failed either way, which is why
+ * it went unnoticed.
+ *
+ * Stated as the inverse it cannot drift: a protocol added tomorrow is a
+ * provider the day it exists, and only the two that genuinely are not have to
+ * be named. A protocol with no logo still falls back to the same Wifi glyph
+ * inside `ProviderIcon`, so widening this changes nothing for them.
+ */
+const NON_PROVIDER_PROTOCOLS: readonly ProviderType[] = ['ftp', 'ftps'];
+
+export const isProviderProtocol = (protocol: ProviderType | undefined): boolean => {
+    return protocol !== undefined && !NON_PROVIDER_PROTOCOLS.includes(protocol);
 };
 
 // Provider-specific icons with status awareness

--- a/src/components/sessionTabProviderIcon.test.ts
+++ b/src/components/sessionTabProviderIcon.test.ts
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+import { describe, it, expect } from 'vitest';
+import { isProviderProtocol } from './SessionTabs';
+import { PROVIDER_LOGOS } from './ProviderLogos';
+import type { ProviderType } from '../types';
+
+/** The `ProviderType` union, read from the source rather than restated here.
+ *  Restating it is what let the original allowlist drift out of date.
+ *  Read through Vite's raw glob, the same way the other source-scanning pins
+ *  do, so the test needs no node type definitions. */
+const TYPES_SOURCE = import.meta.glob('../types.ts', {
+    query: '?raw',
+    import: 'default',
+    eager: true,
+}) as Record<string, string>;
+
+function providerTypeUnion(): string[] {
+    const src = Object.values(TYPES_SOURCE)[0];
+    if (!src) throw new Error('types.ts not found by the raw glob');
+    const block = /export type ProviderType =((?:\s*\|\s*"[^"]+")+)/.exec(src);
+    if (!block) throw new Error('ProviderType union not found in types.ts');
+    return [...block[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+}
+
+describe('session tab provider icon', () => {
+    it('treats every protocol except plain FTP as a provider', () => {
+        const union = providerTypeUnion();
+        expect(union.length).toBeGreaterThan(20);
+
+        for (const protocol of union) {
+            const expected = protocol !== 'ftp' && protocol !== 'ftps';
+            expect(
+                isProviderProtocol(protocol as ProviderType),
+                `${protocol} should ${expected ? '' : 'not '}take the provider icon path`,
+            ).toBe(expected);
+        }
+    });
+
+    it('covers the four protocols the old allowlist had missed', () => {
+        // All four were in ProviderType and absent from the list. Only `swift`
+        // was reachable, and Blomp is where it showed: the PNG, the BlompLogo
+        // component and the PROVIDER_LOGOS entry all existed and none of them
+        // was ever consulted. googlephotos, aerocloud and peer have no registry
+        // entry, so no session can carry them: latent, not broken. They are
+        // pinned here anyway, because "unreachable today" is not a reason to
+        // leave the gap that made swift fail.
+        for (const protocol of ['swift', 'googlephotos', 'aerocloud', 'peer']) {
+            expect(isProviderProtocol(protocol as ProviderType), protocol).toBe(true);
+        }
+    });
+
+    it('still excludes the two that are not providers', () => {
+        expect(isProviderProtocol('ftp')).toBe(false);
+        expect(isProviderProtocol('ftps')).toBe(false);
+        expect(isProviderProtocol(undefined)).toBe(false);
+    });
+
+    it('has a logo registered for Blomp under the id its profiles carry', () => {
+        // The tab resolves `PROVIDER_LOGOS[session.providerId]`, and saved Blomp
+        // profiles carry providerId "blomp". A logo that exists under a
+        // different key is a logo nobody renders.
+        expect(PROVIDER_LOGOS['blomp']).toBeDefined();
+    });
+});


### PR DESCRIPTION
## Why

Three independent defects on `main` after v4.1.8, two of them found against a live Blomp session.

1. **Option keys.** CLI and MCP already used `profile_loader`'s alias table (`webdavScheme` is `tls_mode`, `allowCleartextStorage` is `allow_cleartext_storage_endpoint`). Agent session rewrote camelCase locally and AI tools kept a subset table, so a saved WebDAV scheme or Swift cleartext flag arrived under the wrong key and the provider ignored it. Tracker #628 item 16.

2. **Swift listings.** The GUI listed every Swift container as empty while the CLI listed it correctly. `provider_list_files` defaults the path to `"."`, and `normalize_path` was `trim_matches('/')`, so the first listing asked for keys starting with `./`. There are none. Live-reproduced on Blomp: `ls /` returned ten entries, `ls .` returned zero. Not a regression of 4.1.8; the trim has been there since v3.1.6 and surfaced because Blomp became a production provider.

3. **Swift tab logos.** A connected Blomp session showed the generic Wifi glyph. The PNG, the `BlompLogo` component, and `PROVIDER_LOGOS['blomp']` were all present. The tab first asked a hand-written protocol allowlist whether this is a provider, and `swift` had never been added. A provider is now anything that is not plain FTP.

## Commits

- `99b0df97` fix(profiles): one option-key table for CLI, MCP, agent and AI tools
- `25296832` fix(swift): treat a dot path as the container root
- `583592f9` fix(tabs): stop the provider allowlist deciding which logos exist

## Test plan

- [x] `profile_loader`, `flatten_options`, and AI extra-options unit tests
- [x] Swift `normalize_path` coverage for `.`, `..`, and dotted names (in `swift.rs`)
- [x] Session tab icon pin reads `ProviderType` from source (does not restate the allowlist)
- [x] `npm run ci:pre-push` (fmt, security regression, version drift, vitest, typecheck, i18n 46 locales, clippy -D warnings, full Rust suite, cargo audit)

Tracker: https://github.com/axpdev-lab/aeroftp/issues/628


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved profile option handling so camelCase and provider-specific settings are recognized consistently.
  - Fixed Swift path normalization for nested folders, repeated slashes, dot segments, and parent-directory traversal.
  - Corrected provider detection for supported protocols beyond FTP and FTPS.

- **New Features**
  - Added provider handling for additional protocols, including Blomp.
  - Added Blomp provider icon support, with a generic fallback when no logo is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->