### PR TITLE
fix(deps): move off the yanked chacha20 0.10.1

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1414,9 +1414,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cipher 0.5.2",
@@ -8089,7 +8089,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "chacha20 0.10.1",
+ "chacha20 0.10.2",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
@@ -9974,7 +9974,7 @@ dependencies = [
  "aead 0.6.1",
  "aes 0.9.1",
  "aes-gcm 0.11.0",
- "chacha20 0.10.1",
+ "chacha20 0.10.2",
  "cipher 0.5.2",
  "ctutils",
  "des",


### PR DESCRIPTION
`cargo audit` is red on `main`. Not a vulnerability: crates.io yanked `chacha20` 0.10.1 and the audit step denies yanked crates.

Worth stating why the pull request before this one was green while `main` went red, because it looks like an escape and is not. `checks.yml` runs `cargo audit` with `continue-on-error` on pull requests and authoritative on push to `main`, deliberately, so an advisory published against a transitive dependency cannot red-wall an unrelated PR. The yank landed between that PR's run and its merge, which is the mechanism working rather than failing.

The lock carries two `chacha20` majors. 0.9.1 comes from `chacha20poly1305 0.10.1`, which requires `^0.9` and is untouched. The yanked 0.10.1 comes from `rand` and `ssh-cipher`, and 0.10.2 replaces it.

## Why the lock was edited by hand

`cargo update -p chacha20@0.10.1 --precise 0.10.2` did more than asked. It also re-resolved two unrelated dependencies, downgrading `syn` from 2.0.118 to 1.0.109 inside `data-encoding-macro-internal` and `getrandom` from 0.4.3 to 0.3.4 inside `tempfile`. Both resolutions are valid, but neither belongs to this fix, and a dependency change should be the change it claims to be.

The diff is four lines: the version, the checksum, and the two references.

## Verified, not assumed

- `cargo metadata --locked` exits 0, so the hand-edited lock is coherent and cargo would not rewrite it.
- `cargo check --locked` compiles the workspace clean.
- `cargo audit` reports no yanked crate where it reported one before.
