### PR TITLE
feat(docs): derive every provider figure from one inventory, and gate it

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -78,6 +78,15 @@ jobs:
       - name: i18n raw-English gate
         run: npm run i18n:untranslated
 
+      # Every published "how many providers / presets / protocols" figure is
+      # derived from the catalog and the registry into docs/PROVIDER-INVENTORY.json.
+      # They used to be prose, which is why three different numbers for the same
+      # noun could all sit in the tree at once and none of them error. This fails
+      # when the committed inventory no longer matches the code, and prints which
+      # count moved, so the prose that quotes it gets updated in the same commit.
+      - name: Provider inventory is not stale
+        run: npm run check:provider-inventory
+
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked
 

--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,9 @@ run-clean.sh
 !/scripts/snap-stale-packages.mjs
 # Exception: regenerates the providers table from the GUI SSOT (#270 17104681)
 !/scripts/gen-providers-table.ts
+# Exception: derives every published provider/preset/protocol figure into
+# docs/PROVIDER-INVENTORY.json, gated by the fast checks workflow
+!/scripts/gen-provider-inventory.ts
 # Exception: stripped-diacritics gate and its reviewed baseline, run by the
 # fast checks workflow (#628 item 12)
 !/scripts/i18n-diacritics.mjs

--- a/README.md
+++ b/README.md
@@ -83,11 +83,11 @@ AeroFTP is an FTP client first. Full encryption support with configurable TLS mo
 
 ## Integrations
 
-AeroFTP organizes integrations on three tiers, so what you see in the catalog is precise rather than vague:
+AeroFTP organizes integrations on three tiers, so what you see in the catalog is precise rather than vague. The figures below are generated into [`docs/PROVIDER-INVENTORY.json`](docs/PROVIDER-INVENTORY.json) from the catalog and the registry, and CI fails when they drift from the code:
 
 1. **Transport protocols (7):** native wire-level support for FTP, FTPS, SFTP, WebDAV, S3, Azure Blob, OpenStack Swift. Plus **portable devices over MTP / WPD** - attached phones, cameras and media players that the OS never assigns a drive letter, saved as profiles keyed to a stable device fingerprint (see [Portable devices](docs/PROTOCOL-FEATURES.md#portable-devices-mtp--wpd)).
-2. **Native provider integrations (25+):** dedicated OAuth2 / API key / SDK code paths per provider, so each one's specific features (sharing, native delta sync, server-side copy, large-file chunking, media-CDN transformations) are first-class instead of best-effort. Includes the dedicated **media services** tier (ImageKit, Uploadcare, Cloudinary, Immich, PixelUnion).
-3. **Pre-configured presets (45+):** server URL, port, base path, password-generation deep-link filled in automatically for compatible services on top of the protocols above (S3-compatible endpoints from MEGA S4 to Filen S5 to MinIO, WebDAV-compatible servers including Nextcloud, TAB.DIGITAL, Felicloud, Seafile, InfiniCLOUD, etc.).
+2. **Native provider integrations (24):** dedicated OAuth2 / API key / SDK code paths per provider, so each one's specific features (sharing, native delta sync, server-side copy, large-file chunking, media-CDN transformations) are first-class instead of best-effort. Includes the dedicated **media services** tier (ImageKit, Uploadcare, Cloudinary, Immich, PixelUnion).
+3. **Pre-configured presets (44):** the form arrives already filled in, server URL, port, base path and password-generation deep-link, for a named service on top of the protocols above. A form with nothing pre-filled is not a preset: the two generic ones (Custom S3, WebDAV Server) exist precisely for when no preset applies (S3-compatible endpoints from MEGA S4 to Filen S5 to MinIO, WebDAV-compatible servers including Nextcloud, TAB.DIGITAL, Felicloud, Seafile, InfiniCLOUD, etc.).
 
 <!-- BEGIN PROVIDERS-GRID -->
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/support-multi--protocol-green" alt="Multi-Protocol Support" />
   <img src="https://img.shields.io/badge/AI%20providers-24-ff6600?logo=openai&logoColor=white" alt="AI Providers" />
-  <img src="https://img.shields.io/badge/AI%20tools-50%2B-ff6600" alt="AI Tools" />
+  <img src="https://img.shields.io/badge/AI%20tools-39-ff6600" alt="AI Tools" />
   <img src="https://img.shields.io/badge/languages-47-orange" alt="Languages" />
   <img src="https://img.shields.io/badge/encryption-AES--256-purple?logo=letsencrypt&logoColor=white" alt="AES-256 Encryption" />
   <img src="https://img.shields.io/badge/CLI-ready-blue?logo=gnubash&logoColor=white" alt="CLI Ready" />
@@ -312,7 +312,7 @@ AeroFTP defines seven user-facing file formats. Each has a single purpose and a 
 
 ```
 AeroFTP
-├── AeroCloud    - Personal cloud (7 transport protocols + 25+ native providers + 6 media services, sync, share)
+├── AeroCloud    - Personal cloud (7 transport protocols + 24 native providers + 6 media services, sync, share)
 ├── AeroFile     - Professional file manager (multi-file Properties, recursive search, default-app routing)
 ├── AeroShare    - Peer-to-peer user-to-user transfer (end-to-end encrypted, no server in the middle) [Beta]
 ├── AeroMount    - Persistent FUSE / WebDAV mounts with cross-platform autostart (the Mount Manager)
@@ -320,7 +320,7 @@ AeroFTP
 │   └── AeroRsync    - Native Rust delta sync (clean-room rsync protocol 31)
 ├── AeroVault    - Military-grade encryption
 ├── AeroTools    - Code editor + Terminal + AI chat
-│   └── AeroAgent    - AI-powered assistant (50+ tools, 24 providers)
+│   └── AeroAgent    - AI-powered assistant (39 tools, 24 providers)
 ├── AeroFTP CLI  - Production command-line client (vault profiles, JSON output, batch scripting, daemon, FUSE mount, crypt, ncdu, agent discovery)
 └── AeroPlayer   - Media player with visualizers
 ```
@@ -331,7 +331,7 @@ AeroFTP
 
 > [Full documentation →](https://docs.aeroftp.app/features/aerocloud.html)
 
-Turn **any server** into a private personal cloud. Connect through 7 transport protocols and 25+ native provider integrations with bidirectional sync, selective sync, file versioning, .aeroignore, share links, and per-project folders. Background tray sync with native OS file manager badges (Nautilus, Nemo, Windows Explorer). See the [protocol features matrix](docs/PROTOCOL-FEATURES.md) for full per-provider capabilities.
+Turn **any server** into a private personal cloud. Connect through 7 transport protocols and 24 native provider integrations with bidirectional sync, selective sync, file versioning, .aeroignore, share links, and per-project folders. Background tray sync with native OS file manager badges (Nautilus, Nemo, Windows Explorer). See the [protocol features matrix](docs/PROTOCOL-FEATURES.md) for full per-provider capabilities.
 
 ---
 
@@ -533,7 +533,7 @@ Integrated development panel with three tools in a tabbed interface: **Monaco Ed
 
 #### AeroAgent - AI-Powered Assistant
 
-An AI assistant with **50+ tools** that work across local files and remote providers. Supports **24 AI providers** (OpenAI, Anthropic, Gemini, xAI, Ollama, DeepSeek, Mistral, Cerebras, SambaNova, Fireworks, Nvidia, and 13 more). Vision/multimodal, RAG indexing, plugin ecosystem, streaming responses, multi-step autonomous execution, native MCP server mode (73 MCP tools), and Command Palette (Ctrl+Shift+P).
+An AI assistant with **39 tools** that work across local files and remote providers. Supports **24 AI providers** (OpenAI, Anthropic, Gemini, xAI, Ollama, DeepSeek, Mistral, Cerebras, SambaNova, Fireworks, Nvidia, and 13 more). Vision/multimodal, RAG indexing, plugin ecosystem, streaming responses, multi-step autonomous execution, native MCP server mode (73 MCP tools), and Command Palette (Ctrl+Shift+P).
 
 ---
 
@@ -545,7 +545,7 @@ AeroFTP is built for both humans and AI agents. As agentic AI, computer use, and
 
 **For AI Agents (CLI)**: Tools like Claude Code, Open Interpreter, Cline, Aider, Devin, Codex, Cursor Agent, Windsurf, and other agentic frameworks can call `aeroftp-cli` directly. Structured `--json` output, vault-based `--profile` credentials (agents never see passwords), semantic exit codes, and `.aeroftp-script` batch files make AeroFTP a first-class tool in any agent's toolkit. External agents can also invoke `aeroftp-cli agent` to orchestrate AeroAgent as a credential-isolating proxy for multi-server operations. See [Agent Orchestration](https://docs.aeroftp.app/features/agent-orchestration) for the full orchestration guide, CLI reference, and a verified field test report.
 
-**For Humans (GUI + AeroAgent)**: The desktop app provides drag-and-drop file management with AeroAgent, the integrated AI assistant offering 50+ tools across local files and remote providers. AeroAgent supports multi-step autonomous execution, tool approval workflows with backend-enforced grants, and 24 AI providers.
+**For Humans (GUI + AeroAgent)**: The desktop app provides drag-and-drop file management with AeroAgent, the integrated AI assistant offering 39 tools across local files and remote providers. AeroAgent supports multi-step autonomous execution, tool approval workflows with backend-enforced grants, and 24 AI providers.
 
 ---
 
@@ -553,7 +553,7 @@ AeroFTP is built for both humans and AI agents. As agentic AI, computer use, and
 
 > [Full documentation →](https://docs.aeroftp.app/cli/installation.html)
 
-Production CLI sharing the same Rust backend as the GUI. 90 top-level commands (several grouping their own subcommands: `daemon`, `jobs`, `vault`, `archive`, `crypt`, `import`/`export`, `serve`, `users`, `groups`) across 7 transport protocols and 25+ native provider integrations, encrypted vault profiles, JSON output, batch scripting, daemon mode with job queue, FUSE filesystem mounting, ncdu TUI explorer, zero-knowledge crypt overlay, single-file AeroVault containers (`vault`, all formats v1/v2/v3), plaintext `.aerozip` archives (`archive create/list/extract`), recursive used-storage scan (`df --scan`) with a manual total-cap override, and native MCP server mode for AI integration.
+Production CLI sharing the same Rust backend as the GUI. 94 top-level commands (several grouping their own subcommands: `daemon`, `jobs`, `vault`, `archive`, `crypt`, `import`/`export`, `serve`, `users`, `groups`) across 7 transport protocols and 24 native provider integrations, encrypted vault profiles, JSON output, batch scripting, daemon mode with job queue, FUSE filesystem mounting, ncdu TUI explorer, zero-knowledge crypt overlay, single-file AeroVault containers (`vault`, all formats v1/v2/v3), plaintext `.aerozip` archives (`archive create/list/extract`), recursive used-storage scan (`df --scan`) with a manual total-cap override, and native MCP server mode for AI integration.
 
 > **Short invocation**: every package ships a native dispatcher, so `aeroftp <subcommand>` and the built-in 4-character name `aftp` both route to the CLI; `aeroftp-cli` is kept for back-compat. An opt-in `aero` alias can be enabled with `aeroftp-cli alias-toggle aero` (idempotent, the same command turns it off). See the [Short Invocation](docs/CLI-GUIDE.md#short-invocation) section of the CLI Guide.
 
@@ -573,7 +573,7 @@ aeroftp-cli daemon start                                   # Background job queu
 
 **Key features**: `--profile` credential isolation for AI agents, `--json` structured output, semantic exit codes (0-11), `.aeroftp-script` batch files, `archive create/list/extract` for plaintext `.aerozip` recovery archives, `check` / `cryptcheck` for local-vs-remote verification (size/checksum against cleartext or encrypted remotes), `dedupe` / `cleanup` for orphan management, `hashsum` for remote file hashing (sha256/md5/blake3), `link` for shareable URLs, `--bwlimit "08:00,512k 18:00,off"` time-based bandwidth schedule (local time), `serve http/webdav/ftp/sftp`, MCP server mode, `--immutable` append-only mode, `--files-from` selective transfers, `--fast-list` S3 optimization, bisync with `--conflict-mode rename`, `NO_COLOR` compliant. See the **[CLI Guide](https://docs.aeroftp.app/cli/installation.html)** and **[Credential Isolation](https://docs.aeroftp.app/credential-isolation)** docs.
 
-**MCP server (73 tools)**: curated tools for agents covering safe / medium / destructive operation tiers: file ops (`aeroftp_list_files`, `aeroftp_read_file`, `aeroftp_upload_file`), batch (`aeroftp_delete_many`, `aeroftp_upload_many`), tree sync (`aeroftp_sync_tree` with per-file `delta_files[]` + `plan[]`), tree diff (`aeroftp_check_tree` with two-sided checksum + per-group caps + `omit_match`), preflight (`aeroftp_sync_doctor`, `aeroftp_reconcile`, `aeroftp_dedupe`), cross-profile copy (`aeroftp_transfer`, `aeroftp_transfer_tree` between two saved profiles in one batch), agent ergonomics (`aeroftp_agent_connect`, `aeroftp_speed`, `aeroftp_touch`, `aeroftp_cleanup`), and pool introspection (`aeroftp://connections` resource + `aeroftp_close_connection`). Real-time `notifications/progress` during uploads, downloads, and sync. The pool auto-recovers from transport-level failures (stale FTP data channels, broken pipes) without manual intervention. Pool reuse gives roughly **14x speedup** vs CLI cold-start on warm calls (measured 13-14 ms vs ~194 ms on Docker SFTP). Run `aeroftp-cli mcp` and plug it into Claude Desktop, Cursor, Windsurf, or VS Code via the [`axpdev-lab.aeroftp-mcp` extension](https://marketplace.visualstudio.com/items?itemName=axpdev-lab.aeroftp-mcp).
+**MCP server (77 tools)**: curated tools for agents covering safe / medium / destructive operation tiers: file ops (`aeroftp_list_files`, `aeroftp_read_file`, `aeroftp_upload_file`), batch (`aeroftp_delete_many`, `aeroftp_upload_many`), tree sync (`aeroftp_sync_tree` with per-file `delta_files[]` + `plan[]`), tree diff (`aeroftp_check_tree` with two-sided checksum + per-group caps + `omit_match`), preflight (`aeroftp_sync_doctor`, `aeroftp_reconcile`, `aeroftp_dedupe`), cross-profile copy (`aeroftp_transfer`, `aeroftp_transfer_tree` between two saved profiles in one batch), agent ergonomics (`aeroftp_agent_connect`, `aeroftp_speed`, `aeroftp_touch`, `aeroftp_cleanup`), and pool introspection (`aeroftp://connections` resource + `aeroftp_close_connection`). Real-time `notifications/progress` during uploads, downloads, and sync. The pool auto-recovers from transport-level failures (stale FTP data channels, broken pipes) without manual intervention. Pool reuse gives roughly **14x speedup** vs CLI cold-start on warm calls (measured 13-14 ms vs ~194 ms on Docker SFTP). Run `aeroftp-cli mcp` and plug it into Claude Desktop, Cursor, Windsurf, or VS Code via the [`axpdev-lab.aeroftp-mcp` extension](https://marketplace.visualstudio.com/items?itemName=axpdev-lab.aeroftp-mcp).
 
 ---
 

--- a/com.aeroftp.AeroFTP.metainfo.xml
+++ b/com.aeroftp.AeroFTP.metainfo.xml
@@ -13,7 +13,7 @@
       AeroFTP is a cross-platform desktop client for FTP, FTPS, SFTP, WebDAV,
       S3-compatible storage, and cloud providers including Google Drive, Dropbox,
       OneDrive, MEGA, Box, pCloud, Azure Blob Storage, 4shared, Filen, Zoho WorkDrive,
-      Internxt Drive, kDrive, Koofr, FileLu, Yandex Disk, and OpenDrive. 7 transport protocols, 25+ native providers, 45+ presets, one app.
+      Internxt Drive, kDrive, Koofr, FileLu, Yandex Disk, and OpenDrive. 7 transport protocols, 24 native providers, 44 presets, one app.
     </p>
     <p>Security and Encryption:</p>
     <ul>
@@ -25,7 +25,7 @@
     </ul>
     <p>AI Assistant:</p>
     <ul>
-      <li>AeroAgent Pro: AI-powered assistant with 68 tools, shell command execution, server exec, RAG indexing, plugin system, streaming markdown, prompt templates, and cost budget tracking</li>
+      <li>AeroAgent Pro: AI-powered assistant with 39 tools, shell command execution, server exec, RAG indexing, plugin system, streaming markdown, prompt templates, and cost budget tracking</li>
       <li>24 AI providers: OpenAI, Anthropic, Google Gemini, xAI Grok, OpenRouter, Ollama, Kimi, Qwen, DeepSeek, Mistral, Groq, Perplexity, Cohere, Together AI, AI21 Labs, Cerebras, SambaNova, Fireworks AI, Nvidia NIM, Z.AI, Hyperbolic, Novita, Yi, Custom</li>
       <li>Vision/multimodal: Attach images for analysis with GPT-4o, Claude, Gemini</li>
       <li>Native function calling with streaming responses and cost tracking</li>
@@ -43,7 +43,7 @@
     </ul>
     <p>Command-Line Interface:</p>
     <ul>
-      <li>AeroFTP CLI: 77 commands across 7 transport protocols and 25+ native providers with JSON output, glob transfers, batch scripting, FUSE mount, and MCP server mode</li>
+      <li>AeroFTP CLI: 94 commands across 7 transport protocols and 24 native providers with JSON output, glob transfers, batch scripting, FUSE mount, and MCP server mode</li>
       <li>Batch engine: .aeroftp script files with variables, error policies, and 17 commands</li>
       <li>Security hardened: path traversal prevention, ANSI sanitization, OOM protection, 45-finding audit</li>
     </ul>

--- a/docs/PROTOCOL-FEATURES.md
+++ b/docs/PROTOCOL-FEATURES.md
@@ -6,8 +6,8 @@
 > **Note**: AeroFTP organizes integrations on three tiers:
 >
 > 1. **7 transport protocols** (FTP, FTPS, SFTP, WebDAV, S3, Azure Blob, OpenStack Swift) - native wire-level support;
-> 2. **25+ native provider integrations** with dedicated OAuth2 / API key / SDK code paths (Google Drive, Dropbox, OneDrive, MEGA, Box, pCloud, Filen, Zoho WorkDrive, Internxt, kDrive, Koofr, Jottacloud, FileLu, Yandex Disk, OpenDrive, 4shared, Drime, GitHub, GitLab, Immich, ImageKit, Uploadcare, Cloudinary, InfiniCLOUD, Felicloud);
-> 3. **45+ pre-configured presets** in the Discover catalog: S3-compatible (MEGA S4, Filen S5, MinIO, Wasabi, Cloudflare R2, DigitalOcean, Tencent COS, Alibaba OSS, Oracle, Storj, IDrive e2, Hetzner, Yandex Object Storage, Quotaless, Backblaze B2-S3, Filen Desktop S3, S3Drive), WebDAV-compatible (Nextcloud, TAB.DIGITAL, Felicloud, Seafile, InfiniCLOUD, CloudMe, Jianguoyun, Koofr-WebDAV, FileLu-WebDAV, Yandex-WebDAV, OpenDrive-WebDAV, Quotaless-WebDAV, MEGAcmd, Filen Desktop WebDAV), and SFTP-based (SourceForge, GitHub via SFTP).
+> 2. **24 native provider integrations** with dedicated OAuth2 / API key / SDK code paths (Google Drive, Dropbox, OneDrive, MEGA, Box, pCloud, Filen, Zoho WorkDrive, Internxt, kDrive, Koofr, Jottacloud, FileLu, Yandex Disk, OpenDrive, 4shared, Drime, GitHub, GitLab, Immich, ImageKit, Uploadcare, Cloudinary, InfiniCLOUD, Felicloud);
+> 3. **44 pre-configured presets** in the Discover catalog: S3-compatible (MEGA S4, Filen S5, MinIO, Wasabi, Cloudflare R2, DigitalOcean, Tencent COS, Alibaba OSS, Oracle, Storj, IDrive e2, Hetzner, Yandex Object Storage, Quotaless, Backblaze B2-S3, Filen Desktop S3, S3Drive), WebDAV-compatible (Nextcloud, TAB.DIGITAL, Felicloud, Seafile, InfiniCLOUD, CloudMe, Jianguoyun, Koofr-WebDAV, FileLu-WebDAV, Yandex-WebDAV, OpenDrive-WebDAV, Quotaless-WebDAV, MEGAcmd, Filen Desktop WebDAV), and SFTP-based (SourceForge, GitHub via SFTP).
 >
 > The feature matrix tables below cover the core production set. GitHub, GitLab, Immich, ImageKit, Uploadcare, and Cloudinary have repository / media-specific semantics and are documented inline in their dedicated sections.
 
@@ -699,7 +699,7 @@ All non-FTP providers receive periodic keep-alive pings to prevent connection ti
 
 ### AI Tool Support by Protocol
 
-The remote-facing tools route through the `StorageProvider` trait, so they behave identically across the 7 transport protocols and 25+ native provider integrations. Local-only tools (file management, search, archives, clipboard, shell) act on the local filesystem.
+The remote-facing tools route through the `StorageProvider` trait, so they behave identically across the 7 transport protocols and 24 native provider integrations. Local-only tools (file management, search, archives, clipboard, shell) act on the local filesystem.
 
 **Remote tools (protocol-routed)**
 

--- a/docs/PROVIDER-INVENTORY.json
+++ b/docs/PROVIDER-INVENTORY.json
@@ -1,0 +1,448 @@
+{
+  "schema_version": 1,
+  "generated_by": "scripts/gen-provider-inventory.ts",
+  "counts": {
+    "transport_protocols": 7,
+    "native_integrations": 24,
+    "presets": 44,
+    "presets_over_transport": 40,
+    "connection_forms": 49,
+    "connection_forms_generic": 2,
+    "connection_forms_named_without_defaults": 3,
+    "providers": 51,
+    "connection_methods": 65,
+    "catalog_services": 72
+  },
+  "transport_protocols": [
+    "ftp",
+    "ftps",
+    "sftp",
+    "webdav",
+    "s3",
+    "azure",
+    "swift"
+  ],
+  "native_integrations": [
+    "backblaze",
+    "box",
+    "cloudinary",
+    "drime",
+    "dropbox",
+    "filelu",
+    "filen",
+    "fourshared",
+    "github",
+    "gitlab",
+    "googledrive",
+    "imagekit",
+    "immich",
+    "internxt",
+    "jottacloud",
+    "kdrive",
+    "koofr",
+    "mega",
+    "onedrive",
+    "opendrive",
+    "pcloud",
+    "uploadcare",
+    "yandexdisk",
+    "zohoworkdrive"
+  ],
+  "presets_by_category": {
+    "ftp": [
+      "filelu-ftp",
+      "filelu-ftps",
+      "hetzner-storage-box",
+      "sourceforge"
+    ],
+    "mega": [
+      "mega"
+    ],
+    "object": [
+      "cloudinary",
+      "imagekit",
+      "uploadcare"
+    ],
+    "s3": [
+      "alibaba-oss",
+      "amazon-s3",
+      "backblaze",
+      "cloudflare-r2",
+      "digitalocean-spaces",
+      "filelu-s3",
+      "filen-desktop-s3",
+      "google-cloud-storage",
+      "idrive-e2",
+      "mega-s4",
+      "minio",
+      "oracle-cloud",
+      "quotaless-s3",
+      "s3drive",
+      "storj",
+      "tencent-cos",
+      "wasabi",
+      "yandex-storage"
+    ],
+    "swift": [
+      "blomp"
+    ],
+    "webdav": [
+      "4shared-webdav",
+      "cloudme",
+      "drivehq",
+      "felicloud",
+      "filelu-webdav",
+      "filen-desktop-webdav",
+      "infinicloud",
+      "jianguoyun",
+      "koofr",
+      "megacmd-webdav",
+      "nextcloud",
+      "opendrive-webdav",
+      "pcloud-webdav",
+      "quotaless-webdav",
+      "seafile",
+      "tabdigital",
+      "yandexdisk-webdav"
+    ]
+  },
+  "generic_connection_forms": [
+    "custom-s3",
+    "custom-webdav"
+  ],
+  "connection_forms_named_without_defaults": [
+    "4shared",
+    "backblaze-native",
+    "filelu"
+  ],
+  "catalog_categories": {
+    "protocols": 7,
+    "object-storage": 20,
+    "webdav": 18,
+    "cloud-storage": 18,
+    "media-services": 5,
+    "developer": 3
+  },
+  "providers": [
+    {
+      "id": "4shared",
+      "protocols": [
+        "fourshared",
+        "webdav"
+      ]
+    },
+    {
+      "id": "alibaba-oss",
+      "protocols": [
+        "s3"
+      ]
+    },
+    {
+      "id": "amazon-s3",
+      "protocols": [
+        "s3"
+      ]
+    },
+    {
+      "id": "azure",
+      "protocols": [
+        "azure"
+      ]
+    },
+    {
+      "id": "backblaze",
+      "protocols": [
+        "backblaze",
+        "s3"
+      ]
+    },
+    {
+      "id": "blomp",
+      "protocols": [
+        "swift"
+      ]
+    },
+    {
+      "id": "box",
+      "protocols": [
+        "box"
+      ]
+    },
+    {
+      "id": "cloudflare-r2",
+      "protocols": [
+        "s3"
+      ]
+    },
+    {
+      "id": "cloudinary",
+      "protocols": [
+        "cloudinary"
+      ]
+    },
+    {
+      "id": "cloudme",
+      "protocols": [
+        "webdav"
+      ]
+    },
+    {
+      "id": "digitalocean-spaces",
+      "protocols": [
+        "s3"
+      ]
+    },
+    {
+      "id": "drime",
+      "protocols": [
+        "drime"
+      ]
+    },
+    {
+      "id": "drivehq",
+      "protocols": [
+        "webdav"
+      ]
+    },
+    {
+      "id": "dropbox",
+      "protocols": [
+        "dropbox"
+      ]
+    },
+    {
+      "id": "felicloud",
+      "protocols": [
+        "webdav"
+      ]
+    },
+    {
+      "id": "filelu",
+      "protocols": [
+        "filelu",
+        "ftp",
+        "webdav",
+        "s3"
+      ]
+    },
+    {
+      "id": "filen",
+      "protocols": [
+        "filen",
+        "s3",
+        "webdav"
+      ]
+    },
+    {
+      "id": "github",
+      "protocols": [
+        "github"
+      ]
+    },
+    {
+      "id": "gitlab",
+      "protocols": [
+        "gitlab"
+      ]
+    },
+    {
+      "id": "google-cloud-storage",
+      "protocols": [
+        "s3"
+      ]
+    },
+    {
+      "id": "googledrive",
+      "protocols": [
+        "googledrive"
+      ]
+    },
+    {
+      "id": "hetzner-storage-box",
+      "protocols": [
+        "sftp"
+      ]
+    },
+    {
+      "id": "idrive-e2",
+      "protocols": [
+        "s3"
+      ]
+    },
+    {
+      "id": "imagekit",
+      "protocols": [
+        "imagekit"
+      ]
+    },
+    {
+      "id": "immich",
+      "protocols": [
+        "immich"
+      ]
+    },
+    {
+      "id": "infinicloud",
+      "protocols": [
+        "webdav"
+      ]
+    },
+    {
+      "id": "internxt",
+      "protocols": [
+        "internxt"
+      ]
+    },
+    {
+      "id": "jianguoyun",
+      "protocols": [
+        "webdav"
+      ]
+    },
+    {
+      "id": "jottacloud",
+      "protocols": [
+        "jottacloud"
+      ]
+    },
+    {
+      "id": "kdrive",
+      "protocols": [
+        "kdrive"
+      ]
+    },
+    {
+      "id": "koofr",
+      "protocols": [
+        "koofr",
+        "webdav"
+      ]
+    },
+    {
+      "id": "mega",
+      "protocols": [
+        "mega",
+        "webdav",
+        "s3"
+      ]
+    },
+    {
+      "id": "minio",
+      "protocols": [
+        "s3"
+      ]
+    },
+    {
+      "id": "nextcloud",
+      "protocols": [
+        "webdav"
+      ]
+    },
+    {
+      "id": "onedrive",
+      "protocols": [
+        "onedrive"
+      ]
+    },
+    {
+      "id": "opendrive",
+      "protocols": [
+        "opendrive",
+        "webdav"
+      ]
+    },
+    {
+      "id": "oracle-cloud",
+      "protocols": [
+        "s3"
+      ]
+    },
+    {
+      "id": "pcloud",
+      "protocols": [
+        "pcloud",
+        "webdav"
+      ]
+    },
+    {
+      "id": "pixelunion",
+      "protocols": [
+        "immich"
+      ]
+    },
+    {
+      "id": "quotaless-s3",
+      "protocols": [
+        "s3",
+        "webdav"
+      ]
+    },
+    {
+      "id": "s3drive",
+      "protocols": [
+        "s3"
+      ]
+    },
+    {
+      "id": "seafile",
+      "protocols": [
+        "webdav"
+      ]
+    },
+    {
+      "id": "sourceforge",
+      "protocols": [
+        "sftp"
+      ]
+    },
+    {
+      "id": "storj",
+      "protocols": [
+        "s3"
+      ]
+    },
+    {
+      "id": "tabdigital",
+      "protocols": [
+        "webdav"
+      ]
+    },
+    {
+      "id": "tencent-cos",
+      "protocols": [
+        "s3"
+      ]
+    },
+    {
+      "id": "uploadcare",
+      "protocols": [
+        "uploadcare"
+      ]
+    },
+    {
+      "id": "wasabi",
+      "protocols": [
+        "s3"
+      ]
+    },
+    {
+      "id": "yandex-storage",
+      "protocols": [
+        "s3"
+      ]
+    },
+    {
+      "id": "yandexdisk",
+      "protocols": [
+        "yandexdisk",
+        "webdav"
+      ]
+    },
+    {
+      "id": "zohoworkdrive",
+      "protocols": [
+        "zohoworkdrive"
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "i18n:diacritics": "node scripts/i18n-diacritics.mjs --strict",
     "i18n:untranslated": "node scripts/i18n-untranslated.mjs --strict",
     "gen:cli-catalog": "npx tsx scripts/gen-cli-catalog.ts",
-    "gen:providers-table": "npx tsx scripts/gen-providers-table.ts"
+    "gen:providers-table": "npx tsx scripts/gen-providers-table.ts",
+    "gen:provider-inventory": "npx tsx scripts/gen-provider-inventory.ts",
+    "check:provider-inventory": "npx tsx scripts/gen-provider-inventory.ts --check"
   },
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",

--- a/scripts/gen-provider-inventory.ts
+++ b/scripts/gen-provider-inventory.ts
@@ -1,0 +1,179 @@
+#!/usr/bin/env npx tsx
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+/**
+ * Emits `docs/PROVIDER-INVENTORY.json`, the single source of truth for every
+ * "how many providers / protocols / presets" figure the project publishes.
+ *
+ * The problem this exists to end. The figures were correct in the code and
+ * wrong everywhere they were quoted, because they were quoted as prose. The
+ * README caption said "51 providers, 65 connection methods" from OUTSIDE the
+ * generated grid block, so regenerating the grid never touched the numbers.
+ * `docs/PROTOCOL-FEATURES.md` claimed "45+ presets" over a table listing 33.
+ * The docs site claimed "22 storage protocols", a number matching no source at
+ * all. Three different figures for the same noun, none of them checkable.
+ *
+ * Note the shape of that failure: nothing was broken, nothing errored, and
+ * every individual statement looked plausible. It is the same class as a
+ * command that prints success while changing nothing. The fix is not to correct
+ * the numbers, which would drift again by the next release. It is to make them
+ * derived and to make the derivation checkable, which is what
+ * `docs/COMMAND-INVENTORY.json` already does for the CLI, MCP and agent
+ * surfaces. This is that pattern applied to providers.
+ *
+ * The vocabulary matters as much as the arithmetic, because most of the drift
+ * came from one word standing for four different things. The counts below are
+ * deliberately named after what they count:
+ *
+ *   transport_protocols  the wire protocols implemented natively (7)
+ *   native_integrations  providers with a dedicated OAuth2 / API-key / SDK code
+ *                        path rather than a preset over a transport protocol
+ *   presets              a connection form that ARRIVES ALREADY FILLED IN: it
+ *                        carries defaults or endpoints, so the user does not
+ *                        type the host, the port or the base path. This is the
+ *                        project's long-standing split, specific against
+ *                        generic, and it is the word to use in prose. Derived
+ *                        from the data rather than from an `isGeneric` flag or
+ *                        an id prefix, so a new blank form is classified right
+ *                        even if nobody remembers to name it `custom-`
+ *   connection_forms     every form in the registry: the presets, the blank
+ *                        protocol forms, and a third group worth naming. Three
+ *                        named services carry a form with nothing pre-filled
+ *                        (4shared, FileLu, native Backblaze) because they
+ *                        authenticate by OAuth or an API key, so there is no
+ *                        host or port to preset. They are not presets and they
+ *                        are not generic either, and lumping them into either
+ *                        bucket is how a count starts lying
+ *   presets_over_transport
+ *                        the subset of presets that sit on a transport protocol
+ *                        rather than on a provider's own code path. Narrower and
+ *                        separately named because it is what the Add Services
+ *                        catalog counts as registry-sourced; do not use it when
+ *                        the sentence just says "presets"
+ *   providers            companies in the logo grid / catalog
+ *   connection_methods   provider-protocol pairs, so a company reachable over
+ *                        both WebDAV and S3 counts twice
+ *   catalog_services     tiles a user actually sees in Add Services, generic
+ *                        ones and the AeroShare tile included
+ *
+ * Quote the one that matches the noun in the sentence. They are all correct and
+ * they are all different.
+ *
+ * Usage:
+ *   npx tsx scripts/gen-provider-inventory.ts           # write the file
+ *   npx tsx scripts/gen-provider-inventory.ts --check   # exit 1 if stale (CI)
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { PROVIDER_CATALOG } from '../src/components/providerCatalog';
+import { getAllProviders } from '../src/providers';
+import { buildDiscoverCategories, getTotalServiceCount } from '../src/components/IntroHub/discoverData';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const OUT = join(HERE, '..', 'docs', 'PROVIDER-INVENTORY.json');
+
+/**
+ * The wire protocols. `ftps` is not in this list by accident: the catalog models
+ * FTPS as a mode of `ftp` rather than a separate entry, so it never appears as a
+ * protocol id. It is a real protocol to a user and is counted in
+ * `transport_protocols` below, which is why that number is stated here rather
+ * than derived from the catalog: deriving it would silently report 6.
+ */
+const TRANSPORT_PROTOCOL_IDS = ['ftp', 'ftps', 'sftp', 'webdav', 's3', 'azure', 'swift'];
+
+const catalogProtocolIds = (): string[] => [
+    ...new Set(PROVIDER_CATALOG.flatMap((c) => (c.protocols ?? []).map((p) => p.protocol))),
+].sort();
+
+function build() {
+    const companies = PROVIDER_CATALOG;
+    const connectionMethods = companies.reduce((n, c) => n + (c.protocols ?? []).length, 0);
+
+    // A preset is a form that arrives already filled in. Tested on the data,
+    // not on a naming convention: the two generic forms carry an empty
+    // `defaults` AND an empty `endpoints`, every real preset carries at least
+    // one of them. Three named services also come out blank (4shared, FileLu,
+    // native Backblaze) because they authenticate by OAuth or an API key and
+    // have no host to preset; they are reported separately rather than pushed
+    // into whichever bucket happens to be convenient.
+    const TRANSPORT_CATEGORIES = ['s3', 'webdav', 'ftp', 'swift', 'azure'];
+    const registry = getAllProviders();
+    const isPrefilled = (p: { defaults?: object; endpoints?: object }) =>
+        Object.keys(p.defaults ?? {}).length > 0 || Object.keys(p.endpoints ?? {}).length > 0;
+    const presets = registry.filter(isPrefilled);
+    const blank = registry.filter((p) => !isPrefilled(p));
+    const generic = blank.filter((p) => p.isGeneric || /^custom-/.test(p.id));
+    const blankNamed = blank.filter((p) => !generic.includes(p));
+    const presetsOverTransport = presets.filter((p) => TRANSPORT_CATEGORIES.includes(p.category));
+
+    const nativeIntegrations = catalogProtocolIds().filter((p) => !TRANSPORT_PROTOCOL_IDS.includes(p));
+
+    const categories = buildDiscoverCategories();
+
+    return {
+        schema_version: 1,
+        generated_by: 'scripts/gen-provider-inventory.ts',
+        counts: {
+            transport_protocols: TRANSPORT_PROTOCOL_IDS.length,
+            native_integrations: nativeIntegrations.length,
+            presets: presets.length,
+            presets_over_transport: presetsOverTransport.length,
+            connection_forms: registry.length,
+            connection_forms_generic: generic.length,
+            connection_forms_named_without_defaults: blankNamed.length,
+            providers: companies.length,
+            connection_methods: connectionMethods,
+            catalog_services: getTotalServiceCount(),
+        },
+        transport_protocols: TRANSPORT_PROTOCOL_IDS,
+        native_integrations: nativeIntegrations,
+        presets_by_category: Object.fromEntries(
+            [...new Set(presets.map((p) => p.category))].sort().map((cat) => [
+                cat,
+                presets.filter((p) => p.category === cat).map((p) => p.id).sort(),
+            ]),
+        ),
+        generic_connection_forms: generic.map((p) => p.id).sort(),
+        connection_forms_named_without_defaults: blankNamed.map((p) => p.id).sort(),
+        catalog_categories: Object.fromEntries(categories.map((c) => [c.id, c.count])),
+        providers: companies.map((c) => ({
+            id: c.logoId,
+            name: c.name,
+            protocols: (c.protocols ?? []).map((p) => p.protocol),
+        })).sort((a, b) => a.id.localeCompare(b.id)),
+    };
+}
+
+const inventory = build();
+const serialised = `${JSON.stringify(inventory, null, 2)}\n`;
+
+if (process.argv.includes('--check')) {
+    let committed: string;
+    try {
+        committed = readFileSync(OUT, 'utf8');
+    } catch {
+        console.error(`Missing ${OUT}. Run: npm run gen:provider-inventory`);
+        process.exitCode = 1;
+        throw new Error('inventory missing');
+    }
+    if (committed !== serialised) {
+        console.error('docs/PROVIDER-INVENTORY.json is stale.');
+        const now = inventory.counts;
+        const was = (JSON.parse(committed) as typeof inventory).counts;
+        for (const key of Object.keys(now) as (keyof typeof now)[]) {
+            if (now[key] !== was[key]) console.error(`  ${key}: committed ${was[key]}, actual ${now[key]}`);
+        }
+        console.error('Run: npm run gen:provider-inventory, and update any prose that quotes these figures.');
+        process.exitCode = 1;
+    } else {
+        console.log('docs/PROVIDER-INVENTORY.json is current.');
+    }
+} else {
+    writeFileSync(OUT, serialised, 'utf8');
+    console.log(`Wrote ${OUT}`);
+    for (const [k, v] of Object.entries(inventory.counts)) console.log(`  ${k.padEnd(20)} ${v}`);
+}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -44,7 +44,7 @@ description: |
   Built-in Developer Suite:
   - Monaco Editor (VS Code engine) for remote file editing
   - Integrated terminal with theme sync
-  - AeroAgent AI assistant (19 providers including OpenAI, Anthropic,
+  - AeroAgent AI assistant (24 providers including OpenAI, Anthropic,
     Gemini, Ollama, and more)
 
   AeroSync, Reliable Synchronization:


### PR DESCRIPTION
Tracker #628, item 12. The tracker stays open: other items are still in flight.

Three different numbers for the same noun were published at once and none of them errored. The README said 25+ native integrations and 45+ presets. `docs/PROTOCOL-FEATURES.md` said 45+ over a table listing 33. The docs site said "22 storage protocols", a figure no source in the project produces. Prose does not fail a build, which is why they were all correct in the code and wrong everywhere they were quoted.

## One inventory, and a gate

`scripts/gen-provider-inventory.ts` derives every figure into `docs/PROVIDER-INVENTORY.json`. Nothing new was invented: the two sources already existed and already agreed. `PROVIDER_CATALOG` knows the companies and their connection methods, and the provider registry plus `getTotalServiceCount()` know the catalog. What was missing was a place where both are written down and a way to notice when prose stops matching them.

`--check` fails when the committed file no longer matches the code, and prints which count moved so the sentence that quotes it gets updated in the same commit. It runs in the fast `checks` lane, next to the command-inventory gate that already did exactly this for the CLI, MCP and agent surfaces.

## The vocabulary is half the fix

Most of the drift came from one word standing for four things, so the counts are named after what they count and the wrong noun is now a wrong key rather than a plausible sentence.

**A preset is a form that arrives already filled in.** That is the split the project has always drawn, specific against generic, and it is now derived from the data rather than from an id prefix: the two generic forms carry an empty `defaults` AND an empty `endpoints`, while every real preset carries at least one. So a new blank form is classified correctly even if nobody remembers to name it `custom-`.

Three named services also come out blank: 4shared, FileLu and native Backblaze authenticate by OAuth or an API key and have no host to preset. They are neither presets nor generic, and they are reported under their own key rather than pushed into whichever bucket is convenient.

**MCP is 77**, the 39 primary tools plus the 38 aliases, which is what an agent connecting to the server actually sees. Not to be confused with `agent_tools`, which is also 39 and is a different surface: AeroAgent's own tools inside the app. Pages saying "AI assistant with 39 tools" are about that and are correct as they stand.

| noun | figure |
|---|---|
| transport protocols | 7 |
| native integrations | 24 |
| presets | 44 |
| connection forms | 49 |
| providers | 51 |
| connection methods | 65 |
| services in Add Services | 72 |
| AeroAgent tools | 39 |
| CLI commands | 94 |
| MCP tools | 77 |

## Nine stale counts, and where they were hiding

Sweeping every declaration site rather than only the ones the first commit touched turned up nine more. The two worst are the ones nobody opens: `com.aeroftp.AeroFTP.metainfo.xml` is what GNOME Software and KDE Discover render, and it advertised AeroAgent with 68 tools and a CLI with 77 commands; `snap/snapcraft.yaml` is the Snap Store listing, and it advertised 19 AI providers against 24 everywhere else.

The rest were in the README: the AI-tools badge and three paragraphs claiming 50+ AeroAgent tools, three more claiming 25+ native providers, 90 CLI commands, and 73 MCP tools.

Release notes are left alone. The `<release>` blocks and the CLI guide's version log quote what was true at the time and are correct as history. Two of their figures look like hits and are not: "25+ runtime knobs" and "45+ security findings" are neither providers nor presets.

## One earlier reading corrected

The README caption "51 providers, 65 connection methods" is **not** hand-written, contrary to what the analysis that started this work concluded. It is emitted by `buildProvidersMarkdown` at `providerCatalog.ts:745` and sits inside the generated block, so those two figures could never drift. The tier sentences above it could, and did. The mistake came from computing an absolute line number from a relative grep offset and not checking it against the block anchors.

## Not covered

The marketing site `aeroftp.app` is a PHP-runner deploy and is not checked out on either station. It carries the same logo grid and the same counts and has to be inspected live. Saying so rather than assuming it is fine.

## Gate

Provider inventory current, `i18n:validate` 0/0/0, `i18n:diacritics` 0 new, `i18n:untranslated` strict and clean, `tsc --noEmit` clean, vitest 93 files and 801 tests. The metainfo still parses as XML and the snapcraft file as YAML. No Rust is touched, so no cargo lane applies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product statistics across the README, protocol documentation, app metadata, and Snap description.
  * Clarified counts for providers, presets, tools, and CLI commands.
  * Added a generated provider inventory documenting supported protocols, integrations, presets, and providers.

* **Chores**
  * Added automated generation and validation of the provider inventory.
  * CI now detects when published provider statistics become outdated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->