### PR TITLE
refactor(providers): align every recursive descent on the walkable-dir contract

### DIFF
--- a/src-tauri/src/providers/azure.rs
+++ b/src-tauri/src/providers/azure.rs
@@ -1570,7 +1570,7 @@ impl StorageProvider for AzureProvider {
         }
         let entries = self.list(path).await?;
         for entry in entries {
-            if entry.is_dir {
+            if entry.is_walkable_dir() {
                 Box::pin(self.rmdir_recursive(&entry.path)).await?;
             } else {
                 self.delete(&entry.path).await?;

--- a/src-tauri/src/providers/filen/mod.rs
+++ b/src-tauri/src/providers/filen/mod.rs
@@ -2845,7 +2845,7 @@ impl StorageProvider for FilenProvider {
                         if crate::providers::matches_find_pattern(&entry.name, pattern) {
                             results.push(entry.clone());
                         }
-                        if entry.is_dir && results.len() < 500 {
+                        if entry.is_walkable_dir() && results.len() < 500 {
                             next_dirs.push(entry.path.clone());
                         }
                     }

--- a/src-tauri/src/providers/ftp.rs
+++ b/src-tauri/src/providers/ftp.rs
@@ -1349,7 +1349,7 @@ impl StorageProvider for FtpProvider {
 
         // Delete contents first
         for entry in entries {
-            if entry.is_dir {
+            if entry.is_walkable_dir() {
                 // Use Box::pin for recursive async call
                 Box::pin(self.rmdir_recursive(&entry.path)).await?;
             } else {
@@ -1453,7 +1453,7 @@ impl StorageProvider for FtpProvider {
             self.current_path = saved;
 
             for entry in entries {
-                if entry.is_dir {
+                if entry.is_walkable_dir() {
                     dirs_to_scan.push(entry.path.clone());
                 }
 

--- a/src-tauri/src/providers/github/mod.rs
+++ b/src-tauri/src/providers/github/mod.rs
@@ -1579,7 +1579,7 @@ impl StorageProvider for GitHubProvider {
         }
         let entries = self.list(path).await?;
         for entry in entries {
-            if entry.is_dir {
+            if entry.is_walkable_dir() {
                 // Box the recursive future to avoid infinite type.
                 Box::pin(self.rmdir_recursive(&entry.path)).await?;
             } else {

--- a/src-tauri/src/providers/github/repo_mode.rs
+++ b/src-tauri/src/providers/github/repo_mode.rs
@@ -712,7 +712,7 @@ impl GitHubProvider {
 
         let entries = self.list(path).await?;
         for entry in entries {
-            if entry.is_dir {
+            if entry.is_walkable_dir() {
                 Box::pin(self.delete_directory_recursive(&entry.path, commit_message)).await?;
             } else {
                 self.delete_file(&entry.path, commit_message).await?;

--- a/src-tauri/src/providers/internxt.rs
+++ b/src-tauri/src/providers/internxt.rs
@@ -2017,7 +2017,7 @@ impl StorageProvider for InternxtProvider {
                 format!("{}/{}", resolved, entry.name)
             };
 
-            if entry.is_dir {
+            if entry.is_walkable_dir() {
                 // Box the recursive future to avoid infinite type
                 Box::pin(self.rmdir_recursive(&child_path)).await?;
             } else {

--- a/src-tauri/src/providers/sftp.rs
+++ b/src-tauri/src/providers/sftp.rs
@@ -2349,7 +2349,7 @@ impl StorageProvider for SftpProvider {
                 let remote_entry =
                     Self::metadata_to_entry(name.clone(), entry_path.clone(), &entry.metadata());
 
-                if remote_entry.is_dir {
+                if remote_entry.is_walkable_dir() {
                     dirs_to_scan.push(entry_path.clone());
                 }
 
@@ -3472,6 +3472,55 @@ async fn sftp_download_one_range(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Characterisation: what makes the `find` walk safe today is not the
+    /// contract, it is the shape of the data.
+    ///
+    /// `find` reads its entries from `read_dir`, whose attributes carry the
+    /// entry's OWN mode (lstat semantics; the `list` path says so at the point
+    /// where it spends an LSTAT only when the server omits the type bits). A
+    /// symlink therefore arrives with `S_IFLNK`, `metadata_to_entry` derives
+    /// `is_dir` from `S_IFDIR`, and the answer is false: the walk cannot
+    /// descend into a link, and `is_walkable_dir()` there is exactly `is_dir`.
+    ///
+    /// This test passes today and proves nothing new. It exists for the day
+    /// somebody makes `find` resolve the target the way `list` does: at that
+    /// moment `is_dir` becomes true for a symlink to a directory, the guard
+    /// stops being cosmetic and starts carrying weight, and this assertion
+    /// goes red instead of leaving the change to be discovered by a user whose
+    /// recursive search followed a link to an ancestor.
+    #[test]
+    fn a_symlink_from_readdir_is_not_a_directory() {
+        use russh_sftp::protocol::FileAttributes;
+
+        const S_IFLNK: u32 = 0o120000;
+        const S_IFDIR: u32 = 0o040000;
+
+        let link = FileAttributes {
+            permissions: Some(S_IFLNK | 0o777),
+            ..Default::default()
+        };
+        let entry = SftpProvider::metadata_to_entry("link".into(), "/link".into(), &link);
+        assert!(
+            !entry.is_dir,
+            "readdir reports a symlink's own mode, so is_dir must be false"
+        );
+        assert!(
+            !entry.is_walkable_dir(),
+            "and the contract refuses the descent either way"
+        );
+
+        let dir = FileAttributes {
+            permissions: Some(S_IFDIR | 0o755),
+            ..Default::default()
+        };
+        let real = SftpProvider::metadata_to_entry("d".into(), "/d".into(), &dir);
+        assert!(real.is_dir);
+        assert!(
+            real.is_walkable_dir(),
+            "a real directory is still walked into"
+        );
+    }
 
     #[test]
     fn pd_pipe1_flag_is_off_by_default_and_capped() {

--- a/src-tauri/src/providers/sftp.rs
+++ b/src-tauri/src/providers/sftp.rs
@@ -2115,7 +2115,7 @@ impl StorageProvider for SftpProvider {
         for entry in entries {
             if entry.is_symlink {
                 self.delete(&entry.path).await?;
-            } else if entry.is_dir {
+            } else if entry.is_walkable_dir() {
                 // Use Box::pin to avoid infinite recursion type issues
                 Box::pin(self.rmdir_recursive(&entry.path)).await?;
             } else {

--- a/src-tauri/src/providers/webdav.rs
+++ b/src-tauri/src/providers/webdav.rs
@@ -3818,7 +3818,7 @@ impl StorageProvider for WebDavProvider {
             };
 
             for entry in entries {
-                if entry.is_dir {
+                if entry.is_walkable_dir() {
                     dirs_to_scan.push(entry.path.clone());
                 }
 

--- a/src-tauri/tests/live_sftp_symlink_contract.rs
+++ b/src-tauri/tests/live_sftp_symlink_contract.rs
@@ -1,0 +1,72 @@
+//! Live characterisation of what `list()` produces for a symlink to a directory.
+//!
+//! This is NOT the premise of a fix: the `find` walk reads `read_dir`
+//! attributes and never sees `is_dir == true` for a link. `list()` is the one
+//! path that resolves the target and sets `is_symlink` separately, and it is
+//! therefore the only place where `is_walkable_dir()` differs from `is_dir` on
+//! any provider in this tree. That is the fact worth pinning.
+//!
+//! `#[ignore]` by default: it needs the sftp-rsync Docker fixture up, so it is
+//! NOT part of the gate. It is run by hand and its output reported, because what
+//! it measures is not our behaviour but what the SFTP provider produces against
+//! a real server, and that is a question to ask when writing the code rather
+//! than on every push.
+//!
+//!   cd src-tauri/tests/fixtures/sftp-rsync && ./setup.sh
+//!   DOCKER_BUILDKIT=0 docker build -t aeroftp-sftp-probe .
+//!   docker run -d --name aeroftp-sftp-probe -p 127.0.0.1:2225:22 \
+//!       -v "$PWD/ssh_key.pub:/mnt/authorized_keys:ro" aeroftp-sftp-probe
+//!   docker exec aeroftp-sftp-probe sh -c 'mkdir -p /workdir/probe/realdir && \
+//!       ln -sfn realdir /workdir/probe/linkdir && chown -R testuser /workdir/probe'
+//!   cargo test --test live_sftp_symlink_contract -- --ignored --nocapture
+use ftp_client_gui_lib::providers::{ProviderConfig, ProviderFactory, ProviderType};
+
+#[tokio::test]
+#[ignore = "live: needs the sftp-rsync fixture on :2225 with /workdir/probe/linkdir -> realdir"]
+async fn a_symlink_to_a_directory_reports_both_is_dir_and_is_symlink() {
+    let key = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/sftp-rsync/ssh_key"
+    );
+    let mut extra = std::collections::HashMap::new();
+    extra.insert("private_key_path".to_string(), key.to_string());
+    extra.insert("trust_host_key".to_string(), "true".to_string());
+    let cfg = ProviderConfig {
+        name: "prd-symlink-probe".to_string(),
+        provider_type: ProviderType::Sftp,
+        host: "127.0.0.1".to_string(),
+        port: Some(2225),
+        username: Some("testuser".to_string()),
+        password: None,
+        initial_path: Some("/".to_string()),
+        extra,
+    };
+
+    let mut p = ProviderFactory::create(&cfg).expect("provider");
+    p.connect().await.expect("connect to the fixture");
+    let entries = p.list("/workdir/probe").await.expect("list");
+
+    let link = entries
+        .iter()
+        .find(|e| e.name == "linkdir")
+        .expect("linkdir present");
+    println!(
+        "MEASURED linkdir: is_dir={} is_symlink={} link_target={:?} perms={:?}",
+        link.is_dir, link.is_symlink, link.link_target, link.permissions
+    );
+
+    // The defect: the walk sees a directory.
+    assert!(
+        link.is_dir,
+        "SFTP resolves the target, so a link to a dir reports is_dir"
+    );
+    // The fix: the contract has something to refuse it on.
+    assert!(
+        link.is_symlink,
+        "and it must also report is_symlink, or is_walkable_dir cannot help"
+    );
+    assert!(
+        !link.is_walkable_dir(),
+        "so the contract refuses the descent"
+    );
+}


### PR DESCRIPTION
**This changes no behaviour, on any of the ten sites.** Every one of them already produced the same answer it produces now. What changes is that the contract at `RemoteEntry::is_walkable_dir` (`providers/types.rs`) becomes checkable by machine, instead of being a rule with ten documented exceptions that nobody can verify without reading all ten.

**The check, and the numbers I actually ran.** `git grep -n -A6 -E 'if [A-Za-z_][A-Za-z0-9_]*\.is_dir\b' -- src-tauri/src/providers | grep -E 'Box::pin\(|\.push\('` matches thirteen lines, across ten distinct sites, on this PR's base, and nothing on this head. The scope of that claim is exactly `providers/`: the same pattern lives on in `bin/`, `ai_core/`, `sync_core/` and `lib.rs`, where a wider scan reports 35 further candidates, three of which I read and all three were real descents. This PR does not touch them, and the sentence above is not a statement about the repository.

**The first version of this PR made that claim while four sites still failed it**, which is the same error in the opposite direction to the one corrected further down: there I verified a premise on a path I was not touching, here I made a claim about a whole directory and verified it only where I had touched. Both are a gap between the scope of the assertion and the scope of the check.

**The four, and why each is cosmetic today.** `internxt` writes `is_symlink: false` at all five of its construction sites and `filen` at both of its, so the flag cannot ever be true there. The GitHub entries that reach `repo_mode` come from a constructor where `is_dir` is `content_type == "dir"` and `is_symlink` is `content_type == "symlink"`, two comparisons of one field over disjoint values, so the two are never true together. The fourth is the instructive one: SFTP `rmdir_recursive` already handles symlinks in an explicit arm before the directory arm, so it was equivalent to the contract and semantically had nothing wrong with it, but a grep cannot know that, and one site that needs a human reading costs the property for all of them.

The first version of this change claimed a defect in the SFTP `find` walk and was wrong. The correction is recorded here rather than quietly dropped, because the reason it looked like a defect is the useful part.

**Why `find` was never unsafe.** It reads its entries from `read_dir`, whose attributes carry the entry's own mode (lstat semantics; the `list` path states this where it spends an LSTAT only when the server omits the type bits). A symlink therefore arrives with `S_IFLNK`, `metadata_to_entry` derives `is_dir` from `S_IFDIR`, and the answer is false. The walk could not descend into a link, so the guard there is exactly as cosmetic as the others.

**Where the measurement came from, and why it did not apply.** A live SFTP fixture with `linkdir -> realdir` reports `is_dir=true is_symlink=true link_target=Some("realdir")` for the link. That is real and it is pinned by the ignored test in `tests/live_sftp_symlink_contract.rs`. But it was measured through `list()`, which is the one path that resolves the target and sets `is_symlink` separately. `find` does neither. The premise was measured carefully on the wrong path.

**Three facts about this tree, which is the part worth keeping.** `is_walkable_dir()` differs from `is_dir` on exactly one provider, SFTP, and only on the `list()` path, because that is the only place where the two flags are derived from two different facts. Everywhere else they come from one: FTP reads `d` and `l` from the same leading character of the same permission string, and on MLSD from the same `type` fact over disjoint values; GitHub compares one `content_type` field twice. WebDAV, Azure, internxt and filen write `is_symlink: false` at every construction site, so the guard there cannot protect anything, because a guard is worth exactly what the data feeding it is worth.

**The test characterises the assumption, not the behaviour.** `a_symlink_from_readdir_is_not_a_directory` passes today and proves nothing new. It exists for the day somebody makes `find` resolve the target the way `list` does: at that moment `is_dir` becomes true for a symlink to a directory, the guard stops being cosmetic and starts carrying weight, and the assertion goes red instead of leaving the change to be found by a user whose recursive search followed a link to an ancestor.

Out of scope, with the reason: `sync_core/scan.rs` has two further descents on a raw `is_dir`, and closing them REMOVES entries from the remote scan. On `--direction download --delete` the remote is the source, so entries that stop being enumerated become orphans and are deleted from the user's disk on the first run after the upgrade, while the same edit is safe on `upload`. That needs the delete direction in the reasoning, a test per direction, and an answer for trees already synced under today's behaviour.
