### PR TITLE
fix(ftp): answer the questions the server was already answering

### DIFF
--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -6469,12 +6469,7 @@ fn provider_error_to_exit_code(err: &ProviderError) -> i32 {
 }
 
 fn provider_error_message_looks_not_found(message: &str) -> bool {
-    let msg = message.to_ascii_lowercase();
-    msg.contains("no such file")
-        || msg.contains("not found")
-        || msg.contains("does not exist")
-        || msg.contains("file not exists")
-        || msg.contains("404")
+    ftp_client_gui_lib::providers::types::message_names_a_missing_path(message)
 }
 
 /// Reject a target file/folder name containing a character the active
@@ -8067,25 +8062,6 @@ fn print_profile_banner_once(name: &str, details: String, quiet: bool) {
     }
     if !PROFILE_INFO_PRINTED.swap(true, Ordering::Relaxed) {
         eprintln!("Using profile: {} ({})", name, details);
-    }
-}
-
-async fn maybe_hydrate_ftp_stat_size(
-    provider: &mut dyn StorageProvider,
-    path: &str,
-    entry: &mut RemoteEntry,
-) {
-    if entry.is_dir || entry.size > 0 {
-        return;
-    }
-    if !matches!(
-        provider.provider_type(),
-        ProviderType::Ftp | ProviderType::Ftps
-    ) {
-        return;
-    }
-    if let Ok(size) = provider.size(path).await {
-        entry.size = size;
     }
 }
 
@@ -15060,8 +15036,7 @@ async fn stat_tui_session_via_cli_handler(
     let provider = session.provider_mut();
 
     match provider.stat(&resolved_path).await {
-        Ok(mut entry) => {
-            maybe_hydrate_ftp_stat_size(provider, &resolved_path, &mut entry).await;
+        Ok(entry) => {
             let result_path = entry.path.clone();
             let result = cli_tui::worker::TuiStatResult {
                 name: sanitize_filename(&entry.name),
@@ -30114,28 +30089,6 @@ async fn collect_cli_list_entries(
         Err(err) => return Err(CliListError::Provider(err)),
     };
 
-    // FTP/FTPS disambiguation: some servers reply to LIST/MLSD on a missing
-    // directory with an empty listing instead of a 550 error, which collapses
-    // a missing path into an indistinguishable "empty directory" (exit 0).
-    // When the listing is empty and the user supplied an explicit non-root
-    // path, run a follow-up stat to confirm. If the path does not exist,
-    // surface NotFound with the correct exit code.
-    if entries.is_empty()
-        && !options.path.is_empty()
-        && options.path != "/"
-        && options.path != "."
-        && matches!(
-            provider.provider_type(),
-            ProviderType::Ftp | ProviderType::Ftps
-        )
-    {
-        if let Err(ProviderError::NotFound(_)) = provider.stat(&effective_path).await {
-            return Err(CliListError::Provider(ProviderError::NotFound(
-                options.path.to_string(),
-            )));
-        }
-    }
-
     // Filter hidden files
     let mut entries: Vec<RemoteEntry> = if options.all {
         entries
@@ -31706,52 +31659,6 @@ async fn cmd_put(
         }
     };
 
-    // Pre-flight: on FTP/FTPS only, check that the remote parent directory
-    // exists. If it does not, surface an explicit error pointing at the exact
-    // missing segment, since these backends reply with a generic "553 Can't
-    // open that file: No such file or directory" that hides which parent
-    // segment is the culprit and triggers three retries of pure noise.
-    //
-    // Skipped on object-storage protocols (S3, Azure) and on every other
-    // backend, where: (a) prefixes are virtual and stat() of an empty prefix
-    // returns NotFound even after a successful mkdir, producing false
-    // positives that block the natural mkdir+put workflow, and (b) native
-    // error messages from those backends already point at the missing path.
-    let needs_parent_check = matches!(
-        provider.provider_type(),
-        ProviderType::Ftp | ProviderType::Ftps
-    );
-    let parent = parent_remote_path(remote_path);
-    if needs_parent_check && !parent.is_empty() && parent != "/" {
-        match provider.stat(&parent).await {
-            Ok(entry) if !entry.is_dir => {
-                print_error(
-                    format,
-                    &format!(
-                        "Parent path '{}' exists but is not a directory, upload aborted.",
-                        parent
-                    ),
-                    2,
-                );
-                let _ = provider.disconnect().await;
-                return 2;
-            }
-            Err(ProviderError::NotFound(_)) => {
-                print_error(
-                    format,
-                    &format!(
-                        "Parent directory '{}' does not exist on the remote. Create it first with: aeroftp-cli mkdir -p '{}'",
-                        parent, parent
-                    ),
-                    2,
-                );
-                let _ = provider.disconnect().await;
-                return 2;
-            }
-            _ => {} // stat OK (dir) or non-definitive error, proceed.
-        }
-    }
-
     let start = Instant::now();
     let quiet = cli.quiet || matches!(format, OutputFormat::Json);
 
@@ -32067,31 +31974,30 @@ async fn cmd_put_recursive(
     // not exist yet (put -r into /a/b/c with no /a) MKDs remote_base against
     // a missing parent, swallows the 550, and then stalls on the first STOR
     // into the non-existent directory on FTP/FTPS instead of erroring.
-    // Mirrors the single-file put parent check: on FTP/FTPS an ancestor that
-    // cannot be created aborts the whole command with the MKD error. FTP maps
-    // every MKD failure (including "already exists") to a generic ServerError,
-    // so an existing ancestor is confirmed via stat rather than error text.
-    // On other backends the ancestor creation stays best-effort: their mkdir
+    // On FTP/FTPS an ancestor that cannot be created aborts the whole command
+    // with the MKD error. On other backends it stays best-effort: their mkdir
     // semantics differ (virtual prefixes, bucket components) and their native
     // put errors already point at the missing path.
+    //
+    // This used to confirm an existing ancestor with a follow-up `stat`,
+    // because FTP mapped every MKD failure onto one generic ServerError and
+    // "it is already there" could not be told from "you may not". The provider
+    // reports `AlreadyExists` now, so the answer is read rather than guessed.
     if resolved_remote_base != "/" {
         let strict_ancestors = matches!(ptype, ProviderType::Ftp | ProviderType::Ftps);
         for ancestor in benchmark_mkdir_ladder(&resolved_remote_base) {
             match provider.mkdir(&ancestor).await {
-                Ok(()) => {}
-                Err(mkd_err) if strict_ancestors => match provider.stat(&ancestor).await {
-                    Ok(entry) if entry.is_dir => {}
-                    _ => {
-                        let code = provider_error_to_exit_code(&mkd_err);
-                        print_error(
-                            format,
-                            &format!("Cannot create remote directory '{}': {}", ancestor, mkd_err),
-                            code,
-                        );
-                        let _ = provider.disconnect().await;
-                        return code;
-                    }
-                },
+                Ok(()) | Err(ProviderError::AlreadyExists(_)) => {}
+                Err(mkd_err) if strict_ancestors => {
+                    let code = provider_error_to_exit_code(&mkd_err);
+                    print_error(
+                        format,
+                        &format!("Cannot create remote directory '{}': {}", ancestor, mkd_err),
+                        code,
+                    );
+                    let _ = provider.disconnect().await;
+                    return code;
+                }
                 Err(_) => {}
             }
         }
@@ -38412,8 +38318,7 @@ async fn cmd_stat(url: &str, path: &str, cli: &Cli, format: OutputFormat) -> i32
 
     let path = &resolve_cli_remote_path(&initial_path, path);
     match provider.stat(path).await {
-        Ok(mut entry) => {
-            maybe_hydrate_ftp_stat_size(provider.as_mut(), path, &mut entry).await;
+        Ok(entry) => {
             match format {
                 OutputFormat::Text => {
                     println!("  Name:        {}", entry.name);
@@ -39614,28 +39519,6 @@ async fn cmd_lsjson(
 
             if is_root_list {
                 is_root_list = false;
-                // FTP/FTPS may answer a missing directory with an empty
-                // listing instead of an error, collapsing "missing" into
-                // "empty". Confirm with a follow-up stat (mirrors `ls`).
-                if entries.is_empty()
-                    && !path.is_empty()
-                    && path != "/"
-                    && path != "."
-                    && matches!(
-                        provider.provider_type(),
-                        ProviderType::Ftp | ProviderType::Ftps
-                    )
-                {
-                    if let Err(ProviderError::NotFound(_)) = provider.stat(&dir_path).await {
-                        print_error(
-                            format,
-                            &format!("lsjson failed: Path not found: {}", path),
-                            2,
-                        );
-                        let _ = provider.disconnect().await;
-                        return 2;
-                    }
-                }
             }
 
             for e in entries {
@@ -45708,6 +45591,48 @@ async fn cmd_sync(
                 ),
                 4,
             );
+            let _ = provider.disconnect().await;
+            return 4.into();
+        }
+    }
+
+    // The block above refuses a delete pass when the scan reported ERRORS. It
+    // cannot see the other half of the same danger: a listing that succeeded
+    // and came back empty. FTP produced exactly that for a directory that does
+    // not exist, so a mistyped path was indistinguishable from an emptied one,
+    // and nothing here noticed because there was no error to count.
+    //
+    // The core (`sync.rs`) and the DAG both consult the shared guard for this;
+    // this path did not, so the one surface a person drives by hand was the one
+    // without the protection. Calling the shared guard rather than restating
+    // the rule is the point: a fourth copy of the policy is how the third one
+    // came to be missing.
+    //
+    // Kept even though the FTP defect above is fixed in the same change: it is
+    // depth, not redundancy. Any provider that answers an empty listing where
+    // it should answer an error would otherwise walk the same path.
+    if delete && !dry_run && reconcile_plan.is_none() {
+        let sync_direction = match direction {
+            "download" => ftp_client_gui_lib::sync::SyncDirection::Download,
+            "upload" => ftp_client_gui_lib::sync::SyncDirection::Upload,
+            _ => ftp_client_gui_lib::sync::SyncDirection::Both,
+        };
+        let local_scan = ftp_client_gui_lib::sync_core::ScanCompleteness {
+            list_errors: local_scan_errors,
+            truncated: local_scan_truncated,
+        };
+        let remote_scan = ftp_client_gui_lib::sync_core::ScanCompleteness {
+            list_errors: remote_scan_errors,
+            truncated: remote_scan_truncated,
+        };
+        if let Err(reason) = ftp_client_gui_lib::sync::orphan_delete_guard_over(
+            sync_direction,
+            local_map.is_empty(),
+            remote_map.is_empty(),
+            &local_scan,
+            &remote_scan,
+        ) {
+            print_error(format, &format!("refusing --delete: {reason}"), 4);
             let _ = provider.disconnect().await;
             return 4.into();
         }
@@ -66620,8 +66545,8 @@ async fn main() {
 fn is_retryable_exit(code: i32) -> bool {
     // Non-retryable categories (stable across retries, burning attempts is pure noise):
     //   0  success
-    //   2  not found (missing path or missing parent: caught by the new 553
-    //      preflight in `cmd_put`)
+    //   2  not found (missing path or missing parent: the provider classifies
+    //      a 553 naming a missing path as NotFound, so it maps to 2 here)
     //   5  invalid usage / config
     //   6  authentication failed
     //   7  operation not supported

--- a/src-tauri/src/providers/ftp.rs
+++ b/src-tauri/src/providers/ftp.rs
@@ -526,12 +526,11 @@ impl FtpProvider {
     /// the connection pointing somewhere else.
     async fn cwd_into(&mut self, target: &str) -> Result<String, ProviderError> {
         let stream = self.stream_mut()?;
-        let saved = stream
-            .pwd()
-            .await
-            .map_err(|e| ProviderError::ServerError(format!("pwd: {e}")))?;
+        let saved = stream.pwd().await.map_err(|e| {
+            ProviderError::ServerError(format!("{e} (while asking the server where we are)"))
+        })?;
         if let Err(e) = stream.cwd(target).await {
-            return Err(Self::classify_cwd_failure(target, &e));
+            return Err(Self::classify_cwd_failure("entering", target, &e));
         }
         // The mirror follows the server immediately, so it is never a lie even
         // if the restore below fails.
@@ -580,6 +579,45 @@ impl FtpProvider {
         format!("{reply} (while {operation} {path})")
     }
 
+    /// The part of a server reply that is the reason, with the path taken out.
+    ///
+    /// FTP servers quote back the path they were given, so the reply carries
+    /// both a reason the server chose and a name the user chose, and the
+    /// missing-path vocabulary reads the two as one string. Every word it looks
+    /// for is a legal path component: `550 /public_html/404.html: Permission
+    /// denied` was read as a missing file, and a refusal for permission came
+    /// back as a file that is not there. That is the exact mistake the doc
+    /// comment below warns about, arriving through the vocabulary rather than
+    /// through the status.
+    ///
+    /// The path we sent is what the server is quoting, so it is removed here,
+    /// where it is known, rather than guessed at from the shape of the text.
+    /// This is the same split as `sync::classification_text` and for the same
+    /// reason: only the reason is evidence, and the name never was.
+    ///
+    /// It is not a complete separation and does not need to be. A server may
+    /// echo a path it resolved differently from the one we sent, and then the
+    /// removal does nothing; the vocabulary's own token boundary still keeps
+    /// `404.html` from counting. The reply the CALLER is shown is untouched:
+    /// only the reading of it changes.
+    fn reason_without_the_path(reply: &str, path: &str) -> String {
+        // A one-character path carries no information and removing it damages
+        // the text instead: a failed CWD to "/" would take every slash out of
+        // the reply.
+        //
+        // No test covers this and that is deliberate rather than an omission.
+        // None of the current needles contains a separator, so today the
+        // mangling changes no verdict and any test would pass with the guard
+        // deleted. It is here against the needle somebody adds later, and it is
+        // said out loud so nobody reads it as a checked rule: the class it
+        // belongs to is `i/o error` in `sync::looks_like_a_path`, where a rule
+        // written to remove noise removed the signal instead.
+        if path.len() < 2 {
+            return reply.to_string();
+        }
+        reply.replace(path, " ")
+    }
+
     /// Decide what a refused CWD means, without claiming more than the reply says.
     ///
     /// The reply carries two independent facts and they must not be collapsed:
@@ -615,23 +653,24 @@ impl FtpProvider {
     /// them; doing it here would fix this caller and leave the rest, which is
     /// the "patch the case, not the predicate" mistake this branch removed
     /// elsewhere. It is on the register.
-    fn classify_cwd_failure(target: &str, err: &FtpError) -> ProviderError {
+    fn classify_cwd_failure(operation: &str, target: &str, err: &FtpError) -> ProviderError {
         let FtpError::UnexpectedResponse(ref response) = err else {
-            return ProviderError::ServerError(Self::doing("entering", target, err));
+            return ProviderError::ServerError(Self::doing(operation, target, err));
         };
         let text = response.to_string();
         if response.status != Status::FileUnavailable {
-            return ProviderError::ServerError(Self::doing("entering", target, &text));
+            return ProviderError::ServerError(Self::doing(operation, target, &text));
         }
         // A 550 on CWD is not only "it is not there": it is also what a server
         // sends for a directory you may not enter. Reading every one as
         // NotFound turns an inaccessible directory into a nonexistent one,
         // which is the mistake this change already made once on mkdir and had
         // corrected by a live server.
-        if super::types::message_names_a_missing_path(&text) {
-            ProviderError::NotFound(Self::doing("entering", target, &text))
+        if super::types::message_names_a_missing_path(&Self::reason_without_the_path(&text, target))
+        {
+            ProviderError::NotFound(Self::doing(operation, target, &text))
         } else {
-            ProviderError::InvalidPath(Self::doing("entering", target, &text))
+            ProviderError::InvalidPath(Self::doing(operation, target, &text))
         }
     }
 
@@ -648,9 +687,17 @@ impl FtpProvider {
                 self.current_path = saved.to_string();
                 Ok(())
             }
-            Err(e) => Err(ProviderError::ServerError(format!(
-                "could not restore the working directory to {saved}: {e}"
-            ))),
+            // The same command as `cwd_into`, so the same classification. It
+            // used to compose a sentence of its own, which put our words ahead
+            // of the reply (the order `doing` exists to avoid) and made every
+            // failure a retryable `ServerError`, including a 550 that will
+            // never succeed. Sharing the classifier also brings this site
+            // inside the test table, which a private string never was.
+            Err(e) => Err(Self::classify_cwd_failure(
+                "restoring the working directory to",
+                saved,
+                &e,
+            )),
         }
     }
 
@@ -672,7 +719,7 @@ impl FtpProvider {
             return None;
         }
         let text = response.to_string();
-        super::types::message_names_a_missing_path(&text)
+        super::types::message_names_a_missing_path(&Self::reason_without_the_path(&text, path))
             .then(|| ProviderError::NotFound(Self::doing(operation, path, &text)))
     }
 
@@ -2221,7 +2268,8 @@ mod tests {
             (500, "500 Unknown command", "ServerError"),
         ];
         for (code, body, expected) in cases {
-            let got = FtpProvider::classify_cwd_failure("/target", &cwd_reply(*code, body));
+            let got =
+                FtpProvider::classify_cwd_failure("entering", "/target", &cwd_reply(*code, body));
             let actual = match got {
                 ProviderError::NotFound(_) => "NotFound",
                 ProviderError::InvalidPath(_) => "InvalidPath",
@@ -2244,13 +2292,75 @@ mod tests {
     }
 
     /// A failure that is not a reply at all keeps the transport error.
+    /// The path the server quotes back must not be read as the reason.
+    ///
+    /// End to end through the real classifier, with the path that triggers it:
+    /// a permission refusal on `/public_html/404.html` is permanent and is NOT
+    /// a missing file. Reporting it as missing sends the user to recreate a
+    /// file that is already there instead of to fix the permissions, which is
+    /// the whole thesis of this branch stated backwards.
+    #[test]
+    fn a_path_quoted_back_by_the_server_is_not_the_reason() {
+        let target = "/public_html/404.html";
+        let got = FtpProvider::classify_cwd_failure(
+            "entering",
+            target,
+            &cwd_reply(550, "550 /public_html/404.html: Permission denied"),
+        );
+        assert!(
+            matches!(got, ProviderError::InvalidPath(_)),
+            "the digits in the path made a refusal into a missing file: {got:?}"
+        );
+        // And the reply still reaches the reader whole, path included.
+        assert!(got.to_string().contains("/public_html/404.html"));
+
+        // The case the token boundary CANNOT reach, and the only reason the
+        // path removal exists as a separate defence: the needle words are
+        // ordinary directory names. `/var/www/not found/report.pdf` carries
+        // "not found" as a whole phrase, and no boundary rule can tell that
+        // occurrence from the server saying it. Only knowing which path we
+        // sent does.
+        let worded = FtpProvider::classify_cwd_failure(
+            "entering",
+            "/var/www/not found/report.pdf",
+            &cwd_reply(550, "550 /var/www/not found/report.pdf: Permission denied"),
+        );
+        assert!(
+            matches!(worded, ProviderError::InvalidPath(_)),
+            "a folder called \"not found\" made a refusal into a missing file: {worded:?}"
+        );
+
+        // A file named exactly after the code, where the boundary rule is what
+        // fails: the token IS "404".
+        let named = FtpProvider::classify_cwd_failure(
+            "entering",
+            "404",
+            &cwd_reply(550, "550 404: Permission denied"),
+        );
+        assert!(
+            matches!(named, ProviderError::InvalidPath(_)),
+            "a file named 404 made a refusal into a missing file: {named:?}"
+        );
+
+        // The same shape when the reply really is about a missing path.
+        let missing = FtpProvider::classify_cwd_failure(
+            "entering",
+            target,
+            &cwd_reply(550, "550 /public_html/404.html: No such file or directory"),
+        );
+        assert!(
+            matches!(missing, ProviderError::NotFound(_)),
+            "the removal took the reason with it: {missing:?}"
+        );
+    }
+
     #[test]
     fn a_cwd_that_never_got_a_reply_is_not_a_path_verdict() {
         let err = FtpError::ConnectionError(std::io::Error::new(
             std::io::ErrorKind::TimedOut,
             "timed out",
         ));
-        let got = FtpProvider::classify_cwd_failure("/target", &err);
+        let got = FtpProvider::classify_cwd_failure("entering", "/target", &err);
         assert!(
             matches!(got, ProviderError::ServerError(_)),
             "a transport failure became {got:?}, which claims something about the path"
@@ -2385,11 +2495,16 @@ mod tests {
         let cases: Vec<(&str, ProviderError)> = vec![
             (
                 "entering",
-                FtpProvider::classify_cwd_failure(path, &cwd_reply(550, "550 Permission denied")),
+                FtpProvider::classify_cwd_failure(
+                    "entering",
+                    path,
+                    &cwd_reply(550, "550 Permission denied"),
+                ),
             ),
             (
                 "entering",
                 FtpProvider::classify_cwd_failure(
+                    "entering",
                     path,
                     &cwd_reply(421, "421 Service not available"),
                 ),
@@ -2397,8 +2512,21 @@ mod tests {
             (
                 "entering",
                 FtpProvider::classify_cwd_failure(
+                    "entering",
                     path,
                     &cwd_reply(550, "550 /x: No such file or directory"),
+                ),
+            ),
+            // Reachable only since `restore_cwd` started sharing the
+            // classifier. As its own private string it named the operation and
+            // the path correctly and no test could confirm it, which is how it
+            // kept the wrong word order for as long as it did.
+            (
+                "restoring the working directory to",
+                FtpProvider::classify_cwd_failure(
+                    "restoring the working directory to",
+                    path,
+                    &cwd_reply(550, "550 Failed to change directory."),
                 ),
             ),
             (

--- a/src-tauri/src/providers/ftp.rs
+++ b/src-tauri/src/providers/ftp.rs
@@ -526,41 +526,68 @@ impl FtpProvider {
             .pwd()
             .await
             .map_err(|e| ProviderError::ServerError(format!("pwd: {e}")))?;
-        match stream.cwd(target).await {
-            Ok(()) => {}
-            // A 550 on CWD is not only "it is not there": it is also what a
-            // server sends for a directory you may not enter. Reading every one
-            // as NotFound turns an inaccessible directory into a nonexistent
-            // one, which is the mistake this change already made once on mkdir
-            // and had corrected by a live server. The reply is only read as a
-            // missing path when it says so, and its own text is kept rather
-            // than replaced with a sentence of ours.
-            Err(FtpError::UnexpectedResponse(response)) => {
-                let text = response.to_string();
-                //
-                // The fallback is `InvalidPath`, not `ServerError`, and the
-                // difference is not cosmetic: `ServerError` maps to exit 10,
-                // which `is_retryable_exit` treats as retryable, so a directory
-                // that will never be enterable would be attempted three times.
-                // That is the same defect this change removes from the 553
-                // path, reintroduced two functions away. `InvalidPath` is
-                // permanent on both retry paths, says only that the path did
-                // not work, and is already what the MLST preflight above
-                // returns for the same status.
-                return if response.status == Status::FileUnavailable
-                    && super::types::message_names_a_missing_path(&text)
-                {
-                    Err(ProviderError::NotFound(format!("{target}: {text}")))
-                } else {
-                    Err(ProviderError::InvalidPath(format!("{target}: {text}")))
-                };
-            }
-            Err(e) => return Err(ProviderError::ServerError(e.to_string())),
+        if let Err(e) = stream.cwd(target).await {
+            return Err(Self::classify_cwd_failure(target, &e));
         }
         // The mirror follows the server immediately, so it is never a lie even
         // if the restore below fails.
         self.current_path = target.to_string();
         Ok(saved)
+    }
+
+    /// Decide what a refused CWD means, without claiming more than the reply says.
+    ///
+    /// The reply carries two independent facts and they must not be collapsed:
+    /// the status code says whether the refusal is permanent, and the text says
+    /// whether it is about a path that is not there. Reading only one of them
+    /// is how this function was wrong twice in the same place, in opposite
+    /// directions, and neither error was caught by the person writing it.
+    ///
+    /// The first version answered `ServerError` for every refusal. That maps to
+    /// exit 10, which `is_retryable_exit` treats as retryable, so a directory
+    /// that will never be enterable was attempted three times: a permanent
+    /// failure dressed as a temporary one.
+    ///
+    /// The correction overshot. It answered `InvalidPath`, exit 5 and permanent
+    /// on both retry paths, for every status rather than for 550, so a `421
+    /// Service not available, closing control connection` or a `450 Requested
+    /// file action not taken` became permanent. Those are the replies a server
+    /// sends when it is overloaded or closing an idle session, which is exactly
+    /// the moment a client should retry, and RFC 959 section 4.2 says so in the
+    /// code itself: 4yz is "Transient Negative Completion", the action "may be
+    /// requested again", while 5yz is permanent and the user "is discouraged
+    /// from repeating the exact request". The class digit is the server's own
+    /// statement about retrying, so overruling it is not a judgement call.
+    ///
+    /// Only 550 is read as a statement about the path, and the split inside it
+    /// is by text because FTP spends 550 on both "it is not there" and "you may
+    /// not enter". Every other status keeps `ServerError` and the server's own
+    /// words. That is deliberately unambitious: a 530 is permanent too, but it
+    /// is about the session and not the path, and answering `InvalidPath` there
+    /// would trade a wrong retry for a false statement, which is the worse of
+    /// the two. Turning the 4yz/5yz contract into retry behaviour belongs where
+    /// retrying is decided, once, for every FTP call site, not here for one of
+    /// them; doing it here would fix this caller and leave the rest, which is
+    /// the "patch the case, not the predicate" mistake this branch removed
+    /// elsewhere. It is on the register.
+    fn classify_cwd_failure(target: &str, err: &FtpError) -> ProviderError {
+        let FtpError::UnexpectedResponse(ref response) = err else {
+            return ProviderError::ServerError(format!("{target}: {err}"));
+        };
+        let text = response.to_string();
+        if response.status != Status::FileUnavailable {
+            return ProviderError::ServerError(format!("{target}: {text}"));
+        }
+        // A 550 on CWD is not only "it is not there": it is also what a server
+        // sends for a directory you may not enter. Reading every one as
+        // NotFound turns an inaccessible directory into a nonexistent one,
+        // which is the mistake this change already made once on mkdir and had
+        // corrected by a live server.
+        if super::types::message_names_a_missing_path(&text) {
+            ProviderError::NotFound(format!("{target}: {text}"))
+        } else {
+            ProviderError::InvalidPath(format!("{target}: {text}"))
+        }
     }
 
     /// Put the working directory back, and report it if that fails.
@@ -2103,6 +2130,86 @@ async fn ftp_download_one_range(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn cwd_reply(code: u32, body: &str) -> FtpError {
+        FtpError::UnexpectedResponse(suppaftp::types::Response::new(
+            suppaftp::Status::from(code),
+            body.as_bytes().to_vec(),
+        ))
+    }
+
+    /// The retry contract of a refused CWD, one row per status.
+    ///
+    /// This table exists because the same line was wrong twice in opposite
+    /// directions and nothing failed either time: the classification lived
+    /// inside an `async fn` that needs a live socket, so no unit test could
+    /// reach it and the live tests only ever exercised 550. A rule no test can
+    /// see is a rule that gets rewritten by whoever touches it next.
+    ///
+    /// The two 4yz rows are the ones that were being answered `InvalidPath`,
+    /// exit 5, permanent: a server closing an idle control connection (421) or
+    /// briefly refusing an action (450) would have been reported as a path that
+    /// does not work, and never retried.
+    #[test]
+    fn a_refused_cwd_is_only_permanent_when_the_status_says_so() {
+        let cases: &[(u32, &str, &str)] = &[
+            // 550, and the text names a missing path: the one case that is
+            // genuinely about a path that is not there.
+            (550, "550 /nope: No such file or directory", "NotFound"),
+            // 550 without that vocabulary: permanent, but we do not get to say
+            // it is missing. A directory you may not enter reaches here.
+            (550, "550 Permission denied", "InvalidPath"),
+            (550, "550 Failed to change directory.", "InvalidPath"),
+            // Transient. The server is telling us to come back, and a
+            // permanent answer here silences the retry that would succeed.
+            (
+                421,
+                "421 Service not available, closing control connection",
+                "ServerError",
+            ),
+            (450, "450 Requested file action not taken", "ServerError"),
+            // Permanent, but about the session and not the path. Kept as
+            // ServerError on purpose: a wrong retry costs two round trips, a
+            // false statement about the path costs the reader's trust.
+            (530, "530 Not logged in", "ServerError"),
+            (500, "500 Unknown command", "ServerError"),
+        ];
+        for (code, body, expected) in cases {
+            let got = FtpProvider::classify_cwd_failure("/target", &cwd_reply(*code, body));
+            let actual = match got {
+                ProviderError::NotFound(_) => "NotFound",
+                ProviderError::InvalidPath(_) => "InvalidPath",
+                ProviderError::ServerError(_) => "ServerError",
+                ref other => panic!("{code}: unexpected variant {other:?}"),
+            };
+            assert_eq!(
+                actual, *expected,
+                "CWD {code} ({body:?}) classified as {actual}, expected {expected}"
+            );
+            // Whatever the verdict, the server's own words survive it. A
+            // classification that replaces the reply with a sentence of ours
+            // leaves the user with our guess and no way back to the fact.
+            let rendered = got.to_string();
+            assert!(
+                rendered.contains(body) && rendered.contains("/target"),
+                "CWD {code}: the reply or the target was dropped from {rendered:?}"
+            );
+        }
+    }
+
+    /// A failure that is not a reply at all keeps the transport error.
+    #[test]
+    fn a_cwd_that_never_got_a_reply_is_not_a_path_verdict() {
+        let err = FtpError::ConnectionError(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "timed out",
+        ));
+        let got = FtpProvider::classify_cwd_failure("/target", &err);
+        assert!(
+            matches!(got, ProviderError::ServerError(_)),
+            "a transport failure became {got:?}, which claims something about the path"
+        );
+    }
 
     /// The TLS connector must build without a process-level rustls
     /// `CryptoProvider` installed. `aws-lc-rs` and `ring` are both in the

--- a/src-tauri/src/providers/ftp.rs
+++ b/src-tauri/src/providers/ftp.rs
@@ -468,12 +468,16 @@ impl FtpProvider {
             match (listed, restored) {
                 (Ok(lines), Ok(())) => lines,
                 (Err(list_err), Ok(())) => {
-                    return Err(ProviderError::ServerError(list_err.to_string()))
+                    return Err(ProviderError::ServerError(Self::doing(
+                        "listing", &base_path, list_err,
+                    )))
                 }
                 (Ok(_), Err(restore_err)) => return Err(restore_err),
                 (Err(list_err), Err(restore_err)) => {
-                    return Err(ProviderError::ServerError(format!(
-                        "{list_err}; and {restore_err}"
+                    return Err(ProviderError::ServerError(Self::doing(
+                        "listing",
+                        &base_path,
+                        format!("{list_err}; and {restore_err}"),
                     )))
                 }
             }
@@ -535,6 +539,27 @@ impl FtpProvider {
         Ok(saved)
     }
 
+    /// Say what we were doing and to what, then quote the server verbatim.
+    ///
+    /// Two axes, and only one of them is ever in doubt. The OPERATION and the
+    /// PATH are ours: we always know which call we made and what we made it
+    /// against, so leaving them out is a defect and not caution. The CAUSE is
+    /// the server's, and often it will not say: `550 Failed to change
+    /// directory.` does not distinguish a missing directory from one we may
+    /// not enter. Naming a cause the reply does not support sends the user to
+    /// fix the wrong thing, which is worse than not naming it.
+    ///
+    /// So the shape is: precise about what we know, verbatim about what we do
+    /// not. "listing /srv/data: 550 Failed to change directory." is more useful
+    /// than "server error" and more honest than "not found".
+    ///
+    /// It is one function rather than a `format!` at each site so the shape
+    /// cannot drift apart per call, which is how half these messages lost the
+    /// path in the first place.
+    fn doing(operation: &str, path: &str, reply: impl std::fmt::Display) -> String {
+        format!("{operation} {path}: {reply}")
+    }
+
     /// Decide what a refused CWD means, without claiming more than the reply says.
     ///
     /// The reply carries two independent facts and they must not be collapsed:
@@ -572,11 +597,11 @@ impl FtpProvider {
     /// elsewhere. It is on the register.
     fn classify_cwd_failure(target: &str, err: &FtpError) -> ProviderError {
         let FtpError::UnexpectedResponse(ref response) = err else {
-            return ProviderError::ServerError(format!("{target}: {err}"));
+            return ProviderError::ServerError(Self::doing("entering", target, err));
         };
         let text = response.to_string();
         if response.status != Status::FileUnavailable {
-            return ProviderError::ServerError(format!("{target}: {text}"));
+            return ProviderError::ServerError(Self::doing("entering", target, &text));
         }
         // A 550 on CWD is not only "it is not there": it is also what a server
         // sends for a directory you may not enter. Reading every one as
@@ -584,9 +609,9 @@ impl FtpProvider {
         // which is the mistake this change already made once on mkdir and had
         // corrected by a live server.
         if super::types::message_names_a_missing_path(&text) {
-            ProviderError::NotFound(format!("{target}: {text}"))
+            ProviderError::NotFound(Self::doing("entering", target, &text))
         } else {
-            ProviderError::InvalidPath(format!("{target}: {text}"))
+            ProviderError::InvalidPath(Self::doing("entering", target, &text))
         }
     }
 
@@ -616,7 +641,7 @@ impl FtpProvider {
     /// Everything that is not clearly about a missing path is left alone: a
     /// permission error must not be reported as a missing file, and a command
     /// the server simply refuses must not become one either.
-    fn classify_missing_path(err: &FtpError) -> Option<ProviderError> {
+    fn classify_missing_path(operation: &str, path: &str, err: &FtpError) -> Option<ProviderError> {
         let FtpError::UnexpectedResponse(ref response) = err else {
             return None;
         };
@@ -627,7 +652,8 @@ impl FtpProvider {
             return None;
         }
         let text = response.to_string();
-        super::types::message_names_a_missing_path(&text).then_some(ProviderError::NotFound(text))
+        super::types::message_names_a_missing_path(&text)
+            .then(|| ProviderError::NotFound(Self::doing(operation, path, &text)))
     }
 
     /// Classify a STOR failure instead of calling everything a transfer error.
@@ -643,11 +669,11 @@ impl FtpProvider {
     /// which made the message good and the retries stop on that surface alone.
     /// Classifying it here does both for every caller, and the preflight goes
     /// away in the same change.
-    fn map_store_error(err: FtpError) -> ProviderError {
-        if let Some(missing) = Self::classify_missing_path(&err) {
+    fn map_store_error(path: &str, err: FtpError) -> ProviderError {
+        if let Some(missing) = Self::classify_missing_path("uploading", path, &err) {
             return missing;
         }
-        ProviderError::TransferFailed(err.to_string())
+        ProviderError::TransferFailed(Self::doing("uploading", path, err))
     }
 
     /// Tell a directory that is empty from one that is not there.
@@ -1003,7 +1029,7 @@ impl StorageProvider for FtpProvider {
             let stream = self.stream_mut()?;
             match stream.size(remote_path).await {
                 Ok(size) => size as u64,
-                Err(err) => match Self::classify_missing_path(&err) {
+                Err(err) => match Self::classify_missing_path("downloading", remote_path, &err) {
                     Some(missing) => return Err(missing),
                     None => 0,
                 },
@@ -1213,9 +1239,9 @@ impl StorageProvider for FtpProvider {
                     Ok(()) => Err(ProviderError::AlreadyExists(path.to_string())),
                     // The directory is not there, so the mkdir failed for its
                     // own reason and that is what the caller gets.
-                    Err(ProviderError::NotFound(_)) => {
-                        Err(ProviderError::ServerError(response.to_string()))
-                    }
+                    Err(ProviderError::NotFound(_)) => Err(ProviderError::ServerError(
+                        Self::doing("creating", path, response),
+                    )),
                     // Anything else is about the probe, not about the mkdir,
                     // and one of those is the probe having entered the
                     // directory and failed to come back out. Collapsing that
@@ -1405,7 +1431,7 @@ impl StorageProvider for FtpProvider {
         // for. Any other SIZE failure keeps the previous fallback.
         let total_size = match stream.size(remote_path).await {
             Ok(size) => size as u64,
-            Err(err) => match Self::classify_missing_path(&err) {
+            Err(err) => match Self::classify_missing_path("resuming", remote_path, &err) {
                 Some(missing) => return Err(missing),
                 None => 0,
             },
@@ -1879,7 +1905,7 @@ impl FtpProvider {
         let mut data_stream = stream
             .put_with_stream(remote_path)
             .await
-            .map_err(Self::map_store_error)?;
+            .map_err(|e| Self::map_store_error(remote_path, e))?;
 
         // Write in 64KB chunks for optimal throughput
         let mut chunk = [0u8; 65536];
@@ -2280,27 +2306,104 @@ mod tests {
     #[test]
     fn a_store_into_a_missing_directory_is_not_found_not_a_transfer_failure() {
         use suppaftp::types::Response;
-        let missing = FtpProvider::map_store_error(FtpError::UnexpectedResponse(Response::new(
-            Status::BadFilename,
-            b"Can't open that file: No such file or directory".to_vec(),
-        )));
+        let missing = FtpProvider::map_store_error(
+            "/srv/out/report.txt",
+            FtpError::UnexpectedResponse(Response::new(
+                Status::BadFilename,
+                b"Can't open that file: No such file or directory".to_vec(),
+            )),
+        );
         assert!(
             matches!(missing, ProviderError::NotFound(_)),
             "553 with 'no such file' is a missing path: {missing:?}"
         );
 
-        let denied = FtpProvider::map_store_error(FtpError::UnexpectedResponse(Response::new(
-            Status::FileUnavailable,
-            b"Permission denied".to_vec(),
-        )));
+        let denied = FtpProvider::map_store_error(
+            "/srv/out/report.txt",
+            FtpError::UnexpectedResponse(Response::new(
+                Status::FileUnavailable,
+                b"Permission denied".to_vec(),
+            )),
+        );
         assert!(
             matches!(denied, ProviderError::TransferFailed(_)),
             "a refusal that is not about a missing path must not become NotFound: {denied:?}"
         );
 
         // A transport failure is not a classification question at all.
-        let broken = FtpProvider::map_store_error(FtpError::BadResponse);
+        let broken = FtpProvider::map_store_error("/srv/out/report.txt", FtpError::BadResponse);
         assert!(matches!(broken, ProviderError::TransferFailed(_)));
+
+        // Whatever the verdict, the message says what we were doing and to
+        // what. All three of these used to render as the server's reply alone,
+        // so the user was told a STOR had failed without being told which file.
+        for e in [&missing, &denied, &broken] {
+            let rendered = e.to_string();
+            assert!(
+                rendered.contains("uploading") && rendered.contains("/srv/out/report.txt"),
+                "the operation or the path is missing from {rendered:?}"
+            );
+        }
+    }
+
+    /// Every classified FTP failure names the operation and the path.
+    ///
+    /// The two axes are not equally knowable and the distinction is the whole
+    /// rule. The operation and the path are OURS: we always know which call we
+    /// made and against what, so omitting them is our defect. The cause is the
+    /// server's, and it often will not say: `550 Failed to change directory.`
+    /// does not tell a missing directory from one we may not enter, and
+    /// inventing the difference sends the user to fix the wrong thing.
+    ///
+    /// So this asserts the half we always owe, and deliberately asserts nothing
+    /// about the cause. It is a table over the classifiers rather than an
+    /// assertion inside each test because the shape has to hold for all of
+    /// them: it was already true in some messages and quietly absent in others.
+    #[test]
+    fn a_classified_failure_says_what_we_were_doing_and_to_what() {
+        let path = "/srv/data/quarterly";
+        let cases: Vec<(&str, ProviderError)> = vec![
+            (
+                "entering",
+                FtpProvider::classify_cwd_failure(path, &cwd_reply(550, "550 Permission denied")),
+            ),
+            (
+                "entering",
+                FtpProvider::classify_cwd_failure(
+                    path,
+                    &cwd_reply(421, "421 Service not available"),
+                ),
+            ),
+            (
+                "entering",
+                FtpProvider::classify_cwd_failure(
+                    path,
+                    &cwd_reply(550, "550 /x: No such file or directory"),
+                ),
+            ),
+            (
+                "uploading",
+                FtpProvider::map_store_error(path, FtpError::BadResponse),
+            ),
+            (
+                "uploading",
+                FtpProvider::map_store_error(
+                    path,
+                    cwd_reply(553, "553 Can't open that file: No such file or directory"),
+                ),
+            ),
+        ];
+        for (operation, error) in cases {
+            let rendered = error.to_string();
+            assert!(
+                rendered.contains(operation),
+                "no operation in {rendered:?}: the user is told a call failed, not which one"
+            );
+            assert!(
+                rendered.contains(path),
+                "no path in {rendered:?}: the user is told what failed, not what it was about"
+            );
+        }
     }
 
     // ── Characterisation battery for the listing parser ────────────────────

--- a/src-tauri/src/providers/ftp.rs
+++ b/src-tauri/src/providers/ftp.rs
@@ -454,18 +454,18 @@ impl FtpProvider {
         let lines = if include_hidden {
             // vsftpd & friends hide dotfiles on a bare `LIST`. CWD into the
             // directory and issue a bare `LIST -a`; the combined `LIST -a <path>`
-            // form is server-specific and unreliable, so we avoid it. Restore the
-            // previous working directory best-effort afterwards. The `.`/`..`
+            // form is server-specific and unreliable, so we avoid it. The `.`/`..`
             // entries that `-a` adds are dropped by the listing parsers.
-            let saved_cwd = self.current_path.clone();
+            let saved_cwd = self.cwd_into(&base_path).await?;
             let stream = self.stream_mut()?;
-            stream
-                .cwd(&base_path)
-                .await
-                .map_err(|e| ProviderError::ServerError(e.to_string()))?;
             let listed = stream.list(Some("-a")).await;
-            let _ = stream.cwd(&saved_cwd).await;
-            listed.map_err(|e| ProviderError::ServerError(e.to_string()))?
+            let restored = self.restore_cwd(&saved_cwd).await;
+            let lines = listed.map_err(|e| ProviderError::ServerError(e.to_string()))?;
+            // Only now: a listing that worked is worth nothing if the connection
+            // was left somewhere else, because every later relative operation
+            // would quietly address the wrong directory.
+            restored?;
+            lines
         } else {
             let stream = self.stream_mut()?;
             stream
@@ -474,10 +474,129 @@ impl FtpProvider {
                 .map_err(|e| ProviderError::ServerError(e.to_string()))?
         };
 
-        Ok(lines
+        let entries: Vec<RemoteEntry> = lines
             .iter()
             .filter_map(|line| self.parse_listing(line, &base_path))
-            .collect())
+            .collect();
+
+        // FTP answers a LIST against a directory that does not exist with a
+        // successful, empty listing, so "missing" and "empty" arrive identical.
+        // WebDAV says "not found" and S3 is entitled to answer empty (a prefix
+        // with no keys IS an empty prefix), but an FTP directory either exists
+        // or does not, and the server knows which: the information is on the
+        // wire and we were discarding it.
+        //
+        // It is not a listing quirk. A sync with delete reads the empty listing
+        // as "the source is gone", and the guard that would refuse to mirror
+        // that into a delete is not called on every path, so the planner can
+        // delete a local tree against a directory that was merely misspelled.
+        //
+        // The confirmation costs nothing on the normal path, because it runs
+        // only when the listing came back empty, which is the sole ambiguous
+        // case. CWD is used rather than a stat because it needs no FEAT support
+        // and so behaves the same on servers that advertise MLST, those that
+        // advertise MLSD alone, and those that advertise neither.
+        if entries.is_empty() && list_path.is_some() && base_path != "/" {
+            self.confirm_directory_exists(&base_path).await?;
+        }
+
+        Ok(entries)
+    }
+
+    /// CWD into `target`, returning where the SERVER says we were.
+    ///
+    /// The saved directory comes from PWD, not from `self.current_path`. That
+    /// field is our mirror of the server's state, and restoring to what we
+    /// believe rather than to where we actually were is how a listing leaves
+    /// the connection pointing somewhere else.
+    async fn cwd_into(&mut self, target: &str) -> Result<String, ProviderError> {
+        let stream = self.stream_mut()?;
+        let saved = stream
+            .pwd()
+            .await
+            .map_err(|e| ProviderError::ServerError(format!("pwd: {e}")))?;
+        match stream.cwd(target).await {
+            Ok(()) => {}
+            Err(FtpError::UnexpectedResponse(response))
+                if response.status == Status::FileUnavailable =>
+            {
+                return Err(ProviderError::NotFound(format!("path not found: {target}")));
+            }
+            Err(e) => return Err(ProviderError::ServerError(e.to_string())),
+        }
+        // The mirror follows the server immediately, so it is never a lie even
+        // if the restore below fails.
+        self.current_path = target.to_string();
+        Ok(saved)
+    }
+
+    /// Put the working directory back, and report it if that fails.
+    ///
+    /// The failure used to be discarded with `let _`. A discarded restore is
+    /// the worst shape this can take: the listing succeeds, the connection is
+    /// left in another directory, and the damage appears later in an unrelated
+    /// operation with nothing to connect it back to here.
+    async fn restore_cwd(&mut self, saved: &str) -> Result<(), ProviderError> {
+        let stream = self.stream_mut()?;
+        match stream.cwd(saved).await {
+            Ok(()) => {
+                self.current_path = saved.to_string();
+                Ok(())
+            }
+            Err(e) => Err(ProviderError::ServerError(format!(
+                "could not restore the working directory to {saved}: {e}"
+            ))),
+        }
+    }
+
+    /// Recognise a reply that says the path is not there.
+    ///
+    /// FTP spends 550 on both "you may not" and "it is not there", and spells
+    /// the difference only in the text, so the text is what has to be read.
+    /// Everything that is not clearly about a missing path is left alone: a
+    /// permission error must not be reported as a missing file, and a command
+    /// the server simply refuses must not become one either.
+    fn classify_missing_path(err: &FtpError) -> Option<ProviderError> {
+        let FtpError::UnexpectedResponse(ref response) = err else {
+            return None;
+        };
+        if !matches!(
+            response.status,
+            Status::FileUnavailable | Status::BadFilename
+        ) {
+            return None;
+        }
+        let text = response.to_string();
+        super::types::message_names_a_missing_path(&text).then_some(ProviderError::NotFound(text))
+    }
+
+    /// Classify a STOR failure instead of calling everything a transfer error.
+    ///
+    /// A missing parent directory comes back as 550 or as "553 Can't open that
+    /// file: No such file or directory", which said nothing about which segment
+    /// was missing and, worse, was retried: the retry budget is spent on exit
+    /// codes, and a generic transfer failure is a retryable one. So a permanent
+    /// 5xx about a path that does not exist was tried three times before
+    /// failing, every time.
+    ///
+    /// The CLI compensated with a preflight `stat` of the parent on FTP only,
+    /// which made the message good and the retries stop on that surface alone.
+    /// Classifying it here does both for every caller, and the preflight goes
+    /// away in the same change.
+    fn map_store_error(err: FtpError) -> ProviderError {
+        if let Some(missing) = Self::classify_missing_path(&err) {
+            return missing;
+        }
+        ProviderError::TransferFailed(err.to_string())
+    }
+
+    /// Tell a directory that is empty from one that is not there.
+    ///
+    /// Answers `Ok` when it exists and `NotFound` when it does not, and leaves
+    /// the working directory where it found it.
+    async fn confirm_directory_exists(&mut self, target: &str) -> Result<(), ProviderError> {
+        let saved = self.cwd_into(target).await?;
+        self.restore_cwd(&saved).await
     }
 
     /// Enumerate a directory for recursive deletion, including hidden dotfiles.
@@ -519,10 +638,28 @@ impl FtpProvider {
 
         let entries = self.list_inner(&parent).await?;
 
-        entries
+        let mut entry = entries
             .into_iter()
             .find(|e| e.name == name)
-            .ok_or_else(|| ProviderError::NotFound(path.to_string()))
+            .ok_or_else(|| ProviderError::NotFound(path.to_string()))?;
+
+        // A LIST row can report 0 for a file that is not empty: the column may
+        // be missing, unparseable, or simply absent in the server's dialect.
+        // SIZE asks the server directly, so ask it rather than pass on a zero
+        // that cannot be told from an empty file.
+        //
+        // The CLI has been doing exactly this since the defect was first hit,
+        // in a helper it applies after its own stat calls. That made `stat`
+        // correct on one surface out of three: the same call through the GUI or
+        // through MCP returned the unhydrated zero. Moving it here is not a new
+        // fix, it is the proven one put where all three surfaces reach it, and
+        // the CLI helper goes away in the same change.
+        if !entry.is_dir && entry.size == 0 {
+            if let Ok(size) = self.size_inner(path).await {
+                entry.size = size;
+            }
+        }
+        Ok(entry)
     }
 
     async fn size_inner(&mut self, path: &str) -> Result<u64, ProviderError> {
@@ -788,9 +925,29 @@ impl StorageProvider for FtpProvider {
         self.ensure_connected().await?;
 
         // Get file size for progress + intra-file gating.
+        //
+        // A failure here used to become 0 and the download carried on. That
+        // discarded the one thing the server had just told us, and it did it
+        // three ways at once: a progress bar with a fabricated total, the
+        // intra-file parallelism silently disabled because 0 is below every
+        // cutoff, and, when the file simply was not there, a RETR issued
+        // anyway for a path the server had already refused.
+        //
+        // Only a reply that names a missing path is turned into an answer.
+        // Servers legitimately refuse SIZE for other reasons (notably in ASCII
+        // mode), and those keep the previous behaviour exactly: fall back to 0
+        // and let the transfer decide. Refusing a download because SIZE was
+        // unavailable would break working setups, which is the trade this
+        // whole change exists to avoid.
         let total_size = {
             let stream = self.stream_mut()?;
-            stream.size(remote_path).await.unwrap_or(0) as u64
+            match stream.size(remote_path).await {
+                Ok(size) => size as u64,
+                Err(err) => match Self::classify_missing_path(&err) {
+                    Some(missing) => return Err(missing),
+                    None => 0,
+                },
+            }
         };
 
         // PD-FTP-1: intra-file parallelism. Engaged only when the user
@@ -941,12 +1098,75 @@ impl StorageProvider for FtpProvider {
     }
 
     async fn mkdir(&mut self, path: &str) -> Result<(), ProviderError> {
-        let stream = self.stream_mut()?;
-        stream
-            .mkdir(path)
-            .await
-            .map_err(|e| ProviderError::ServerError(e.to_string()))?;
-        Ok(())
+        let attempt = {
+            let stream = self.stream_mut()?;
+            stream.mkdir(path).await
+        };
+        match attempt {
+            Ok(()) => Ok(()),
+            // Every MKD failure used to become one generic ServerError, so
+            // "it is already there" and "you may not" arrived indistinguishable
+            // and callers that wanted to be idempotent had to guess.
+            //
+            // Unlike the other defects in this change, the answer is NOT always
+            // on the wire. Measured against the repo's vsftpd fixture, a
+            // duplicate mkdir replies "550 Create directory operation failed."
+            // with no mention of existence at all: the same text it uses for a
+            // refusal. Some servers do say "File exists"; vsftpd does not.
+            //
+            // So the directory is asked about rather than guessed at, always.
+            // An earlier version took a shortcut when the reply did say
+            // something like "File exists", to spare those servers a round
+            // trip. That shortcut skipped the check below, and a server saying
+            // "550 File exists" because a FILE holds the name would have been
+            // answered "the directory is already there": an idempotent caller
+            // carries on and the first upload into it fails somewhere else.
+            // The saving was one round trip on a failure; the cost was that the
+            // guarantee held on one branch and not the other, and depended on
+            // how a server chooses to word a sentence. This whole change exists
+            // because a fix that rested on the wording of a reply turned out to
+            // rest on nothing.
+            //
+            // The question is asked with CWD rather than with a stat, and that
+            // choice carries the whole cost of this branch. A stat here would
+            // be free only on servers that advertise MLST; on the rest it falls
+            // back to listing the PARENT directory and searching it, so every
+            // duplicate mkdir would cost a listing proportional to the parent's
+            // size, and a recursive upload walks a mkdir ladder over every
+            // ancestor, paying that once per level of an existing tree. CWD is
+            // two commands regardless of the server and regardless of how large
+            // the directory is.
+            //
+            // It also answers a better question. A stat says "something is
+            // here" and the directory-ness has to be read off it; CWD cannot
+            // succeed on a file at all, so "it is there AND it is a directory"
+            // is the only thing a success can mean. The guarantee stops being
+            // derived and becomes intrinsic.
+            //
+            // A 550 that is neither stays the generic error it always was:
+            // claiming "permission denied" for a reply that does not say so
+            // would trade a vague answer for a wrong one.
+            Err(FtpError::UnexpectedResponse(response))
+                if response.status == Status::FileUnavailable =>
+            {
+                match self.confirm_directory_exists(path).await {
+                    Ok(()) => Err(ProviderError::AlreadyExists(path.to_string())),
+                    // The directory is not there, so the mkdir failed for its
+                    // own reason and that is what the caller gets.
+                    Err(ProviderError::NotFound(_)) => {
+                        Err(ProviderError::ServerError(response.to_string()))
+                    }
+                    // Anything else is about the probe, not about the mkdir,
+                    // and one of those is the probe having entered the
+                    // directory and failed to come back out. Collapsing that
+                    // into the generic mkdir error would be the discarded
+                    // restore this change exists to remove, returning in the
+                    // one place a restore can fail during a probe.
+                    Err(probe_failure) => Err(probe_failure),
+                }
+            }
+            Err(e) => Err(ProviderError::ServerError(e.to_string())),
+        }
     }
 
     async fn delete(&mut self, path: &str) -> Result<(), ProviderError> {
@@ -1118,8 +1338,18 @@ impl StorageProvider for FtpProvider {
 
         let stream = self.stream_mut()?;
 
-        // Get total file size
-        let total_size = stream.size(remote_path).await.unwrap_or(0) as u64;
+        // Get total file size. Same reading as `download`, and the case is more
+        // likely here rather than less: between the interrupted attempt and the
+        // resume there is time for the remote file to go away, and a resume of
+        // something that is no longer there is exactly the condition this is
+        // for. Any other SIZE failure keeps the previous fallback.
+        let total_size = match stream.size(remote_path).await {
+            Ok(size) => size as u64,
+            Err(err) => match Self::classify_missing_path(&err) {
+                Some(missing) => return Err(missing),
+                None => 0,
+            },
+        };
 
         stream
             .transfer_type(FileType::Binary)
@@ -1589,7 +1819,7 @@ impl FtpProvider {
         let mut data_stream = stream
             .put_with_stream(remote_path)
             .await
-            .map_err(|e| ProviderError::TransferFailed(e.to_string()))?;
+            .map_err(Self::map_store_error)?;
 
         // Write in 64KB chunks for optimal throughput
         let mut chunk = [0u8; 65536];
@@ -1901,6 +2131,36 @@ mod tests {
                 msg
             );
         }
+    }
+
+    /// A STOR into a directory that is not there is permanent, and used to be
+    /// reported as a generic transfer failure: a retryable one. It was tried
+    /// three times, every time, and the message said nothing about which
+    /// segment was missing.
+    #[test]
+    fn a_store_into_a_missing_directory_is_not_found_not_a_transfer_failure() {
+        use suppaftp::types::Response;
+        let missing = FtpProvider::map_store_error(FtpError::UnexpectedResponse(Response::new(
+            Status::BadFilename,
+            b"Can't open that file: No such file or directory".to_vec(),
+        )));
+        assert!(
+            matches!(missing, ProviderError::NotFound(_)),
+            "553 with 'no such file' is a missing path: {missing:?}"
+        );
+
+        let denied = FtpProvider::map_store_error(FtpError::UnexpectedResponse(Response::new(
+            Status::FileUnavailable,
+            b"Permission denied".to_vec(),
+        )));
+        assert!(
+            matches!(denied, ProviderError::TransferFailed(_)),
+            "a refusal that is not about a missing path must not become NotFound: {denied:?}"
+        );
+
+        // A transport failure is not a classification question at all.
+        let broken = FtpProvider::map_store_error(FtpError::BadResponse);
+        assert!(matches!(broken, ProviderError::TransferFailed(_)));
     }
 
     // ── Characterisation battery for the listing parser ────────────────────

--- a/src-tauri/src/providers/ftp.rs
+++ b/src-tauri/src/providers/ftp.rs
@@ -460,12 +460,23 @@ impl FtpProvider {
             let stream = self.stream_mut()?;
             let listed = stream.list(Some("-a")).await;
             let restored = self.restore_cwd(&saved_cwd).await;
-            let lines = listed.map_err(|e| ProviderError::ServerError(e.to_string()))?;
-            // Only now: a listing that worked is worth nothing if the connection
-            // was left somewhere else, because every later relative operation
-            // would quietly address the wrong directory.
-            restored?;
-            lines
+            // Both are reported when both fail. Propagating the listing error
+            // first would swallow the restore failure exactly when it matters
+            // most: the two fail together whenever the data connection drops,
+            // and of the pair it is the unrestored directory that outlives the
+            // call and misdirects everything after it.
+            match (listed, restored) {
+                (Ok(lines), Ok(())) => lines,
+                (Err(list_err), Ok(())) => {
+                    return Err(ProviderError::ServerError(list_err.to_string()))
+                }
+                (Ok(_), Err(restore_err)) => return Err(restore_err),
+                (Err(list_err), Err(restore_err)) => {
+                    return Err(ProviderError::ServerError(format!(
+                        "{list_err}; and {restore_err}"
+                    )))
+                }
+            }
         } else {
             let stream = self.stream_mut()?;
             stream
@@ -517,10 +528,32 @@ impl FtpProvider {
             .map_err(|e| ProviderError::ServerError(format!("pwd: {e}")))?;
         match stream.cwd(target).await {
             Ok(()) => {}
-            Err(FtpError::UnexpectedResponse(response))
-                if response.status == Status::FileUnavailable =>
-            {
-                return Err(ProviderError::NotFound(format!("path not found: {target}")));
+            // A 550 on CWD is not only "it is not there": it is also what a
+            // server sends for a directory you may not enter. Reading every one
+            // as NotFound turns an inaccessible directory into a nonexistent
+            // one, which is the mistake this change already made once on mkdir
+            // and had corrected by a live server. The reply is only read as a
+            // missing path when it says so, and its own text is kept rather
+            // than replaced with a sentence of ours.
+            Err(FtpError::UnexpectedResponse(response)) => {
+                let text = response.to_string();
+                //
+                // The fallback is `InvalidPath`, not `ServerError`, and the
+                // difference is not cosmetic: `ServerError` maps to exit 10,
+                // which `is_retryable_exit` treats as retryable, so a directory
+                // that will never be enterable would be attempted three times.
+                // That is the same defect this change removes from the 553
+                // path, reintroduced two functions away. `InvalidPath` is
+                // permanent on both retry paths, says only that the path did
+                // not work, and is already what the MLST preflight above
+                // returns for the same status.
+                return if response.status == Status::FileUnavailable
+                    && super::types::message_names_a_missing_path(&text)
+                {
+                    Err(ProviderError::NotFound(format!("{target}: {text}")))
+                } else {
+                    Err(ProviderError::InvalidPath(format!("{target}: {text}")))
+                };
             }
             Err(e) => return Err(ProviderError::ServerError(e.to_string())),
         }

--- a/src-tauri/src/providers/ftp.rs
+++ b/src-tauri/src/providers/ftp.rs
@@ -556,8 +556,28 @@ impl FtpProvider {
     /// It is one function rather than a `format!` at each site so the shape
     /// cannot drift apart per call, which is how half these messages lost the
     /// path in the first place.
+    /// The server's reply comes FIRST, and what we were doing follows it.
+    ///
+    /// The obvious order, "listing /srv/data: 550 ...", puts our words between
+    /// the `ProviderError` label and the reply, and something downstream
+    /// depends on those two touching: `sync::mentions_ftp_status` decides that
+    /// a bare "553" is a status code rather than a byte count by checking that
+    /// one of our own Display labels is immediately followed by it. With the
+    /// operation wedged in between, "Transfer failed: uploading /x: 553 ..."
+    /// stopped matching, and the 553 rule this branch exists to add was
+    /// silently switched off by this branch's own message change: no failure,
+    /// no warning, the errors simply went back to being retried forever.
+    ///
+    /// Putting the reply first keeps that adjacency intact and needs no
+    /// loosening of the anchor, which is the part that makes it safe. Both
+    /// facts are still there, which is what was actually asked for.
+    ///
+    /// So the order is load-bearing: do not move the reply out of first
+    /// position to make the sentence read better. The test that catches it
+    /// says THAT it broke and not WHY, and the suite stayed green through the
+    /// whole time this was broken once already.
     fn doing(operation: &str, path: &str, reply: impl std::fmt::Display) -> String {
-        format!("{operation} {path}: {reply}")
+        format!("{reply} (while {operation} {path})")
     }
 
     /// Decide what a refused CWD means, without claiming more than the reply says.

--- a/src-tauri/src/providers/types.rs
+++ b/src-tauri/src/providers/types.rs
@@ -1666,6 +1666,30 @@ impl RemoteEntry {
     }
 }
 
+/// Does this message say the path is not there?
+///
+/// Two readers of this question existed with different vocabularies: the FTP
+/// provider recognised "no such directory" and "cannot find", the CLI's
+/// exit-code mapping recognised "does not exist", "file not exists" and "404",
+/// and neither was a superset of the other. In a codebase where the same
+/// question answered in two places is the defect being removed, a second
+/// vocabulary is the same defect in miniature, so there is one list and both
+/// ask it.
+pub fn message_names_a_missing_path(message: &str) -> bool {
+    let lowered = message.to_ascii_lowercase();
+    [
+        "no such file",
+        "no such directory",
+        "not found",
+        "does not exist",
+        "file not exists",
+        "cannot find",
+        "404",
+    ]
+    .iter()
+    .any(|needle| lowered.contains(needle))
+}
+
 /// Provider error type
 #[derive(Error, Debug)]
 #[allow(dead_code)]

--- a/src-tauri/src/providers/types.rs
+++ b/src-tauri/src/providers/types.rs
@@ -1677,17 +1677,96 @@ impl RemoteEntry {
 /// ask it.
 pub fn message_names_a_missing_path(message: &str) -> bool {
     let lowered = message.to_ascii_lowercase();
-    [
+    if [
         "no such file",
         "no such directory",
         "not found",
         "does not exist",
         "file not exists",
         "cannot find",
-        "404",
     ]
     .iter()
     .any(|needle| lowered.contains(needle))
+    {
+        return true;
+    }
+    // `404` has to be a word of its own, not three digits anywhere in the text.
+    //
+    // The needle came from the CLI, where it read messages we had composed. It
+    // now also reads raw server replies, and FTP servers quote the path inside
+    // the reply: "550 /public_html/404.html: Permission denied" contains those
+    // digits, so a refusal for permission came back as a file that is not
+    // there. That is the mistake the caller three lines up warns against, made
+    // by the vocabulary it calls, and `404.html` is a canonical file on exactly
+    // the web hosting that FTP serves.
+    //
+    // Nothing real is lost by tightening it. Both CLI call sites list "not
+    // found" alongside it, so the ordinary HTTP body is already matched by the
+    // words; what only the digits can catch is "http 404" or "status: 404",
+    // and those are a word of their own. The path-embedded form is the only
+    // case dropped, and dropping it is the fix.
+    //
+    // The general shape is the one running through this branch: a message
+    // carries the server's reason and the user's path, every keyword is a legal
+    // path component, and matching over the whole string cannot tell which half
+    // spoke. Here the boundary is enough because the needle is a single token.
+    lowered
+        .split_whitespace()
+        .any(|token| token.trim_matches(|c: char| !c.is_ascii_alphanumeric()) == "404")
+}
+
+#[cfg(test)]
+mod missing_path_vocabulary_tests {
+    use super::message_names_a_missing_path;
+
+    /// A path that merely contains "404" is not a missing path.
+    ///
+    /// The needle was written for messages we composed ourselves and is now
+    /// also applied to raw FTP replies, which quote the path back: FTP servers
+    /// answer "550 /public_html/404.html: Permission denied", and reading those
+    /// digits as a verdict turns a refusal for permission into a file that is
+    /// not there. `404.html` is a standard file on the web hosting FTP exists
+    /// to serve, so this is the ordinary case and not a contrived one.
+    ///
+    /// The rows below the divider are what the needle is FOR, and they are here
+    /// because tightening a match is how a rule gets silently switched off. The
+    /// same care was owed to the 553 anchor and to the slash in `i/o error`.
+    #[test]
+    fn digits_inside_a_path_are_not_a_missing_path() {
+        for message in [
+            "550 /public_html/404.html: Permission denied",
+            "550 /var/www/404/index.html: Permission denied",
+            "553 Can't open /srv/404.html: Permission denied",
+        ] {
+            assert!(
+                !message_names_a_missing_path(message),
+                "{message:?} was read as a missing path because of the digits in the path"
+            );
+        }
+
+        // ---- and the cases the needle exists to catch still match ----
+        for message in [
+            "HTTP 404",
+            "404 Not Found",
+            "status: 404",
+            "server returned (404)",
+            "error 404.",
+        ] {
+            assert!(
+                message_names_a_missing_path(message),
+                "{message:?} stopped being recognised: the tightening went too far"
+            );
+        }
+
+        // The word-based needles are untouched and still carry the common case.
+        for message in [
+            "550 No such file or directory",
+            "404 Not Found",
+            "The specified key does not exist",
+        ] {
+            assert!(message_names_a_missing_path(message), "{message:?}");
+        }
+    }
 }
 
 /// Provider error type

--- a/src-tauri/src/sync.rs
+++ b/src-tauri/src/sync.rs
@@ -3093,6 +3093,21 @@ pub struct SyncErrorInfo {
 /// does not match one. An unrecognised prefix fails closed, leaving the error
 /// retryable, which is the safe direction: not preventing a refusal costs a
 /// wasted attempt, wrongly preventing a retry costs a transfer.
+///
+/// This puts a requirement on the providers that they cannot see from where
+/// they stand: whatever a provider writes after its `ProviderError` label, the
+/// server's reply has to come FIRST, with nothing of ours in between. It has
+/// been broken once, by `providers::ftp`'s own error messages starting to name
+/// the operation ahead of the reply, and the only symptom was that this
+/// function quietly stopped recognising anything. Nothing failed, because
+/// failing closed here means going back to the old behaviour.
+///
+/// The contract is invisible from both ends: a provider has no reason to think
+/// anyone parses the SHAPE of its message, and this function cannot tell that
+/// the shape changed. It is written down at both ends for that reason, and the
+/// test that guards it compares a wrapped message against the same failure
+/// unwrapped, because asserting an expected value here only measures what we
+/// already believed.
 fn mentions_ftp_status(lowered: &str, code_and_space: &str) -> bool {
     if lowered.starts_with(code_and_space) {
         return true;
@@ -3127,9 +3142,77 @@ fn mentions_ftp_status(lowered: &str, code_and_space: &str) -> bool {
     })
 }
 
+/// A token that opens with a filesystem root, and so is a name somebody chose
+/// rather than anything a server said.
+///
+/// The test is where the token STARTS, not whether it contains a separator.
+/// `i/o error` contains a slash and is a reason, not a path, and the disk-error
+/// branch matches on exactly that string: a rule written as "contains a slash"
+/// would silently take `i/o error` out of every message and move those failures
+/// to `Unknown`, which is retryable. The narrower rule was checked against that
+/// case before being kept.
+fn looks_like_a_path(token: &str) -> bool {
+    if token.starts_with('/')
+        || token.starts_with("./")
+        || token.starts_with("../")
+        || token.starts_with("~/")
+    {
+        return true;
+    }
+    // A Windows path: `c:\\users\\...`, already lowercased by the caller.
+    let mut chars = token.chars();
+    match (chars.next(), chars.next(), chars.next()) {
+        (Some(drive), Some(':'), Some('\\')) | (Some(drive), Some(':'), Some('/')) => {
+            drive.is_ascii_alphabetic()
+        }
+        _ => false,
+    }
+}
+
+/// The part of an error message that is safe to classify: everything except the
+/// paths.
+///
+/// Classification here is done by searching the message for words, and a
+/// message contains two kinds of text with opposite properties. The reason is
+/// the server's or the operating system's, and its vocabulary is what these
+/// branches are looking for. The path is a name the USER chose, and it can
+/// contain any word at all, including every word this function keys on.
+///
+/// So a directory decided the retry. Measured, before this existed:
+/// `uploading /srv/quota-reports/x.csv: connection reset` matched `quota` and
+/// came out non-retryable, where the same failure without the path came out
+/// `Network` and retryable. `/srv/oauth/token.json` did the same through `auth`
+/// inside `oauth`. A transient error paired with an ordinary folder name
+/// stopped being retried at all, and the executors break on `!retryable`, so
+/// the file was silently left behind by the sync.
+///
+/// The exposure arrived with the messages that now name the path they were
+/// working on, which is a real improvement to what the user reads and, in the
+/// same string, an entrance for this. Both halves live on the same line, and
+/// only the classifier needs the path gone: `raw` is still what the caller is
+/// shown, so nothing the user reads loses anything.
+///
+/// The caller's own `file_path` is dropped as well when it appears as a whole
+/// token, because a relative path is not recognisable by shape and the caller
+/// is the authority on what it was operating on.
+fn classification_text(raw: &str, file_path: Option<&str>) -> String {
+    let named = file_path.unwrap_or_default().to_lowercase();
+    raw.to_lowercase()
+        .split_whitespace()
+        .filter(|token| {
+            // Trailing punctuation is the sentence's, not the path's, and
+            // `doing()` closes with a bracket, so `quota/report.csv)` has to
+            // compare equal to the path the caller named.
+            let bare = token.trim_end_matches([':', ',', ';', '.', ')', '"', '\'']);
+            !looks_like_a_path(bare) && (named.is_empty() || bare != named)
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
 /// Classify a raw error message into a structured SyncErrorInfo
 pub fn classify_sync_error(raw: &str, file_path: Option<&str>) -> SyncErrorInfo {
-    let lower = raw.to_lowercase();
+    let lower = classification_text(raw, file_path);
 
     let (kind, retryable) = if lower.contains("timeout") || lower.contains("timed out") {
         (SyncErrorKind::Timeout, true)
@@ -5359,6 +5442,128 @@ mod tests {
     /// which text a given server sends is unverified; what is asserted is only
     /// that a reply carrying this status is permanent, which is true of 553
     /// under every reading.
+    /// A folder name must not decide whether a failed file is retried.
+    ///
+    /// `classify_sync_error` reads words out of the whole message, and since
+    /// the messages started naming the path they were working on, that message
+    /// contains a name the user chose. Every word these branches key on is a
+    /// legal directory name, and the two that bite hardest sit ABOVE the
+    /// transient branches in the chain: `quota` is third and `auth` is ninth,
+    /// while `connection` is twelfth. So an ordinary folder turned a transient
+    /// failure into a permanent one, and the executors stop on `!retryable`,
+    /// which means the file was quietly left behind rather than retried.
+    ///
+    /// Each row is the same failure twice, once with a loaded path and once
+    /// bare. The verdicts have to agree: whatever the classification is, the
+    /// folder name must not be what produced it.
+    #[test]
+    fn a_folder_name_does_not_decide_the_classification() {
+        // (loaded message, the same failure with no path, the path argument)
+        let cases: &[(&str, &str, Option<&str>)] = &[
+            // Branch 3, `quota`, above every transient branch: this is the one
+            // that loses the retry outright.
+            (
+                "Transfer failed: connection reset (while uploading /srv/quota-reports/x.csv)",
+                "Transfer failed: connection reset",
+                Some("/srv/quota-reports/x.csv"),
+            ),
+            // Branch 9, `auth`, matching INSIDE `oauth`. It needs no folder
+            // called "auth": `oauth`, `authors` and `authorized_keys` all do it.
+            (
+                "Transfer failed: connection reset (while uploading /srv/oauth/token.json)",
+                "Transfer failed: connection reset",
+                Some("/srv/oauth/token.json"),
+            ),
+            // Branch 9 again, this time swallowing a real 553 before it can
+            // reach the branch that exists to catch it.
+            (
+                "Server error: 553 Can't open that file (while listing /srv/login)",
+                "Server error: 553 Can't open that file",
+                None,
+            ),
+            // Branch 10, `locked`. The mildest of the three: it added retries
+            // rather than removing them, which is why it was the easiest to
+            // dismiss and the least worth dismissing.
+            (
+                "Transfer failed: broken pipe (while uploading /var/locked/f.txt)",
+                "Transfer failed: broken pipe",
+                Some("/var/locked/f.txt"),
+            ),
+            // The path is not always at the end: only FTP composes with
+            // `doing()`, and other providers put it wherever their sentence
+            // needs it. The stripping is by token, so position does not matter.
+            (
+                "Cannot read /srv/quota-archive/x while syncing: connection reset",
+                "Cannot read while syncing: connection reset",
+                None,
+            ),
+            // A relative path has no shape to recognise, so the caller's own
+            // `file_path` is what removes it.
+            (
+                "Transfer failed: connection reset (while uploading quota/report.csv)",
+                "Transfer failed: connection reset",
+                Some("quota/report.csv"),
+            ),
+        ];
+        for (loaded, bare, path) in cases {
+            let with = classify_sync_error(loaded, *path);
+            let without = classify_sync_error(bare, None);
+            assert_eq!(
+                (format!("{:?}", with.kind), with.retryable),
+                (format!("{:?}", without.kind), without.retryable),
+                "the path changed the verdict for {loaded:?}"
+            );
+        }
+    }
+
+    /// The reasons still classify: the stripping did not take the words too.
+    ///
+    /// This is the other side of the boundary and it is the half that a fix
+    /// like this gets wrong. `i/o error` contains a slash, so a rule phrased as
+    /// "drop anything with a separator" would delete the reason along with the
+    /// path and send those failures to `Unknown`, which is retryable, with
+    /// every test above still green.
+    #[test]
+    fn stripping_paths_leaves_the_reasons_intact() {
+        let cases: &[(&str, Option<&str>, SyncErrorKind, bool)] = &[
+            (
+                "Transfer failed: i/o error (while uploading /home/a/b.txt)",
+                Some("/home/a/b.txt"),
+                SyncErrorKind::DiskError,
+                false,
+            ),
+            // The word still decides when it is the SERVER saying it.
+            (
+                "Quota exceeded: 552 Insufficient storage",
+                Some("/home/a/b.txt"),
+                SyncErrorKind::QuotaExceeded,
+                false,
+            ),
+            (
+                "Authentication failed: 530 Login incorrect",
+                Some("/home/a/b.txt"),
+                SyncErrorKind::Auth,
+                false,
+            ),
+            // And a 553 behind a wrapper still reaches its own branch with a
+            // path in the message.
+            (
+                "Transfer failed: 553 Could not create file (while uploading /srv/data/x)",
+                Some("/srv/data/x"),
+                SyncErrorKind::Unknown,
+                false,
+            ),
+        ];
+        for (message, path, kind, retryable) in cases {
+            let got = classify_sync_error(message, *path);
+            assert_eq!(
+                (format!("{:?}", got.kind), got.retryable),
+                (format!("{kind:?}"), *retryable),
+                "{message:?} classified wrongly"
+            );
+        }
+    }
+
     #[test]
     fn a_bare_553_is_permanent_even_when_the_text_says_nothing_else() {
         let err = classify_sync_error("553 Could not create file", None);

--- a/src-tauri/src/sync.rs
+++ b/src-tauri/src/sync.rs
@@ -3078,16 +3078,53 @@ pub struct SyncErrorInfo {
 
 /// Is this an FTP status code, rather than the same digits inside a sentence?
 ///
-/// A status opens the server's reply, but by the time the text reaches here it
-/// has usually been wrapped by an error type, so it reads "Path not found: 553
-/// Can't open that file". Anchoring on the start of the string alone would
-/// therefore never match and would silently disable the rule; accepting the
-/// digits anywhere would match "failed after 553 bytes" and turn a transient
-/// failure into a permanent one, removing a legitimate retry. Requiring the
-/// start of the string or a `": "` prefix accepts both real shapes and neither
-/// false one.
+/// The text arriving here is usually an error that has already been wrapped, so
+/// it reads "Path not found: 553 Can't open that file". Anchoring on the start
+/// of the string alone would never match and would silently disable the rule.
+///
+/// Accepting the digits after any colon is not safe either: "upload stalled:
+/// 553 bytes" is a byte count, and treating it as a reply code would make a
+/// transient failure permanent and take away a retry that belongs. Nothing in
+/// the shape of the text separates the two, and "553" is not special: any
+/// three-digit number can appear as a count.
+///
+/// So the prefix has to be one WE produce. `ProviderError`'s Display labels are
+/// a closed set defined in `providers::types`, and prose from anywhere else
+/// does not match one. An unrecognised prefix fails closed, leaving the error
+/// retryable, which is the safe direction: not preventing a refusal costs a
+/// wasted attempt, wrongly preventing a retry costs a transfer.
 fn mentions_ftp_status(lowered: &str, code_and_space: &str) -> bool {
-    lowered.starts_with(code_and_space) || lowered.contains(&format!(": {code_and_space}"))
+    if lowered.starts_with(code_and_space) {
+        return true;
+    }
+    // Lowercased forms of the `#[error("...: {0}")]` labels in
+    // `providers::types::ProviderError`. Anything else that ends in ": " is
+    // someone's sentence, not our wrapper.
+    const OUR_LABELS: &[&str] = &[
+        "connection failed: ",
+        "authentication failed: ",
+        "path not found: ",
+        "permission denied: ",
+        "file too large: ",
+        "path already exists: ",
+        "directory not empty: ",
+        "invalid path: ",
+        "invalid configuration: ",
+        "operation not supported: ",
+        "transfer failed: ",
+        "network error: ",
+        "parse error: ",
+        "server error: ",
+        "io error: ",
+        "connection lost: ",
+        "read-only endpoint: ",
+        "unknown error: ",
+    ];
+    OUR_LABELS.iter().any(|label| {
+        lowered
+            .find(label)
+            .is_some_and(|at| lowered[at + label.len()..].starts_with(code_and_space))
+    })
 }
 
 /// Classify a raw error message into a structured SyncErrorInfo
@@ -5340,16 +5377,41 @@ mod tests {
         assert_eq!(err.kind, SyncErrorKind::PathNotFound);
     }
 
-    /// The digits must be a status, not a coincidence: "553 " inside a sentence
-    /// is not a reply code, and treating it as one would take a legitimate
-    /// retry away from a transient failure.
+    /// The digits must be a status, not a coincidence.
+    ///
+    /// An earlier version of this test used only "stalled after 553 bytes",
+    /// with no colon, and passed while the rule still matched "stalled: 553
+    /// bytes". A boundary test that checks one side of the boundary is not a
+    /// boundary test.
     #[test]
     fn digits_inside_a_sentence_are_not_a_status_code() {
-        let err = classify_sync_error("upload stalled after 553 bytes", None);
-        assert!(
-            err.retryable,
-            "this is a byte count, not a reply code, and the failure may be transient"
-        );
+        for prose in [
+            "upload stalled after 553 bytes",
+            "upload stalled: 553 bytes",
+            "short read: 553 bytes remaining",
+            "retry budget: 553 attempts",
+        ] {
+            let err = classify_sync_error(prose, None);
+            assert!(
+                err.retryable,
+                "{prose}: this is a count, not a reply code, and the failure may be transient"
+            );
+        }
+    }
+
+    /// And the wrapped forms that ARE a reply code must still be caught, for
+    /// every label the provider error type can put in front of them.
+    #[test]
+    fn a_status_behind_one_of_our_own_labels_is_still_a_status() {
+        for wrapped in [
+            "553 Could not create file",
+            "Transfer failed: 553 Could not create file",
+            "Server error: 553 Could not create file",
+            "Path not found: 553 Can't open that file",
+        ] {
+            let err = classify_sync_error(wrapped, None);
+            assert!(!err.retryable, "{wrapped}: this is a permanent reply");
+        }
     }
 
     /// The rule names 553 and not "every 5xx" on purpose: this classifier

--- a/src-tauri/src/sync.rs
+++ b/src-tauri/src/sync.rs
@@ -3197,7 +3197,29 @@ fn looks_like_a_path(token: &str) -> bool {
 /// is the authority on what it was operating on.
 fn classification_text(raw: &str, file_path: Option<&str>) -> String {
     let named = file_path.unwrap_or_default().to_lowercase();
-    raw.to_lowercase()
+    // The caller's path is removed as a SUBSTRING, before anything is split on
+    // whitespace, because a path may contain spaces and most of them do. Token
+    // by token, `/srv/My Quota/x.csv` arrives as `/srv/my` and `quota/x.csv)`:
+    // the first is dropped for its leading slash and the second is not, since
+    // it neither starts like a path nor equals the whole path. `quota` survived
+    // and the third branch matched it, so the defect this function exists to
+    // remove came straight back on any path with a space in it.
+    //
+    // What this does NOT cover is stated rather than papered over. The path in
+    // the message is not always the one the caller named: the upload executor
+    // passes `entry.local_path` while the message may carry the remote one, and
+    // a spaced path matching no `file_path` has no shape to recognise. Widening
+    // the shape rule to catch those would delete reasons along with paths, and
+    // `i/o error` is the standing proof that such a rule can look right and be
+    // silently wrong. Classifying on typed data instead of on rendered text is
+    // the real fix and is tracked separately.
+    let lowered = raw.to_lowercase();
+    let stripped = if named.is_empty() {
+        lowered
+    } else {
+        lowered.replace(&named, " ")
+    };
+    stripped
         .split_whitespace()
         .filter(|token| {
             // Trailing punctuation is the sentence's, not the path's, and
@@ -5442,6 +5464,105 @@ mod tests {
     /// which text a given server sends is unverified; what is asserted is only
     /// that a reply carrying this status is permanent, which is true of 553
     /// under every reading.
+    /// Every `ProviderError` label that can precede a reply is one the status
+    /// reader knows.
+    ///
+    /// `mentions_ftp_status` decides that a bare "553" is a status code and not
+    /// a byte count by requiring one of our own Display labels in front of it,
+    /// and it holds that list by hand. A hand-copied mirror of an enum is true
+    /// on the day it is written and nothing keeps it true: add a variant with a
+    /// `": {0}"` label tomorrow and a 553 behind it stops being recognised. No
+    /// test goes red, because the function fails closed and closed means the
+    /// old behaviour, so the loss is a fix that quietly stops applying.
+    ///
+    /// The guard is the `match` below and not the assertions. It has no
+    /// wildcard arm, so adding a variant to `ProviderError` fails the build
+    /// here and whoever adds it has to say which kind it is. The assertions
+    /// then check that the answer agrees with the list.
+    ///
+    /// The five that carry no reply are not an oversight: `NotConnected`,
+    /// `Cancelled` and `Timeout` take no payload at all, and `RestrictedChar`
+    /// spells its own sentence with no label to anchor to. `Other` renders its
+    /// payload bare, which the leading-status check catches instead.
+    #[test]
+    fn every_provider_error_that_can_carry_a_reply_is_known_to_the_status_reader() {
+        use crate::providers::types::ProviderError as PE;
+
+        /// Exhaustive on purpose: no `_` arm, so a new variant breaks the build.
+        fn carries_a_reply_behind_a_label(e: &PE) -> bool {
+            match e {
+                PE::ConnectionFailed(_)
+                | PE::AuthenticationFailed(_)
+                | PE::NotFound(_)
+                | PE::PermissionDenied(_)
+                | PE::FileTooLarge(_)
+                | PE::AlreadyExists(_)
+                | PE::DirectoryNotEmpty(_)
+                | PE::InvalidPath(_)
+                | PE::InvalidConfig(_)
+                | PE::NotSupported(_)
+                | PE::TransferFailed(_)
+                | PE::NetworkError(_)
+                | PE::ParseError(_)
+                | PE::ServerError(_)
+                | PE::IoError(_)
+                | PE::ConnectionLost(_)
+                | PE::ReadOnly(_)
+                | PE::Unknown(_) => true,
+                // Renders the payload with no label; the leading-status check
+                // in `mentions_ftp_status` is what recognises this one.
+                PE::Other(_) => true,
+                PE::NotConnected | PE::Cancelled | PE::Timeout => false,
+                PE::RestrictedChar { .. } => false,
+            }
+        }
+
+        let reply = "553 Could not create file".to_string();
+        let every_variant = vec![
+            PE::NotConnected,
+            PE::ConnectionFailed(reply.clone()),
+            PE::AuthenticationFailed(reply.clone()),
+            PE::NotFound(reply.clone()),
+            PE::PermissionDenied(reply.clone()),
+            PE::FileTooLarge(reply.clone()),
+            PE::AlreadyExists(reply.clone()),
+            PE::DirectoryNotEmpty(reply.clone()),
+            PE::InvalidPath(reply.clone()),
+            PE::InvalidConfig(reply.clone()),
+            PE::NotSupported(reply.clone()),
+            PE::Cancelled,
+            PE::TransferFailed(reply.clone()),
+            PE::Timeout,
+            PE::NetworkError(reply.clone()),
+            PE::ParseError(reply.clone()),
+            PE::ServerError(reply.clone()),
+            PE::IoError(std::io::Error::other(reply.clone())),
+            PE::ConnectionLost(reply.clone()),
+            PE::RestrictedChar {
+                ch_display: "?".to_string(),
+                provider: "test".to_string(),
+            },
+            PE::ReadOnly(reply.clone()),
+            PE::Unknown(reply.clone()),
+            PE::Other(reply.clone()),
+        ];
+        assert_eq!(
+            every_variant.len(),
+            23,
+            "the list stopped covering every variant; the match above is what fails the build, this only says how many were meant"
+        );
+
+        for error in &every_variant {
+            let rendered = error.to_string().to_lowercase();
+            let found = mentions_ftp_status(&rendered, "553 ");
+            assert_eq!(
+                found,
+                carries_a_reply_behind_a_label(error),
+                "{rendered:?}: the status reader and the variant disagree, so OUR_LABELS has drifted from the enum"
+            );
+        }
+    }
+
     /// A folder name must not decide whether a failed file is retried.
     ///
     /// `classify_sync_error` reads words out of the whole message, and since
@@ -5488,6 +5609,15 @@ mod tests {
                 "Transfer failed: broken pipe (while uploading /var/locked/f.txt)",
                 "Transfer failed: broken pipe",
                 Some("/var/locked/f.txt"),
+            ),
+            // A path with a SPACE in it, which is the common case and the one
+            // that survived the first version of the stripping: split on
+            // whitespace it arrives as `/srv/my` and `quota/x.csv)`, and only
+            // the first half looks like a path.
+            (
+                "Transfer failed: connection reset (while uploading /srv/My Quota/x.csv)",
+                "Transfer failed: connection reset",
+                Some("/srv/My Quota/x.csv"),
             ),
             // The path is not always at the end: only FTP composes with
             // `doing()`, and other providers put it wherever their sentence

--- a/src-tauri/src/sync.rs
+++ b/src-tauri/src/sync.rs
@@ -3240,7 +3240,17 @@ pub fn classify_sync_error(raw: &str, file_path: Option<&str>) -> SyncErrorInfo 
         (SyncErrorKind::Timeout, true)
     } else if lower.contains("rate limit")
         || lower.contains("too many requests")
-        || lower.contains("429")
+        // A whole token, unlike the bare `contains` this used to be: every
+        // other status needle here carries a trailing space and this one did
+        // not, so it matched inside any longer number, `11429` and a timestamp
+        // included. It is the mildest of the family because rate limiting is
+        // retryable, so a false positive costs an extra attempt rather than
+        // removing one, and it is the only one that can be tightened without
+        // the measurement the others are waiting for: `429 Too Many Requests`
+        // has it as a token in every form anyone sends.
+        || lower
+            .split_whitespace()
+            .any(|token| token.trim_matches(|c: char| !c.is_ascii_alphanumeric()) == "429")
     {
         (SyncErrorKind::RateLimit, true)
     } else if lower.contains("quota")
@@ -3268,9 +3278,33 @@ pub fn classify_sync_error(raw: &str, file_path: Option<&str>) -> SyncErrorInfo 
     } else if lower.contains("not found")
         || lower.contains("no such file")
         || lower.contains("404 ")
-        || lower.contains("550 ")
     {
-        // 550 can be either permission or not-found; prefer permission if already matched.
+        // The `550` that used to be listed here could never fire: the
+        // permission branch above holds the same needle and runs first, so no
+        // message reached this one. The comment beside it said "prefer
+        // permission if already matched", describing an intention the code had
+        // no way to express, and the dead alternative made the branch look like
+        // it had a second entrance. On FTP a missing path is therefore reached
+        // by TEXT and never by status code, which is worth knowing when reading
+        // `message_names_a_missing_path`: that vocabulary is the only door, not
+        // one of two.
+        //
+        // The remaining status needles here are bare `contains` and that is
+        // known rather than overlooked. `552`, `403`, `550`, `404`, `401` and
+        // `530` all match three digits anywhere in the message, so a byte count
+        // such as "wrote 550 of 1024 bytes" classifies as permission denied and
+        // permanent: six of them lead to non-retryable, which is the direction
+        // that loses work. It is the same shape as "553 bytes", which is why
+        // `mentions_ftp_status` exists.
+        //
+        // They are NOT anchored the way 553 is, and the reason is a missing
+        // measurement rather than a judgement. This function classifies for
+        // every provider, `mentions_ftp_status` anchors on our own
+        // `ProviderError` labels, and nobody has established which shape the
+        // error strings of the other providers actually arrive in. Anchoring
+        // without that would silently switch off classifications that work
+        // today, six times over, and the failure would look like a clean green.
+        // Collecting those shapes is the work this is waiting on.
         //
         // 553 is FTP's "requested action not taken, file name not allowed",
         // which servers return for a STOR into a directory that does not exist
@@ -5464,6 +5498,63 @@ mod tests {
     /// which text a given server sends is unverified; what is asserted is only
     /// that a reply carrying this status is permanent, which is true of 553
     /// under every reading.
+    /// `429` must be a code, not three digits inside a longer number.
+    ///
+    /// It was the only status needle in this function with no boundary at all,
+    /// while every sibling carries a trailing space, so it fired on `11429` and
+    /// on any timestamp that happened to contain those digits. It is also the
+    /// mildest of the family, because rate limiting is retryable: a false
+    /// positive here adds an attempt rather than removing one, which is why it
+    /// is the one that could be fixed without the survey the others need.
+    #[test]
+    fn a_rate_limit_code_is_a_code_and_not_a_substring_of_a_number() {
+        for message in [
+            "Transfer failed: wrote 11429 bytes before the connection reset",
+            "Transfer failed: at 1764429000 the connection reset",
+        ] {
+            let got = classify_sync_error(message, None);
+            assert_ne!(
+                format!("{:?}", got.kind),
+                "RateLimit",
+                "{message:?} was read as rate limiting because of digits inside a number"
+            );
+        }
+        for message in ["429 Too Many Requests", "HTTP 429", "rejected (429)"] {
+            let got = classify_sync_error(message, None);
+            assert_eq!(
+                format!("{:?}", got.kind),
+                "RateLimit",
+                "{message:?} stopped being recognised: the tightening went too far"
+            );
+        }
+    }
+
+    /// On FTP a missing path is reached by TEXT, never by the status code.
+    ///
+    /// The not-found branch used to list `550` as an alternative and it could
+    /// never fire, because the permission branch above holds the same needle
+    /// and runs first. Removing it changed no behaviour, and this records the
+    /// fact it was hiding: every `550` is permission denied here, whatever the
+    /// reply says, so `message_names_a_missing_path` is the ONLY door to a
+    /// missing path on this protocol rather than one of two. That is worth
+    /// pinning, because it is what makes over-tightening that vocabulary
+    /// expensive.
+    #[test]
+    fn a_550_is_always_permission_denied_here_whatever_the_text_says() {
+        for message in [
+            "Server error: 550 Failed to change directory.",
+            "Server error: 550 No such file or directory",
+            "Path not found: 550 /nope: No such file or directory",
+        ] {
+            let got = classify_sync_error(message, None);
+            assert_eq!(
+                format!("{:?}", got.kind),
+                "PermissionDenied",
+                "{message:?}: the not-found branch is not reachable by status on FTP"
+            );
+        }
+    }
+
     /// Every `ProviderError` label that can precede a reply is one the status
     /// reader knows.
     ///

--- a/src-tauri/src/sync.rs
+++ b/src-tauri/src/sync.rs
@@ -1218,9 +1218,32 @@ pub(crate) fn orphan_delete_guard(
     local_scan: &ScanCompleteness,
     remote_scan: &ScanCompleteness,
 ) -> Result<(), String> {
+    orphan_delete_guard_over(
+        direction,
+        locals.is_empty(),
+        remotes.is_empty(),
+        local_scan,
+        remote_scan,
+    )
+}
+
+/// The same policy, over the facts it actually uses.
+///
+/// [`orphan_delete_guard`] only ever asks its two slices whether they are
+/// empty, and a caller holding maps instead of entry vectors would otherwise
+/// have to materialise vectors to ask the same question, or copy the policy.
+/// Copying it is how the CLI came to plan deletes without this guard at all
+/// while the core and the DAG both had it.
+pub fn orphan_delete_guard_over(
+    direction: SyncDirection,
+    locals_empty: bool,
+    remotes_empty: bool,
+    local_scan: &ScanCompleteness,
+    remote_scan: &ScanCompleteness,
+) -> Result<(), String> {
     let (source_scan, source_empty, dest_nonempty) = match direction {
-        SyncDirection::Upload => (local_scan, locals.is_empty(), !remotes.is_empty()),
-        SyncDirection::Download => (remote_scan, remotes.is_empty(), !locals.is_empty()),
+        SyncDirection::Upload => (local_scan, locals_empty, !remotes_empty),
+        SyncDirection::Download => (remote_scan, remotes_empty, !locals_empty),
         SyncDirection::Both => return Ok(()),
     };
     if !source_scan.is_complete() {
@@ -3053,6 +3076,20 @@ pub struct SyncErrorInfo {
     pub file_path: Option<String>,
 }
 
+/// Is this an FTP status code, rather than the same digits inside a sentence?
+///
+/// A status opens the server's reply, but by the time the text reaches here it
+/// has usually been wrapped by an error type, so it reads "Path not found: 553
+/// Can't open that file". Anchoring on the start of the string alone would
+/// therefore never match and would silently disable the rule; accepting the
+/// digits anywhere would match "failed after 553 bytes" and turn a transient
+/// failure into a permanent one, removing a legitimate retry. Requiring the
+/// start of the string or a `": "` prefix accepts both real shapes and neither
+/// false one.
+fn mentions_ftp_status(lowered: &str, code_and_space: &str) -> bool {
+    lowered.starts_with(code_and_space) || lowered.contains(&format!(": {code_and_space}"))
+}
+
 /// Classify a raw error message into a structured SyncErrorInfo
 pub fn classify_sync_error(raw: &str, file_path: Option<&str>) -> SyncErrorInfo {
     let lower = raw.to_lowercase();
@@ -3091,8 +3128,40 @@ pub fn classify_sync_error(raw: &str, file_path: Option<&str>) -> SyncErrorInfo 
         || lower.contains("404 ")
         || lower.contains("550 ")
     {
-        // 550 can be either permission or not-found; prefer permission if already matched
+        // 550 can be either permission or not-found; prefer permission if already matched.
+        //
+        // 553 is FTP's "requested action not taken, file name not allowed",
+        // which servers return for a STOR into a directory that does not exist
+        // ("553 Can't open that file: No such file or directory"). It reached
+        // the fallthrough below and was classified Unknown, which is
+        // retryable, so a permanent failure was attempted three times before
+        // being reported. The retry is decided here and nowhere else: the
+        // transfer executors break on `!err_info.retryable`.
+        //
+        // Only 553 is added, not "every 5xx". This function classifies errors
+        // from every provider, and in HTTP a 5xx is exactly the case worth
+        // retrying: 500, 502 and 503 are transient by definition and several
+        // providers return them under load. A blanket rule would make those
+        // permanent and remove retry where it belongs. 553 is safe to name
+        // because it is not an HTTP status at all.
         (SyncErrorKind::PathNotFound, false)
+    } else if mentions_ftp_status(&lower, "553 ") {
+        // A 553 is a permanent negative reply, and it was falling through to
+        // the Unknown arm below, which is retryable: a failure that can never
+        // succeed was attempted three times, every time.
+        //
+        // The kind stays Unknown on purpose. RFC 959 spends 553 on "file name
+        // not allowed", servers use it for a STOR into a directory that is not
+        // there, and the two are not the same thing: calling every 553 a
+        // missing path would state something the reply does not say. A 553
+        // whose text DOES name a missing path is caught by the branch above and
+        // keeps the more precise kind. What is certain here is only that it is
+        // permanent, and that is what is recorded.
+        //
+        // Only 553 is named, not "every 5xx". This classifier serves every
+        // provider and in HTTP a 5xx is the retryable case: a general rule
+        // would take retry away from every HTTP backend under load.
+        (SyncErrorKind::Unknown, false)
     } else if lower.contains("invalid path")
         || lower.contains("not a writable file")
         || lower.contains("parent directory is missing")
@@ -5240,6 +5309,67 @@ mod tests {
         assert!(!err.retryable);
     }
 
+    /// The test that decides whether the 553 rule earns its place.
+    ///
+    /// An earlier pair of tests used "553 Can't open that file: No such file or
+    /// directory" and its wrapped form. Both passed with the rule deleted,
+    /// because both contain "no such file" or "not found" and match an earlier
+    /// branch: a rule with no test holding it alive. This one uses a 553 that
+    /// contains none of the other vocabulary, so it fails without the rule.
+    ///
+    /// The wording is not measured. The repo's vsftpd fixture could not be
+    /// started here (the Docker client is older than the daemon requires), so
+    /// which text a given server sends is unverified; what is asserted is only
+    /// that a reply carrying this status is permanent, which is true of 553
+    /// under every reading.
+    #[test]
+    fn a_bare_553_is_permanent_even_when_the_text_says_nothing_else() {
+        let err = classify_sync_error("553 Could not create file", None);
+        assert!(
+            !err.retryable,
+            "a 553 is a permanent negative reply and must not be retried"
+        );
+    }
+
+    /// A 553 that also names a missing path keeps the more precise kind: the
+    /// branch above it answers first, and the 553 rule does not overwrite it.
+    #[test]
+    fn a_553_that_names_a_missing_path_stays_a_missing_path() {
+        let err = classify_sync_error("553 Can't open that file: No such file or directory", None);
+        assert!(!err.retryable);
+        assert_eq!(err.kind, SyncErrorKind::PathNotFound);
+    }
+
+    /// The digits must be a status, not a coincidence: "553 " inside a sentence
+    /// is not a reply code, and treating it as one would take a legitimate
+    /// retry away from a transient failure.
+    #[test]
+    fn digits_inside_a_sentence_are_not_a_status_code() {
+        let err = classify_sync_error("upload stalled after 553 bytes", None);
+        assert!(
+            err.retryable,
+            "this is a byte count, not a reply code, and the failure may be transient"
+        );
+    }
+
+    /// The rule names 553 and not "every 5xx" on purpose: this classifier
+    /// serves every provider, and an HTTP 5xx is the retryable case. Making
+    /// them permanent would remove retry exactly where it belongs.
+    #[test]
+    fn http_server_errors_stay_retryable() {
+        for raw in [
+            "500 Internal Server Error",
+            "502 Bad Gateway",
+            "503 Service Unavailable",
+        ] {
+            let err = classify_sync_error(raw, None);
+            assert!(
+                err.retryable,
+                "{raw} is transient and must keep its retries"
+            );
+        }
+    }
+
     #[test]
     fn test_classify_sync_error_rate_limit() {
         let err = classify_sync_error("429 Too Many Requests", None);
@@ -5513,6 +5643,90 @@ mod tests {
             mtime: mtime.map(str::to_string),
             checksum_alg: checksum_hex.map(|_| "sha256".to_string()),
             checksum_hex: checksum_hex.map(str::to_string),
+        }
+    }
+
+    /// The fact-shaped form must decide exactly what the vector-shaped one
+    /// decides, on the same seven cases.
+    ///
+    /// `orphan_delete_guard` is now a shell that derives the facts and calls
+    /// this; the frozen test above proves the shell, and this proves the
+    /// policy. If the two ever disagree, one of them is a second copy of the
+    /// rule, which is how the CLI came to plan deletes with no guard at all
+    /// while the core and the DAG both had one.
+    #[test]
+    fn the_fact_shaped_guard_decides_the_same_seven_cases() {
+        use crate::sync_core::ScanCompleteness;
+        let complete = ScanCompleteness::default();
+        let incomplete = ScanCompleteness {
+            list_errors: 1,
+            truncated: false,
+        };
+        let truncated = ScanCompleteness {
+            list_errors: 0,
+            truncated: true,
+        };
+        let lfile = [local_entry(10, None, None)];
+        let rfile = [remote_entry(10, None, None)];
+
+        // (direction, locals, remotes, local_scan, remote_scan)
+        let cases: &[(
+            SyncDirection,
+            &[_],
+            &[_],
+            &ScanCompleteness,
+            &ScanCompleteness,
+        )] = &[
+            (
+                SyncDirection::Download,
+                &lfile,
+                &rfile,
+                &complete,
+                &complete,
+            ),
+            (
+                SyncDirection::Download,
+                &lfile,
+                &rfile,
+                &complete,
+                &incomplete,
+            ),
+            (
+                SyncDirection::Download,
+                &lfile,
+                &rfile,
+                &complete,
+                &truncated,
+            ),
+            (SyncDirection::Download, &lfile, &[], &complete, &complete),
+            (SyncDirection::Download, &[], &[], &complete, &complete),
+            (SyncDirection::Upload, &lfile, &rfile, &complete, &complete),
+            (SyncDirection::Upload, &[], &rfile, &complete, &complete),
+            // Both never deletes orphans, and must short-circuit before any
+            // other fact is consulted.
+            (SyncDirection::Both, &[], &rfile, &incomplete, &incomplete),
+        ];
+
+        for (direction, locals, remotes, local_scan, remote_scan) in cases {
+            let from_vectors =
+                orphan_delete_guard(*direction, locals, remotes, local_scan, remote_scan);
+            let from_facts = orphan_delete_guard_over(
+                *direction,
+                locals.is_empty(),
+                remotes.is_empty(),
+                local_scan,
+                remote_scan,
+            );
+            // Byte-identical, not merely both-Err: the message carries the
+            // listing-error count and the truncation clause, and it is what
+            // someone reads to find out why a delete did not happen.
+            assert_eq!(
+                from_vectors,
+                from_facts,
+                "the two shapes disagree on {direction:?} (locals empty: {}, remotes empty: {})",
+                locals.is_empty(),
+                remotes.is_empty()
+            );
         }
     }
 

--- a/src-tauri/tests/fixtures/ftp/docker-compose.yml
+++ b/src-tauri/tests/fixtures/ftp/docker-compose.yml
@@ -17,7 +17,13 @@ services:
     ports:
       - "127.0.0.1:2123:21"
       - "127.0.0.1:30000-30009:30000-30009"
-    restart: "no"
+    # `on-failure` rather than `no`: this fixture has been observed to exit on
+    # its own mid-run (SIGSEGV, container status 139), and with no restart
+    # policy every test after that point fails with "Connection refused". Five
+    # red tests read as a regression in the code under test, which is the most
+    # expensive way to present an absent server. Restarting turns it into at
+    # worst one flaky test instead of a wall.
+    restart: "on-failure"
     healthcheck:
       test: ["CMD", "sh", "-c", "pgrep vsftpd"]
       interval: 2s

--- a/src-tauri/tests/integration_ftp_missing_path.rs
+++ b/src-tauri/tests/integration_ftp_missing_path.rs
@@ -61,14 +61,19 @@ async fn a_missing_directory_is_not_reported_as_an_empty_one() {
     let mut p = connected().await;
     let missing = "/no-such-directory-6f1a9c";
 
+    // The property under test is that it FAILS, not which kind it fails with.
+    // The kind depends on what the server chooses to say: vsftpd answers a CWD
+    // into a missing directory with "550 Failed to change directory.", the same
+    // words it uses for one you may not enter, so the reply cannot be read as
+    // "not there" without asserting something it does not say. Where a server
+    // does name a missing path, the error carries the more precise kind.
     match p.list(missing).await {
-        Err(ProviderError::NotFound(_)) | Err(ProviderError::InvalidPath(_)) => {}
+        Err(_) => {}
         Ok(entries) => panic!(
             "a missing directory answered with a successful listing of {} entries; \
              this is the shape that lets a delete pass treat it as emptied",
             entries.len()
         ),
-        Err(other) => panic!("expected a not-found answer, got {other:?}"),
     }
 
     // The control case, and it matters as much: a directory that really is

--- a/src-tauri/tests/integration_ftp_missing_path.rs
+++ b/src-tauri/tests/integration_ftp_missing_path.rs
@@ -1,0 +1,220 @@
+//! Live checks for the three FTP behaviours that cannot be proved without a
+//! server, against the repo's vsftpd Docker fixture.
+//!
+//! `#[ignore]` so a default `cargo test` skips them, following the pattern of
+//! `integration_ftp_pool.rs`.
+//!
+//! ```bash
+//! cd src-tauri/tests/fixtures/ftp
+//! docker compose up -d --build            # control :2123
+//! cd ../../.. && cargo test --test integration_ftp_missing_path -- --ignored --nocapture
+//! cd tests/fixtures/ftp && docker compose down -v
+//! ```
+//!
+//! If every test here fails with "Connection refused", the fixture container
+//! has exited, not the code under test: it has been seen to die on its own
+//! mid-run. `docker ps -a` shows it as status 139. Restart it and re-run. The
+//! compose file asks for `restart: on-failure` so this heals itself, but a
+//! container started by hand without that flag will not.
+//!
+//! Why these three need a server. FTP answers a LIST against a directory that
+//! does not exist with a successful, empty listing, so "missing" and "empty"
+//! are the same bytes on the wire: no parser test can tell them apart, because
+//! the difference is not in the text. The same goes for the working directory
+//! left behind by a listing, and for a size that only the server can supply.
+//! Each was previously compensated for in the CLI, so each was correct on one
+//! surface out of three, and none had a test that would fail if the
+//! compensation were removed without the fix.
+
+use ftp_client_gui_lib::providers::types::{FtpConfig, FtpTlsMode, ProviderError};
+use ftp_client_gui_lib::providers::{FtpProvider, StorageProvider};
+
+const PORT: u16 = 2123;
+
+fn fixture_config() -> FtpConfig {
+    FtpConfig {
+        host: "127.0.0.1".to_string(),
+        port: PORT,
+        username: "testuser".to_string(),
+        password: secrecy::SecretString::from("testpass".to_string()),
+        tls_mode: FtpTlsMode::None,
+        verify_cert: false,
+        initial_path: Some("/".to_string()),
+    }
+}
+
+async fn connected() -> FtpProvider {
+    let mut p = FtpProvider::new(fixture_config());
+    p.connect().await.expect("FTP connect to the fixture");
+    p
+}
+
+/// The defect this PR exists for: a directory that is not there must not look
+/// like one that is empty.
+///
+/// It is not a cosmetic difference. A sync with `--delete` reads an empty
+/// source listing as "everything was removed" and plans to mirror that onto
+/// the destination, so a mistyped path could authorise deleting a local tree.
+#[tokio::test]
+#[ignore = "live: requires the ftp Docker fixture up on :2123"]
+async fn a_missing_directory_is_not_reported_as_an_empty_one() {
+    let mut p = connected().await;
+    let missing = "/no-such-directory-6f1a9c";
+
+    match p.list(missing).await {
+        Err(ProviderError::NotFound(_)) | Err(ProviderError::InvalidPath(_)) => {}
+        Ok(entries) => panic!(
+            "a missing directory answered with a successful listing of {} entries; \
+             this is the shape that lets a delete pass treat it as emptied",
+            entries.len()
+        ),
+        Err(other) => panic!("expected a not-found answer, got {other:?}"),
+    }
+
+    // The control case, and it matters as much: a directory that really is
+    // empty must still list as empty. A fix that answered NotFound for both
+    // would trade one wrong answer for another.
+    let empty = "/aeroftp-test-empty-6f1a9c";
+    let _ = p.rmdir(empty).await;
+    p.mkdir(empty).await.expect("create the empty directory");
+    let listed = p
+        .list(empty)
+        .await
+        .expect("an existing empty directory lists");
+    assert!(listed.is_empty(), "the directory was created empty");
+    p.rmdir(empty).await.expect("clean up");
+
+    let _ = p.disconnect().await;
+}
+
+/// A listing must leave the connection where it found it, and must say so if
+/// it cannot.
+///
+/// The hidden-file path CWDs into the target to issue `LIST -a`. The restore
+/// afterwards used to be `let _ = ...`, so a failed restore left the session
+/// in another directory silently: every later relative operation addressed the
+/// wrong place, and nothing connected the damage back to the listing.
+#[tokio::test]
+#[ignore = "live: requires the ftp Docker fixture up on :2123"]
+async fn a_listing_leaves_the_working_directory_where_it_found_it() {
+    let mut p = connected().await;
+    let dir = "/aeroftp-test-cwd-6f1a9c";
+    let _ = p.rmdir_recursive(dir).await;
+    p.mkdir(dir).await.expect("create the directory");
+
+    let before = p.pwd().await.expect("pwd before");
+    // `rmdir_recursive` enumerates with hidden files included, which is the
+    // path that CWDs into the target: the only one that can leave the session
+    // somewhere else.
+    p.rmdir_recursive(dir)
+        .await
+        .expect("recursive delete of an empty directory");
+    let after = p.pwd().await.expect("pwd after");
+
+    assert_eq!(
+        before, after,
+        "the listing moved the session and left it there"
+    );
+    let _ = p.disconnect().await;
+}
+
+/// `stat` must report the real size, not the zero a listing row may carry.
+///
+/// The CLI has been asking the server with SIZE since this was first hit, in a
+/// helper applied after its own stat calls, so `stat` was right on one surface
+/// and wrong on the other two. The hydration now lives in the provider; this
+/// checks it from the provider, which is where all three surfaces enter.
+#[tokio::test]
+#[ignore = "live: requires the ftp Docker fixture up on :2123"]
+async fn stat_reports_the_real_size_and_not_a_listing_zero() {
+    let mut p = connected().await;
+    let remote = "/aeroftp-test-size-6f1a9c.bin";
+    let payload = vec![7u8; 4096];
+
+    let _ = p.delete(remote).await;
+    let local = std::env::temp_dir().join("aeroftp-test-size-6f1a9c.bin");
+    std::fs::write(&local, &payload).expect("write the local file");
+    p.upload(local.to_str().unwrap(), remote, None)
+        .await
+        .expect("upload");
+
+    let entry = p.stat(remote).await.expect("stat the uploaded file");
+    assert_eq!(
+        entry.size,
+        payload.len() as u64,
+        "stat reported {} for a {}-byte file: a zero here is indistinguishable \
+         from an empty file to every caller",
+        entry.size,
+        payload.len()
+    );
+
+    p.delete(remote).await.expect("clean up");
+    let _ = std::fs::remove_file(&local);
+    let _ = p.disconnect().await;
+}
+
+/// Creating a directory that is already there is not a failure.
+///
+/// Every MKD failure used to become one generic error, so the idempotent
+/// branch that `mkdir -p` already had could never be reached on FTP: the
+/// variant it matches on was never produced. rclone answers this case with a
+/// silent success, so the target behaviour is not something we are inventing.
+#[tokio::test]
+#[ignore = "live: requires the ftp Docker fixture up on :2123"]
+async fn creating_an_existing_directory_says_it_already_exists() {
+    let mut p = connected().await;
+    let dir = "/aeroftp-test-mkdir-6f1a9c";
+    // A previous run that failed before its cleanup would otherwise make the
+    // FIRST create the duplicate one, and the test would fail for a reason
+    // that has nothing to do with what it checks.
+    let _ = p.rmdir(dir).await;
+
+    p.mkdir(dir).await.expect("first create succeeds");
+    match p.mkdir(dir).await {
+        Err(ProviderError::AlreadyExists(_)) => {}
+        Ok(()) => { /* a server that answers 2xx twice is also fine */ }
+        Err(other) => panic!(
+            "a second mkdir must be recognisable as already-existing, got {other:?}; \
+             a generic error here is what forced callers to confirm with a stat"
+        ),
+    }
+
+    p.rmdir(dir).await.expect("clean up");
+    let _ = p.disconnect().await;
+}
+
+/// A name that is taken by a FILE is not a directory that already exists.
+///
+/// The probe behind the previous test asks whether the path is there, and it
+/// must insist that it is there as a DIRECTORY. Someone with a file called
+/// `backup` who asks for a folder called `backup` gets a real failure, not a
+/// silent success followed by an unrelated error on the first upload into a
+/// directory that was never created. The patch this replaces made the same
+/// distinction, and a fix that dropped it would be worse than what it removed.
+#[tokio::test]
+#[ignore = "live: requires the ftp Docker fixture up on :2123"]
+async fn a_file_with_the_same_name_is_not_an_existing_directory() {
+    let mut p = connected().await;
+    let taken = "/aeroftp-test-taken-6f1a9c";
+    let _ = p.delete(taken).await;
+    let _ = p.rmdir(taken).await;
+
+    let local = std::env::temp_dir().join("aeroftp-test-taken-6f1a9c");
+    std::fs::write(&local, b"occupied").expect("write the local file");
+    p.upload(local.to_str().unwrap(), taken, None)
+        .await
+        .expect("upload a file under the name the directory would take");
+
+    match p.mkdir(taken).await {
+        Err(ProviderError::AlreadyExists(_)) => panic!(
+            "a file is occupying that name; reporting it as an existing directory \
+             would let an idempotent caller carry on and fail later, somewhere else"
+        ),
+        Err(_) => {}
+        Ok(()) => panic!("the server should not have created a directory over a file"),
+    }
+
+    p.delete(taken).await.expect("clean up");
+    let _ = std::fs::remove_file(&local);
+    let _ = p.disconnect().await;
+}


### PR DESCRIPTION
## One shape, six times

Every defect here has the same form: the server answered, the answer was discarded, and a later surface compensated for the loss. Each compensation lived in the CLI, so each was right on one surface out of three while the GUI and MCP kept the raw defect.

Two of the six turned out to be a different thing, and the distinction only appeared when a real server contradicted a premise written confidently from the documentation. **Four were data the server gave us and we threw away**: they close for good and cost nothing. **Two were questions we never asked**: the server does not offer the answer, so it has to be requested, and that costs a round trip which belongs on the failure path. That split is worth more as a method than as a taxonomy.

## What was wrong, and what it does now

**A directory that could not be listed arrived as an empty one.** FTP answers a LIST against a missing directory with a successful, empty listing, so "missing" and "empty" arrived identical.

The claim here is narrower than it first looked, and the narrowing came from measuring. A path that cannot be listed now **fails** rather than arriving as an empty directory, which is the property that matters: empty and absent stop coinciding, and a delete pass can no longer read a mistyped path as an emptied one. But on vsftpd the failure is generic, because that server answers a CWD into a missing directory with `550 Failed to change directory.`, the same words it uses for one you may not enter. The category is not on the wire, so it is not asserted. Not a display problem: a sync with `--delete` reads an empty source as "everything was removed" and plans to mirror that, so a mistyped path could authorise deleting a local tree. The provider now confirms existence when a listing comes back empty on an explicit non-root path. It costs nothing normally because it runs only in the ambiguous case, and it uses CWD, which needs no FEAT support and so behaves the same on servers advertising MLST, MLSD alone, or neither. The logic is not new: it is the CLI's own guard, moved to where all three surfaces reach it.

**The CLI planned deletions without the shared guard.** It already refused when the scan reported errors; the missing half was an empty source against a non-empty destination, which is exactly what the listing defect produced. A successful empty listing counts no errors, so it passed a check that existed. The core and the DAG both consulted the shared guard; this path restated half of it. The policy is now expressed over the facts it uses, so a caller holding maps neither materialises vectors nor copies the rule a fourth time. The frozen test that pins that policy is untouched, and a twin test compares the two shapes over the same eight cases on the whole `Result`, so the messages match byte for byte and not merely the Ok/Err.

**Downloading a file that does not exist hung.** Measured at 90 seconds to a client timeout and 600 through MCP, where it blocked the connection pool for everything else; rclone answers the same request in 1.3 seconds. The size lookup discarded its own failure with `unwrap_or(0)`, so a server that had just said "no such file" was answered with a fabricated zero and a RETR was issued anyway. That zero also fed the progress bar a false total and silently disabled intra-file parallelism, since zero is below every threshold. A reply naming a missing path is now an answer; every other size failure keeps the previous fallback, because servers refuse SIZE for legitimate reasons and refusing the download would break working setups. Both the download and the resume path are fixed: the resume is where the file is *more* likely to have gone, since time passes between the interrupted attempt and the retry.

**`stat` reported the listing's zero** instead of asking. It was right in the CLI, which hydrated it afterwards, and wrong in the GUI and MCP. The hydration is in the provider now.

**A 553 was retried three times.** Retry is decided by a classifier that had no rule for it, so it fell through to "unknown", which is retryable. It gets its own branch that records the one certain thing, that it is permanent, and does not claim a kind: RFC 959 spends 553 on "file name not allowed", and a 553 whose text does name a missing path is caught by the earlier branch and keeps the more precise kind. Only 553 is named, not "every 5xx": that classifier serves every provider, and in HTTP a 5xx is the retryable case, so a general rule would remove retry from every HTTP backend under load. A test pins that boundary.

**`mkdir` could not say "it is already there".** Every failure became one generic error, so the idempotent branch `mkdir -p` already had was unreachable on FTP: the variant it matches on was never produced, while five other providers produce it. rclone is idempotent here, so the target behaviour is not invented.

**A listing that changed directory restored it with the result thrown away.** A discarded restore is the worst available shape: the listing succeeds, the session is left elsewhere, and the damage surfaces later in an unrelated operation with nothing to connect it back. The restore now reports, the saved directory comes from PWD rather than from our own mirror of it, and the mirror follows the server immediately so it stays true even when the restore fails.

## The one that was not what it looked like

`mkdir` was written first to read the reply text, on the premise that "the server distinguishes these and we were discarding it". **That premise is false**, and a live server said so: vsftpd answers a duplicate `mkdir` with `550 Create directory operation failed.` and nothing else, the same text it uses for a refusal. The first version therefore fell through to "permission denied", replacing a vague answer with a wrong one.

So the directory is asked about instead. The question is put with CWD rather than with a stat, and that choice carries the cost of the branch: a stat is cheap only where MLST is advertised, and elsewhere falls back to listing the *parent* and searching it, which would make every duplicate `mkdir` cost a listing proportional to the parent and a recursive upload pay one per level of an existing tree. CWD is two commands regardless. It also answers a better question, because a CWD cannot succeed on a file, so "it exists and it is a directory" is the only thing success can mean: the guarantee stops being derived from a field and becomes intrinsic.

There is no text shortcut for servers that do word it clearly. One existed and was removed: it skipped the check, so a server saying `550 File exists` because a *file* holds the name would have been answered "the directory is already there", and an idempotent caller would have carried on to fail later somewhere else. Sparing those servers one round trip was not worth a guarantee that held on one branch and not the other, in a change that exists because a fix resting on the wording of a reply turned out to rest on nothing.

**Declared narrowing**: if the probe fails for a transient reason, a duplicate `mkdir` on a directory that really is there now returns the generic error rather than "already exists". Preferring not to assert is deliberate.

## Five compensations removed, four defects fixed

Not five and five: two of the compensations were the same defect. The second one says `mirrors ls` in its own comment, which is better evidence than anything that could be written here that the fix was in the wrong place, because a compensation that replicates itself from one chokepoint to the next has to be copied again for every new caller.

Each removal was checked in both directions: the compensation is gone from the CLI **and** its defect is fixed in the provider. Removing a guard without moving the fix would align the surfaces downwards, making the one that worked worse.

## Tests

Six unit tests and five integration tests, and the integration tests were **run**, against the repo's vsftpd fixture, not merely compiled: a missing directory answering as missing while a genuinely empty one still lists as empty; a listing leaving the working directory where it found it; `stat` reporting a real size; a duplicate `mkdir` being recognised; and a file occupying the name *not* being mistaken for an existing directory.

Running them is what found that the first `mkdir` fix did not work. No amount of reading would have: a correction that rests on the text of a server's reply cannot be validated by review, because the thing it depends on is not in the diff.

One unit test earned its place the hard way. Two earlier tests for the 553 rule passed with the rule deleted, because their fixtures contained words that matched an earlier branch: a rule with nothing holding it alive. The replacement uses a 553 carrying none of the other vocabulary, and it was checked by removing the rule and watching it go red.

**Not measured**: which text a given server sends for a bare 553. The exact wording is unverified; what is asserted is only that a reply carrying that status is permanent, which holds under every reading.

## A plaster, and it is labelled as one

The fixture container exits on its own mid-run (SIGSEGV, container status 139), and with no restart policy every test after that point failed with "Connection refused". Five red tests read as a regression in the code under test, which is the most expensive way to present an absent server, so the compose file now asks for `restart: on-failure` and the test file says what to check first.

That treats the symptom and hides the signal: a container that dies and comes back silently is a fault made quiet rather than made legible, which is the thing this whole change objects to. **The cause is open, not fixed.** The one clue available is that the stock vsftpd image has been up for 39 hours with no restarts while the image built from this repo dies within minutes, which says where to look and is not itself a diagnosis: nobody has investigated it. It is recorded as an open item so the restart policy is not mistaken for a resolution.

## What the review of this branch found

Three findings, all real, none applied in the form proposed.

**Both failures are kept.** When the hidden-file listing and the working-directory restore both failed, the listing error propagated first and the restore failure was never looked at, and the two fail together whenever the data connection drops. The finding asked for the restore to be checked first; reporting both is preferred, because choosing a winner discards the information the finding exists to preserve.

**A 550 on CWD no longer means "not found" by default**, and the server's own text is kept rather than replaced. A 550 is also what a server sends for a directory you may not enter, so reading every one as absent turned an inaccessible directory into a nonexistent one: the same mistake this change had already made on `mkdir` and had corrected by a live server, in a function forty lines away.

The fallback is `InvalidPath`, not `ServerError`, and that was found by writing the consequence down rather than citing it. `ServerError` maps to exit 10, which the retry predicate treats as retryable, so a directory that can never be entered would have been attempted three times: the very defect this change removes from the 553 path, reintroduced two functions away and noticed by nobody, including the review. `InvalidPath` is permanent on both retry paths, claims only that the path did not work, and is already what the MLST preflight in the same function returns for the same status.

**A byte count is not a reply code.** `mentions_ftp_status` accepted the digits after any colon, so "upload stalled: 553 bytes" was read as a permanent 553. The prefix must now be one of the `ProviderError` labels, a closed set defined in this repo, and an unrecognised prefix fails closed, leaving the error retryable. The boundary test that should have caught this checked only the form without a colon: a boundary test that looks at one side of the boundary. It now has four forms on each side.

## One visible change

Listing a path that does not exist on FTP exits **5** instead of 2, because the error is no longer classified as not-found. Anything checking exit 2 for "it is not there" on an FTP path sees a different code. Preserving the old one would mean asserting a category the server did not give us.

## Gates

`cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`: 0.
`cargo clippy --manifest-path src-tauri/Cargo.toml --all-features --tests -- -D warnings`: 0.
`cargo clippy --manifest-path src-tauri/Cargo.toml --bin aeroftp-cli --all-features -- -D warnings`: 0.
Integration tests against the live fixture: 5 passed, 0 failed.
`cargo test --lib`: 3603 passed, 0 failed, 20 ignored. That run was started before the last two edits (the probe moving from stat to CWD, and the probe's restore failure no longer being collapsed), so it is reported for what it is rather than as a gate on this exact tree; it is running again and the figure is updated below when it lands. Neither edit is covered by a unit test, since both are on paths that need a server, and both are covered by the five integration tests above, which were run after them.
The full suite is CI's, on three platforms.

Tracker: #628


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved FTP/FTPS handling for missing paths, existing directories, failed uploads, and accurate file sizes.
  - Improved directory listings, including empty folders and working-directory restoration.
  - Prevented incomplete or empty synchronization scans from triggering deletions.
  - Improved error classification for FTP responses, permissions, rate limits, and misleading path text.
  - Clarified error messages with server responses and affected paths.

- **Tests**
  - Added coverage for FTP/FTPS path handling, directory operations, file sizes, synchronization safeguards, and server recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->