### PR TITLE
fix(i18n): stop truncating the diacritics report on a pipe

### DIFF
--- a/scripts/i18n-diacritics.mjs
+++ b/scripts/i18n-diacritics.mjs
@@ -158,13 +158,20 @@ for (const file of readdirSync(LOCALES_DIR).filter((f) => f.endsWith('.json')).s
     }
 }
 
+// `process.exitCode`, never `process.exit()`. Exiting outright abandons any
+// stdout still queued, and stdout to a pipe is queued: past the 64KB buffer the
+// report is cut mid-string and the caller gets unparseable JSON. Setting the
+// code instead lets node drain and exit on its own.
+const code = () => (strict && total > 0 ? 1 : 0);
+
 if (asJson) {
     console.log(JSON.stringify(found, null, 2));
-    process.exit(strict && total > 0 ? 1 : 0);
+    process.exitCode = code();
+} else {
+    console.log(`\n${total} new suspected stripped-diacritic string(s), ${suppressed} already reviewed and accepted.`);
+    if (total > 0) {
+        console.log('A hit is a question for a human, never an automated rewrite (see issue #512).');
+        console.log(`Judged correct as written? Add it to ${'scripts/i18n-diacritics-accepted.json'} with the reason.`);
+    }
+    process.exitCode = code();
 }
-console.log(`\n${total} new suspected stripped-diacritic string(s), ${suppressed} already reviewed and accepted.`);
-if (total > 0) {
-    console.log('A hit is a question for a human, never an automated rewrite (see issue #512).');
-    console.log(`Judged correct as written? Add it to ${'scripts/i18n-diacritics-accepted.json'} with the reason.`);
-}
-process.exit(strict && total > 0 ? 1 : 0);


### PR DESCRIPTION
fix(i18n): stop the diacritics gate truncating its own JSON report

The `--json` branch called `process.exit()` immediately after `console.log`. Exiting outright abandons whatever stdout is still queued, and stdout to a pipe is queued, so past the 64KB buffer the report is cut mid-string and the caller receives unparseable JSON. It sets `process.exitCode` and lets node drain instead.

This is latent rather than theoretical: today the gate reports 0 new hits and 37 accepted, so its JSON never reaches the buffer. It was found by hitting the same wall in a new sibling gate whose report is 317KB, where the truncation is immediate and total.

Behaviour is otherwise unchanged: same exit codes, same output, `--strict` still the only way to fail.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01X2kkic9wN3zTtVyBG6YMEx


Tracker #628. The tracker stays open: other items are still in flight.

Kept separate from the untranslated-strings gate (#637) on purpose, so it stands on its own if that one slips.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved command-line exit handling to ensure output is fully written before the process ends.
  - Preserved strict-mode status reporting for both JSON and plain-text results.
  - Prevented plain-text guidance from appearing alongside JSON output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->