### PR TITLE
fix(pcloud): stop offering a trash button pCloud cannot honour

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17793,7 +17793,14 @@ const App: React.FC = () => {
                         opendrive: () => setShowOpenDriveTrash(true),
                         yandexdisk: () => setShowYandexTrash(true),
                         kdrive: () => setShowKDriveTrash(true),
-                        pcloud: () => setShowPCloudTrash(true),
+                        // pcloud: disabled: pCloud refuses its trash endpoints to OAuth
+                        // access tokens. Verified live against a real account: listfolder
+                        // returns result 0 while trash_list returns result 1000 "Log in
+                        // required." for the same token, on Bearer and on access_token
+                        // query param alike, and userinfo?getauth=1 mints no session token
+                        // for an OAuth caller. pCloud OAuth has no trash permission to
+                        // request (manageshares is the only one), so no re-authorization
+                        // fixes it. See docs/dev/drafts/TRACKER-628-DRAFT-pcloud-trash.md
                         onedrive: () => setShowOneDriveTrash(true),
                         backblaze: () => setShowB2Hidden(true),
                         s3: () => setShowS3Trash(true),


### PR DESCRIPTION
## What

Removes the View Trash affordance for pCloud. It could never work, and the way it failed read like a broken login.

## Why, with the evidence

This is the last "Known issues found after release" row on #628, carried before that on #458 and #422, and reported in #397. It survived two code reviews, each concluding the trash code path was correct. It was, and that is exactly why reading it again never closed the item. I ran it against a real pCloud account instead.

pCloud refuses its trash endpoints to OAuth access tokens. In a single connected session, with a single token:

- `listfolder` returns `result: 0`
- `trash_list` returns `result: 1000, "Log in required."`
- and it does so identically as a Bearer header and as an `access_token` query parameter, with and without `recursive=1`, and with an explicit `folderid=0`

A control `listfolder` call fired between two failing trash calls returns `result: 0`, so the token is demonstrably valid at that instant. The refresh token was never the problem: the profile had been idle eight weeks and a plain listing worked on the first try with no re-authentication.

`userinfo?getauth=1` returns no `auth` field for an OAuth caller, so an OAuth connection cannot fall back to a session token either.

## Why no setting can fix it

pCloud's OAuth authorization accepts one optional permission, `manageshares`. There is no trash scope to request, so re-authorizing or re-registering the app changes nothing. For corroboration, rclone does not implement CleanUp for pCloud at all, while it does implement it for Google Drive. The pCloud web and desktop clients reach the trash because they authenticate with a session login rather than a third-party OAuth token.

## The change

One entry removed from the toolbar trash affordance map in `src/App.tsx`, with the reason recorded inline. This mirrors the `internxt` entry already disabled in that same map for the same class of reason. No new user-facing strings, so no locale work.

Verified live in the dev GUI after the change: pCloud connects, the remote panel lists normally, the trash button is gone and the authentication error with it.

`PCloudTrashManager` and the four `pcloud_*_trash` commands are now unreachable and are left in place, as internxt's are. Whether to remove that path outright is a separate call, since it touches the provider feature matrix.

## Also worth recording

The comment at `pcloud.rs:396` states that pCloud trash and revisions endpoints reject Bearer header auth, which is why those calls use a query parameter. This run disproves that for trash: both transports are refused identically. Revisions still ride the same helper on that unverified premise and were not tested here.

## Gate

`npm run typecheck` clean, `npm run i18n:validate` clean (46/46 locales, 0 placeholders), `npx vitest run` 801 passed across 93 files. No Rust changed.

Refs #397, #628.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the unavailable pCloud trash action to prevent users from accessing a function that cannot authenticate correctly.
  * The trash menu now no longer offers the unsupported pCloud option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->