### PR TITLE
refactor(ftp): converge both FTP listing parsers onto one shared module

### DIFF
--- a/src-tauri/src/ftp.rs
+++ b/src-tauri/src/ftp.rs
@@ -42,6 +42,11 @@ pub struct RemoteFile {
     pub is_dir: bool,
     pub modified: Option<String>,
     pub permissions: Option<String>,
+    /// Where a symlink points. This side used to discard it and leave the
+    /// `name -> target` arrow inside `path`; PR-D needs it to align the
+    /// symlink contract across surfaces, and a surface with no data cannot
+    /// honour a contract.
+    pub link_target: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -827,129 +832,41 @@ impl FtpManager {
     }
 
     /// Parse FTP listing string into RemoteFile
+    /// Parse one listing row, through the shared parser in
+    /// `crate::providers::ftp_listing`.
+    ///
+    /// This used to be a second, drifted copy of that parser. The copies had
+    /// grown ten differences, and this side was the worse of the two: its DOS
+    /// dialect had no date guard, it matched `<DIR>` anywhere in the row, it
+    /// dropped symlink targets while leaving the arrow in the path, it kept
+    /// the `.` and `..` rows, and above all it had no way to FAIL. Any row it
+    /// did not understand became an entry anyway, with `is_dir` guessed from
+    /// whether the name contained a dot, so `total 12` at the head of an `ls`
+    /// listing arrived as a directory. An entry that is missing makes an
+    /// operation do nothing; an invented directory makes it do something.
+    ///
+    /// A row that is not a listing row is now an error, which the caller
+    /// already skips, instead of an invention.
     fn parse_ftp_listing(&self, listing: &str) -> Result<RemoteFile> {
         if listing.trim().is_empty() {
             return Err(FtpManagerError::InvalidPath("Empty listing".to_string()).into());
         }
-
-        debug!("Parsing FTP listing: {}", listing);
-
-        // Try to parse Unix-style listing first
-        if let Some(file) = self.parse_unix_listing(listing) {
-            debug!("Parsed as Unix: {} (is_dir: {})", file.name, file.is_dir);
-            return Ok(file);
-        }
-
-        // Try to parse DOS-style listing
-        if let Some(file) = self.parse_dos_listing(listing) {
-            debug!("Parsed as DOS: {} (is_dir: {})", file.name, file.is_dir);
-            return Ok(file);
-        }
-
-        // Fallback: treat as simple filename
-        // Check if it might be a directory (no extension, common dir indicators)
-        let name = listing.trim().to_string();
-        let is_likely_dir = !name.contains('.') || name == "." || name == "..";
-
-        debug!(
-            "Fallback parsing: {} (guessed is_dir: {})",
-            name, is_likely_dir
-        );
-
-        let path = if self.current_path.ends_with('/') {
-            format!("{}{}", self.current_path, name)
-        } else {
-            format!("{}/{}", self.current_path, name)
-        };
-
+        let entry = crate::providers::ftp_listing::parse_listing(listing, &self.current_path)
+            .ok_or_else(|| {
+                FtpManagerError::InvalidPath(format!("Unrecognised listing row: {listing}"))
+            })?;
         Ok(RemoteFile {
-            name,
-            path,
-            size: None,
-            is_dir: is_likely_dir,
-            modified: None,
-            permissions: None,
-        })
-    }
-
-    fn parse_unix_listing(&self, listing: &str) -> Option<RemoteFile> {
-        let parts: Vec<&str> = listing.split_whitespace().collect();
-        if parts.len() < 9 {
-            return None;
-        }
-
-        let permissions = parts[0];
-        let is_dir = permissions.starts_with('d');
-        let is_symlink = permissions.starts_with('l');
-
-        // Join all parts from index 8 onwards to handle filenames with spaces
-        // Unix listing format: permissions links owner group size month day time/year name...
-        let name = parts[8..].join(" ");
-        let size = parts.get(4).and_then(|s| s.parse().ok());
-
-        let modified = if parts.len() >= 8 {
-            Some(format!("{} {} {}", parts[5], parts[6], parts[7]))
-        } else {
-            None
-        };
-
-        let path = if self.current_path.ends_with('/') {
-            format!("{}{}", self.current_path, name)
-        } else {
-            format!("{}/{}", self.current_path, name)
-        };
-
-        let actual_name = if is_symlink && name.contains(" -> ") {
-            name.split(" -> ").next()?.to_string()
-        } else {
-            name
-        };
-
-        Some(RemoteFile {
-            name: actual_name,
-            path,
-            size,
-            is_dir,
-            modified,
-            permissions: Some(permissions.to_string()),
-        })
-    }
-
-    fn parse_dos_listing(&self, listing: &str) -> Option<RemoteFile> {
-        let parts: Vec<&str> = listing.split_whitespace().collect();
-        if parts.len() < 4 {
-            return None;
-        }
-
-        let is_dir = parts.contains(&"<DIR>");
-        let size = if is_dir {
-            None
-        } else {
-            parts.get(2).and_then(|s| s.parse().ok())
-        };
-
-        // DOS format: date time <DIR>/size name...
-        // Find the filename start (after date, time, and either <DIR> or size)
-        let name_start_idx = 3;
-        let name = if parts.len() > name_start_idx {
-            parts[name_start_idx..].join(" ")
-        } else {
-            parts.last()?.to_string()
-        };
-
-        let path = if self.current_path.ends_with('/') {
-            format!("{}{}", self.current_path, name)
-        } else {
-            format!("{}/{}", self.current_path, name)
-        };
-
-        Some(RemoteFile {
-            name,
-            path,
-            size,
-            is_dir,
-            modified: Some(format!("{} {}", parts[0], parts[1])),
-            permissions: None,
+            name: entry.name,
+            path: entry.path,
+            // `RemoteEntry.size` is a plain `u64`, so an unknown size arrives
+            // here as 0 and cannot be told from an empty file. That is a real
+            // loss against the old code on this side, and it is the reason the
+            // shared type is queued to grow an explicit "unknown".
+            size: Some(entry.size),
+            is_dir: entry.is_dir,
+            modified: entry.modified,
+            permissions: entry.permissions,
+            link_target: entry.link_target,
         })
     }
 }
@@ -958,4 +875,103 @@ impl Default for FtpManager {
     fn default() -> Self {
         Self::new()
     }
+}
+
+#[cfg(test)]
+mod charac_tests {
+    use super::*;
+
+    // Characterisation battery for the LEGACY listing parser, the twin of the
+    // one in providers/ftp.rs. Same input rows, so the two baselines can be
+    // diffed row by row and every behaviour change the convergence causes is
+    // enumerated rather than discovered. Pins today's behaviour, defects
+    // included.
+
+    const CHARAC_ROWS: &[&str] = &[
+        "drwxr-xr-x    2 user     group        4096 Jan 20 10:00 projects",
+        "-rw-r--r--    1 user     group         123 Jan 20 10:00 notes.txt",
+        "-rw-r--r--    1 user     group         123 Jan 20 10:00 my report.txt",
+        "-rw-r--r--    1 user     group         123 Jan 20 10:00 a  b.txt",
+        "lrwxrwxrwx    1 user     group           7 Jan 20 10:00 link -> target",
+        "lrwxrwxrwx    1 user     group           7 Jan 20 10:00 dangling",
+        "-rw-r--r--    1 user     group        ???? Jan 20 10:00 odd.txt",
+        "-rw-r--r-- 1 user group 123 Jan 20 10:00",
+        "drwxr-xr-x    2 user     group        4096 Jan 20 10:00 .",
+        "drwxr-xr-x    2 user     group        4096 Jan 20 10:00 ..",
+        "",
+        "total 12",
+        "01-23-24  10:30AM       <DIR>          folder",
+        "01-23-24  10:30AM           12345      file.txt",
+        "01-23-2024  10:30AM         12345      file.txt",
+        "01-23-24  10:30AM           12345      my file.txt",
+        "01-23-24 10:30AM 12345 a b c d e f",
+        "not-a-date 10:30AM <DIR> folder",
+        "drwxr-xr-x 2 1001 1001 4096 Jul 21 09:41 .",
+    ];
+
+    fn charac_table() -> String {
+        let m = FtpManager::new();
+        let mut out = String::new();
+        for line in CHARAC_ROWS {
+            let rendered = match m.parse_ftp_listing(line) {
+                Err(e) => format!("<err: {e}>"),
+                Ok(f) => format!(
+                    "name={:?} path={:?} dir={} size={:?} perms={:?} mod={:?}",
+                    f.name, f.path, f.is_dir, f.size, f.permissions, f.modified
+                ),
+            };
+            out.push_str(&format!("LIST {line:?}\n  {rendered}\n"));
+        }
+        out
+    }
+
+    #[test]
+    fn charac_legacy_listing_parser_behaviour_is_unchanged() {
+        let actual = charac_table();
+        assert_eq!(
+            actual.trim(),
+            CHARAC_BASELINE.trim(),
+            "\nthe legacy listing parser changed behaviour\n--- ACTUAL ---\n{actual}\n--- EXPECTED ---\n{}\n",
+            CHARAC_BASELINE
+        );
+    }
+
+    const CHARAC_BASELINE: &str = r#"LIST "drwxr-xr-x    2 user     group        4096 Jan 20 10:00 projects"
+  name="projects" path="/projects" dir=true size=Some(4096) perms=Some("drwxr-xr-x") mod=Some("Jan 20 10:00")
+LIST "-rw-r--r--    1 user     group         123 Jan 20 10:00 notes.txt"
+  name="notes.txt" path="/notes.txt" dir=false size=Some(123) perms=Some("-rw-r--r--") mod=Some("Jan 20 10:00")
+LIST "-rw-r--r--    1 user     group         123 Jan 20 10:00 my report.txt"
+  name="my report.txt" path="/my report.txt" dir=false size=Some(123) perms=Some("-rw-r--r--") mod=Some("Jan 20 10:00")
+LIST "-rw-r--r--    1 user     group         123 Jan 20 10:00 a  b.txt"
+  name="a b.txt" path="/a b.txt" dir=false size=Some(123) perms=Some("-rw-r--r--") mod=Some("Jan 20 10:00")
+LIST "lrwxrwxrwx    1 user     group           7 Jan 20 10:00 link -> target"
+  name="link" path="/link" dir=false size=Some(7) perms=Some("lrwxrwxrwx") mod=Some("Jan 20 10:00")
+LIST "lrwxrwxrwx    1 user     group           7 Jan 20 10:00 dangling"
+  name="dangling" path="/dangling" dir=false size=Some(7) perms=Some("lrwxrwxrwx") mod=Some("Jan 20 10:00")
+LIST "-rw-r--r--    1 user     group        ???? Jan 20 10:00 odd.txt"
+  name="odd.txt" path="/odd.txt" dir=false size=Some(0) perms=Some("-rw-r--r--") mod=Some("Jan 20 10:00")
+LIST "-rw-r--r-- 1 user group 123 Jan 20 10:00"
+  <err: Invalid path: Unrecognised listing row: -rw-r--r-- 1 user group 123 Jan 20 10:00>
+LIST "drwxr-xr-x    2 user     group        4096 Jan 20 10:00 ."
+  <err: Invalid path: Unrecognised listing row: drwxr-xr-x    2 user     group        4096 Jan 20 10:00 .>
+LIST "drwxr-xr-x    2 user     group        4096 Jan 20 10:00 .."
+  <err: Invalid path: Unrecognised listing row: drwxr-xr-x    2 user     group        4096 Jan 20 10:00 ..>
+LIST ""
+  <err: Invalid path: Empty listing>
+LIST "total 12"
+  <err: Invalid path: Unrecognised listing row: total 12>
+LIST "01-23-24  10:30AM       <DIR>          folder"
+  name="folder" path="/folder" dir=true size=Some(0) perms=None mod=Some("01-23-24 10:30AM")
+LIST "01-23-24  10:30AM           12345      file.txt"
+  name="file.txt" path="/file.txt" dir=false size=Some(12345) perms=None mod=Some("01-23-24 10:30AM")
+LIST "01-23-2024  10:30AM         12345      file.txt"
+  name="file.txt" path="/file.txt" dir=false size=Some(12345) perms=None mod=Some("01-23-2024 10:30AM")
+LIST "01-23-24  10:30AM           12345      my file.txt"
+  name="my file.txt" path="/my file.txt" dir=false size=Some(12345) perms=None mod=Some("01-23-24 10:30AM")
+LIST "01-23-24 10:30AM 12345 a b c d e f"
+  name="f" path="/f" dir=false size=Some(0) perms=Some("01-23-24") mod=Some("c d e")
+LIST "not-a-date 10:30AM <DIR> folder"
+  <err: Invalid path: Unrecognised listing row: not-a-date 10:30AM <DIR> folder>
+LIST "drwxr-xr-x 2 1001 1001 4096 Jul 21 09:41 ."
+  <err: Invalid path: Unrecognised listing row: drwxr-xr-x 2 1001 1001 4096 Jul 21 09:41 .>"#;
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -702,6 +702,7 @@ async fn aerovault_overlay_list(
                         is_dir: true,
                         modified: None,
                         permissions: None,
+                        link_target: None,
                     });
                 }
                 continue;
@@ -715,6 +716,7 @@ async fn aerovault_overlay_list(
                 is_dir: entry.is_dir,
                 modified: Some(entry.modified),
                 permissions: None,
+                link_target: None,
             });
         }
     } else {
@@ -763,6 +765,7 @@ async fn aerovault_overlay_list(
                         is_dir: true,
                         modified: None,
                         permissions: None,
+                        link_target: None,
                     });
                 }
                 continue;
@@ -790,6 +793,7 @@ async fn aerovault_overlay_list(
                 is_dir,
                 modified,
                 permissions: None,
+                link_target: None,
             });
         }
     }

--- a/src-tauri/src/providers/ftp.rs
+++ b/src-tauri/src/providers/ftp.rs
@@ -303,275 +303,15 @@ impl FtpProvider {
         ))
     }
 
-    /// Parse FTP listing into RemoteEntry
+    // The parsers themselves live in `super::ftp_listing`, shared with the
+    // legacy `crate::ftp::FtpManager`. These stay as thin methods so the call
+    // sites below read unchanged.
     fn parse_listing(&self, line: &str, base_path: &str) -> Option<RemoteEntry> {
-        // Try Unix format first, then DOS format
-        self.parse_unix_listing(line, base_path)
-            .or_else(|| self.parse_dos_listing(line, base_path))
+        super::ftp_listing::parse_listing(line, base_path)
     }
 
-    /// Shape check for the leading token of a DOS-style listing row:
-    /// `MM-DD-YY` or `MM-DD-YYYY`, all digits.
-    fn is_dos_date(token: &str) -> bool {
-        let mut fields = token.split('-');
-        let valid = match (fields.next(), fields.next(), fields.next()) {
-            (Some(month), Some(day), Some(year)) => {
-                [month, day].iter().all(|f| f.len() == 2)
-                    && (year.len() == 2 || year.len() == 4)
-                    && [month, day, year]
-                        .iter()
-                        .all(|f| f.bytes().all(|b| b.is_ascii_digit()))
-            }
-            _ => false,
-        };
-        valid && fields.next().is_none()
-    }
-
-    fn join_remote_path(base_path: &str, name: &str) -> String {
-        if name.starts_with('/') {
-            return name.to_string();
-        }
-
-        let trimmed_base = base_path.trim_end_matches('/');
-        if trimmed_base.is_empty() {
-            format!("/{}", name.trim_start_matches('/'))
-        } else {
-            format!("{}/{}", trimmed_base, name.trim_start_matches('/'))
-        }
-    }
-
-    fn normalize_mlsd_name(name: &str) -> String {
-        let trimmed = name.trim_end_matches('/');
-        std::path::Path::new(trimmed)
-            .file_name()
-            .map(|value| value.to_string_lossy().to_string())
-            .filter(|value| !value.is_empty())
-            .unwrap_or_else(|| name.to_string())
-    }
-
-    /// Parse Unix-style listing (ls -l format)
-    fn parse_unix_listing(&self, line: &str, base_path: &str) -> Option<RemoteEntry> {
-        let parts: Vec<&str> = line.split_whitespace().collect();
-        if parts.len() < 9 {
-            return None;
-        }
-
-        let permissions = parts[0];
-        let is_dir = permissions.starts_with('d');
-        let is_symlink = permissions.starts_with('l');
-
-        // Get size (might be in different position depending on format)
-        let size: u64 = parts[4].parse().unwrap_or(0);
-
-        // Name is everything after the 8th part (to handle spaces in names)
-        let name = parts[8..].join(" ");
-
-        // Handle symlinks (name -> target)
-        let (actual_name, link_target) = if is_symlink && name.contains(" -> ") {
-            let parts: Vec<&str> = name.splitn(2, " -> ").collect();
-            (
-                parts[0].to_string(),
-                Some(parts.get(1).unwrap_or(&"").to_string()),
-            )
-        } else {
-            (name, None)
-        };
-
-        // Skip . and .. entries
-        if actual_name == "." || actual_name == ".." {
-            return None;
-        }
-
-        let path = Self::join_remote_path(base_path, &actual_name);
-
-        // Parse date (parts[5..8] typically contain month day time/year)
-        let modified = if parts.len() >= 8 {
-            Some(format!("{} {} {}", parts[5], parts[6], parts[7]))
-        } else {
-            None
-        };
-
-        Some(RemoteEntry {
-            name: actual_name,
-            path,
-            is_dir,
-            size,
-            modified,
-            permissions: Some(permissions.to_string()),
-            owner: Some(parts[2].to_string()),
-            group: Some(parts[3].to_string()),
-            is_symlink,
-            link_target,
-            mime_type: None,
-            metadata: Default::default(),
-        })
-    }
-
-    /// Parse DOS-style listing (Windows FTP servers)
-    fn parse_dos_listing(&self, line: &str, base_path: &str) -> Option<RemoteEntry> {
-        // DOS format: 01-23-24  10:30AM       <DIR>          folder_name
-        // Or:         01-23-24  10:30AM           12345      file.txt
-
-        let parts: Vec<&str> = line.split_whitespace().collect();
-        if parts.len() < 4 {
-            return None;
-        }
-
-        // A DOS row always opens with a `MM-DD-YY[YY]` date. Requiring the
-        // shape keeps this parser from resurrecting a Unix line that
-        // parse_unix_listing already rejected (e.g. the "." / ".." rows that
-        // `LIST -a` adds): a Unix permissions field never looks like a date.
-        if !Self::is_dos_date(parts[0]) {
-            return None;
-        }
-
-        // In the DOS format parts[2] is always either "<DIR>" or the numeric
-        // size. Requiring that alone is NOT enough: on a server that renders
-        // owner/group as numeric ids (vsftpd's default text_userdb_names=NO)
-        // the Unix "." row `drwxr-xr-x 2 1001 1001 4096 Jul 21 09:41 .` has a
-        // numeric parts[2] (the uid) and would otherwise become a bogus file
-        // named "1001 4096 Jul 21 09:41 ." that recursive delete then DELEs,
-        // which the server answers with `550 Delete operation failed`.
-        let is_dir = parts[2] == "<DIR>";
-        let size: u64 = if is_dir {
-            0
-        } else {
-            match parts[2].parse() {
-                Ok(value) => value,
-                Err(_) => return None,
-            }
-        };
-        let name = parts[3..].join(" ");
-
-        // Skip . and .. entries
-        if name == "." || name == ".." {
-            return None;
-        }
-
-        let path = Self::join_remote_path(base_path, &name);
-
-        let modified = Some(format!("{} {}", parts[0], parts[1]));
-
-        Some(RemoteEntry {
-            name,
-            path,
-            is_dir,
-            size,
-            modified,
-            permissions: None,
-            owner: None,
-            group: None,
-            is_symlink: false,
-            link_target: None,
-            mime_type: None,
-            metadata: Default::default(),
-        })
-    }
-
-    /// Parse MLSD/MLST line (RFC 3659 machine-readable format)
-    /// Format: "fact1=val1;fact2=val2; filename"
     fn parse_mlsd_entry(&self, line: &str, base_path: &str) -> Option<RemoteEntry> {
-        // Split on first space after semicolons to get facts and filename
-        let (facts_str, name) = line.split_once(' ')?;
-        let raw_name = name.trim();
-        let name = Self::normalize_mlsd_name(raw_name);
-
-        if name == "." || name == ".." {
-            return None;
-        }
-
-        let mut is_dir = false;
-        let mut is_symlink = false;
-        let mut size: u64 = 0;
-        let mut modified: Option<String> = None;
-        let mut permissions: Option<String> = None;
-        let mut owner: Option<String> = None;
-        let mut group: Option<String> = None;
-
-        for fact in facts_str.split(';') {
-            let fact = fact.trim();
-            if fact.is_empty() {
-                continue;
-            }
-            let (key, value) = match fact.split_once('=') {
-                Some((k, v)) => (k.to_lowercase(), v),
-                None => continue,
-            };
-
-            match key.as_str() {
-                "type" => {
-                    let v_lower = value.to_lowercase();
-                    is_dir = v_lower == "dir" || v_lower == "cdir" || v_lower == "pdir";
-                    is_symlink = v_lower == "os.unix=symlink" || v_lower == "os.unix=slink";
-                }
-                "size" | "sizd" => {
-                    size = value.parse().unwrap_or(0);
-                }
-                "modify" => {
-                    // YYYYMMDDHHMMSS[.sss] → format nicely
-                    modified = Some(Self::format_mlsd_time(value));
-                }
-                "unix.mode" => {
-                    permissions = Some(value.to_string());
-                }
-                "unix.owner" | "unix.uid" => {
-                    owner = Some(value.to_string());
-                }
-                "unix.group" | "unix.gid" => {
-                    group = Some(value.to_string());
-                }
-                "perm"
-                    // MLSD perm facts (e.g. "rwcedf") - store as metadata
-                    if permissions.is_none() => {
-                        permissions = Some(value.to_string());
-                    }
-                _ => {}
-            }
-        }
-
-        // Skip cdir/pdir (current/parent directory entries)
-        if facts_str.to_lowercase().contains("type=cdir")
-            || facts_str.to_lowercase().contains("type=pdir")
-        {
-            return None;
-        }
-
-        let path = Self::join_remote_path(base_path, raw_name);
-
-        Some(RemoteEntry {
-            name,
-            path,
-            is_dir,
-            size,
-            modified,
-            permissions,
-            owner,
-            group,
-            is_symlink,
-            link_target: None,
-            mime_type: None,
-            metadata: Default::default(),
-        })
-    }
-
-    /// Format MLSD timestamp (YYYYMMDDHHMMSS) to readable form.
-    /// Appends 'Z' suffix because MLSD timestamps are always UTC per RFC 3659.
-    fn format_mlsd_time(ts: &str) -> String {
-        if ts.len() >= 14 {
-            format!(
-                "{}-{}-{} {}:{}:{}Z",
-                &ts[0..4],
-                &ts[4..6],
-                &ts[6..8],
-                &ts[8..10],
-                &ts[10..12],
-                &ts[12..14]
-            )
-        } else if ts.len() >= 8 {
-            format!("{}-{}-{}", &ts[0..4], &ts[4..6], &ts[6..8])
-        } else {
-            ts.to_string()
-        }
+        super::ftp_listing::parse_mlsd_entry(line, base_path)
     }
 
     fn is_stale_data_connection_error(err: &ProviderError) -> bool {
@@ -2163,9 +1903,17 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_parse_unix_listing() {
-        let provider = FtpProvider::new(FtpConfig {
+    // ── Characterisation battery for the listing parser ────────────────────
+    //
+    // These exist to prove that moving the parser into a shared module changes
+    // NOTHING. They pin today's behaviour, defects included: where the parser
+    // is wrong the baseline records the wrong answer, marked DEFECT. Changing
+    // an expectation here to make it look right would destroy the only
+    // evidence that the move preserved behaviour. Fixes belong to a later
+    // change, which will edit this baseline deliberately and say why.
+
+    fn charac_provider() -> FtpProvider {
+        FtpProvider::new(FtpConfig {
             host: "test".to_string(),
             port: 21,
             username: "user".to_string(),
@@ -2173,10 +1921,195 @@ mod tests {
             tls_mode: FtpTlsMode::None,
             verify_cert: true,
             initial_path: None,
-        });
+        })
+    }
 
+    const CHARAC_LIST_ROWS: &[(&str, &str)] = &[
+        (
+            "drwxr-xr-x    2 user     group        4096 Jan 20 10:00 projects",
+            "/",
+        ),
+        (
+            "-rw-r--r--    1 user     group         123 Jan 20 10:00 notes.txt",
+            "/",
+        ),
+        (
+            "-rw-r--r--    1 user     group         123 Jan 20 10:00 my report.txt",
+            "/",
+        ),
+        // DEFECT: runs of spaces inside a name are collapsed to one.
+        (
+            "-rw-r--r--    1 user     group         123 Jan 20 10:00 a  b.txt",
+            "/",
+        ),
+        (
+            "lrwxrwxrwx    1 user     group           7 Jan 20 10:00 link -> target",
+            "/",
+        ),
+        (
+            "lrwxrwxrwx    1 user     group           7 Jan 20 10:00 dangling",
+            "/",
+        ),
+        // DEFECT: an unparseable size becomes 0, indistinguishable from empty.
+        (
+            "-rw-r--r--    1 user     group        ???? Jan 20 10:00 odd.txt",
+            "/",
+        ),
+        // DEFECT: fewer than nine tokens is dropped in silence.
+        ("-rw-r--r-- 1 user group 123 Jan 20 10:00", "/"),
+        (
+            "drwxr-xr-x    2 user     group        4096 Jan 20 10:00 .",
+            "/",
+        ),
+        (
+            "drwxr-xr-x    2 user     group        4096 Jan 20 10:00 ..",
+            "/",
+        ),
+        (
+            "-rw-r--r--    1 user     group         123 Jan 20 10:00 f.txt",
+            "/scope",
+        ),
+        (
+            "-rw-r--r--    1 user     group         123 Jan 20 10:00 f.txt",
+            "/scope/",
+        ),
+        ("", "/"),
+        ("total 12", "/"),
+        ("01-23-24  10:30AM       <DIR>          folder", "/"),
+        ("01-23-24  10:30AM           12345      file.txt", "/"),
+        ("01-23-2024  10:30AM         12345      file.txt", "/"),
+        ("01-23-24  10:30AM           12345      my file.txt", "/"),
+        // DEFECT: a DOS row with a long enough name reaches nine tokens and is
+        // taken by the Unix parser first, because the dispatch tries Unix and
+        // only falls back when it fails.
+        ("01-23-24 10:30AM 12345 a b c d e f", "/"),
+        ("not-a-date 10:30AM <DIR> folder", "/"),
+        // The DOS parser's guard: a Unix row with numeric owner/group must not
+        // be resurrected as a DOS file.
+        ("drwxr-xr-x 2 1001 1001 4096 Jul 21 09:41 .", "/"),
+    ];
+
+    const CHARAC_MLSD_ROWS: &[(&str, &str)] = &[
+        ("type=dir;modify=20260120100000; projects", "/home"),
+        (
+            "type=file;size=123;modify=20260120100000; notes.txt",
+            "/home",
+        ),
+        (
+            "type=file;size=123;modify=20260120100000; my report.txt",
+            "/home",
+        ),
+        (
+            "type=file;size=????;modify=20260120100000; odd.txt",
+            "/home",
+        ),
+        ("type=cdir;modify=20260101000000; .", "/"),
+        ("type=pdir;modify=20260101000000; ..", "/"),
+        ("type=file;size=1; /absolute/path/name.txt", "/"),
+        ("no-facts-here", "/"),
+    ];
+
+    fn charac_table() -> String {
+        let p = charac_provider();
+        let mut out = String::new();
+        for (line, base) in CHARAC_LIST_ROWS {
+            let rendered = match p.parse_listing(line, base) {
+                None => "<none>".to_string(),
+                Some(e) => format!(
+                    "name={:?} path={:?} dir={} size={} sym={} link={:?} perms={:?} owner={:?} group={:?} mod={:?}",
+                    e.name, e.path, e.is_dir, e.size, e.is_symlink, e.link_target,
+                    e.permissions, e.owner, e.group, e.modified
+                ),
+            };
+            out.push_str(&format!("LIST {line:?} @ {base:?}\n  {rendered}\n"));
+        }
+        for (line, base) in CHARAC_MLSD_ROWS {
+            let rendered = match p.parse_mlsd_entry(line, base) {
+                None => "<none>".to_string(),
+                Some(e) => format!(
+                    "name={:?} path={:?} dir={} size={} mod={:?}",
+                    e.name, e.path, e.is_dir, e.size, e.modified
+                ),
+            };
+            out.push_str(&format!("MLSD {line:?} @ {base:?}\n  {rendered}\n"));
+        }
+        out
+    }
+
+    #[test]
+    fn charac_listing_parser_behaviour_is_unchanged() {
+        let actual = charac_table();
+        assert_eq!(
+            actual.trim(),
+            CHARAC_BASELINE.trim(),
+            "\nthe listing parser changed behaviour\n--- ACTUAL ---\n{actual}\n--- EXPECTED ---\n{}\n",
+            CHARAC_BASELINE
+        );
+    }
+
+    const CHARAC_BASELINE: &str = r#"LIST "drwxr-xr-x    2 user     group        4096 Jan 20 10:00 projects" @ "/"
+  name="projects" path="/projects" dir=true size=4096 sym=false link=None perms=Some("drwxr-xr-x") owner=Some("user") group=Some("group") mod=Some("Jan 20 10:00")
+LIST "-rw-r--r--    1 user     group         123 Jan 20 10:00 notes.txt" @ "/"
+  name="notes.txt" path="/notes.txt" dir=false size=123 sym=false link=None perms=Some("-rw-r--r--") owner=Some("user") group=Some("group") mod=Some("Jan 20 10:00")
+LIST "-rw-r--r--    1 user     group         123 Jan 20 10:00 my report.txt" @ "/"
+  name="my report.txt" path="/my report.txt" dir=false size=123 sym=false link=None perms=Some("-rw-r--r--") owner=Some("user") group=Some("group") mod=Some("Jan 20 10:00")
+LIST "-rw-r--r--    1 user     group         123 Jan 20 10:00 a  b.txt" @ "/"
+  name="a b.txt" path="/a b.txt" dir=false size=123 sym=false link=None perms=Some("-rw-r--r--") owner=Some("user") group=Some("group") mod=Some("Jan 20 10:00")
+LIST "lrwxrwxrwx    1 user     group           7 Jan 20 10:00 link -> target" @ "/"
+  name="link" path="/link" dir=false size=7 sym=true link=Some("target") perms=Some("lrwxrwxrwx") owner=Some("user") group=Some("group") mod=Some("Jan 20 10:00")
+LIST "lrwxrwxrwx    1 user     group           7 Jan 20 10:00 dangling" @ "/"
+  name="dangling" path="/dangling" dir=false size=7 sym=true link=None perms=Some("lrwxrwxrwx") owner=Some("user") group=Some("group") mod=Some("Jan 20 10:00")
+LIST "-rw-r--r--    1 user     group        ???? Jan 20 10:00 odd.txt" @ "/"
+  name="odd.txt" path="/odd.txt" dir=false size=0 sym=false link=None perms=Some("-rw-r--r--") owner=Some("user") group=Some("group") mod=Some("Jan 20 10:00")
+LIST "-rw-r--r-- 1 user group 123 Jan 20 10:00" @ "/"
+  <none>
+LIST "drwxr-xr-x    2 user     group        4096 Jan 20 10:00 ." @ "/"
+  <none>
+LIST "drwxr-xr-x    2 user     group        4096 Jan 20 10:00 .." @ "/"
+  <none>
+LIST "-rw-r--r--    1 user     group         123 Jan 20 10:00 f.txt" @ "/scope"
+  name="f.txt" path="/scope/f.txt" dir=false size=123 sym=false link=None perms=Some("-rw-r--r--") owner=Some("user") group=Some("group") mod=Some("Jan 20 10:00")
+LIST "-rw-r--r--    1 user     group         123 Jan 20 10:00 f.txt" @ "/scope/"
+  name="f.txt" path="/scope/f.txt" dir=false size=123 sym=false link=None perms=Some("-rw-r--r--") owner=Some("user") group=Some("group") mod=Some("Jan 20 10:00")
+LIST "" @ "/"
+  <none>
+LIST "total 12" @ "/"
+  <none>
+LIST "01-23-24  10:30AM       <DIR>          folder" @ "/"
+  name="folder" path="/folder" dir=true size=0 sym=false link=None perms=None owner=None group=None mod=Some("01-23-24 10:30AM")
+LIST "01-23-24  10:30AM           12345      file.txt" @ "/"
+  name="file.txt" path="/file.txt" dir=false size=12345 sym=false link=None perms=None owner=None group=None mod=Some("01-23-24 10:30AM")
+LIST "01-23-2024  10:30AM         12345      file.txt" @ "/"
+  name="file.txt" path="/file.txt" dir=false size=12345 sym=false link=None perms=None owner=None group=None mod=Some("01-23-2024 10:30AM")
+LIST "01-23-24  10:30AM           12345      my file.txt" @ "/"
+  name="my file.txt" path="/my file.txt" dir=false size=12345 sym=false link=None perms=None owner=None group=None mod=Some("01-23-24 10:30AM")
+LIST "01-23-24 10:30AM 12345 a b c d e f" @ "/"
+  name="f" path="/f" dir=false size=0 sym=false link=None perms=Some("01-23-24") owner=Some("12345") group=Some("a") mod=Some("c d e")
+LIST "not-a-date 10:30AM <DIR> folder" @ "/"
+  <none>
+LIST "drwxr-xr-x 2 1001 1001 4096 Jul 21 09:41 ." @ "/"
+  <none>
+MLSD "type=dir;modify=20260120100000; projects" @ "/home"
+  name="projects" path="/home/projects" dir=true size=0 mod=Some("2026-01-20 10:00:00Z")
+MLSD "type=file;size=123;modify=20260120100000; notes.txt" @ "/home"
+  name="notes.txt" path="/home/notes.txt" dir=false size=123 mod=Some("2026-01-20 10:00:00Z")
+MLSD "type=file;size=123;modify=20260120100000; my report.txt" @ "/home"
+  name="my report.txt" path="/home/my report.txt" dir=false size=123 mod=Some("2026-01-20 10:00:00Z")
+MLSD "type=file;size=????;modify=20260120100000; odd.txt" @ "/home"
+  name="odd.txt" path="/home/odd.txt" dir=false size=0 mod=Some("2026-01-20 10:00:00Z")
+MLSD "type=cdir;modify=20260101000000; ." @ "/"
+  <none>
+MLSD "type=pdir;modify=20260101000000; .." @ "/"
+  <none>
+MLSD "type=file;size=1; /absolute/path/name.txt" @ "/"
+  name="name.txt" path="/absolute/path/name.txt" dir=false size=1 mod=None
+MLSD "no-facts-here" @ "/"
+  <none>"#;
+
+    #[test]
+    fn test_parse_unix_listing() {
         let line = "drwxr-xr-x    2 user     group        4096 Jan 20 10:00 projects";
-        let entry = provider.parse_unix_listing(line, "/").unwrap();
+        let entry = super::super::ftp_listing::parse_unix_listing(line, "/").unwrap();
 
         assert_eq!(entry.name, "projects");
         assert!(entry.is_dir);
@@ -2324,18 +2257,8 @@ mod tests {
 
     #[test]
     fn test_parse_dos_listing() {
-        let provider = FtpProvider::new(FtpConfig {
-            host: "test".to_string(),
-            port: 21,
-            username: "user".to_string(),
-            password: "pass".to_string().into(),
-            tls_mode: FtpTlsMode::None,
-            verify_cert: true,
-            initial_path: None,
-        });
-
         let line = "01-20-26  10:00AM       <DIR>          Projects";
-        let entry = provider.parse_dos_listing(line, "/").unwrap();
+        let entry = super::super::ftp_listing::parse_dos_listing(line, "/").unwrap();
 
         assert_eq!(entry.name, "Projects");
         assert!(entry.is_dir);

--- a/src-tauri/src/providers/ftp_listing.rs
+++ b/src-tauri/src/providers/ftp_listing.rs
@@ -1,0 +1,286 @@
+//! The FTP listing parser, shared by both FTP implementations.
+//!
+//! Two of them exist: `providers::ftp::FtpProvider` and the legacy
+//! `crate::ftp::FtpManager`, which the AI agent fallback, `gui_tools`,
+//! `cloud_service`, the transfer-queue scan and the no-protocol branch of the
+//! file panel all still reach. Each carried its own copy of this parser and the
+//! copies had drifted apart, so a defect fixed in one stayed open in the other.
+//!
+//! Everything here is pure: a line of text and a base path in, an entry out.
+//! No I/O, no connection, no `self`. That is not tidiness, it is the only way
+//! to test the cases a live server cannot be made to produce on demand: DOS
+//! listings, rows with missing columns, servers without MLSD.
+//!
+//! The three formats are one question with three grammars, so they live
+//! together: `LIST` in its Unix and DOS dialects, and RFC 3659 `MLSD`.
+
+use super::types::RemoteEntry;
+
+pub(crate) fn parse_listing(line: &str, base_path: &str) -> Option<RemoteEntry> {
+    // Try Unix format first, then DOS format
+    parse_unix_listing(line, base_path).or_else(|| parse_dos_listing(line, base_path))
+}
+
+/// Shape check for the leading token of a DOS-style listing row:
+/// `MM-DD-YY` or `MM-DD-YYYY`, all digits.
+pub(crate) fn is_dos_date(token: &str) -> bool {
+    let mut fields = token.split('-');
+    let valid = match (fields.next(), fields.next(), fields.next()) {
+        (Some(month), Some(day), Some(year)) => {
+            [month, day].iter().all(|f| f.len() == 2)
+                && (year.len() == 2 || year.len() == 4)
+                && [month, day, year]
+                    .iter()
+                    .all(|f| f.bytes().all(|b| b.is_ascii_digit()))
+        }
+        _ => false,
+    };
+    valid && fields.next().is_none()
+}
+
+pub(crate) fn join_remote_path(base_path: &str, name: &str) -> String {
+    if name.starts_with('/') {
+        return name.to_string();
+    }
+
+    let trimmed_base = base_path.trim_end_matches('/');
+    if trimmed_base.is_empty() {
+        format!("/{}", name.trim_start_matches('/'))
+    } else {
+        format!("{}/{}", trimmed_base, name.trim_start_matches('/'))
+    }
+}
+
+pub(crate) fn normalize_mlsd_name(name: &str) -> String {
+    let trimmed = name.trim_end_matches('/');
+    std::path::Path::new(trimmed)
+        .file_name()
+        .map(|value| value.to_string_lossy().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| name.to_string())
+}
+
+/// Parse Unix-style listing (ls -l format)
+pub(crate) fn parse_unix_listing(line: &str, base_path: &str) -> Option<RemoteEntry> {
+    let parts: Vec<&str> = line.split_whitespace().collect();
+    if parts.len() < 9 {
+        return None;
+    }
+
+    let permissions = parts[0];
+    let is_dir = permissions.starts_with('d');
+    let is_symlink = permissions.starts_with('l');
+
+    // Get size (might be in different position depending on format)
+    let size: u64 = parts[4].parse().unwrap_or(0);
+
+    // Name is everything after the 8th part (to handle spaces in names)
+    let name = parts[8..].join(" ");
+
+    // Handle symlinks (name -> target)
+    let (actual_name, link_target) = if is_symlink && name.contains(" -> ") {
+        let parts: Vec<&str> = name.splitn(2, " -> ").collect();
+        (
+            parts[0].to_string(),
+            Some(parts.get(1).unwrap_or(&"").to_string()),
+        )
+    } else {
+        (name, None)
+    };
+
+    // Skip . and .. entries
+    if actual_name == "." || actual_name == ".." {
+        return None;
+    }
+
+    let path = join_remote_path(base_path, &actual_name);
+
+    // Parse date (parts[5..8] typically contain month day time/year)
+    let modified = if parts.len() >= 8 {
+        Some(format!("{} {} {}", parts[5], parts[6], parts[7]))
+    } else {
+        None
+    };
+
+    Some(RemoteEntry {
+        name: actual_name,
+        path,
+        is_dir,
+        size,
+        modified,
+        permissions: Some(permissions.to_string()),
+        owner: Some(parts[2].to_string()),
+        group: Some(parts[3].to_string()),
+        is_symlink,
+        link_target,
+        mime_type: None,
+        metadata: Default::default(),
+    })
+}
+
+/// Parse DOS-style listing (Windows FTP servers)
+pub(crate) fn parse_dos_listing(line: &str, base_path: &str) -> Option<RemoteEntry> {
+    // DOS format: 01-23-24  10:30AM       <DIR>          folder_name
+    // Or:         01-23-24  10:30AM           12345      file.txt
+
+    let parts: Vec<&str> = line.split_whitespace().collect();
+    if parts.len() < 4 {
+        return None;
+    }
+
+    // A DOS row always opens with a `MM-DD-YY[YY]` date. Requiring the
+    // shape keeps this parser from resurrecting a Unix line that
+    // parse_unix_listing already rejected (e.g. the "." / ".." rows that
+    // `LIST -a` adds): a Unix permissions field never looks like a date.
+    if !is_dos_date(parts[0]) {
+        return None;
+    }
+
+    // In the DOS format parts[2] is always either "<DIR>" or the numeric
+    // size. Requiring that alone is NOT enough: on a server that renders
+    // owner/group as numeric ids (vsftpd's default text_userdb_names=NO)
+    // the Unix "." row `drwxr-xr-x 2 1001 1001 4096 Jul 21 09:41 .` has a
+    // numeric parts[2] (the uid) and would otherwise become a bogus file
+    // named "1001 4096 Jul 21 09:41 ." that recursive delete then DELEs,
+    // which the server answers with `550 Delete operation failed`.
+    let is_dir = parts[2] == "<DIR>";
+    let size: u64 = if is_dir {
+        0
+    } else {
+        match parts[2].parse() {
+            Ok(value) => value,
+            Err(_) => return None,
+        }
+    };
+    let name = parts[3..].join(" ");
+
+    // Skip . and .. entries
+    if name == "." || name == ".." {
+        return None;
+    }
+
+    let path = join_remote_path(base_path, &name);
+
+    let modified = Some(format!("{} {}", parts[0], parts[1]));
+
+    Some(RemoteEntry {
+        name,
+        path,
+        is_dir,
+        size,
+        modified,
+        permissions: None,
+        owner: None,
+        group: None,
+        is_symlink: false,
+        link_target: None,
+        mime_type: None,
+        metadata: Default::default(),
+    })
+}
+
+/// Parse MLSD/MLST line (RFC 3659 machine-readable format)
+/// Format: "fact1=val1;fact2=val2; filename"
+pub(crate) fn parse_mlsd_entry(line: &str, base_path: &str) -> Option<RemoteEntry> {
+    // Split on first space after semicolons to get facts and filename
+    let (facts_str, name) = line.split_once(' ')?;
+    let raw_name = name.trim();
+    let name = normalize_mlsd_name(raw_name);
+
+    if name == "." || name == ".." {
+        return None;
+    }
+
+    let mut is_dir = false;
+    let mut is_symlink = false;
+    let mut size: u64 = 0;
+    let mut modified: Option<String> = None;
+    let mut permissions: Option<String> = None;
+    let mut owner: Option<String> = None;
+    let mut group: Option<String> = None;
+
+    for fact in facts_str.split(';') {
+        let fact = fact.trim();
+        if fact.is_empty() {
+            continue;
+        }
+        let (key, value) = match fact.split_once('=') {
+            Some((k, v)) => (k.to_lowercase(), v),
+            None => continue,
+        };
+
+        match key.as_str() {
+            "type" => {
+                let v_lower = value.to_lowercase();
+                is_dir = v_lower == "dir" || v_lower == "cdir" || v_lower == "pdir";
+                is_symlink = v_lower == "os.unix=symlink" || v_lower == "os.unix=slink";
+            }
+            "size" | "sizd" => {
+                size = value.parse().unwrap_or(0);
+            }
+            "modify" => {
+                // YYYYMMDDHHMMSS[.sss] → format nicely
+                modified = Some(format_mlsd_time(value));
+            }
+            "unix.mode" => {
+                permissions = Some(value.to_string());
+            }
+            "unix.owner" | "unix.uid" => {
+                owner = Some(value.to_string());
+            }
+            "unix.group" | "unix.gid" => {
+                group = Some(value.to_string());
+            }
+            "perm"
+                // MLSD perm facts (e.g. "rwcedf") - store as metadata
+                if permissions.is_none() => {
+                    permissions = Some(value.to_string());
+                }
+            _ => {}
+        }
+    }
+
+    // Skip cdir/pdir (current/parent directory entries)
+    if facts_str.to_lowercase().contains("type=cdir")
+        || facts_str.to_lowercase().contains("type=pdir")
+    {
+        return None;
+    }
+
+    let path = join_remote_path(base_path, raw_name);
+
+    Some(RemoteEntry {
+        name,
+        path,
+        is_dir,
+        size,
+        modified,
+        permissions,
+        owner,
+        group,
+        is_symlink,
+        link_target: None,
+        mime_type: None,
+        metadata: Default::default(),
+    })
+}
+
+/// Format MLSD timestamp (YYYYMMDDHHMMSS) to readable form.
+/// Appends 'Z' suffix because MLSD timestamps are always UTC per RFC 3659.
+pub(crate) fn format_mlsd_time(ts: &str) -> String {
+    if ts.len() >= 14 {
+        format!(
+            "{}-{}-{} {}:{}:{}Z",
+            &ts[0..4],
+            &ts[4..6],
+            &ts[6..8],
+            &ts[8..10],
+            &ts[10..12],
+            &ts[12..14]
+        )
+    } else if ts.len() >= 8 {
+        format!("{}-{}-{}", &ts[0..4], &ts[4..6], &ts[6..8])
+    } else {
+        ts.to_string()
+    }
+}

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -34,6 +34,7 @@ pub mod filelu;
 pub mod filen;
 pub mod fourshared;
 pub mod ftp;
+pub mod ftp_listing;
 pub mod github;
 pub mod gitlab;
 pub mod google_drive;


### PR DESCRIPTION
## Why this is not a pure move

Two FTP implementations exist and each carried its own copy of the listing parser. `providers::ftp::FtpProvider` is the one most surfaces use; the legacy `crate::ftp::FtpManager` is still reached by the AI agent fallback, `gui_tools`, `cloud_service`, the transfer-queue scan and the file panel's no-protocol branch. The copies had drifted apart, so a defect fixed in one stayed open in the other, and every later fix in this campaign would have had to be written twice or would have quietly covered only half the product.

The plan was a pure move. It cannot be one: the copies differ in ten measurable ways, and no shared module can serve both without changing one of them. Preserving both behaviours would mean a parser whose API carries six flags whose only purpose is to keep a defect alive, and a later change would have to remove them again.

The point of separating a move from a fix is that a regression stays attributable. Purity was the means, not the goal, so the goal is met here with evidence instead: a characterisation battery of the same synthetic rows was frozen against **both** parsers before the change. The provider's baseline is byte-identical afterwards, which is the proof that side did not move. The legacy's differences are enumerated below, every one of them.

Nothing was fixed here. Each of the ten changes is the legacy adopting what the provider already did.

## The ten changes, row by row

| # | row | before | after | reaches consumers |
|---|---|---|---|---|
| 1 | `lrwxrwxrwx    1 user     group           7 Jan 20 10:00 link -> target` | name="link" path="/link -> target" dir=false size=Some(7) perms=Some("lrwxrwxrwx") mod=Some("Jan 20 10:00") | name="link" path="/link" dir=false size=Some(7) perms=Some("lrwxrwxrwx") mod=Some("Jan 20 10:00") | yes |
| 2 | `-rw-r--r--    1 user     group        ???? Jan 20 10:00 odd.txt` | name="odd.txt" path="/odd.txt" dir=false size=None perms=Some("-rw-r--r--") mod=Some("Jan 20 10:00") | name="odd.txt" path="/odd.txt" dir=false size=Some(0) perms=Some("-rw-r--r--") mod=Some("Jan 20 10:00") | yes |
| 3 | `-rw-r--r-- 1 user group 123 Jan 20 10:00` | name="group 123 Jan 20 10:00" path="/group 123 Jan 20 10:00" dir=false size=None perms=None mod=Some("-rw-r--r-- 1") | row rejected | yes |
| 4 | `drwxr-xr-x    2 user     group        4096 Jan 20 10:00 .` | name="." path="/." dir=true size=Some(4096) perms=Some("drwxr-xr-x") mod=Some("Jan 20 10:00") | row rejected | no, already filtered |
| 5 | `drwxr-xr-x    2 user     group        4096 Jan 20 10:00 ..` | name=".." path="/.." dir=true size=Some(4096) perms=Some("drwxr-xr-x") mod=Some("Jan 20 10:00") | row rejected | no, already filtered |
| 6 | `total 12` | name="total 12" path="/total 12" dir=true size=None perms=None mod=None | row rejected | no, already filtered |
| 7 | `01-23-24  10:30AM       <DIR>          folder` | name="folder" path="/folder" dir=true size=None perms=None mod=Some("01-23-24 10:30AM") | name="folder" path="/folder" dir=true size=Some(0) perms=None mod=Some("01-23-24 10:30AM") | yes |
| 8 | `01-23-24 10:30AM 12345 a b c d e f` | name="f" path="/f" dir=false size=None perms=Some("01-23-24") mod=Some("c d e") | name="f" path="/f" dir=false size=Some(0) perms=Some("01-23-24") mod=Some("c d e") | yes |
| 9 | `not-a-date 10:30AM <DIR> folder` | name="folder" path="/folder" dir=true size=None perms=None mod=Some("not-a-date 10:30AM") | row rejected | yes |
| 10 | `drwxr-xr-x 2 1001 1001 4096 Jul 21 09:41 .` | name="." path="/." dir=true size=Some(4096) perms=Some("drwxr-xr-x") mod=Some("Jul 21 09:41") | row rejected | no, already filtered |
**Four of the ten never reach a consumer.** The caller already filtered them before this change, at `src/ftp.rs`: rows beginning `total ` or `Total `, recursive-listing directory headers ending in `:`, and entries named `.` or `..` dropped by name after parsing. So the observable delta is six rows, not ten, and a reader should not infer a larger change than the one that happened. Those three guards are now dead code, which is exactly the pattern this campaign exists to remove: a compensation left standing after the responsibility moved down. They are not removed here, because removing them would be a fix inside a convergence; they belong to the next change.

**Three of the six visible ones are the parser inventing data.** Row 3, an eight-token Unix row, arrived as a file named after a fragment of the listing line. Row 9, a row with no DOS date, arrived as a valid directory. And row 6, an `ls` header, arrived as a directory that does not exist. The legacy parser had no way to fail: whatever it could not read fell through to a fallback that took the raw line as a filename and guessed `is_dir` from whether the name contained a dot. An entry that is missing makes an operation do nothing. A directory that does not exist makes it do something: a recursive delete descends into it, a sync recurses, a tree enumerates it. Row 6 is not reproducible on either lab server, which are vsftpd and emit no `total` line, so it is covered by a synthetic row rather than by a live test.

**Row 1 is the symlink path.** The name was split on the arrow but the path was built before the split, so `link -> target` stayed inside it and any operation using that path addressed a file whose name literally contained the arrow.

## The size rows, stated precisely

Rows 2, 7 and 8 lose a distinction: `size: None` becomes `Some(0)`. `RemoteEntry.size` is a plain `u64` and cannot say "unknown", while the legacy type could.

The provider does not change here, and the wording matters because it drives a queued decision: this is not "the legacy behaviour was better and we chose the worse one". It is the shared type having no way to express the unknown. Every one of the seven consumers of `RemoteFile.size` already collapses it with `.unwrap_or(0)` (`lib.rs` at four sites, `ai_core/tauri_impl.rs`, `cloud_service.rs`, `transfer_queue_scan.rs`), so no caller ever observed the difference. The loss is in the type, not yet in the behaviour.

Recovering the real value where a listing reports 0 for a non-empty file is a separate change and is queued: it moves the hydration that the CLI does today down into the provider, so all three surfaces get it, and it needs no type change. Giving callers a way to say "unknown" is a further step across every provider, and it is recorded as its own item so that a change touching hundreds of call sites is not justified by a regression that does not exist yet.

## One structural addition

`RemoteFile` gains a `link_target` field. It is not a behaviour change and so does not appear in the table above, which is precisely why it is called out here: it changes the shape serialised to the frontend, and a reader scanning a list of behaviour changes would not find it.

It is additive and no consumer reads it yet, so it cannot produce a regression. It is here rather than later because this side discarded symlink targets entirely, and the queued change that aligns the symlink contract across surfaces cannot be honoured by a surface that has no symlink data to honour it with.

## What the review checked, and what it did not

The cross-review compared the two legacy baselines rather than reading the claimed list, and then did the check that matters: it normalised the common fields and compared the converged legacy against the **provider's** baseline over the shared inputs. Zero residual divergences, so every change is accounted for by "the provider already did this" and none is an invented correction. It confirmed that a row that now fails is skipped by the caller's `if let Ok(...)` rather than aborting the listing, which was the real risk of giving the parser a way to fail.

It did not run the tests, and says so: it verified that the assertion exists and is frozen, not that it passes. It did not read the module line by line against the old code, relying on the baseline, which covers 28 rows and not every possible input. Of the legacy's call sites it examined `.size`, the handling of `.` and `..`, and the listing loop's error path, and nothing else.

One correction to its report, in the same direction: it counted three invisible rows. There are four. Row 10, the vsftpd row with numeric owner and group, was also named `.` and so was already dropped by the same filter.

## Gates

`cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`: 0.
`cargo clippy --manifest-path src-tauri/Cargo.toml --lib --tests -- -D warnings`: 0.
Both characterisation batteries pass, and `providers::ftp` is 17 passed, 0 failed.
The full suite result is added below once it finishes; two runs were killed by the environment earlier today, so compiling and running are done as separate steps.

Tracker: #628


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved FTP directory listing compatibility across Unix, DOS, and MLSD/MLST formats.
  - Symlink destinations are now preserved and displayed correctly.
  - Invalid, summary, and navigation entries are no longer shown as files or folders.
  - Unknown file sizes are handled consistently without disrupting listings.

- **Reliability**
  - FTP listings now provide more accurate file types, paths, timestamps, and metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->