### PR TITLE
fix(providers): mark DigitalOcean Spaces stable, it is a standard connector

### DIFF
--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -912,14 +912,7 @@ export const PROVIDERS: ProviderConfig[] = [
         category: 's3',
         icon: 'Cloud',
         color: '#0069FF',
-        // NOT a known defect: never verified live, because the trial account
-        // used for testing expired and no other Spaces account was available.
-        // It is an ordinary S3 endpoint dispatching through the same stack as
-        // the other presets, so the expectation is that it works. Clearing this
-        // needs ten minutes with any Spaces key, not a code change. Recording
-        // the reason because a bare `stable: false` is indistinguishable from a
-        // known-broken provider, and that is how this one stayed hidden.
-        stable: false,
+        stable: true,
         fields: [
             { ...COMMON_FIELDS.accessKeyId, label: 'Spaces Key', helpText: 'API → Spaces Keys → Key' },
             { ...COMMON_FIELDS.secretAccessKey, label: 'Spaces Secret', helpText: 'API → Spaces Keys → Secret' },


### PR DESCRIPTION
Tracker #628. The tracker stays open: other items are still in flight.

DigitalOcean Spaces carried `stable: false` with a comment saying it was not a known defect, only that it had never been verified live because the trial account used for testing expired. The owner's call is that this does not warrant gating a standard connector: it is an ordinary S3 endpoint dispatching through the same stack as the other forty-eight presets, with no provider-specific code path of its own.

The comment goes with the flag. A note explaining a deferral that no longer exists is worse than no note.

## The field is set, not deleted, and that distinction matters

`stable` is optional (`stable?: boolean`) and every consumer tests it as falsy:

- `src/components/ProviderSelector.tsx:82`, `if (stableOnly && !p.stable) return false`
- `src/components/ProviderSelector.tsx:105,109`, dims the tile and renders a badge on `!provider.stable`
- `src/providers/registry.ts:2061`, `getAll().filter(p => p.stable)`

So removing the line would NOT have promoted anything. The preset would have stayed filtered out and dimmed exactly as before, while `UnstableProviderNotice.tsx:20` (which tests `provider.stable !== false`) stopped rendering its warning: the same broken state, minus the notice that says so. `stable: true` is what the other forty-eight presets carry, and all forty-nine now do.

## Gate

Provider inventory current, `tsc --noEmit` clean, vitest 93 files and 801 tests, `i18n:validate` clean. No figure in `docs/PROVIDER-INVENTORY.json` moves: `stable` is not a counted field, the preset was always in the catalogue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * DigitalOcean Spaces is now marked as a stable provider option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->