### PR TITLE
fix(providers): promote S3Drive on evidence, and say why DigitalOcean stays hidden

### DIFF
--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -912,6 +912,13 @@ export const PROVIDERS: ProviderConfig[] = [
         category: 's3',
         icon: 'Cloud',
         color: '#0069FF',
+        // NOT a known defect: never verified live, because the trial account
+        // used for testing expired and no other Spaces account was available.
+        // It is an ordinary S3 endpoint dispatching through the same stack as
+        // the other presets, so the expectation is that it works. Clearing this
+        // needs ten minutes with any Spaces key, not a code change. Recording
+        // the reason because a bare `stable: false` is indistinguishable from a
+        // known-broken provider, and that is how this one stayed hidden.
         stable: false,
         fields: [
             { ...COMMON_FIELDS.accessKeyId, label: 'Spaces Key', helpText: 'API → Spaces Keys → Key' },
@@ -1108,7 +1115,11 @@ export const PROVIDERS: ProviderConfig[] = [
         category: 's3',
         icon: 'HardDrive',
         color: '#0E7490',
-        stable: false,
+        // Verified live on 2026-08-26 against the dev-vault profile: connect,
+        // list, put, get with byte-identical content, and delete. The flag had
+        // been sitting here with no recorded reason, which is the only thing
+        // that kept it unverified for months.
+        stable: true,
         fields: [
             { ...COMMON_FIELDS.accessKeyId, placeholder: 'AKIA...', helpText: 'From S3Drive: open the "Setup with Rclone" page and copy the access_key_id value.' },
             { ...COMMON_FIELDS.secretAccessKey, helpText: 'From S3Drive: same "Setup with Rclone" page, copy the secret_access_key value.' },


### PR DESCRIPTION
Came out of the count review on [docs#6](https://github.com/axpdev-lab/docs.aeroftp.app/pull/6): while working out how many providers AeroFTP really supports, two presets turned out to be hidden behind a `stable: false` that nobody had explained.

That flag hides the tile from the protocol grid and puts a warning on it in Add Service. With no reason recorded, a preset that was simply never tested looks exactly like one that is known broken, and that is how both of these stayed hidden.

### S3Drive: verified, promoted

Tested live against the dev-vault profile, against `https://storage.kapsa.io`:

| Step | Result |
|---|---|
| connect + list | OK |
| put (43 B, scratch prefix) | OK |
| list back | OK, 43 B |
| get | OK, byte-identical to the source |
| delete both probes | OK, prefix left empty |

The first upload attempt failed once and the built-in retry carried it. The second upload went through first time, so that was transient rather than a property of the endpoint. Worth knowing, not worth blocking on.

`stable: true`, with the evidence in a comment beside the flag.

### DigitalOcean Spaces: untouched, but no longer unexplained

Nothing to test it with: the trial account used for testing expired and no other Spaces key was available. That is now written next to the flag instead of left implied.

It is an ordinary S3 endpoint dispatching through the same stack as the other nineteen S3 presets, so the expectation is that it works. **Clearing it needs ten minutes with any Spaces key, not a code change.** If you have one, say so and I will run the same probe.

### Verified green

`tsc`, vitest at 92 files and 797 tests. No Rust touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gpkDULZYjdzke3wULZyDw


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a documented verification status for DigitalOcean Spaces.
  * Updated S3Drive’s availability status following successful connection and file operation verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->