### PR TITLE
fix(webdav): re-negotiate Digest on every request path, not five of them

### DIFF
--- a/src-tauri/src/providers/webdav.rs
+++ b/src-tauri/src/providers/webdav.rs
@@ -1133,6 +1133,17 @@ impl WebDavProvider {
     /// nonce still equals the one just used and `adopt_rotated_nonce` refused,
     /// so both arms are false and a revoked credential still costs exactly one
     /// request.
+    ///
+    /// Known imprecision, deliberately left: `used` comes from a read of the
+    /// shared challenge taken just before the request is built, not from the
+    /// single read inside `authorization` that actually computes the header.
+    /// A sibling rotating in that window makes the snapshot disagree with what
+    /// the request really carried, and the second arm then grants a replay
+    /// that was not needed. It costs one extra request and cannot storm, since
+    /// the replay is still capped at one. Closing it means having
+    /// `authorization` report the nonce it used, which changes the signature
+    /// `request` and `request_url` share across some forty call sites; the
+    /// trade was not worth making inside this fix.
     fn should_replay_after_401(&self, response: &reqwest::Response, used: &Option<String>) -> bool {
         if self.adopt_rotated_nonce(response) {
             return true;

--- a/src-tauri/src/providers/webdav.rs
+++ b/src-tauri/src/providers/webdav.rs
@@ -816,7 +816,7 @@ impl WebDavProvider {
     }
 
     /// Make an authenticated request (Basic or Digest depending on server)
-    fn request(&mut self, method: Method, path: &str) -> reqwest::RequestBuilder {
+    fn request(&self, method: Method, path: &str) -> reqwest::RequestBuilder {
         let url = self.build_url(path);
         let builder = self.client.request(method.clone(), &url);
 
@@ -1260,7 +1260,7 @@ impl WebDavProvider {
 
     /// Make an authenticated request to an arbitrary URL (for OCS / trashbin endpoints
     /// that live outside the WebDAV files path).
-    fn request_url(&mut self, method: Method, url: &str) -> reqwest::RequestBuilder {
+    fn request_url(&self, method: Method, url: &str) -> reqwest::RequestBuilder {
         let builder = self.client.request(method.clone(), url);
         if self.config.anonymous {
             return builder;

--- a/src-tauri/src/providers/webdav.rs
+++ b/src-tauri/src/providers/webdav.rs
@@ -904,7 +904,14 @@ impl WebDavProvider {
             None
         };
 
+        // A rotated Digest nonce is replayed at most once per call, tracked
+        // here rather than by attempt number: the 425 loop may already have
+        // burned attempts, and a second rotation inside one call is the retry
+        // storm the `stale` gate exists to prevent.
+        let mut digest_replayed = false;
+
         for attempt in 1..=MAX_ATTEMPTS {
+            let nonce_used = self.digest_nonce_snapshot();
             let mut req = self.request(method.clone(), path);
             if let Some(ref r) = referer {
                 req = req.header("Referer", r);
@@ -916,6 +923,14 @@ impl WebDavProvider {
                 .send()
                 .await
                 .map_err(|e| ProviderError::NetworkError(describe_reqwest_error(&e)))?;
+
+            if response.status() == StatusCode::UNAUTHORIZED
+                && !digest_replayed
+                && self.should_replay_after_401(&response, &nonce_used)
+            {
+                digest_replayed = true;
+                continue;
+            }
 
             if response.status() != StatusCode::TOO_EARLY || attempt == MAX_ATTEMPTS {
                 return Ok(response);
@@ -932,6 +947,52 @@ impl WebDavProvider {
         }
 
         unreachable!("retry loop must return on final attempt")
+    }
+
+    /// Send a request and, on a `401` carrying a genuinely rotated Digest
+    /// nonce, rebuild it and send it exactly once more.
+    ///
+    /// `build` runs once per attempt, so the `Authorization` header is
+    /// recomputed from the challenge the provider holds *now*: a replay never
+    /// re-presents the dead nonce, and a body is rebuilt from its source
+    /// instead of being buffered for a retry that usually never happens.
+    ///
+    /// Replaying on `401` is safe for every caller, idempotent or not,
+    /// because a `401` means the server rejected the request BEFORE applying
+    /// it: there is no intermediate state. That is what separates this from
+    /// replaying a timeout or a `5xx`, where the server may already have
+    /// acted and idempotence would have to decide. It is why `MOVE`, `DELETE`
+    /// and the multipart `complete` can all go through here safely.
+    ///
+    /// Exactly one replay, structurally: a straight-line `if`, no loop. A
+    /// second rotation inside one call is the storm the `stale` gate exists
+    /// to prevent.
+    ///
+    /// This is one half of a pair; [`Self::send_with_too_early_retry`] is the
+    /// other, and heals `425 Too Early` on the same principle for the two
+    /// GET paths that need it. Do not add a third variant: extend one of
+    /// these, or every future request site will pick a different half and the
+    /// gap this pair closes will reopen.
+    async fn send_replaying_digest(
+        &self,
+        build: impl Fn() -> reqwest::RequestBuilder,
+    ) -> Result<reqwest::Response, ProviderError> {
+        let nonce_used = self.digest_nonce_snapshot();
+        let response = build()
+            .send()
+            .await
+            .map_err(|e| ProviderError::NetworkError(e.to_string()))?;
+
+        if response.status() == StatusCode::UNAUTHORIZED
+            && self.should_replay_after_401(&response, &nonce_used)
+        {
+            return build()
+                .send()
+                .await
+                .map_err(|e| ProviderError::NetworkError(e.to_string()));
+        }
+
+        Ok(response)
     }
 
     /// Send a PROPFIND and, on a `401` that carries a fresh
@@ -1038,6 +1099,50 @@ impl WebDavProvider {
     /// The repair is pool-wide, not per-caller: the challenge lives behind a
     /// shared `Arc`, so one worker adopting the rotated nonce fixes it for
     /// every `clone_for_transfer` sibling still presenting the dead one.
+    /// The nonce this provider holds right now, or `None` when the connection
+    /// is not Digest-authenticated.
+    ///
+    /// Read immediately before a request is sent so that a `401` can be told
+    /// apart from a sibling worker's repair: see
+    /// [`Self::should_replay_after_401`].
+    fn digest_nonce_snapshot(&self) -> Option<String> {
+        self.digest_auth.as_ref().map(|state| state.nonce())
+    }
+
+    /// Whether a `401` should be replayed once, given the nonce the failed
+    /// request actually carried.
+    ///
+    /// Two things can make a replay right, and only one of them is a rotation
+    /// this worker performs itself:
+    ///
+    /// - `adopt_rotated_nonce` succeeded: the server offered `stale=true` with
+    ///   a nonce we were not holding, and we installed it.
+    /// - It refused, but the nonce we hold is no longer the one this request
+    ///   used. A sibling worker hit the same rotation first and repaired the
+    ///   shared challenge, so the server is now offering back the nonce that
+    ///   sibling already installed. `renegotiate` correctly declines to adopt
+    ///   what it already has, but this request still went out with a dead
+    ///   nonce and deserves its one replay, with the fresh one.
+    ///
+    /// Without the second arm, concurrent transfers lose whichever requests
+    /// lost the race: measured against Apache `mod_auth_digest` with a 2s
+    /// `AuthDigestNonceLifetime`, a 60-file recursive download failed a
+    /// random 2 to 6 files per run while the rest succeeded.
+    ///
+    /// The anti-storm property is untouched. When nothing changed, the held
+    /// nonce still equals the one just used and `adopt_rotated_nonce` refused,
+    /// so both arms are false and a revoked credential still costs exactly one
+    /// request.
+    fn should_replay_after_401(&self, response: &reqwest::Response, used: &Option<String>) -> bool {
+        if self.adopt_rotated_nonce(response) {
+            return true;
+        }
+        match (used, self.digest_nonce_snapshot()) {
+            (Some(before), Some(now)) => *before != now,
+            _ => false,
+        }
+    }
+
     fn adopt_rotated_nonce(&self, response: &reqwest::Response) -> bool {
         let Some(existing) = self.digest_auth.as_ref() else {
             return false;
@@ -3237,25 +3342,56 @@ impl StorageProvider for WebDavProvider {
             return Err(ProviderError::NotConnected);
         }
 
-        let file = tokio::fs::File::open(local_path)
+        let total_size = tokio::fs::metadata(local_path)
             .await
-            .map_err(ProviderError::IoError)?;
-        let total_size = file.metadata().await.map_err(ProviderError::IoError)?.len();
+            .map_err(ProviderError::IoError)?
+            .len();
 
         // Stream file with Content-Length header (required by some HTTP/1.1 servers).
         // 256 KiB capacity matches our SFTP default and avoids the 4 KiB read
         // chunks ReaderStream uses by default, which churn syscalls and bottleneck
         // local-network throughput.
-        let stream = tokio_util::io::ReaderStream::with_capacity(file, 256 * 1024);
-        let body = reqwest::Body::wrap_stream(stream);
+        //
+        // Built per attempt rather than once: the body is a stream over an open
+        // file and `send` consumes it, so a Digest replay has to rebuild it. It
+        // rebuilds from `local_path`, which costs one file descriptor, instead
+        // of buffering `total_size` bytes to hold a copy for a retry that
+        // usually never happens: that would defeat the streaming this path
+        // exists for, on files of arbitrary size. Reopening also guarantees the
+        // replay starts at offset zero instead of wherever the first attempt
+        // stopped reading.
+        let put_body = || async {
+            let file = tokio::fs::File::open(local_path)
+                .await
+                .map_err(ProviderError::IoError)?;
+            let stream = tokio_util::io::ReaderStream::with_capacity(file, 256 * 1024);
+            Ok::<reqwest::Body, ProviderError>(reqwest::Body::wrap_stream(stream))
+        };
 
-        let response = self
+        let nonce_used = self.digest_nonce_snapshot();
+        let mut response = self
             .request(Method::PUT, remote_path)
             .header("Content-Length", total_size)
-            .body(body)
+            .body(put_body().await?)
             .send()
             .await
             .map_err(|e| ProviderError::NetworkError(e.to_string()))?;
+
+        // The single-PUT path used to map a 401 straight into
+        // `upload_failure_error`'s catch-all, so a rotated nonce failed the
+        // whole upload. Replay exactly once, on the same `stale=true` gate the
+        // other paths use.
+        if response.status() == StatusCode::UNAUTHORIZED
+            && self.should_replay_after_401(&response, &nonce_used)
+        {
+            response = self
+                .request(Method::PUT, remote_path)
+                .header("Content-Length", total_size)
+                .body(put_body().await?)
+                .send()
+                .await
+                .map_err(|e| ProviderError::NetworkError(e.to_string()))?;
+        }
 
         match response.status() {
             StatusCode::OK | StatusCode::CREATED | StatusCode::NO_CONTENT => {
@@ -3277,10 +3413,8 @@ impl StorageProvider for WebDavProvider {
         // Apache does not 301 to a scheme-downgraded URL that loses auth.
         let col = Self::collection_path(path);
         let response = self
-            .request(webdav_methods::mkcol(), &col)
-            .send()
-            .await
-            .map_err(|e| ProviderError::NetworkError(e.to_string()))?;
+            .send_replaying_digest(|| self.request(webdav_methods::mkcol(), &col))
+            .await?;
 
         match response.status() {
             // RFC 4918 §9.3.1: 201 Created on success, 405 Method Not Allowed
@@ -3307,10 +3441,8 @@ impl StorageProvider for WebDavProvider {
         }
 
         let response = self
-            .request(Method::DELETE, path)
-            .send()
-            .await
-            .map_err(|e| ProviderError::NetworkError(e.to_string()))?;
+            .send_replaying_digest(|| self.request(Method::DELETE, path))
+            .await?;
 
         match response.status() {
             StatusCode::OK | StatusCode::NO_CONTENT | StatusCode::ACCEPTED => Ok(()),
@@ -3348,13 +3480,13 @@ impl StorageProvider for WebDavProvider {
         };
 
         let response = self
-            .request(webdav_methods::move_method(), from)
-            .header("Destination", destination)
-            .header("Overwrite", "F") // Don't overwrite existing
-            .header("Depth", move_depth)
-            .send()
-            .await
-            .map_err(|e| ProviderError::NetworkError(e.to_string()))?;
+            .send_replaying_digest(|| {
+                self.request(webdav_methods::move_method(), from)
+                    .header("Destination", &destination)
+                    .header("Overwrite", "F") // Don't overwrite existing
+                    .header("Depth", move_depth)
+            })
+            .await?;
 
         match response.status() {
             StatusCode::OK | StatusCode::CREATED | StatusCode::NO_CONTENT => Ok(()),
@@ -3889,11 +4021,11 @@ impl StorageProvider for WebDavProvider {
         let token_header = format!("<{}>", lock_token);
 
         let response = self
-            .request(webdav_methods::unlock(), path)
-            .header("Lock-Token", &token_header)
-            .send()
-            .await
-            .map_err(|e| ProviderError::NetworkError(e.to_string()))?;
+            .send_replaying_digest(|| {
+                self.request(webdav_methods::unlock(), path)
+                    .header("Lock-Token", &token_header)
+            })
+            .await?;
 
         match response.status() {
             reqwest::StatusCode::OK | reqwest::StatusCode::NO_CONTENT => Ok(()),
@@ -3952,12 +4084,12 @@ impl StorageProvider for WebDavProvider {
         let destination = self.build_url(to);
 
         let response = self
-            .request(webdav_methods::copy(), from)
-            .header("Destination", destination)
-            .header("Overwrite", "F")
-            .send()
-            .await
-            .map_err(|e| ProviderError::NetworkError(e.to_string()))?;
+            .send_replaying_digest(|| {
+                self.request(webdav_methods::copy(), from)
+                    .header("Destination", &destination)
+                    .header("Overwrite", "F")
+            })
+            .await?;
 
         match response.status() {
             StatusCode::OK | StatusCode::CREATED | StatusCode::NO_CONTENT => Ok(()),
@@ -4332,11 +4464,11 @@ impl StorageProvider for WebDavProvider {
         }
 
         let response = self
-            .request(Method::GET, remote_path)
-            .header("Range", format!("bytes={}-", offset))
-            .send()
-            .await
-            .map_err(|e| ProviderError::NetworkError(e.to_string()))?;
+            .send_replaying_digest(|| {
+                self.request(Method::GET, remote_path)
+                    .header("Range", format!("bytes={}-", offset))
+            })
+            .await?;
 
         match response.status() {
             StatusCode::PARTIAL_CONTENT => {
@@ -4487,11 +4619,11 @@ impl StorageProvider for WebDavProvider {
         let range_header = format!("bytes={}-{}", offset, end);
 
         let response = self
-            .request(Method::GET, path)
-            .header("Range", &range_header)
-            .send()
-            .await
-            .map_err(|e| ProviderError::NetworkError(e.to_string()))?;
+            .send_replaying_digest(|| {
+                self.request(Method::GET, path)
+                    .header("Range", &range_header)
+            })
+            .await?;
 
         let status = response.status();
         match status {


### PR DESCRIPTION
## What was wrong

#636 wired `stale=true` re-negotiation into five call sites. That map was built by grepping for `UNAUTHORIZED`, so it found only the sites that name the status: the ones that let a 401 fall into a catch-all `status =>` arm were invisible, and they are most of the provider.

Measured live against Apache `mod_auth_digest`, a recursive download of 60 files lost **52 of them**. Every `GET` that met an expired nonce failed with "Authentication failed during transfer" and was never replayed. Upload, ranged reads, resume, `DELETE`, `MOVE`, `COPY`, `MKCOL` and `UNLOCK` shared the gap.

## What this does

`send_replaying_digest` takes a closure that rebuilds the request, so a replay recomputes its own `Authorization` header and never re-presents the dead nonce. `send_with_too_early_retry` gains the same gate, which covers the two download paths; its loop already rebuilt the request per attempt.

Replaying on 401 is safe for every caller, idempotent or not: a 401 means the server rejected the request **before** applying it. That is what separates it from replaying a timeout or a 5xx, where the server may already have acted. It is why `MOVE`, `DELETE` and the multipart `complete` can all go through here.

The single `PUT` rebuilds its body by reopening `local_path` rather than buffering the file, the same reasoning that keeps `PartBody` replayable from its source. A fresh handle also guarantees the replay starts at offset zero.

`request` and `request_url` move to `&self` in a separate first commit. They never wrote to `self`; the `&mut` blocked a caller from holding a rebuild closure while a helper borrows `self`.

## The concurrency defect, which unit tests could not have shown

After the first pass the download went from 8/60 to 58/60. The remaining failures were **different files on every run**, which is a race, not a missed path.

The "adopt only a nonce we are not already holding" rule is what stops a revoked password becoming a retry storm. Under parallel transfers a sibling worker often adopts the rotation first, so the server offers back a nonce the shared challenge already has and `renegotiate` correctly declines. The request that lost the race then died holding a nonce that was already dead.

A replay is now also granted when the held nonce differs from the one the failed request carried. The anti-storm property is unchanged: when nothing rotated, both arms are false and a bad credential still costs exactly one request.

The existing unit tests verified that a sibling *receives* a rotated nonce, not that a sibling with a request already in flight can replay it. Those are different properties.

## Verification

Apache 2.4.58, `AuthType Digest`, `AuthDigestNonceLifetime` tuned so a single request completes inside the window while the session crosses it repeatedly. `tc netem` filtered to the lab port alone shaped the link so uploads span the window; `RATE_LIMIT` cannot, being an output filter.

| | before | after |
|---|---|---|
| Recursive download, 60 files | 8 downloaded, 52 failed | **60/60**, three consecutive runs |
| Nonce rotations observed | 53 | 12 to 17 per run |
| Recursive upload, 24 files | not reachable | **24/24**, four rotations on `PUT` |
| Integrity | not reached | every MD5 matches, both directions |
| 401s per path | 1, never replayed | never more than 1, always replayed |

Local gate: `cargo fmt` clean, three clippy runs `rc=0 error=0` (read without a pipe between cargo and the exit code), full suite 4052 passed 0 failed across 22 blocks.

## Known limit, written down not hidden

The nonce snapshot is read just before the request is built, while `authorization` takes a single guard to compute the header. A sibling rotating in that window makes the snapshot disagree with what the request carried, and the sibling-repair arm then grants a replay that was not needed. It costs one extra request and cannot storm. Closing it means having `authorization` report the nonce it used, which changes a signature shared across some forty call sites; the trade was not worth making inside this fix.

## Method note

The test window is narrow and has a rule: **slowest single request < `AuthDigestNonceLifetime` < session duration**. Below it the configuration is unsatisfiable and a correct client fails too, because the replay arrives after the nonce is dead again. Above it nothing rotates and a green result proves nothing: 24/24 with zero rotations is not a pass. `AuthDigestNonceLifetime 0` is unusable entirely, since the one-time nonce table is per-process and breaks under a multi-process MPM.

## Where the boundary is, measured

The tuning rule above has a sharper form, established by sweeping the nonce lifetime against injected one-way network delay (`tc netem`, scoped to the lab port) under a 60-file recursive download:

> The replay succeeds while **`RTT < AuthDigestNonceLifetime`**, and fails exactly when `RTT >= L`.

The reason is mechanical: the nonce is minted when the server emits the `401`, and it has to still be alive when the replay reaches the server. That is one round trip, and there is no margin to recover: the credential simply expires in flight.

| one-way delay | lifetime | network RTT | RTT/L | result |
|---|---|---|---|---|
| 0 ms | 1 s | 0 ms | 0.00 | 60/60 |
| 300 ms | 1 s | 600 ms | 0.60 | 60/60 |
| 400 ms | 1 s | 800 ms | 0.80 | 60/60 |
| 500 ms | 1 s | 1000 ms | 1.00 | **0/60** |
| 600 ms | 1 s | 1200 ms | 1.20 | **0/60** |
| 700 ms | 1 s | 1400 ms | 1.40 | **0/60** |
| 700 ms | 2 s | 1400 ms | 0.70 | 60/60 |
| 800 ms | 2 s | 1600 ms | 0.80 | 60/60 |
| 1000 ms | 2 s | 2000 ms | 1.00 | **0/60** |

The threshold moves with `L` and keeps the ratio: it breaks between 400 and 500 ms at `L=1`, and between 800 and 1000 ms at `L=2`. The second pair was predicted from the first before being measured.

Three regimes follow:

| regime | condition | what happens |
|---|---|---|
| broken | `RTT >= L` | 0/60. The replay is sent and arrives holding a nonce that already died |
| usable | `RTT < L < session duration` | 60/60, real rotations, one 401 per path |
| inert | `L >= session duration` | 60/60 but **zero rotations**: the green proves nothing |

Optimal is `L` around three to five times the RTT, and below a third of the session so rotations stay frequent.

**Diagnostic signature.** The maximum number of `401`s on any single path separates the regimes with no ambiguity: **1 means healthy** (one challenge, one replay, done), **2 means the configuration is unsatisfiable** (the replay went out and died too). Nothing else needs to be read to tell them apart.

The broken regime needs `RTT >= L`. Against Apache's default `AuthDigestNonceLifetime` of 300 s that would take a five-minute round trip, so it does not occur outside a lab with a deliberately short lifetime. It is also not a client-side limit: no client can do better, because the server is handing out a credential that expires before it can be used. Chasing the rotation further is the retry storm the `stale` gate exists to prevent.
