### PR TITLE
fix(b2): size the header budget by what the bucket actually imposes

### DIFF
--- a/src-tauri/src/providers/b2.rs
+++ b/src-tauri/src/providers/b2.rs
@@ -37,7 +37,19 @@ const COPY_MAX_SIZE: u64 = 5 * 1024 * 1024 * 1024; // 5 GB hard limit on b2_copy
 const COPY_PART_MAX_SIZE: u64 = 5 * 1024 * 1024 * 1024; // 5 GB per b2_copy_part call
 const MAX_FILE_SIZE: u64 = 10 * 1024 * 1024 * 1024 * 1024; // 10 TB practical ceiling
 const DEFAULT_LIST_PAGE: u32 = 1000;
+/// B2 caps `fileName` + `fileInfo` at 7 000 bytes, but only 2 048 on a bucket
+/// with server-side encryption or Object Lock. From 2026-09-14 Backblaze turns
+/// SSE-B2 on by default for new buckets and rolls it out to existing ones, so
+/// the smaller budget stops being the exception. Documented as: "For files that
+/// are encrypted with server-side encryption or files that are in Object
+/// Lock-enabled buckets, the limit is reduced to 2,048 bytes".
 const HEADER_BUDGET_STD: usize = 7000;
+const HEADER_BUDGET_REDUCED: usize = 2048;
+/// `upload` sends one `fileInfo` entry, `src_last_modified_millis`, and B2
+/// counts the whole `fileInfo` map against the same budget as the file name.
+/// The key is 24 bytes and a millisecond epoch is 13 digits today; the extra
+/// byte covers the day that becomes 14.
+const SRC_LAST_MODIFIED_INFO_BYTES: usize = "src_last_modified_millis".len() + 14;
 const PLACEHOLDER_NAME: &str = ".bzEmpty";
 
 /// Upper bound on concurrent Range streams for multi-thread download
@@ -156,6 +168,172 @@ struct B2ApiError {
 struct B2Bucket {
     bucket_id: String,
     bucket_name: String,
+    /// Kept as raw JSON on purpose, and interpreted by [`bucket_encryption`].
+    ///
+    /// Backblaze's own documentation disagrees with itself here: the OpenAPI
+    /// schema on `b2-list-buckets` marks `value` as non-nullable while the
+    /// prose on the server-side-encryption page states it IS null when the key
+    /// lacks `readBucketEncryption`. A typed field would make some legal shape
+    /// fail to deserialise, and that error would not stop at the budget: it
+    /// would fail the whole bucket listing, that is, the connect. Trading a
+    /// wrong budget for a broken connection is a far worse deal than the defect
+    /// this field exists to fix, so nothing here can propagate a parse error
+    /// and every shape we do not recognise becomes `Unknown`.
+    #[serde(default)]
+    default_server_side_encryption: Option<serde_json::Value>,
+    /// Raw for the same reason, and with a third example of why: the OpenAPI
+    /// schema types `defaultRetention.period` as a string while its own
+    /// examples show an object. Nothing here may fail the bucket listing.
+    #[serde(default)]
+    file_lock_configuration: Option<serde_json::Value>,
+}
+
+/// What one bucket setting says about the header budget.
+///
+/// `Unknown` is a real answer, not a missing one: B2 wraps both settings in
+/// `isClientAuthorizedToRead`, and a key without the matching capability is
+/// told nothing. That is a fact about our key, never about the bucket, and
+/// bucket-restricted keys are the norm.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Setting {
+    /// Read, and it lowers the budget.
+    Reduces,
+    /// Read, and it does not.
+    DoesNot,
+    /// Not read: absent, not permitted, or a shape Backblaze does not document.
+    Unknown,
+}
+
+/// The two documented reasons B2 lowers the budget, read independently.
+///
+/// They are NOT symmetric and must not be collapsed into one test. Encryption
+/// is read from `value.mode`; Object Lock is read from `value.isFileLockEnabled`
+/// and only from there, because "If default bucket retention is disabled, then
+/// mode and period will both be null" while the lock itself is on. Deciding the
+/// budget from `defaultRetention` would get exactly that state wrong.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct BucketBudget {
+    /// From `defaultServerSideEncryption`, gated by `readBucketEncryption`.
+    ///
+    /// `Reduces` here carries a derivation of ours, not a quoted rule.
+    /// Backblaze documents that "All uploads to that bucket, from the time
+    /// default encryption is enabled onward, will then be encrypted with SSE-B2
+    /// by default unless you explicitly specify SSE-C", and separately that
+    /// encrypted files get the 2 048 byte limit. That a bucket with default
+    /// encryption therefore gets the smaller budget follows from those two
+    /// documented statements; no single sentence says it.
+    encryption: Setting,
+    /// From `fileLockConfiguration`, gated by `readBucketRetentions`. Unlike
+    /// the above this needs no derivation: the limit is documented against
+    /// "files that are in Object Lock-enabled buckets", a property of the
+    /// bucket.
+    object_lock: Setting,
+}
+
+impl BucketBudget {
+    /// Before `resolve_bucket_id` has run we have read neither setting.
+    const UNREAD: Self = Self {
+        encryption: Setting::Unknown,
+        object_lock: Setting::Unknown,
+    };
+
+    /// B2's `fileName` + `fileInfo` budget for this bucket.
+    ///
+    /// An unread setting gets the standard budget on purpose. Our check is a
+    /// courtesy that turns B2's late refusal into an early, readable one; B2 is
+    /// the authority on what it accepts. Refusing a path B2 would have taken
+    /// would break a working setup with no way for the user to override us,
+    /// whereas the permissive choice leaves the authority to say no. What it
+    /// costs is the early warning on a bucket we cannot read, which
+    /// `reduced_budget_hint` explains after the fact instead.
+    fn bytes(self) -> usize {
+        if self.encryption == Setting::Reduces || self.object_lock == Setting::Reduces {
+            HEADER_BUDGET_REDUCED
+        } else {
+            HEADER_BUDGET_STD
+        }
+    }
+
+    /// Why the budget is the smaller one, for an error a reader can act on.
+    fn reduced_because(self) -> Option<&'static str> {
+        match (self.encryption, self.object_lock) {
+            (Setting::Reduces, Setting::Reduces) => {
+                Some("this bucket uses server-side encryption and has Object Lock enabled")
+            }
+            (Setting::Reduces, _) => Some("this bucket uses server-side encryption"),
+            (_, Setting::Reduces) => Some("this bucket has Object Lock enabled"),
+            _ => None,
+        }
+    }
+
+    /// The settings we could not read, named by the capability that would have
+    /// let us. Empty when both were readable.
+    fn unread_capabilities(self) -> Vec<&'static str> {
+        let mut missing = Vec::new();
+        if self.encryption == Setting::Unknown {
+            missing.push("readBucketEncryption");
+        }
+        if self.object_lock == Setting::Unknown {
+            missing.push("readBucketRetentions");
+        }
+        missing
+    }
+}
+
+/// Pull the payload out of one of B2's capability-gated wrappers.
+///
+/// Both settings arrive as `{ "isClientAuthorizedToRead": bool, "value": ... }`,
+/// and both are documented to carry a null `value` when the key lacks the
+/// capability. `None` here means "we did not read it", whatever the reason.
+fn authorized_value(
+    field: Option<&serde_json::Value>,
+) -> Option<&serde_json::Map<String, serde_json::Value>> {
+    let serde_json::Value::Object(wrapper) = field? else {
+        return None;
+    };
+    if wrapper.get("isClientAuthorizedToRead") != Some(&serde_json::Value::Bool(true)) {
+        return None;
+    }
+    match wrapper.get("value") {
+        Some(serde_json::Value::Object(value)) => Some(value),
+        _ => None,
+    }
+}
+
+/// Read both budget-relevant settings out of a `b2_list_buckets` entry.
+///
+/// Every shape that is not the documented one lands on `Unknown`, which the
+/// permissive budget turns into today's behaviour. Reading an unrecognised
+/// shape as `DoesNot` would assert "this bucket does not lower the budget" on
+/// no evidence, which is guessing, only quieter.
+fn bucket_budget(bucket: &B2Bucket) -> BucketBudget {
+    let encryption = match authorized_value(bucket.default_server_side_encryption.as_ref()) {
+        Some(value) => match value.get("mode") {
+            // Documented when disabled: "algorithm and mode will both be
+            // returned as null".
+            Some(serde_json::Value::Null) => Setting::DoesNot,
+            // Documented when enabled: `{ "algorithm": "AES256", "mode":
+            // "SSE-B2" }`. Any other mode Backblaze may add still encrypts.
+            Some(serde_json::Value::String(mode)) if !mode.is_empty() => Setting::Reduces,
+            _ => Setting::Unknown,
+        },
+        None => Setting::Unknown,
+    };
+    let object_lock = match authorized_value(bucket.file_lock_configuration.as_ref()) {
+        // `isFileLockEnabled` and only that. The lock can be on while
+        // `defaultRetention` is `{ "mode": null, "period": null }`, so reading
+        // the retention instead would call that bucket unlocked.
+        Some(value) => match value.get("isFileLockEnabled") {
+            Some(serde_json::Value::Bool(true)) => Setting::Reduces,
+            Some(serde_json::Value::Bool(false)) => Setting::DoesNot,
+            _ => Setting::Unknown,
+        },
+        None => Setting::Unknown,
+    };
+    BucketBudget {
+        encryption,
+        object_lock,
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -325,6 +503,9 @@ pub struct B2Provider {
     download_url: String,
     auth_token: SecretString,
     bucket_id: String,
+    /// Drives the header budget. Unread until `resolve_bucket_id` has run, and
+    /// it stays unread for a key that may not see the settings.
+    bucket_budget: BucketBudget,
 
     current_path: String,
     connected: bool,
@@ -353,6 +534,7 @@ impl B2Provider {
             download_url: String::new(),
             auth_token: SecretString::new(String::new().into()),
             bucket_id: String::new(),
+            bucket_budget: BucketBudget::UNREAD,
             current_path: "/".to_string(),
             connected: false,
             multi_thread_streams: 1,
@@ -468,6 +650,7 @@ impl B2Provider {
                     bucket_name
                 ))
             })?;
+        self.bucket_budget = bucket_budget(&target);
         self.bucket_id = target.bucket_id;
         Ok(())
     }
@@ -510,13 +693,70 @@ impl B2Provider {
         file_name: &str,
         info_extra: usize,
     ) -> Result<(), ProviderError> {
-        if file_name.len() + info_extra > HEADER_BUDGET_STD {
+        let used = file_name.len() + info_extra;
+        let budget = self.bucket_budget.bytes();
+        if used > budget {
+            let because = match self.bucket_budget.reduced_because() {
+                Some(reason) => format!(" ({reason})"),
+                None => String::new(),
+            };
             return Err(ProviderError::InvalidConfig(format!(
-                "file name + metadata exceed B2 header budget ({} bytes)",
-                HEADER_BUDGET_STD
+                "file name + metadata are {used} bytes, over B2's {budget}-byte header budget{because}"
             )));
         }
         Ok(())
+    }
+
+    /// What to add to a B2 rejection when we let through an upload the smaller
+    /// budget would have stopped.
+    ///
+    /// This is the honest half of the permissive choice in
+    /// [`BucketBudget::bytes`]: on a bucket whose settings we may not read, a
+    /// path over 2 048 bytes is accepted here and can be refused by B2 with an
+    /// error that explains nothing. The hint names what we could NOT read and
+    /// which capability would have let us, and deliberately does not claim the
+    /// bucket is encrypted or locked, because we have no basis for either and
+    /// asserting one would be the same mistake in words.
+    fn reduced_budget_hint(&self, file_name: &str, info_extra: usize) -> Option<String> {
+        let unread = self.bucket_budget.unread_capabilities();
+        if unread.is_empty() {
+            return None;
+        }
+        let used = file_name.len() + info_extra;
+        if used <= HEADER_BUDGET_REDUCED {
+            return None;
+        }
+        Some(format!(
+            "file name + metadata are {used} bytes; this application key cannot read {} \
+             (it lacks the {} capability), and B2 lowers the limit from {HEADER_BUDGET_STD} to \
+             {HEADER_BUDGET_REDUCED} bytes on a bucket with server-side encryption or Object Lock",
+            if unread.len() == 2 {
+                "the bucket's encryption or Object Lock settings"
+            } else if unread[0] == "readBucketEncryption" {
+                "the bucket's encryption setting"
+            } else {
+                "the bucket's Object Lock setting"
+            },
+            unread.join(" / ")
+        ))
+    }
+
+    fn annotate_with_reduced_budget(
+        &self,
+        err: ProviderError,
+        file_name: &str,
+        info_extra: usize,
+    ) -> ProviderError {
+        // A rejected budget comes back as a 400, which `map_b2_status` maps to
+        // `ServerError`; leave every other failure (auth, network, not found)
+        // untouched rather than blaming the budget for it.
+        let ProviderError::ServerError(ref message) = err else {
+            return err;
+        };
+        match self.reduced_budget_hint(file_name, info_extra) {
+            Some(hint) => ProviderError::ServerError(format!("{message}. {hint}")),
+            None => err,
+        }
     }
 
     async fn list_file_names(
@@ -1995,7 +2235,10 @@ impl StorageProvider for B2Provider {
         }
         let abs = self.resolved_path(remote_path);
         let key = self.b2_key(&abs);
-        self.validate_header_budget(&key, 0)?;
+        // The upload below sends one `fileInfo` entry, and B2 counts it against
+        // the same budget as the name.
+        let info_extra = SRC_LAST_MODIFIED_INFO_BYTES;
+        self.validate_header_budget(&key, info_extra)?;
         let metadata = tokio::fs::metadata(local_path)
             .await
             .map_err(|e| ProviderError::Other(format!("stat local: {}", e)))?;
@@ -2066,7 +2309,11 @@ impl StorageProvider for B2Provider {
         let status = resp.status();
         if !status.is_success() {
             let text = resp.text().await.unwrap_or_default();
-            return Err(map_b2_status(status, &text, "b2_upload_file"));
+            return Err(self.annotate_with_reduced_budget(
+                map_b2_status(status, &text, "b2_upload_file"),
+                &key,
+                info_extra,
+            ));
         }
         let parsed: UploadFileResponse = resp
             .json()
@@ -2123,10 +2370,10 @@ impl StorageProvider for B2Provider {
         let status = resp.status();
         if !status.is_success() {
             let text = resp.text().await.unwrap_or_default();
-            return Err(map_b2_status(
-                status,
-                &text,
-                "b2_upload_file (mkdir placeholder)",
+            return Err(self.annotate_with_reduced_budget(
+                map_b2_status(status, &text, "b2_upload_file (mkdir placeholder)"),
+                &key,
+                0,
             ));
         }
         Ok(())
@@ -2704,7 +2951,10 @@ impl StorageProvider for B2Provider {
         let abs = self.resolved_path(remote_path);
         let key = self.b2_key(&abs);
         self.validate_header_budget(&key, 0)?;
-        let started = self.start_large_file(&key).await?;
+        let started = self
+            .start_large_file(&key)
+            .await
+            .map_err(|e| self.annotate_with_reduced_budget(e, &key, 0))?;
         Ok(MultipartHandle {
             upload_id: started.file_id,
             remote_path: key,
@@ -3204,6 +3454,348 @@ mod tests {
             .is_ok());
     }
 
+    // ── Reduced header budget (SSE default from 2026-09-14, Object Lock) ───
+
+    fn bucket_from(json: serde_json::Value) -> B2Bucket {
+        serde_json::from_value(json).expect("bucket parses")
+    }
+
+    /// A bucket entry carrying one setting, with the other left absent.
+    fn bucket_with(field: &str, wrapper: serde_json::Value) -> B2Bucket {
+        let mut json = serde_json::json!({ "bucketId": "i", "bucketName": "n" });
+        json[field] = wrapper;
+        bucket_from(json)
+    }
+
+    fn authorized(value: serde_json::Value) -> serde_json::Value {
+        serde_json::json!({ "isClientAuthorizedToRead": true, "value": value })
+    }
+
+    fn provider_with(budget: BucketBudget) -> B2Provider {
+        let mut p = B2Provider::new(B2Config {
+            application_key_id: "id".into(),
+            application_key: SecretString::new("k".into()),
+            bucket: "b".into(),
+            initial_path: None,
+        });
+        p.bucket_budget = budget;
+        p
+    }
+
+    fn budget_of(encryption: Setting, object_lock: Setting) -> BucketBudget {
+        BucketBudget {
+            encryption,
+            object_lock,
+        }
+    }
+
+    // ── Encryption, gated by readBucketEncryption ──────────────────────────
+
+    #[test]
+    fn an_encrypting_bucket_reduces_the_budget() {
+        let bucket = bucket_with(
+            "defaultServerSideEncryption",
+            authorized(serde_json::json!({ "algorithm": "AES256", "mode": "SSE-B2" })),
+        );
+        assert_eq!(bucket_budget(&bucket).encryption, Setting::Reduces);
+    }
+
+    /// Documented for a disabled default: "algorithm and mode will both be
+    /// returned as null."
+    #[test]
+    fn a_plain_bucket_does_not_reduce_the_budget() {
+        let bucket = bucket_with(
+            "defaultServerSideEncryption",
+            authorized(serde_json::json!({ "algorithm": null, "mode": null })),
+        );
+        assert_eq!(bucket_budget(&bucket).encryption, Setting::DoesNot);
+    }
+
+    // ── Object Lock, gated by readBucketRetentions ─────────────────────────
+
+    /// The trap this pair exists for: the lock can be ON while its default
+    /// retention is off, and B2 documents exactly that shape. Reading
+    /// `defaultRetention` instead of `isFileLockEnabled` would call the second
+    /// bucket unlocked and hand it the 7 000 byte budget it must not have.
+    #[test]
+    fn object_lock_is_read_from_the_flag_not_from_the_retention() {
+        let with_retention = bucket_with(
+            "fileLockConfiguration",
+            authorized(serde_json::json!({
+                "defaultRetention": { "mode": "governance", "period": { "duration": 2, "unit": "years" } },
+                "isFileLockEnabled": true
+            })),
+        );
+        assert_eq!(bucket_budget(&with_retention).object_lock, Setting::Reduces);
+
+        // "If default bucket retention is disabled, then mode and period will
+        // both be null" - and the lock is still enabled.
+        let without_retention = bucket_with(
+            "fileLockConfiguration",
+            authorized(serde_json::json!({
+                "defaultRetention": { "mode": null, "period": null },
+                "isFileLockEnabled": true
+            })),
+        );
+        assert_eq!(
+            bucket_budget(&without_retention).object_lock,
+            Setting::Reduces,
+            "a lock with no default retention is still a lock"
+        );
+    }
+
+    #[test]
+    fn an_unlocked_bucket_does_not_reduce_the_budget() {
+        let bucket = bucket_with(
+            "fileLockConfiguration",
+            authorized(serde_json::json!({
+                "defaultRetention": { "mode": null, "period": null },
+                "isFileLockEnabled": false
+            })),
+        );
+        assert_eq!(bucket_budget(&bucket).object_lock, Setting::DoesNot);
+    }
+
+    // ── The three ways we end up not knowing, for either setting ───────────
+
+    /// Cause 1: the field is absent. The prose does not describe this, but the
+    /// OpenAPI schema marks both fields optional, so it is legal.
+    #[test]
+    fn absent_fields_leave_both_settings_unknown() {
+        let bucket = bucket_from(serde_json::json!({ "bucketId": "i", "bucketName": "n" }));
+        let budget = bucket_budget(&bucket);
+        assert_eq!(budget.encryption, Setting::Unknown);
+        assert_eq!(budget.object_lock, Setting::Unknown);
+    }
+
+    /// Cause 2: the key may list buckets but not read these settings, which is
+    /// the normal shape of a bucket-restricted key. Documented for both:
+    /// `isClientAuthorizedToRead` false and `value` null.
+    #[test]
+    fn an_unauthorized_key_leaves_the_setting_unknown() {
+        let denied = serde_json::json!({ "isClientAuthorizedToRead": false, "value": null });
+        assert_eq!(
+            bucket_budget(&bucket_with("defaultServerSideEncryption", denied.clone())).encryption,
+            Setting::Unknown
+        );
+        assert_eq!(
+            bucket_budget(&bucket_with("fileLockConfiguration", denied)).object_lock,
+            Setting::Unknown
+        );
+    }
+
+    /// Cause 3: authorised, but the payload is not a shape Backblaze documents.
+    /// None of these may be read as "this bucket does not lower the budget".
+    #[test]
+    fn an_undocumented_payload_leaves_the_setting_unknown() {
+        for value in [
+            serde_json::json!(null),
+            serde_json::json!("SSE-B2"),
+            serde_json::json!({}),
+            serde_json::json!({ "mode": "" }),
+            serde_json::json!({ "mode": 7 }),
+        ] {
+            let bucket = bucket_with("defaultServerSideEncryption", authorized(value.clone()));
+            assert_eq!(
+                bucket_budget(&bucket).encryption,
+                Setting::Unknown,
+                "value {value} must not be read as a definite answer"
+            );
+        }
+        for value in [
+            serde_json::json!(null),
+            serde_json::json!({}),
+            serde_json::json!({ "isFileLockEnabled": "true" }),
+            serde_json::json!({ "defaultRetention": { "mode": null, "period": null } }),
+        ] {
+            let bucket = bucket_with("fileLockConfiguration", authorized(value.clone()));
+            assert_eq!(
+                bucket_budget(&bucket).object_lock,
+                Setting::Unknown,
+                "value {value} must not be read as a definite answer"
+            );
+        }
+    }
+
+    /// The guarantee that matters most: no shape of either field may fail the
+    /// deserialisation, because that error would not stop at the budget, it
+    /// would fail `b2_list_buckets` and therefore the connect. Backblaze's
+    /// documentation contradicts itself in three places about these types, so
+    /// nothing can be trusted to bound what arrives.
+    #[test]
+    fn no_shape_of_either_field_can_break_the_bucket_listing() {
+        let hostile = [
+            serde_json::json!(null),
+            serde_json::json!("nonsense"),
+            serde_json::json!(42),
+            serde_json::json!([1, 2, 3]),
+            serde_json::json!({ "isClientAuthorizedToRead": "yes", "value": {} }),
+            serde_json::json!({ "isClientAuthorizedToRead": true }),
+            serde_json::json!({ "unexpected": true }),
+        ];
+        for field in ["defaultServerSideEncryption", "fileLockConfiguration"] {
+            for shape in &hostile {
+                let parsed: Result<B2Bucket, _> = serde_json::from_value(serde_json::json!({
+                    "bucketId": "i",
+                    "bucketName": "n",
+                    field: shape
+                }));
+                let bucket = parsed.expect("the bucket must still parse");
+                let budget = bucket_budget(&bucket);
+                assert_eq!(budget.bytes(), HEADER_BUDGET_STD);
+                assert!(!budget.unread_capabilities().is_empty());
+            }
+        }
+    }
+
+    // ── The budget, and the choice inside Unknown ──────────────────────────
+
+    #[test]
+    fn either_reason_alone_is_enough_to_reduce_the_budget() {
+        assert_eq!(
+            budget_of(Setting::Reduces, Setting::DoesNot).bytes(),
+            HEADER_BUDGET_REDUCED
+        );
+        assert_eq!(
+            budget_of(Setting::DoesNot, Setting::Reduces).bytes(),
+            HEADER_BUDGET_REDUCED
+        );
+        assert_eq!(
+            budget_of(Setting::DoesNot, Setting::DoesNot).bytes(),
+            HEADER_BUDGET_STD
+        );
+        // A reason we CAN see wins over one we cannot.
+        assert_eq!(
+            budget_of(Setting::Unknown, Setting::Reduces).bytes(),
+            HEADER_BUDGET_REDUCED
+        );
+        // The deliberate choice: B2 is the authority on what it accepts, so we
+        // never refuse a path it might take.
+        assert_eq!(BucketBudget::UNREAD.bytes(), HEADER_BUDGET_STD);
+    }
+
+    #[test]
+    fn a_long_path_is_refused_only_where_a_reason_was_actually_read() {
+        let long = "x".repeat(HEADER_BUDGET_REDUCED + 1);
+        assert!(provider_with(budget_of(Setting::Reduces, Setting::DoesNot))
+            .validate_header_budget(&long, 0)
+            .is_err());
+        assert!(provider_with(budget_of(Setting::DoesNot, Setting::Reduces))
+            .validate_header_budget(&long, 0)
+            .is_err());
+        assert!(provider_with(budget_of(Setting::DoesNot, Setting::DoesNot))
+            .validate_header_budget(&long, 0)
+            .is_ok());
+        assert!(provider_with(BucketBudget::UNREAD)
+            .validate_header_budget(&long, 0)
+            .is_ok());
+    }
+
+    #[test]
+    fn the_refusal_names_the_reason_it_was_refused_for() {
+        let long = "x".repeat(HEADER_BUDGET_REDUCED + 1);
+        let cases = [
+            (
+                budget_of(Setting::Reduces, Setting::DoesNot),
+                "server-side encryption",
+            ),
+            (
+                budget_of(Setting::DoesNot, Setting::Reduces),
+                "Object Lock enabled",
+            ),
+            (
+                budget_of(Setting::Reduces, Setting::Reduces),
+                "encryption and has Object Lock",
+            ),
+        ];
+        for (budget, expected) in cases {
+            let text = provider_with(budget)
+                .validate_header_budget(&long, 0)
+                .expect_err("over the reduced budget")
+                .to_string();
+            assert!(text.contains("2048"), "must name the budget: {text}");
+            assert!(text.contains(expected), "must say why: {text}");
+        }
+    }
+
+    // ── The hint, for the case the check cannot warn about in advance ──────
+
+    #[test]
+    fn the_hint_names_the_capability_we_lack_without_claiming_what_we_did_not_read() {
+        let long = "x".repeat(HEADER_BUDGET_REDUCED + 1);
+
+        let both = provider_with(BucketBudget::UNREAD)
+            .reduced_budget_hint(&long, 0)
+            .expect("neither setting read, path over the smaller budget");
+        assert!(both.contains("readBucketEncryption"), "{both}");
+        assert!(both.contains("readBucketRetentions"), "{both}");
+        assert!(both.contains("2048") && both.contains("7000"), "{both}");
+        // The whole point: we never say the bucket IS encrypted or locked.
+        assert!(
+            !both.contains("this bucket uses") && !both.contains("this bucket has"),
+            "the hint must not assert what we could not read: {both}"
+        );
+
+        // Only one setting unreadable: name only that one.
+        let only_lock = provider_with(budget_of(Setting::DoesNot, Setting::Unknown))
+            .reduced_budget_hint(&long, 0)
+            .expect("Object Lock unread");
+        assert!(only_lock.contains("readBucketRetentions"), "{only_lock}");
+        assert!(!only_lock.contains("readBucketEncryption"), "{only_lock}");
+    }
+
+    #[test]
+    fn the_hint_stays_quiet_when_it_has_nothing_to_add() {
+        let long = "x".repeat(HEADER_BUDGET_REDUCED + 1);
+        // Nothing to say when both settings were read, either way.
+        assert!(provider_with(budget_of(Setting::Reduces, Setting::DoesNot))
+            .reduced_budget_hint(&long, 0)
+            .is_none());
+        assert!(provider_with(budget_of(Setting::DoesNot, Setting::DoesNot))
+            .reduced_budget_hint(&long, 0)
+            .is_none());
+        // Nor when the path fits the smaller budget anyway.
+        assert!(provider_with(BucketBudget::UNREAD)
+            .reduced_budget_hint("photos/cats/fluffy.jpg", 0)
+            .is_none());
+    }
+
+    #[test]
+    fn only_a_server_error_is_annotated() {
+        let long = "x".repeat(HEADER_BUDGET_REDUCED + 1);
+        let p = provider_with(BucketBudget::UNREAD);
+
+        let annotated = p.annotate_with_reduced_budget(
+            ProviderError::ServerError("b2_upload_file (400): bad_request".into()),
+            &long,
+            0,
+        );
+        assert!(annotated.to_string().contains("readBucketEncryption"));
+
+        // A network or auth failure is not the budget's fault; leave it alone.
+        let untouched = p.annotate_with_reduced_budget(
+            ProviderError::ConnectionFailed("upload send: timeout".into()),
+            &long,
+            0,
+        );
+        assert!(untouched.to_string().contains("upload send: timeout"));
+        assert!(!untouched.to_string().contains("readBucketEncryption"));
+    }
+
+    #[test]
+    fn upload_counts_the_file_info_entry_it_actually_sends() {
+        // `upload` sends `src_last_modified_millis`, and B2 counts fileInfo
+        // against the same budget as the name, so the check must too.
+        assert_eq!(SRC_LAST_MODIFIED_INFO_BYTES, 24 + 14);
+        let at_budget = "x".repeat(HEADER_BUDGET_REDUCED - SRC_LAST_MODIFIED_INFO_BYTES);
+        let p = provider_with(budget_of(Setting::Reduces, Setting::DoesNot));
+        assert!(p
+            .validate_header_budget(&at_budget, SRC_LAST_MODIFIED_INFO_BYTES)
+            .is_ok());
+        assert!(p
+            .validate_header_budget(&format!("{at_budget}x"), SRC_LAST_MODIFIED_INFO_BYTES)
+            .is_err());
+    }
     // ── Phase 2 ────────────────────────────────────────────────────────────
 
     #[test]

--- a/src-tauri/src/providers/b2.rs
+++ b/src-tauri/src/providers/b2.rs
@@ -810,7 +810,13 @@ impl B2Provider {
         if !self.bucket_budget.has_unknown() {
             return None;
         }
-        let used = file_name.len() + info_extra;
+        // Measured on the encoded form, the same metre `encoded_length_hint`
+        // uses. On the raw one the two hints leave a hole exactly where both
+        // uncertainties meet: a bucket we could not read, and a name that fits
+        // raw but not encoded. There neither hint fired and the upload failed
+        // with nothing said, which is the one case this PR exists to cover.
+        // Encoding never shortens, so this is also never quieter than before.
+        let used = Self::encoded_len(file_name) + info_extra;
         if used <= HEADER_BUDGET_REDUCED {
             return None;
         }
@@ -3990,6 +3996,38 @@ mod tests {
             0,
         );
         assert!(!unknown_status.to_string().contains("readBucketEncryption"));
+    }
+
+    /// The gap the two hints left between them: a bucket whose settings we
+    /// could not read, and a name that fits raw and overflows once encoded.
+    /// Before this, neither hint fired and the upload failed in silence.
+    #[test]
+    fn the_two_hints_leave_no_silent_gap_between_them() {
+        // Each space triples under encoding: 700 raw become 2100, which with
+        // the metadata charge is over the reduced budget and far under the
+        // standard one. The raw form fits comfortably.
+        let spacey = " ".repeat(700);
+        let p = provider_with(BucketBudget::UNREAD);
+        let used_raw = spacey.len() + SRC_LAST_MODIFIED_INFO_BYTES;
+        assert!(
+            used_raw <= HEADER_BUDGET_REDUCED,
+            "the raw form must fit, or the case is not the one under test"
+        );
+        assert!(
+            B2Provider::encoded_len(&spacey) + SRC_LAST_MODIFIED_INFO_BYTES > HEADER_BUDGET_REDUCED,
+            "and the encoded form must not, or there is no gap to close"
+        );
+        let annotated = p.annotate_with_reduced_budget(
+            ProviderError::ServerError("b2_upload_file (400): bad_request".into()),
+            Some(400),
+            &spacey,
+            SRC_LAST_MODIFIED_INFO_BYTES,
+        );
+        let text = annotated.to_string();
+        assert!(
+            text.contains("readBucketEncryption") || text.contains("percent-encoded"),
+            "an upload that failed here must not be answered with silence: {text}"
+        );
     }
 
     /// Backblaze documents the byte cap and the percent-encoded header

--- a/src-tauri/src/providers/b2.rs
+++ b/src-tauri/src/providers/b2.rs
@@ -50,6 +50,23 @@ const HEADER_BUDGET_REDUCED: usize = 2048;
 /// The key is 24 bytes and a millisecond epoch is 13 digits today; the extra
 /// byte covers the day that becomes 14.
 const SRC_LAST_MODIFIED_INFO_BYTES: usize = "src_last_modified_millis".len() + 14;
+
+/// How many `fileInfo` bytes an upload of this size will actually send.
+///
+/// A single-shot upload carries `src_last_modified_millis`; the large-file
+/// path does not, because `b2_start_large_file` sends only `bucketId`,
+/// `fileName` and `contentType`. Charging the large path for metadata it never
+/// sends would make the check 38 bytes stricter than B2, and refuse a name B2
+/// would have accepted: the exact failure this check exists to prevent, in
+/// miniature. Reported by an automated review of the first version of this
+/// change, and confirmed against `start_large_file`.
+fn upload_info_extra(size: u64) -> usize {
+    if size > SINGLE_UPLOAD_RECOMMENDED_MAX {
+        0
+    } else {
+        SRC_LAST_MODIFIED_INFO_BYTES
+    }
+}
 const PLACEHOLDER_NAME: &str = ".bzEmpty";
 
 /// Upper bound on concurrent Range streams for multi-thread download
@@ -2237,12 +2254,14 @@ impl StorageProvider for B2Provider {
         let key = self.b2_key(&abs);
         // The upload below sends one `fileInfo` entry, and B2 counts it against
         // the same budget as the name.
-        let info_extra = SRC_LAST_MODIFIED_INFO_BYTES;
-        self.validate_header_budget(&key, info_extra)?;
         let metadata = tokio::fs::metadata(local_path)
             .await
             .map_err(|e| ProviderError::Other(format!("stat local: {}", e)))?;
         let size = metadata.len();
+        // The charge depends on which upload this turns out to be, so the size
+        // has to be known first.
+        let info_extra = upload_info_extra(size);
+        self.validate_header_budget(&key, info_extra)?;
         if size > SINGLE_UPLOAD_RECOMMENDED_MAX {
             // Large path: retry once on master-token failure during start_large_file.
             // progress is moved on first attempt; the rare retry runs without it.
@@ -3780,6 +3799,36 @@ mod tests {
         );
         assert!(untouched.to_string().contains("upload send: timeout"));
         assert!(!untouched.to_string().contains("readBucketEncryption"));
+    }
+
+    /// The charge must follow the upload that will actually happen. Charging a
+    /// large upload for metadata it never sends would refuse a name B2 accepts.
+    #[test]
+    fn only_the_single_shot_upload_is_charged_for_its_file_info() {
+        assert_eq!(upload_info_extra(0), SRC_LAST_MODIFIED_INFO_BYTES);
+        assert_eq!(
+            upload_info_extra(SINGLE_UPLOAD_RECOMMENDED_MAX),
+            SRC_LAST_MODIFIED_INFO_BYTES
+        );
+        assert_eq!(upload_info_extra(SINGLE_UPLOAD_RECOMMENDED_MAX + 1), 0);
+
+        // The 38 bytes are the whole difference between accepting and refusing
+        // a name at the edge of the reduced budget.
+        let at_edge = "x".repeat(HEADER_BUDGET_REDUCED);
+        let p = provider_with(budget_of(Setting::Reduces, Setting::DoesNot));
+        assert!(
+            p.validate_header_budget(
+                &at_edge,
+                upload_info_extra(SINGLE_UPLOAD_RECOMMENDED_MAX + 1)
+            )
+            .is_ok(),
+            "a large upload sends no fileInfo, so this name fits"
+        );
+        assert!(
+            p.validate_header_budget(&at_edge, upload_info_extra(1))
+                .is_err(),
+            "a single-shot upload does send one, so the same name does not"
+        );
     }
 
     #[test]

--- a/src-tauri/src/providers/b2.rs
+++ b/src-tauri/src/providers/b2.rs
@@ -217,8 +217,23 @@ enum Setting {
     Reduces,
     /// Read, and it does not.
     DoesNot,
-    /// Not read: absent, not permitted, or a shape Backblaze does not document.
-    Unknown,
+    /// B2 told us we may not read it: the field is absent, the wrapper is not
+    /// the documented shape, or `isClientAuthorizedToRead` is not true. The key
+    /// lacks the capability, and naming it is a statement we can defend.
+    Unauthorized,
+    /// We were authorised and read it, and the payload is not a shape Backblaze
+    /// documents. The key HAS the capability, so blaming a missing capability
+    /// here would assert something the response itself contradicts.
+    Unrecognised,
+}
+
+impl Setting {
+    /// Both of these mean "we do not know", and the budget treats them alike.
+    /// They differ only in what we may say about WHY, which is the whole point
+    /// of keeping them apart.
+    fn is_unknown(self) -> bool {
+        matches!(self, Setting::Unauthorized | Setting::Unrecognised)
+    }
 }
 
 /// The two documented reasons B2 lowers the budget, read independently.
@@ -250,8 +265,8 @@ struct BucketBudget {
 impl BucketBudget {
     /// Before `resolve_bucket_id` has run we have read neither setting.
     const UNREAD: Self = Self {
-        encryption: Setting::Unknown,
-        object_lock: Setting::Unknown,
+        encryption: Setting::Unauthorized,
+        object_lock: Setting::Unauthorized,
     };
 
     /// B2's `fileName` + `fileInfo` budget for this bucket.
@@ -287,33 +302,56 @@ impl BucketBudget {
     /// let us. Empty when both were readable.
     fn unread_capabilities(self) -> Vec<&'static str> {
         let mut missing = Vec::new();
-        if self.encryption == Setting::Unknown {
+        if self.encryption == Setting::Unauthorized {
             missing.push("readBucketEncryption");
         }
-        if self.object_lock == Setting::Unknown {
+        if self.object_lock == Setting::Unauthorized {
             missing.push("readBucketRetentions");
         }
         missing
     }
+
+    /// True when a setting was read but not understood. Distinct from a missing
+    /// capability: here the key was allowed to look, so the hint must describe
+    /// the payload, not the permissions.
+    fn has_unrecognised(self) -> bool {
+        self.encryption == Setting::Unrecognised || self.object_lock == Setting::Unrecognised
+    }
+
+    /// Any reason at all that a setting could not be turned into an answer.
+    fn has_unknown(self) -> bool {
+        self.encryption.is_unknown() || self.object_lock.is_unknown()
+    }
 }
 
-/// Pull the payload out of one of B2's capability-gated wrappers.
+/// What one of B2's capability-gated wrappers actually told us.
 ///
-/// Both settings arrive as `{ "isClientAuthorizedToRead": bool, "value": ... }`,
-/// and both are documented to carry a null `value` when the key lacks the
-/// capability. `None` here means "we did not read it", whatever the reason.
-fn authorized_value(
-    field: Option<&serde_json::Value>,
-) -> Option<&serde_json::Map<String, serde_json::Value>> {
-    let serde_json::Value::Object(wrapper) = field? else {
-        return None;
+/// Both settings arrive as `{ "isClientAuthorizedToRead": bool, "value": ... }`.
+/// The two ways of not getting an answer are NOT the same fact and must not be
+/// collapsed: one is about our key, the other about the payload, and only the
+/// first justifies naming a missing capability.
+enum Wrapper<'a> {
+    /// B2 would not show it to us: absent, not an object, or the flag is not
+    /// true. Documented as `isClientAuthorizedToRead` false with a null value.
+    Denied,
+    /// Shown to us, and the payload is an object we can look inside.
+    Value(&'a serde_json::Map<String, serde_json::Value>),
+    /// Shown to us, and the payload is not the shape Backblaze documents. The
+    /// key has the capability, so blaming one here would contradict the
+    /// response itself.
+    Unusable,
+}
+
+fn read_wrapper(field: Option<&serde_json::Value>) -> Wrapper<'_> {
+    let Some(serde_json::Value::Object(wrapper)) = field else {
+        return Wrapper::Denied;
     };
     if wrapper.get("isClientAuthorizedToRead") != Some(&serde_json::Value::Bool(true)) {
-        return None;
+        return Wrapper::Denied;
     }
     match wrapper.get("value") {
-        Some(serde_json::Value::Object(value)) => Some(value),
-        _ => None,
+        Some(serde_json::Value::Object(value)) => Wrapper::Value(value),
+        _ => Wrapper::Unusable,
     }
 }
 
@@ -324,28 +362,31 @@ fn authorized_value(
 /// shape as `DoesNot` would assert "this bucket does not lower the budget" on
 /// no evidence, which is guessing, only quieter.
 fn bucket_budget(bucket: &B2Bucket) -> BucketBudget {
-    let encryption = match authorized_value(bucket.default_server_side_encryption.as_ref()) {
-        Some(value) => match value.get("mode") {
+    let encryption = match read_wrapper(bucket.default_server_side_encryption.as_ref()) {
+        Wrapper::Value(value) => match value.get("mode") {
             // Documented when disabled: "algorithm and mode will both be
             // returned as null".
             Some(serde_json::Value::Null) => Setting::DoesNot,
             // Documented when enabled: `{ "algorithm": "AES256", "mode":
             // "SSE-B2" }`. Any other mode Backblaze may add still encrypts.
             Some(serde_json::Value::String(mode)) if !mode.is_empty() => Setting::Reduces,
-            _ => Setting::Unknown,
+            // Authorised, so the key is not the problem: the payload is.
+            _ => Setting::Unrecognised,
         },
-        None => Setting::Unknown,
+        Wrapper::Unusable => Setting::Unrecognised,
+        Wrapper::Denied => Setting::Unauthorized,
     };
-    let object_lock = match authorized_value(bucket.file_lock_configuration.as_ref()) {
+    let object_lock = match read_wrapper(bucket.file_lock_configuration.as_ref()) {
         // `isFileLockEnabled` and only that. The lock can be on while
         // `defaultRetention` is `{ "mode": null, "period": null }`, so reading
         // the retention instead would call that bucket unlocked.
-        Some(value) => match value.get("isFileLockEnabled") {
+        Wrapper::Value(value) => match value.get("isFileLockEnabled") {
             Some(serde_json::Value::Bool(true)) => Setting::Reduces,
             Some(serde_json::Value::Bool(false)) => Setting::DoesNot,
-            _ => Setting::Unknown,
+            _ => Setting::Unrecognised,
         },
-        None => Setting::Unknown,
+        Wrapper::Unusable => Setting::Unrecognised,
+        Wrapper::Denied => Setting::Unauthorized,
     };
     BucketBudget {
         encryption,
@@ -734,46 +775,106 @@ impl B2Provider {
     /// which capability would have let us, and deliberately does not claim the
     /// bucket is encrypted or locked, because we have no basis for either and
     /// asserting one would be the same mistake in words.
+    /// The name as it actually travels: `X-Bz-File-Name` carries it
+    /// percent-encoded, and encoding only ever grows it. A space becomes `%20`,
+    /// an accented letter's two UTF-8 bytes become six characters.
+    fn encoded_len(file_name: &str) -> usize {
+        urlencoding::encode(file_name).len()
+    }
+
+    /// What to add when the name we measured and the name we sent differ enough
+    /// to matter.
+    ///
+    /// Backblaze documents the 7000 byte cap and, separately, that the header
+    /// is "in percent-encoded UTF-8", and never says which form the cap applies
+    /// to. So we refuse only on the raw length, which cannot be stricter than
+    /// B2 under either reading, and when the encoded form is the one that
+    /// overflows we say so instead of blocking. Being wrong about which form
+    /// B2 measures then costs an explained late refusal, not a refusal of names
+    /// B2 would have taken.
+    fn encoded_length_hint(&self, file_name: &str, info_extra: usize) -> Option<String> {
+        let raw = file_name.len() + info_extra;
+        let encoded = Self::encoded_len(file_name) + info_extra;
+        let budget = self.bucket_budget.bytes();
+        if raw > budget || encoded <= budget {
+            return None;
+        }
+        Some(format!(
+            "the name is {raw} bytes but travels percent-encoded as {encoded}, over the \
+             {budget}-byte budget; B2 does not document which of the two forms the limit applies \
+             to, so this upload was not refused locally"
+        ))
+    }
+
     fn reduced_budget_hint(&self, file_name: &str, info_extra: usize) -> Option<String> {
-        let unread = self.bucket_budget.unread_capabilities();
-        if unread.is_empty() {
+        if !self.bucket_budget.has_unknown() {
             return None;
         }
         let used = file_name.len() + info_extra;
         if used <= HEADER_BUDGET_REDUCED {
             return None;
         }
+        // Say why we could not tell, and say only what is true. A key that was
+        // allowed to read the setting and got back a payload we did not
+        // recognise does NOT lack the capability, and telling the reader it
+        // does would be a false statement dressed as a diagnosis.
+        let unread = self.bucket_budget.unread_capabilities();
+        let because = match (unread.as_slice(), self.bucket_budget.has_unrecognised()) {
+            ([], _) => "the bucket's settings came back in a shape this build does not recognise"
+                .to_string(),
+            (caps, false) => format!(
+                "this application key cannot read {} (it lacks the {} capability)",
+                if caps.len() == 2 {
+                    "the bucket's encryption or Object Lock settings"
+                } else if caps[0] == "readBucketEncryption" {
+                    "the bucket's encryption setting"
+                } else {
+                    "the bucket's Object Lock setting"
+                },
+                caps.join(" / ")
+            ),
+            (caps, true) => format!(
+                "this application key lacks the {} capability, and the other setting came back in \
+                 a shape this build does not recognise",
+                caps.join(" / ")
+            ),
+        };
         Some(format!(
-            "file name + metadata are {used} bytes; this application key cannot read {} \
-             (it lacks the {} capability), and B2 lowers the limit from {HEADER_BUDGET_STD} to \
-             {HEADER_BUDGET_REDUCED} bytes on a bucket with server-side encryption or Object Lock",
-            if unread.len() == 2 {
-                "the bucket's encryption or Object Lock settings"
-            } else if unread[0] == "readBucketEncryption" {
-                "the bucket's encryption setting"
-            } else {
-                "the bucket's Object Lock setting"
-            },
-            unread.join(" / ")
+            "file name + metadata are {used} bytes; {because}, and B2 lowers the limit from \
+             {HEADER_BUDGET_STD} to {HEADER_BUDGET_REDUCED} bytes on a bucket with server-side \
+             encryption or Object Lock"
         ))
     }
 
     fn annotate_with_reduced_budget(
         &self,
         err: ProviderError,
+        status: Option<u16>,
         file_name: &str,
         info_extra: usize,
     ) -> ProviderError {
-        // A rejected budget comes back as a 400, which `map_b2_status` maps to
-        // `ServerError`; leave every other failure (auth, network, not found)
-        // untouched rather than blaming the budget for it.
+        // Only a 400 can be a rejected budget. `map_b2_status` funnels 403,
+        // 503 and its catch-all into the same `ServerError`, so the variant
+        // alone cannot tell a bad request from a permission error or an
+        // outage: attaching a note about header budgets to either of those
+        // would be answering a question nobody asked.
+        if status != Some(400) {
+            return err;
+        }
         let ProviderError::ServerError(ref message) = err else {
             return err;
         };
-        match self.reduced_budget_hint(file_name, info_extra) {
-            Some(hint) => ProviderError::ServerError(format!("{message}. {hint}")),
-            None => err,
+        let hints: Vec<String> = [
+            self.encoded_length_hint(file_name, info_extra),
+            self.reduced_budget_hint(file_name, info_extra),
+        ]
+        .into_iter()
+        .flatten()
+        .collect();
+        if hints.is_empty() {
+            return err;
         }
+        ProviderError::ServerError(format!("{message}. {}", hints.join(". ")))
     }
 
     async fn list_file_names(
@@ -2259,8 +2360,20 @@ impl StorageProvider for B2Provider {
             .map_err(|e| ProviderError::Other(format!("stat local: {}", e)))?;
         let size = metadata.len();
         // The charge depends on which upload this turns out to be, so the size
-        // has to be known first.
-        let info_extra = upload_info_extra(size);
+        // has to be known first. It also depends on whether the one header we
+        // send is actually sendable: `src_last_modified_millis` is written only
+        // when the local mtime is readable (see below), so charging for it
+        // unconditionally would bill bytes that never leave.
+        let mtime_millis = metadata
+            .modified()
+            .ok()
+            .and_then(|m| m.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| d.as_millis().to_string());
+        let info_extra = if mtime_millis.is_some() {
+            upload_info_extra(size)
+        } else {
+            0
+        };
         self.validate_header_budget(&key, info_extra)?;
         if size > SINGLE_UPLOAD_RECOMMENDED_MAX {
             // Large path: retry once on master-token failure during start_large_file.
@@ -2309,13 +2422,11 @@ impl StorageProvider for B2Provider {
             )
             .header(CONTENT_TYPE, "b2/x-auto")
             .header(HeaderName::from_static("x-bz-content-sha1"), &sha1);
-        if let Ok(modified) = metadata.modified() {
-            if let Ok(epoch) = modified.duration_since(std::time::UNIX_EPOCH) {
-                req = req.header(
-                    HeaderName::from_static("x-bz-info-src_last_modified_millis"),
-                    epoch.as_millis().to_string(),
-                );
-            }
+        if let Some(ref millis) = mtime_millis {
+            req = req.header(
+                HeaderName::from_static("x-bz-info-src_last_modified_millis"),
+                millis,
+            );
         }
         if let Some(ref p) = progress {
             p(0, size);
@@ -2330,6 +2441,7 @@ impl StorageProvider for B2Provider {
             let text = resp.text().await.unwrap_or_default();
             return Err(self.annotate_with_reduced_budget(
                 map_b2_status(status, &text, "b2_upload_file"),
+                Some(status.as_u16()),
                 &key,
                 info_extra,
             ));
@@ -2391,6 +2503,7 @@ impl StorageProvider for B2Provider {
             let text = resp.text().await.unwrap_or_default();
             return Err(self.annotate_with_reduced_budget(
                 map_b2_status(status, &text, "b2_upload_file (mkdir placeholder)"),
+                Some(status.as_u16()),
                 &key,
                 0,
             ));
@@ -2973,7 +3086,10 @@ impl StorageProvider for B2Provider {
         let started = self
             .start_large_file(&key)
             .await
-            .map_err(|e| self.annotate_with_reduced_budget(e, &key, 0))?;
+            // No status here: `start_large_file` has already mapped it away, and
+            // inferring one from the message text is the guess this change
+            // removed. Better no hint than a hint attached to the wrong error.
+            .map_err(|e| self.annotate_with_reduced_budget(e, None, &key, 0))?;
         Ok(MultipartHandle {
             upload_id: started.file_id,
             remote_path: key,
@@ -3583,8 +3699,8 @@ mod tests {
     fn absent_fields_leave_both_settings_unknown() {
         let bucket = bucket_from(serde_json::json!({ "bucketId": "i", "bucketName": "n" }));
         let budget = bucket_budget(&bucket);
-        assert_eq!(budget.encryption, Setting::Unknown);
-        assert_eq!(budget.object_lock, Setting::Unknown);
+        assert_eq!(budget.encryption, Setting::Unauthorized);
+        assert_eq!(budget.object_lock, Setting::Unauthorized);
     }
 
     /// Cause 2: the key may list buckets but not read these settings, which is
@@ -3595,11 +3711,11 @@ mod tests {
         let denied = serde_json::json!({ "isClientAuthorizedToRead": false, "value": null });
         assert_eq!(
             bucket_budget(&bucket_with("defaultServerSideEncryption", denied.clone())).encryption,
-            Setting::Unknown
+            Setting::Unauthorized
         );
         assert_eq!(
             bucket_budget(&bucket_with("fileLockConfiguration", denied)).object_lock,
-            Setting::Unknown
+            Setting::Unauthorized
         );
     }
 
@@ -3617,7 +3733,7 @@ mod tests {
             let bucket = bucket_with("defaultServerSideEncryption", authorized(value.clone()));
             assert_eq!(
                 bucket_budget(&bucket).encryption,
-                Setting::Unknown,
+                Setting::Unrecognised,
                 "value {value} must not be read as a definite answer"
             );
         }
@@ -3630,7 +3746,7 @@ mod tests {
             let bucket = bucket_with("fileLockConfiguration", authorized(value.clone()));
             assert_eq!(
                 bucket_budget(&bucket).object_lock,
-                Setting::Unknown,
+                Setting::Unrecognised,
                 "value {value} must not be read as a definite answer"
             );
         }
@@ -3685,7 +3801,7 @@ mod tests {
         );
         // A reason we CAN see wins over one we cannot.
         assert_eq!(
-            budget_of(Setting::Unknown, Setting::Reduces).bytes(),
+            budget_of(Setting::Unauthorized, Setting::Reduces).bytes(),
             HEADER_BUDGET_REDUCED
         );
         // The deliberate choice: B2 is the authority on what it accepts, so we
@@ -3756,7 +3872,7 @@ mod tests {
         );
 
         // Only one setting unreadable: name only that one.
-        let only_lock = provider_with(budget_of(Setting::DoesNot, Setting::Unknown))
+        let only_lock = provider_with(budget_of(Setting::DoesNot, Setting::Unauthorized))
             .reduced_budget_hint(&long, 0)
             .expect("Object Lock unread");
         assert!(only_lock.contains("readBucketRetentions"), "{only_lock}");
@@ -3786,6 +3902,7 @@ mod tests {
 
         let annotated = p.annotate_with_reduced_budget(
             ProviderError::ServerError("b2_upload_file (400): bad_request".into()),
+            Some(400),
             &long,
             0,
         );
@@ -3794,11 +3911,115 @@ mod tests {
         // A network or auth failure is not the budget's fault; leave it alone.
         let untouched = p.annotate_with_reduced_budget(
             ProviderError::ConnectionFailed("upload send: timeout".into()),
+            Some(400),
             &long,
             0,
         );
         assert!(untouched.to_string().contains("upload send: timeout"));
         assert!(!untouched.to_string().contains("readBucketEncryption"));
+    }
+
+    /// The defect this split exists for: a key that WAS allowed to read the
+    /// setting, and got back a payload we did not recognise, does not lack the
+    /// capability. Saying it does is a false statement dressed as a diagnosis.
+    #[test]
+    fn an_unrecognised_payload_is_never_blamed_on_a_missing_capability() {
+        let long = "x".repeat(HEADER_BUDGET_REDUCED + 1);
+        let hint = provider_with(budget_of(Setting::Unrecognised, Setting::Unrecognised))
+            .reduced_budget_hint(&long, 0)
+            .expect("neither setting usable, path over the smaller budget");
+        assert!(
+            !hint.contains("capability"),
+            "the key has the capability here: {hint}"
+        );
+        assert!(
+            hint.contains("shape this build does not recognise"),
+            "{hint}"
+        );
+
+        // Mixed: one cause each, and both must be described truthfully.
+        let mixed = provider_with(budget_of(Setting::Unauthorized, Setting::Unrecognised))
+            .reduced_budget_hint(&long, 0)
+            .expect("one unauthorised, one unrecognised");
+        assert!(mixed.contains("readBucketEncryption"), "{mixed}");
+        assert!(mixed.contains("does not recognise"), "{mixed}");
+        assert!(
+            !mixed.contains("readBucketRetentions"),
+            "that capability is present, so it must not be named: {mixed}"
+        );
+    }
+
+    /// `map_b2_status` funnels 403, 503 and its catch-all into the same
+    /// `ServerError`, so the variant cannot say which it was. Only a 400 can be
+    /// a rejected budget; the others must be left alone.
+    #[test]
+    fn only_a_bad_request_is_annotated_not_every_server_error() {
+        let long = "x".repeat(HEADER_BUDGET_REDUCED + 1);
+        let p = provider_with(BucketBudget::UNREAD);
+
+        let bad_request = p.annotate_with_reduced_budget(
+            ProviderError::ServerError("b2_upload_file (400): bad_request".into()),
+            Some(400),
+            &long,
+            0,
+        );
+        assert!(bad_request.to_string().contains("readBucketEncryption"));
+
+        for (status, message) in [
+            (403u16, "b2_upload_file: access denied"),
+            (503u16, "b2_upload_file: service unavailable"),
+        ] {
+            let other = p.annotate_with_reduced_budget(
+                ProviderError::ServerError(message.into()),
+                Some(status),
+                &long,
+                0,
+            );
+            assert_eq!(
+                other.to_string(),
+                format!("Server error: {message}"),
+                "a {status} is not a budget refusal and must not be annotated"
+            );
+        }
+
+        // No status available at all: no hint, rather than a guess.
+        let unknown_status = p.annotate_with_reduced_budget(
+            ProviderError::ServerError("b2_start_large_file: something".into()),
+            None,
+            &long,
+            0,
+        );
+        assert!(!unknown_status.to_string().contains("readBucketEncryption"));
+    }
+
+    /// Backblaze documents the byte cap and the percent-encoded header
+    /// separately and never says which form the cap applies to. So a name that
+    /// fits raw and overflows encoded is NOT refused locally, and the rejection
+    /// that may follow explains itself.
+    #[test]
+    fn a_name_that_only_overflows_once_encoded_is_explained_not_refused() {
+        // Spaces triple under encoding: 800 of them are 800 bytes raw, 2400
+        // encoded, so this straddles the reduced budget.
+        let spacey = " ".repeat(800);
+        let p = provider_with(budget_of(Setting::Reduces, Setting::DoesNot));
+        assert!(
+            p.validate_header_budget(&spacey, 0).is_ok(),
+            "the raw name fits, so we must not be stricter than B2 might be"
+        );
+        let hint = p
+            .encoded_length_hint(&spacey, 0)
+            .expect("raw fits, encoded does not");
+        assert!(
+            hint.contains("800 bytes") && hint.contains("2400"),
+            "{hint}"
+        );
+        assert!(hint.contains("not refused locally"), "{hint}");
+
+        // When both forms fit, there is nothing to say.
+        assert!(p.encoded_length_hint("plain.txt", 0).is_none());
+        // When even the raw form overflows, the refusal already happened.
+        let huge = "x".repeat(HEADER_BUDGET_REDUCED + 1);
+        assert!(p.encoded_length_hint(&huge, 0).is_none());
     }
 
     /// The charge must follow the upload that will actually happen. Charging a


### PR DESCRIPTION
## What is wrong

B2 caps `fileName` + `fileInfo` at 7000 bytes, but only 2048 on a bucket with server-side encryption or Object Lock:

> For files that are encrypted with server-side encryption or files that are in Object Lock-enabled buckets, the limit is reduced to 2,048 bytes.

`HEADER_BUDGET_STD` was hardcoded at 7000 and knew about neither trigger. The `_STD` suffix shows the smaller budget was known when the constant was written, and never implemented.

From 2026-09-14 Backblaze turns SSE-B2 on by default for new buckets and rolls it out to existing ones. From then a path between 2 049 and 7000 bytes passes our check and is refused by B2. The refusal is not the damage. The check exists to turn a late, unreadable server error into an early, clear one, and on such a bucket it would quietly stop doing that while still looking like it worked.

## What this does

Reads `defaultServerSideEncryption` and `fileLockConfiguration` from the `b2_list_buckets` response we already make at connect, and sizes the budget from them. Both fields were arriving and being discarded, so this costs no extra API call.

**The two triggers are not symmetric, and collapsing them into one test would be a bug.** Encryption is read from `value.mode`. Object Lock is read from `value.isFileLockEnabled` and only from there, because B2 documents a state where the lock is on and its default retention is off:

> If default bucket retention is disabled, then mode and period will both be null.

Deciding the budget from `defaultRetention` would call exactly that bucket unlocked and give it a budget it must not have. There is a test for that shape specifically.

Each setting carries three explicit states rather than a boolean with a hole in it. Not-read is a real state, not a missing answer: B2 gates both behind `isClientAuthorizedToRead`, and a key lacking `readBucketEncryption` or `readBucketRetentions` is told nothing. That is the normal shape of a bucket-restricted key, so it is where real users will land. Three distinct causes lead there, each named in the code and covered by its own test: the field is absent, the key is not authorised, or the payload is not a shape Backblaze documents.

## The choice when a setting cannot be read

It keeps the 7000 budget.

B2 is the authority on what it accepts; our check is a courtesy that moves B2's refusal earlier. A pre-check that refuses a path B2 would have taken breaks a working setup, deterministically, with no way for the user to override us. The permissive choice leaves the authority to say no.

What it costs is the early warning on a bucket we cannot read. So a rejection there now carries a hint naming which setting we could not read, which capability would have let us, and how large the path is. The hint deliberately does not say the bucket is encrypted or locked, because we did not read that either, and asserting it would be the same mistake in words.

## Tolerant parsing, and why it is not laziness

Both fields are deserialised as raw JSON and interpreted in one place, rather than typed.

Backblaze's own documentation contradicts itself about these types in three separate places: the OpenAPI schema on `b2-list-buckets` marks `value` non-nullable while the prose states the opposite for both settings, and `defaultRetention.period` is typed as a string while the same page's examples show an object.

> If the client does not have readBucketEncryption app key capability, then isClientAuthorizedToRead is false and value is null.

Neither the schema nor the prose can be trusted to bound what arrives, and a parse error here would not stop at the budget: it would fail `b2_list_buckets`, that is, the connect. Trading a wrong budget for a broken connection is a far worse deal than the defect being fixed. `no_shape_of_either_field_can_break_the_bucket_listing` feeds seven hostile shapes through both fields and asserts the bucket still parses and still lands on the permissive budget.

**That contradiction is now settled by measurement, so nobody has to work it out again.** A live account whose key lacks `readBucketRetentions` returns:

```json
"fileLockConfiguration": {"isClientAuthorizedToRead": false, "value": null}
```

The prose is right and the OpenAPI schema is wrong. The tolerant parse was the correct call either way, but it is no longer a bet on which half of the documentation to believe.

## A correction that came with it

The check was not counting the one `X-Bz-Info` header uploads send, `src_last_modified_millis`, which B2 counts against the same budget as the name. That was already wrong at 7000 and merely invisible there; at 2048 those bytes are exactly the margin the check exists to catch.

## Why the scope grew, and by how much

This started as "read one field and pick one of two numbers". It is 602 insertions. Three things were added on purpose and each has a reason.

The **error hint**, because the permissive choice knowingly leaves a gap on buckets we cannot read, and a change that names a gap and then declines the few lines that mitigate it is worse than a slightly larger one.

The **`X-Bz-Info` accounting**, because a check called `validate_header_budget` that does not count what B2 counts is simply wrong, and was already wrong before this change.

**Object Lock**, because the thesis here is that the check must reflect what B2 actually imposes. Shipping with the other documented trigger left at 7000 would have made that thesis false in a case we can now name and quote. It was excluded earlier for a good reason, that its payload shape was undocumented; that reason stopped being true when the citation arrived.

## One derivation is ours

Object Lock is documented against the bucket, so that half needs no interpretation.

Encryption does. The 2048 limit is documented per file ("files that are encrypted with server-side encryption"), while default encryption is a property of the bucket. Backblaze separately documents that "All uploads to that bucket, from the time default encryption is enabled onward, will then be encrypted with SSE-B2 by default unless you explicitly specify SSE-C". That a bucket with default encryption gets the smaller budget follows from those two statements, each quoted in the code. It is derived from documented facts, not itself documented, and the code says so.

## What is deliberately not here

**Copy and rename get the budget check but not the after-the-fact hint.** Their bodies have many exit points and wrapping them would mean restructuring two functions to improve an error message, out of proportion to the mitigation. The check itself applies there and works.

**The S3-compatible path is out of scope.** Whether SSE-B2 changes ETag semantics on Backblaze's S3 endpoint is unverified, and settling it needs a live test rather than an inference from how AWS behaves.

## What was checked against a live account, state by state

A live B2 account was probed read-only, with temporary instrumentation that was reverted before this commit. The parser was confronted with real responses rather than only with fixtures, and the coverage is uneven, so it is listed per state rather than summarised.

**Verified on the wire.** Encryption `DoesNot`: the account returns `"defaultServerSideEncryption": {"isClientAuthorizedToRead": true, "value": {"algorithm": null, "mode": null}}`, the documented disabled shape, read here as not reducing. Object Lock `Unknown`: the same account's key lacks `readBucketRetentions` and the field comes back unauthorised with a null value, read here as unread.

**Cross-checked from a second, independent source.** The authorize response carries the key's capability list, and it contains `readBucketEncryption` but not `readBucketRetentions`. That is a different part of the API agreeing with what the wrapper said: the parser's two verdicts match the key's actual permissions.

**Not reachable on that account.** Encryption `Reduces` needs default encryption switched on for the bucket, which is a configuration write on a real bucket and was not done. Encryption `Unknown` cannot occur there at all, because the key is authorised for it. Object Lock `Reduces` and `DoesNot` need a key that may read retentions.

**Covered by unit tests only, and not observable live by anyone.** The undocumented and hostile payload shapes: they depend on B2 returning something other than what it documents, which is not in our gift to produce.

## Tests

Twenty, taking `b2.rs` from 38 to 58. They cover both triggers read independently, the Object Lock shape a naive reading would get backwards, the three distinct causes of a setting being unread, the budget each combination selects, the refusal text naming the reason it was refused for, the hint's contents and its silence when it has nothing to add, that only a `ServerError` is annotated, that the upload counts its own `fileInfo` entry, and the parse-safety guarantee above.

## What the review found, and what it did not

An automated review reported no actionable comments, and flagged something in its merge-risk paragraph anyway. Half of it was real and is fixed here; the other half was checked and is not.

**Confirmed and fixed.** `upload` validated the budget while charging the single-shot metadata entry, 38 bytes, before reading the file size and therefore before knowing which upload this would be. The large-file path sends no `fileInfo` at all: `b2_start_large_file` carries only `bucketId`, `fileName` and `contentType`. So for any file over the single-shot threshold the check was 38 bytes stricter than what actually goes on the wire, and a name between 2011 and 2048 bytes on a reduced budget would have been refused by us on an upload B2 would have accepted. That is the defect this change exists to remove, in miniature, and the permissive argument above condemns it directly.

The fix is not the one suggested. Moving the validation after the branch would have left the large path with no validation at all, because `upload_large_file` does not validate on its own: that trades a check which is too strict for a check which is absent. Instead `upload_info_extra(size)` decides the charge from the size, and both paths stay validated with what each actually sends. It is a free function so the decision can be tested without touching a filesystem, and the test asserts that a name of exactly 2048 bytes passes with the large-file charge and fails with the single-shot one: those 38 bytes are the whole difference at the edge.

One ordering change comes with it: the file's metadata is now read before the budget is validated, so a local file that does not exist reports that rather than the name length. That is the better order anyway.

**Checked and not confirmed.** The same paragraph pointed at the reconnect path. It was read and the defect is not there: `maybe_reauth` re-runs `resolve_bucket_id`, which rewrites the budget consistently. Reporting which half survives is worth more than applying both.

A later review of that fix raised three more, all real, and none was applied in the form proposed.

**The budget measured the raw name; the wire carries it percent-encoded.** The proposed remedy was to measure the encoded form.

An earlier draft of this section said Backblaze never states which form the cap applies to. That was wrong, and the correction is recorded here rather than quietly dropped. [cloud-storage-file-information](https://www.backblaze.com/docs/cloud-storage-file-information) says it explicitly: *"Backblaze B2 limits the combined header size for the file name and all file information to 7,000 bytes. This limit applies to the fully encoded HTTP header line, including the carriage-return and newline."* So for the standard budget the form **is** documented, it is the encoded one, and it includes the header line and the CRLF, neither of which this check counts. Measuring the raw name is therefore deliberately under-strict, not neutral.

The reduced budget is a different matter, and the documentation contradicts itself about it. The same page says the 2048 limit *"is only on the file information header names and values"*, which would exclude the file name entirely; [b2-upload-file](https://www.backblaze.com/apidocs/b2-upload-file) says *"The file name and file info must fit within a 7,000 byte limit. For files that are uploaded with Server-Side Encryption ... the size limit is reduced to 2,048 bytes"*, same subject with a lower cap. Under one reading a long name must be refused; under the other, refusing it refuses something B2 accepts. Lose that bet and we refuse names B2 accepts, on every name containing a space or an accent, which is the failure this whole change exists to remove. So refusal still happens only on the raw length, and a name that fits raw while overflowing encoded is let through with the difference recorded so a rejection explains itself.

What makes refusing on the raw form safe is simpler than weighing the readings: percent-encoding never shortens a string, so the encoded form is always at least the raw one, and refusing on the raw length cannot be stricter than B2 whichever form B2 counts. That holds under both readings, so the contradiction does not need resolving to make the decision, which is why it was not settled by writing to a real bucket: the measurement would have changed a comment, not a line of code. It is recorded as an open question with that reason attached, so it reads as one we chose not to answer rather than one we forgot.

**And in practice this check cannot currently refuse anything.** File names are capped separately: [cloud-storage-files](https://www.backblaze.com/docs/cloud-storage-files) says *"Names should be a UTF-8 string up to 1024 bytes"*. A legal name is therefore at most 1024 bytes raw, or 3072 encoded in the worst case, and with the 38 bytes of metadata this upload sends that is at most 1062 raw and 3110 encoded. Neither reaches 7000, and 1062 does not reach 2048 either. The refusal path can fire only on a name that already violates the 1024 rule, where it would blame the header budget for a name that is oversized for an entirely different reason.

So what this change actually delivers today is the hints, not the refusal, and the model behind the refusal needs revisiting with these three pages side by side. That is queued as its own change rather than rewritten here: the refusal measured against the encoded form, the 2048 applied to file information rather than to the name, the header line and CRLF counted, and the reduced budget speaking only through a hint. Doing it now would mean rewriting the core of this PR after a review has approved it on a different model, which is how an unreviewed defect gets in.

**A missing capability was blamed for every unread setting.** One of the causes is a key that *was* authorised and got back a payload we did not recognise; telling that user they lack `readBucketEncryption` states what the response itself contradicts. The causes are separate types now.

That fix is also the clearest argument in this PR for writing the test before believing the fix. The test written to confirm it failed, on a case the finding did not mention: the wrapper reader collapsed "denied" and "authorised but unusable" into one value as well, one level below where the finding pointed. Applying the finding literally and checking the result by eye would have removed the visible symptom and left the message lying from a different place, with nothing to show for it. The finding was right about where it hurt and wrong about where it came from, which is the normal case: an automated review is a good indicator and a poor specification.

**Between the two hints there was one case where nothing was said at all.** They measured different things against different budgets: the reduced-budget hint compared the raw name against 2048, the encoding hint compared the encoded name against whatever budget was in force, which on an unread bucket is 7000. A name of 700 raw bytes travels as 2100: the first sees 738 and stays quiet, the second sees 2138 against 7000 and stays quiet too. On a bucket that really is encrypted, that upload is refused and the user is told nothing. It sits exactly on the intersection of the two uncertainties this change is built around, and it is the one place where the change contradicts its own thesis. Both hints measure the encoded form now. That finding was marked trivial; the others were about saying something wrong, this one was about saying nothing.

Its test failed before the fix, but for the wrong reason: the first fixture used 670 spaces, which encode to exactly 2048, the boundary, so the hint was right to stay quiet. Red before and green after would have looked correct while proving nothing, because the fixture never entered the window it was meant to probe. A test that fails for a cause other than the one you are hunting looks exactly like a test that fails for the right one, so the test now asserts its own preconditions: that the raw form fits the reduced budget and the encoded form does not. If someone later changes the constant or the encoding and the fixture slides out of that window, the test says so instead of passing on.

**Every `ServerError` was being annotated with a header-budget hint**, and `map_b2_status` funnels 403, 503 and its catch-all into that single variant, so a permission error and an outage were answered with a note about file names. Only a 400 is annotated now, from the status already in scope rather than inferred from the message; where no status is available the hint is dropped rather than attached on a guess.

## Gates

All exit codes read without a pipe.

`cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`: 0.
`cargo clippy --manifest-path src-tauri/Cargo.toml --all-features --tests -- -D warnings`: 0.
`cargo clippy --manifest-path src-tauri/Cargo.toml --bin aeroftp-cli --all-features -- -D warnings`: 0.
`cargo test --manifest-path src-tauri/Cargo.toml`: 4135 passed, 0 failed, 65 ignored across 21 blocks. Two earlier attempts were killed by the environment during compilation and reported nothing; compiling and running as separate steps got a complete result.

Tracker: #628
