### PR TITLE
fix(ftp): stop waiting for bytes the server already refused to send

### DIFF
--- a/src-tauri/src/providers/ftp.rs
+++ b/src-tauri/src/providers/ftp.rs
@@ -1360,12 +1360,7 @@ impl StorageProvider for FtpProvider {
             let n = match step {
                 DataStep::Read(n) => n,
                 DataStep::ControlRefused => {
-                    let stream = self.stream.as_mut().ok_or(ProviderError::NotConnected)?;
-                    let refusal = stream
-                        .read_response_in(&[Status::ClosingDataConnection])
-                        .await
-                        .err()
-                        .unwrap_or(FtpError::BadResponse);
+                    let refusal = self.read_queued_refusal().await?;
                     let _ = self.abandon_transfer(data_stream).await;
                     return Err(Self::classify_data_failure("reading", remote_path, refusal));
                 }
@@ -1740,12 +1735,7 @@ impl StorageProvider for FtpProvider {
             let n = match step {
                 DataStep::Read(n) => n,
                 DataStep::ControlRefused => {
-                    let stream = self.stream.as_mut().ok_or(ProviderError::NotConnected)?;
-                    let refusal = stream
-                        .read_response_in(&[Status::ClosingDataConnection])
-                        .await
-                        .err()
-                        .unwrap_or(FtpError::BadResponse);
+                    let refusal = self.read_queued_refusal().await?;
                     let _ = self.abandon_transfer(data_stream).await;
                     return Err(Self::classify_data_failure(
                         "resuming",
@@ -2054,12 +2044,7 @@ impl StorageProvider for FtpProvider {
             let n = match step {
                 DataStep::Read(n) => n,
                 DataStep::ControlRefused => {
-                    let stream = self.stream.as_mut().ok_or(ProviderError::NotConnected)?;
-                    let refusal = stream
-                        .read_response_in(&[Status::ClosingDataConnection])
-                        .await
-                        .err()
-                        .unwrap_or(FtpError::BadResponse);
+                    let refusal = self.read_queued_refusal().await?;
                     let _ = self.abandon_transfer(data_stream).await;
                     return Err(Self::classify_data_failure(
                         "reading a range of",
@@ -2201,6 +2186,7 @@ enum ControlWatch {
 }
 
 /// What one turn of a data-reading loop produced.
+#[derive(Debug)]
 enum DataStep {
     /// Bytes from the data channel; `0` is end of stream.
     Read(usize),
@@ -2276,6 +2262,30 @@ impl FtpProvider {
             self.stream = None;
         }
         verdict
+    }
+
+    /// Read the refusal the server has queued, without waiting for one that
+    /// may not be there.
+    ///
+    /// Reached only after a peek has seen bytes on the control channel, so a
+    /// reply is expected. Expected is not guaranteed: a partial line, or a TLS
+    /// record carrying something other than a complete reply, leaves
+    /// `read_response_in` waiting, and it has no deadline of its own. Every
+    /// wait on this path is bounded now, including the one that reports why the
+    /// other ones ended.
+    ///
+    /// One function rather than four copies at the sites that need it.
+    async fn read_queued_refusal(&mut self) -> Result<FtpError, ProviderError> {
+        const REFUSAL_BUDGET: std::time::Duration = std::time::Duration::from_secs(5);
+        let stream = self.stream.as_mut().ok_or(ProviderError::NotConnected)?;
+        let read = stream.read_response_in(&[Status::ClosingDataConnection]);
+        Ok(match tokio::time::timeout(REFUSAL_BUDGET, read).await {
+            // A refusal, which is what this path exists to report.
+            Ok(Err(err)) => err,
+            // A positive reply, or nothing at all in time: neither is a
+            // refusal, and neither is worth waiting past its budget for.
+            _ => FtpError::BadResponse,
+        })
     }
 
     /// Decide whether a session survives, from what `abort` said about it.
@@ -2355,13 +2365,41 @@ impl FtpProvider {
         S: tokio::io::AsyncRead + Unpin,
     {
         if matches!(watch, ControlWatch::Spoke) {
-            // The server has already spoken and the data are the only thing
-            // left to wait for. Silence now means the transfer is over one way
-            // or another, so the short deadline applies and its expiry is a
-            // refusal to be read, not a plain timeout.
-            return match Self::read_with_deadline(data, buf, DATA_IDLE_AFTER_CONTROL_SPOKE).await {
-                Err(ProviderError::TransferFailed(_)) => Ok(DataStep::ControlRefused),
-                other => other,
+            // The server is believed to have spoken and the data are the only
+            // thing left to wait for, so the short deadline applies.
+            let step = Self::read_with_deadline(data, buf, DATA_IDLE_AFTER_CONTROL_SPOKE).await;
+            let Err(ProviderError::TransferFailed(_)) = step else {
+                return step;
+            };
+            // The deadline expired. Whether that is a refusal waiting to be
+            // read or an ordinary timeout is decided by LOOKING, not assumed.
+            //
+            // Treating every expiry here as a refusal was a way back into the
+            // defect this function exists to remove: `readable()` can wake
+            // spuriously, `poll_peek` then returns nothing, and this state is
+            // entered with no reply queued at all. The caller would go on to
+            // read a reply that was never sent, on a channel with no deadline,
+            // and wait for ever. A remedy for an unbounded wait must not open
+            // one where it claims to close them.
+            //
+            // The check is another peek, so it consumes nothing and works on an
+            // encrypted channel too: bytes waiting mean the server spoke, even
+            // when what it said cannot be read from this side.
+            let mut probe = [0u8; 1];
+            let mut got = tokio::io::ReadBuf::new(&mut probe);
+            // Polled exactly once and always Ready: "is there something now",
+            // never "wait until there is".
+            let queued = std::future::poll_fn(|cx| {
+                std::task::Poll::Ready(match control.poll_peek(cx, &mut got) {
+                    std::task::Poll::Ready(Ok(bytes)) => bytes,
+                    _ => 0,
+                })
+            })
+            .await;
+            return if queued > 0 {
+                Ok(DataStep::ControlRefused)
+            } else {
+                step
             };
         }
         tokio::select! {
@@ -2477,12 +2515,7 @@ impl FtpProvider {
                 // so it is read HERE, outside the select, where cancelling it
                 // is not a possibility.
                 DataStep::ControlRefused => {
-                    let stream = self.stream.as_mut().ok_or(ProviderError::NotConnected)?;
-                    let refusal = stream
-                        .read_response_in(&[Status::ClosingDataConnection])
-                        .await
-                        .err()
-                        .unwrap_or(FtpError::BadResponse);
+                    let refusal = self.read_queued_refusal().await?;
                     let _ = self.abandon_transfer(data_stream).await;
                     return Err(Self::classify_data_failure(
                         "downloading",
@@ -3692,6 +3725,77 @@ mod data_channel_watch_tests {
         let client = TcpStream::connect(addr).await.unwrap();
         let (server, _) = l.accept().await.unwrap();
         (client, server)
+    }
+
+    /// A wait that simply ended is not a refusal, and must not be reported as
+    /// one.
+    ///
+    /// `readable()` is allowed to wake without anything to read. The peek then
+    /// returns nothing, and the watch moves to `Spoke` believing the server has
+    /// spoken when it has not. If the shortened deadline that follows is read
+    /// as a refusal, the caller goes to collect a reply that was never sent.
+    ///
+    /// That is the defect this whole change exists to remove, reintroduced by
+    /// the remedy: an unbounded wait, opened at the point that claims to close
+    /// them. So the expiry is decided by looking at the control channel again,
+    /// not by assuming what put the watch into `Spoke`.
+    ///
+    /// The clock is virtual, so the thirty seconds pass at once.
+    #[tokio::test(start_paused = true)]
+    async fn a_deadline_that_simply_expired_is_not_a_refusal() {
+        let (mut data, _data_peer_kept_open) = silent_pair().await;
+        let (control, _control_peer_says_nothing) = silent_pair().await;
+
+        let mut buf = [0u8; 64];
+        // Entered as though a spurious wake had already happened: nothing was
+        // ever sent on the control channel.
+        let mut watch = ControlWatch::Spoke;
+
+        let step =
+            FtpProvider::read_watching_control(&mut data, &control, &mut buf, &mut watch).await;
+
+        match step {
+            Err(ProviderError::TransferFailed(msg)) => {
+                assert!(
+                    msg.contains("no data arrived"),
+                    "the timeout should be reported as itself: {msg:?}"
+                );
+            }
+            Ok(DataStep::ControlRefused) => panic!(
+                "an expired deadline with an empty control channel was called a refusal; the \
+                 caller would then wait for a reply that was never sent"
+            ),
+            other => panic!("unexpected outcome: {other:?}"),
+        }
+    }
+
+    /// The same expiry IS a refusal when the server really did speak.
+    ///
+    /// The other side of the boundary: without this row, the fix above could be
+    /// "never report a refusal" and still pass.
+    #[tokio::test(start_paused = true)]
+    async fn a_deadline_that_expired_on_a_queued_reply_is_a_refusal() {
+        let (mut data, _data_peer_kept_open) = silent_pair().await;
+        let (control, mut control_peer) = silent_pair().await;
+
+        control_peer
+            .write_all(b"550 Failed to open file.\r\n")
+            .await
+            .unwrap();
+        control_peer.flush().await.unwrap();
+        // Real time, so the bytes actually arrive before the virtual clock runs.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let mut buf = [0u8; 64];
+        let mut watch = ControlWatch::Spoke;
+
+        let step =
+            FtpProvider::read_watching_control(&mut data, &control, &mut buf, &mut watch).await;
+
+        assert!(
+            matches!(step, Ok(DataStep::ControlRefused)),
+            "a reply waiting unread on the control channel is a refusal to be collected"
+        );
     }
 
     /// A session is only thrown away when the server's idea of it has actually

--- a/src-tauri/src/providers/ftp.rs
+++ b/src-tauri/src/providers/ftp.rs
@@ -1127,9 +1127,35 @@ impl StorageProvider for FtpProvider {
         Ok(())
     }
 
+    /// Close the session without waiting for a goodbye that may never come.
+    ///
+    /// `quit()` sends QUIT and then READS the reply, with no deadline, and this
+    /// is called through `reconnect_after_data_error` from seven places, all of
+    /// them after something has already gone wrong on the wire. On a server
+    /// that has stopped answering, the remedy meant to throw a poisoned
+    /// connection away hung on the goodbye instead: the cure was the disease.
+    ///
+    /// The `let _ =` that used to stand here reads as a defence and is not one.
+    /// It discards the RESULT, not the WAIT: if the reply never arrives the
+    /// await never returns and the discard is never reached. A line that looks
+    /// careful in exactly the case where it is not is worse than an obviously
+    /// bare one, because a reader scanning for risk skips it.
+    ///
+    /// The stream is taken out of the struct first, so the QUIT frees nothing
+    /// on this side: it is a courtesy to the server, and a courtesy is not
+    /// worth an unbounded wait. Under the budget it is attempted; past it the
+    /// connection is simply dropped. The same shape, and the same five seconds,
+    /// as `FtpManager::disconnect`, which has bounded this since long before
+    /// tonight.
     async fn disconnect(&mut self) -> Result<(), ProviderError> {
+        const GOODBYE_BUDGET: std::time::Duration = std::time::Duration::from_secs(5);
         if let Some(mut stream) = self.stream.take() {
-            let _ = stream.quit().await;
+            if tokio::time::timeout(GOODBYE_BUDGET, stream.quit())
+                .await
+                .is_err()
+            {
+                tracing::debug!("[FTP] QUIT went unanswered; dropping the connection");
+            }
         }
         Ok(())
     }
@@ -1310,7 +1336,7 @@ impl StorageProvider for FtpProvider {
         // H2: Read with size cap to prevent OOM
         let mut data = Vec::new();
         let limit_usize = (limit + 1) as usize;
-        let mut watch_control = true;
+        let mut watch_control = ControlWatch::Quiet;
         loop {
             let mut buf = [0u8; 8192];
             let step = {
@@ -1320,7 +1346,16 @@ impl StorageProvider for FtpProvider {
                     .ok_or(ProviderError::NotConnected)?
                     .get_ref();
                 Self::read_watching_control(&mut data_stream, control, &mut buf, &mut watch_control)
-                    .await?
+                    .await
+            };
+            // The deadline expiring is an early exit too, and it leaves exactly
+            // the state `abandon_transfer` exists for.
+            let step = match step {
+                Ok(step) => step,
+                Err(err) => {
+                    let _ = self.abandon_transfer(data_stream).await;
+                    return Err(err);
+                }
             };
             let n = match step {
                 DataStep::Read(n) => n,
@@ -1331,6 +1366,7 @@ impl StorageProvider for FtpProvider {
                         .await
                         .err()
                         .unwrap_or(FtpError::BadResponse);
+                    let _ = self.abandon_transfer(data_stream).await;
                     return Err(Self::classify_data_failure("reading", remote_path, refusal));
                 }
             };
@@ -1681,7 +1717,7 @@ impl StorageProvider for FtpProvider {
         // Stream chunks from FTP data stream directly to disk
         let mut transferred = offset;
         let mut buf = vec![0u8; 64 * 1024]; // 64 KB chunks
-        let mut watch_control = true;
+        let mut watch_control = ControlWatch::Quiet;
         loop {
             let step = {
                 let control = self
@@ -1690,7 +1726,16 @@ impl StorageProvider for FtpProvider {
                     .ok_or(ProviderError::NotConnected)?
                     .get_ref();
                 Self::read_watching_control(&mut data_stream, control, &mut buf, &mut watch_control)
-                    .await?
+                    .await
+            };
+            // The deadline expiring is an early exit too, and it leaves exactly
+            // the state `abandon_transfer` exists for.
+            let step = match step {
+                Ok(step) => step,
+                Err(err) => {
+                    let _ = self.abandon_transfer(data_stream).await;
+                    return Err(err);
+                }
             };
             let n = match step {
                 DataStep::Read(n) => n,
@@ -1701,6 +1746,7 @@ impl StorageProvider for FtpProvider {
                         .await
                         .err()
                         .unwrap_or(FtpError::BadResponse);
+                    let _ = self.abandon_transfer(data_stream).await;
                     return Err(Self::classify_data_failure(
                         "resuming",
                         remote_path,
@@ -1980,7 +2026,7 @@ impl StorageProvider for FtpProvider {
         // Read exactly `len` bytes (or until EOF if file is shorter)
         let mut buf = vec![0u8; len as usize];
         let mut total_read = 0usize;
-        let mut watch_control = true;
+        let mut watch_control = ControlWatch::Quiet;
         while total_read < len as usize {
             let step = {
                 let control = self
@@ -1994,7 +2040,16 @@ impl StorageProvider for FtpProvider {
                     &mut buf[total_read..],
                     &mut watch_control,
                 )
-                .await?
+                .await
+            };
+            // The deadline expiring is an early exit too, and it leaves exactly
+            // the state `abandon_transfer` exists for.
+            let step = match step {
+                Ok(step) => step,
+                Err(err) => {
+                    let _ = self.abandon_transfer(data_stream).await;
+                    return Err(err);
+                }
             };
             let n = match step {
                 DataStep::Read(n) => n,
@@ -2005,6 +2060,7 @@ impl StorageProvider for FtpProvider {
                         .await
                         .err()
                         .unwrap_or(FtpError::BadResponse);
+                    let _ = self.abandon_transfer(data_stream).await;
                     return Err(Self::classify_data_failure(
                         "reading a range of",
                         path,
@@ -2080,6 +2136,70 @@ fn canonical_hash_key(server_algo: &str) -> String {
 /// lacked it.
 const DATA_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1800);
 
+/// How long the data may stay silent AFTER the server has spoken on control.
+///
+/// Reading the first byte of a reply only works in the clear. Under FTPS the
+/// control channel carries TLS records, and a record opens with a ContentType
+/// in 0x14..0x18 while ASCII `4` and `5` are 0x34 and 0x35: the sets do not
+/// intersect, so no server can put a reply's digits there. That is the
+/// protocol, not an observation, and it means the classification below cannot
+/// work on an encrypted control channel. Without this, an FTPS user got the
+/// full 1800 seconds, which is what the connection did before any of this.
+///
+/// What survives encryption is the READINESS. The server spoke, even if what it
+/// said is unreadable from this side of the TLS layer, and during a healthy
+/// transfer it has no reason to: the preliminary reply was consumed when the
+/// data channel opened, and the completion reply comes after the data are done.
+///
+/// So a reply arriving mid-transfer SHORTENS the deadline instead of ending the
+/// wait, and the deadline is inactivity rather than a grace period. That is
+/// what makes it safe. A transfer finishing normally keeps delivering the bytes
+/// already in flight, each one resets the timer, and this never fires; it fires
+/// only when the server has spoken AND the data have stopped, which are never
+/// both true in a healthy transfer. Arming on readiness alone would cut short a
+/// transfer that was ending well.
+///
+/// The asymmetry of the number is the thing to hold on to: too long only delays
+/// an error, too short truncates a transfer that was succeeding. In doubt, up.
+const DATA_IDLE_AFTER_CONTROL_SPOKE: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// The state a session was left in by `abandon_transfer`.
+///
+/// The way out has two levels and they end in opposite places, and a caller
+/// that carries on afterwards has to know which. That caller is not
+/// hypothetical: `list_inner_opts` disables MLSD when it fails and then
+/// CONTINUES, in the same call, to the LIST branch, which opens a second data
+/// channel. On that path "give up" does not mean "the operation is over", it
+/// means "try the other way", and a session quietly discarded would turn a
+/// server that advertises MLSD without honouring it from "falls back to LIST
+/// and works" into `NotConnected`.
+///
+/// So the outcome of the CLEANUP is reported, which is not the same as the
+/// reason for the exit. The reason is deliberately not distinguished: the state
+/// to repair is identical whatever caused it, and a caller that cares about the
+/// cause knows it before calling. Where the session ended up is the one thing
+/// only this function knows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SessionAfterAbandon {
+    /// The server took the abort. The control session is clean and the next
+    /// command can use it.
+    Reusable,
+    /// The server refused the abort or did not answer in time, and the
+    /// connection was dropped. Anything that carries on must dial again first.
+    Discarded,
+}
+
+/// What is known about the control channel while a transfer is running.
+enum ControlWatch {
+    /// Nothing heard: race the readiness against the data read.
+    Quiet,
+    /// The server has spoken and what it said could not be read, either because
+    /// the channel is encrypted or because the reply was not a refusal. The
+    /// socket stays readable, so racing it again would spin the loop; the
+    /// deadline shortens instead and the data get the last word.
+    Spoke,
+}
+
 /// What one turn of a data-reading loop produced.
 enum DataStep {
     /// Bytes from the data channel; `0` is end of stream.
@@ -2090,6 +2210,77 @@ enum DataStep {
 }
 
 impl FtpProvider {
+    /// The one way out of a data transfer that has failed.
+    ///
+    /// Leaving a data loop early drops the `DataStream` and never calls
+    /// `finalize`, so inside `suppaftp` the private `data_connection_open`
+    /// stays true and the completion reply stays unread on the control
+    /// channel. What happens next depends on what the caller does next, and
+    /// one of the two is bad: another data command trips
+    /// `guard_multiple_data_connections` and is recognised as a stale
+    /// connection, which reconnects and works, while a CONTROL command reads
+    /// the stale `226 Transfer complete` as its own reply and fails saying the
+    /// previous operation succeeded. An error that names the success of
+    /// something else is the worst kind of message to hand a user.
+    ///
+    /// Those exits were rare before this change and are not any more: a
+    /// deadline and a refusal were added to five loops. A defect made common by
+    /// a change belongs to that change.
+    ///
+    /// TWO LEVELS, and the second is not belt and braces. `abort()` is the
+    /// crate's own way out: ABOR, then drop the stream in that order, then the
+    /// flag cleared and 426 or 226 consumed. But it reads those replies with
+    /// `read_response_in`, WHICH HAS NO TIMEOUT, and every exit handled here
+    /// happens exactly when the server may have stopped answering. Called bare,
+    /// the cure hangs for the reason the disease does. So it gets a budget, and
+    /// a server that will not even answer ABOR has a session that cannot be
+    /// trusted: it is dropped rather than reused, and the next command dials a
+    /// fresh one.
+    ///
+    /// WHAT THIS DOES NOT COVER, said here because a function that looks
+    /// complete is read as complete. It runs on exits that RETURN. A future
+    /// dropped from outside never reaches it: dropping an async fn runs the
+    /// destructors of its locals and none of the code that follows. The
+    /// transfer executor wraps a download in `tokio::time::timeout` and lets
+    /// the future fall on expiry, so on that path the session is left exactly
+    /// as this function exists to prevent, and the retry that follows reuses
+    /// the same connection. Moving that deadline inside the data loop would
+    /// turn it into an ordinary error return and bring it back through here,
+    /// which is where the shared data-loop primitive will put it anyway.
+    ///
+    /// One function rather than five copies, because `DataStream` implements
+    /// both `AsyncRead` and `AsyncWrite`, so the same way out serves RETR and
+    /// STOR, and because a shared data-loop primitive is being built on top of
+    /// these call sites: five copies would have to be unified and re-reviewed
+    /// one by one.
+    async fn abandon_transfer<S>(&mut self, data_stream: S) -> SessionAfterAbandon
+    where
+        S: tokio::io::AsyncRead + Unpin + 'static,
+    {
+        // Five seconds, and the asymmetry here points the OPPOSITE way to the
+        // one on the transfer deadlines above, which is worth saying because
+        // the two constants sit near each other and a reader who assumes they
+        // share a rule will think one of them is wrong.
+        //
+        // On a transfer deadline, too short truncates something that was
+        // succeeding, so in doubt it goes up. Here, too short discards a session
+        // that would have cleaned itself and costs one reconnect; too long makes
+        // somebody wait who has already been waiting. So in doubt it goes down.
+        const ABORT_BUDGET: std::time::Duration = std::time::Duration::from_secs(5);
+        let Some(stream) = self.stream.as_mut() else {
+            return SessionAfterAbandon::Discarded;
+        };
+        match tokio::time::timeout(ABORT_BUDGET, stream.abort(data_stream)).await {
+            Ok(Ok(())) => SessionAfterAbandon::Reusable,
+            // It refused, or it did not answer in time. Either way its idea of
+            // this connection no longer matches ours, so it is not reused.
+            _ => {
+                self.stream = None;
+                SessionAfterAbandon::Discarded
+            }
+        }
+    }
+
     /// Read from the data channel while watching the control channel.
     ///
     /// A transfer that can never succeed used to wait for ever. Measured: a
@@ -2122,46 +2313,65 @@ impl FtpProvider {
         data: &mut S,
         control: &tokio::net::TcpStream,
         buf: &mut [u8],
-        watch_control: &mut bool,
+        watch: &mut ControlWatch,
     ) -> Result<DataStep, ProviderError>
     where
         S: tokio::io::AsyncRead + Unpin,
     {
-        if !*watch_control {
-            return Self::read_with_deadline(data, buf).await;
+        if matches!(watch, ControlWatch::Spoke) {
+            // The server has already spoken and the data are the only thing
+            // left to wait for. Silence now means the transfer is over one way
+            // or another, so the short deadline applies and its expiry is a
+            // refusal to be read, not a plain timeout.
+            return match Self::read_with_deadline(data, buf, DATA_IDLE_AFTER_CONTROL_SPOKE).await {
+                Err(ProviderError::TransferFailed(_)) => Ok(DataStep::ControlRefused),
+                other => other,
+            };
         }
         tokio::select! {
             biased;
             _ = control.readable() => {
+                // Non-blocking on purpose: `readable()` can wake spuriously,
+                // and an awaiting `peek` would then stall the data loop it was
+                // meant to protect.
                 let mut probe = [0u8; 1];
-                // Ready, so this returns at once; and it does not consume.
-                match control.peek(&mut probe).await {
-                    Ok(1) if probe[0] == b'4' || probe[0] == b'5' => Ok(DataStep::ControlRefused),
-                    // A completion reply, or nothing readable after all: stop
-                    // watching so the loop cannot spin on a socket that stays
-                    // ready, and let the data channel finish normally.
+                let mut got = tokio::io::ReadBuf::new(&mut probe);
+                let peeked = std::future::poll_fn(|cx| control.poll_peek(cx, &mut got))
+                    .await
+                    .unwrap_or(0);
+                let first = got.filled().first().copied();
+                match first {
+                    Some(b'4') | Some(b'5') if peeked > 0 => Ok(DataStep::ControlRefused),
+                    // Anything else: a completion reply, a TLS record whose
+                    // content cannot be read, or a spurious wake. The server
+                    // spoke or may have; either way the classification is not
+                    // available and the deadline takes over.
                     _ => {
-                        *watch_control = false;
-                        Self::read_with_deadline(data, buf).await
+                        *watch = ControlWatch::Spoke;
+                        Self::read_with_deadline(data, buf, DATA_IDLE_AFTER_CONTROL_SPOKE).await
                     }
                 }
             }
-            step = Self::read_with_deadline(data, buf) => step,
+            step = Self::read_with_deadline(data, buf, DATA_IDLE_TIMEOUT) => step,
         }
     }
 
     /// One data read that cannot wait for ever.
-    async fn read_with_deadline<S>(data: &mut S, buf: &mut [u8]) -> Result<DataStep, ProviderError>
+    async fn read_with_deadline<S>(
+        data: &mut S,
+        buf: &mut [u8],
+        idle: std::time::Duration,
+    ) -> Result<DataStep, ProviderError>
     where
         S: tokio::io::AsyncRead + Unpin,
     {
         use tokio::io::AsyncReadExt;
-        match tokio::time::timeout(DATA_IDLE_TIMEOUT, data.read(buf)).await {
+        match tokio::time::timeout(idle, data.read(buf)).await {
             Ok(Ok(n)) => Ok(DataStep::Read(n)),
             Ok(Err(e)) => Err(ProviderError::TransferFailed(e.to_string())),
             Err(_) => Err(ProviderError::TransferFailed(format!(
                 "no data arrived for {}s",
-                DATA_IDLE_TIMEOUT.as_secs()
+                idle.as_secs()
             ))),
         }
     }
@@ -2197,7 +2407,7 @@ impl FtpProvider {
 
         let mut chunk = vec![0u8; self.buffer_size];
         let mut transferred: u64 = 0;
-        let mut watch_control = true;
+        let mut watch_control = ControlWatch::Quiet;
 
         loop {
             let step = {
@@ -2212,7 +2422,16 @@ impl FtpProvider {
                     &mut chunk,
                     &mut watch_control,
                 )
-                .await?
+                .await
+            };
+            // The deadline expiring is an early exit too, and it leaves exactly
+            // the state `abandon_transfer` exists for.
+            let step = match step {
+                Ok(step) => step,
+                Err(err) => {
+                    let _ = self.abandon_transfer(data_stream).await;
+                    return Err(err);
+                }
             };
             let n = match step {
                 DataStep::Read(0) => break,
@@ -2228,6 +2447,7 @@ impl FtpProvider {
                         .await
                         .err()
                         .unwrap_or(FtpError::BadResponse);
+                    let _ = self.abandon_transfer(data_stream).await;
                     return Err(Self::classify_data_failure(
                         "downloading",
                         remote_path,
@@ -3462,7 +3682,7 @@ mod data_channel_watch_tests {
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
         let mut buf = [0u8; 64];
-        let mut watch = true;
+        let mut watch = ControlWatch::Quiet;
         let step = tokio::time::timeout(
             std::time::Duration::from_secs(5),
             FtpProvider::read_watching_control(
@@ -3481,8 +3701,8 @@ mod data_channel_watch_tests {
             "a 550 sitting unread in the control socket has to stop the wait"
         );
         assert!(
-            watch,
-            "a refusal must not switch the watch off: the caller still has to read the reply"
+            matches!(watch, ControlWatch::Quiet),
+            "a refusal must not move the watch on: the caller still has to read the reply"
         );
     }
 
@@ -3507,7 +3727,7 @@ mod data_channel_watch_tests {
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
         let mut buf = [0u8; 64];
-        let mut watch = true;
+        let mut watch = ControlWatch::Quiet;
         let step = tokio::time::timeout(
             std::time::Duration::from_secs(5),
             FtpProvider::read_watching_control(
@@ -3528,8 +3748,9 @@ mod data_channel_watch_tests {
             }
         }
         assert!(
-            !watch,
-            "after a non-refusal the watch has to stop, or the loop spins on a ready socket"
+            matches!(watch, ControlWatch::Spoke),
+            "after a non-refusal the watch must record that the server spoke: the socket stays \
+             readable, so racing it again would spin, and the shortened deadline takes over"
         );
 
         // And the reply is still there for the finalizer: peek did not eat it.

--- a/src-tauri/src/providers/ftp.rs
+++ b/src-tauri/src/providers/ftp.rs
@@ -2270,37 +2270,50 @@ impl FtpProvider {
         let Some(stream) = self.stream.as_mut() else {
             return SessionAfterAbandon::Discarded;
         };
-        match tokio::time::timeout(ABORT_BUDGET, stream.abort(data_stream)).await {
-            Ok(Ok(())) => SessionAfterAbandon::Reusable,
+        let outcome = tokio::time::timeout(ABORT_BUDGET, stream.abort(data_stream)).await;
+        let verdict = Self::session_after_abort(outcome.as_ref().ok());
+        if matches!(verdict, SessionAfterAbandon::Discarded) {
+            self.stream = None;
+        }
+        verdict
+    }
+
+    /// Decide whether a session survives, from what `abort` said about it.
+    ///
+    /// `None` means the abort never finished inside its budget.
+    ///
+    /// Split out from the caller because it is the only part that decides
+    /// anything, and inside the caller it could not be reached without a live
+    /// socket, a pooled provider and two operations in a row. A branch that
+    /// changes behaviour and cannot be reached by a test is where a regression
+    /// hides; "not testable" and "not testable without extracting four lines"
+    /// are different claims, and only the first is a limit.
+    fn session_after_abort(abort: Option<&Result<(), FtpError>>) -> SessionAfterAbandon {
+        match abort {
+            Some(Ok(())) => SessionAfterAbandon::Reusable,
             // 225, "no transfer to abort": there was nothing to stop, because
-            // the refusal that ended it has already been read. `abort` reports
-            // this as an error only because 225 is not in the two codes it
-            // waits for, and by the time it looks at the code it has already
-            // done the work that matters. Its order is `ABOR`, drop the stream,
-            // CLEAR the connection flag, and only then read the reply; and the
-            // reader consumes the line before deciding whether to accept it. So
-            // the flag is down, the line is gone, and the control channel is
-            // aligned: the session is clean and throwing it away would cost a
-            // reconnect, with a fresh TLS handshake, for every missing file on
-            // the pooled providers behind the GUI, the MCP server and the TUI.
+            // the refusal that ended the transfer has already been read.
+            // `abort` calls that an error only because 225 is not one of the
+            // two codes it waits for, and by the time it looks at the code it
+            // has already done the work that matters. Its order is ABOR, drop
+            // the stream, CLEAR the connection flag, and only then read the
+            // reply; and the reader consumes the line before deciding whether
+            // to accept it. So the flag is down, the line is gone, and the
+            // control channel is aligned: the session is clean.
             //
-            // That cost would have been introduced here, by reading any error
-            // from `abort` as a broken session, and it was nearly recorded as a
-            // limitation of the crate instead. Both servers in the lab answer
-            // 225 to a bare ABOR, measured: "225 No transfer to abort." and
-            // "225 No transfer to ABOR."
-            Ok(Err(FtpError::UnexpectedResponse(reply)))
+            // Throwing it away would cost a reconnect, with a fresh TLS
+            // handshake, for every missing file on the pooled providers behind
+            // the GUI, the MCP server and the TUI. Both servers in the lab
+            // answer 225 to a bare ABOR, measured: "225 No transfer to abort."
+            // and "225 No transfer to ABOR."
+            Some(Err(FtpError::UnexpectedResponse(reply)))
                 if reply.status == Status::DataConnectionOpen =>
             {
                 SessionAfterAbandon::Reusable
             }
-            // It refused for another reason, or it did not answer in time.
-            // Either way its idea of this connection no longer matches ours,
-            // so it is not reused.
-            _ => {
-                self.stream = None;
-                SessionAfterAbandon::Discarded
-            }
+            // Refused for another reason, or never answered. Either way the
+            // server's idea of this connection no longer matches ours.
+            _ => SessionAfterAbandon::Discarded,
         }
     }
 
@@ -3679,6 +3692,63 @@ mod data_channel_watch_tests {
         let client = TcpStream::connect(addr).await.unwrap();
         let (server, _) = l.accept().await.unwrap();
         (client, server)
+    }
+
+    /// A session is only thrown away when the server's idea of it has actually
+    /// diverged from ours.
+    ///
+    /// The row that matters is 225. After a refusal has been read there is no
+    /// transfer left to abort and servers say so with that code, measured as
+    /// "225 No transfer to abort." on pyftpdlib and "225 No transfer to ABOR."
+    /// on vsftpd. `abort` reports it as an error, because it waits for 226 or
+    /// 426, and reading that as a broken session would discard a connection
+    /// that is perfectly usable: by then `abort` has already cleared the
+    /// connection flag and its reader has already consumed the line, so the
+    /// control channel is aligned. The cost of getting this wrong is a
+    /// reconnect, with a fresh TLS handshake, for every missing file on a
+    /// pooled provider, which is the commonest case this branch touches.
+    ///
+    /// The rows below it are what must NOT be swept along: another refusal is
+    /// still a refusal, a malformed reply is still one, and an abort that never
+    /// finished says nothing at all. Widening the first row to "any error means
+    /// the session is fine" would keep connections whose state is unknown.
+    #[test]
+    fn only_a_server_that_disagrees_costs_the_session() {
+        use suppaftp::types::Response;
+        let verdict =
+            |r: Option<&Result<(), FtpError>>| format!("{:?}", FtpProvider::session_after_abort(r));
+
+        assert_eq!(verdict(Some(&Ok(()))), "Reusable", "a clean abort keeps it");
+
+        let nothing_to_abort = Err(FtpError::UnexpectedResponse(Response::new(
+            Status::DataConnectionOpen,
+            b"225 No transfer to abort.".to_vec(),
+        )));
+        assert_eq!(
+            verdict(Some(&nothing_to_abort)),
+            "Reusable",
+            "225 means there was nothing to stop, not that the session is broken"
+        );
+
+        // ---- and the rows that must still cost the session ----
+        let refused = Err(FtpError::UnexpectedResponse(Response::new(
+            Status::NotImplemented,
+            b"502 Command not implemented.".to_vec(),
+        )));
+        assert_eq!(
+            verdict(Some(&refused)),
+            "Discarded",
+            "a refusal that is not 225 leaves the connection in an unknown state"
+        );
+
+        let malformed = Err(FtpError::BadResponse);
+        assert_eq!(verdict(Some(&malformed)), "Discarded");
+
+        assert_eq!(
+            verdict(None),
+            "Discarded",
+            "an abort that never finished tells us nothing, so the session goes"
+        );
     }
 
     /// The reply the server already sent ends the wait, instead of the wait

--- a/src-tauri/src/providers/ftp.rs
+++ b/src-tauri/src/providers/ftp.rs
@@ -2272,8 +2272,31 @@ impl FtpProvider {
         };
         match tokio::time::timeout(ABORT_BUDGET, stream.abort(data_stream)).await {
             Ok(Ok(())) => SessionAfterAbandon::Reusable,
-            // It refused, or it did not answer in time. Either way its idea of
-            // this connection no longer matches ours, so it is not reused.
+            // 225, "no transfer to abort": there was nothing to stop, because
+            // the refusal that ended it has already been read. `abort` reports
+            // this as an error only because 225 is not in the two codes it
+            // waits for, and by the time it looks at the code it has already
+            // done the work that matters. Its order is `ABOR`, drop the stream,
+            // CLEAR the connection flag, and only then read the reply; and the
+            // reader consumes the line before deciding whether to accept it. So
+            // the flag is down, the line is gone, and the control channel is
+            // aligned: the session is clean and throwing it away would cost a
+            // reconnect, with a fresh TLS handshake, for every missing file on
+            // the pooled providers behind the GUI, the MCP server and the TUI.
+            //
+            // That cost would have been introduced here, by reading any error
+            // from `abort` as a broken session, and it was nearly recorded as a
+            // limitation of the crate instead. Both servers in the lab answer
+            // 225 to a bare ABOR, measured: "225 No transfer to abort." and
+            // "225 No transfer to ABOR."
+            Ok(Err(FtpError::UnexpectedResponse(reply)))
+                if reply.status == Status::DataConnectionOpen =>
+            {
+                SessionAfterAbandon::Reusable
+            }
+            // It refused for another reason, or it did not answer in time.
+            // Either way its idea of this connection no longer matches ours,
+            // so it is not reused.
             _ => {
                 self.stream = None;
                 SessionAfterAbandon::Discarded
@@ -2697,10 +2720,9 @@ async fn ftp_download_one_range(
 
     let mut data_stream = {
         let stream = worker.stream_mut()?;
-        stream
-            .retr_as_stream(&remote_path)
-            .await
-            .map_err(|e| FtpProvider::classify_data_failure("checksumming", &remote_path, e))?
+        stream.retr_as_stream(&remote_path).await.map_err(|e| {
+            FtpProvider::classify_data_failure("downloading a range of", &remote_path, e)
+        })?
     };
 
     let mut out = tokio::fs::OpenOptions::new()

--- a/src-tauri/src/providers/ftp.rs
+++ b/src-tauri/src/providers/ftp.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use suppaftp::tokio::{AsyncRustlsConnector, AsyncRustlsFtpStream};
 use suppaftp::types::FileType;
 use suppaftp::{FtpError, Status};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::AsyncWriteExt;
 use tokio_util::sync::CancellationToken;
 
 use super::checksum_matrix;
@@ -780,10 +780,93 @@ impl FtpProvider {
     /// Classifying it here does both for every caller, and the preflight goes
     /// away in the same change.
     fn map_store_error(path: &str, err: FtpError) -> ProviderError {
-        if let Some(missing) = Self::classify_missing_path("uploading", path, &err) {
+        Self::classify_data_failure("uploading", path, err)
+    }
+
+    /// What a refused data command means: the same two axes as a refused CWD.
+    ///
+    /// STOR and RETR both answered `TransferFailed` for every failure, which is
+    /// exit 4 and retryable, so a permanent refusal was attempted three times.
+    /// Measured against vsftpd 3.0.5: a `put` into a directory that does not
+    /// exist is refused with `553 Could not create file.` and a `get` of a file
+    /// that is not there with `550 Failed to open file.`, both instantly, and
+    /// both were then retried twice more for nothing.
+    ///
+    /// The STATUS decides permanence, not the text. RFC 959 section 4.2 makes
+    /// 5yz permanent and 4yz transient, which is the rule already applied to
+    /// CWD on this branch; applying it here rather than naming the two new
+    /// replies is the difference between fixing the predicate and patching the
+    /// case. And the two replies are exactly why: NEITHER names a missing path.
+    /// "Could not create file" and "Failed to open file" say the operation did
+    /// not happen, and a server sends them both for a path that is absent and
+    /// for one it will not let you touch. Adding them to the missing-path
+    /// vocabulary would state something the server did not, which is the defect
+    /// removed from the 550 on CWD two commits ago.
+    ///
+    /// So a permanent refusal becomes `InvalidPath`: non-retryable on both
+    /// paths, and saying only that the path did not work. `NotFound` stays for
+    /// the replies that do name a missing path, and 4yz keeps `TransferFailed`
+    /// and its retry, because there the server has asked to be tried again.
+    fn classify_data_failure(operation: &str, path: &str, err: FtpError) -> ProviderError {
+        if let Some(missing) = Self::classify_missing_path(operation, path, &err) {
             return missing;
         }
-        ProviderError::TransferFailed(Self::doing("uploading", path, err))
+        if let FtpError::UnexpectedResponse(ref response) = err {
+            let code = response.status as u32;
+            if (500..600).contains(&code) {
+                let text = response.to_string();
+                return ProviderError::InvalidPath(Self::doing(operation, path, &text));
+            }
+        }
+        ProviderError::TransferFailed(Self::doing(operation, path, err))
+    }
+
+    /// Turn a permanent upload refusal into one the user can act on.
+    ///
+    /// The CLI used to check the parent BEFORE every upload and say "Parent
+    /// directory '...' does not exist on the remote. Create it first with:
+    /// aeroftp-cli mkdir -p '...'". That check was removed with four others
+    /// when the provider started classifying these failures itself, and for
+    /// four of them the reasoning held. For this one it did not: a classifier
+    /// reads a reply, and what was lost was not a classification but a
+    /// SENTENCE THE USER COULD ACT ON. `553 Could not create file.` is
+    /// accurate and tells nobody what to do next.
+    ///
+    /// It is asked AFTER the failure, not before it, and that is the whole
+    /// difference from the check that was removed. A preflight pays on every
+    /// upload, including the overwhelming majority that succeed; this pays only
+    /// when one has already failed permanently, so the fast path is untouched.
+    /// It also lands in the provider rather than in the CLI, so the GUI and the
+    /// MCP server get the same sentence, which the removed check never gave
+    /// them.
+    ///
+    /// The probe is `confirm_directory_exists`, the same CWD pair `mkdir` uses,
+    /// so there is one way in this file to ask whether a directory is there. If
+    /// the parent turns out to exist, the refusal was about something else and
+    /// the original error is returned untouched: we do not trade a true vague
+    /// answer for a false specific one. The same if the probe itself fails,
+    /// because then we know nothing new.
+    async fn name_the_missing_parent(
+        &mut self,
+        remote_path: &str,
+        err: ProviderError,
+    ) -> ProviderError {
+        // Only a permanent refusal is worth a round trip, and only when there
+        // is a parent to ask about.
+        if !matches!(err, ProviderError::InvalidPath(_)) {
+            return err;
+        }
+        let parent = match remote_path.rsplit_once('/') {
+            Some((p, _)) if !p.is_empty() && p != "/" => p.to_string(),
+            _ => return err,
+        };
+        match self.confirm_directory_exists(&parent).await {
+            Err(ProviderError::NotFound(_)) => ProviderError::NotFound(format!(
+                "parent directory {parent} does not exist on the remote; create it first with: \
+                 aeroftp-cli mkdir -p '{parent}' (the server refused the upload with: {err})"
+            )),
+            _ => err,
+        }
     }
 
     /// Tell a directory that is empty from one that is not there.
@@ -1192,7 +1275,6 @@ impl StorageProvider for FtpProvider {
     }
 
     async fn download_to_bytes(&mut self, remote_path: &str) -> Result<Vec<u8>, ProviderError> {
-        use tokio::io::AsyncReadExt;
         let limit = super::MAX_DOWNLOAD_TO_BYTES;
 
         // PD-FTP-1: dial the connection so an in-memory read works on a
@@ -1223,17 +1305,35 @@ impl StorageProvider for FtpProvider {
         let mut data_stream = stream
             .retr_as_stream(remote_path)
             .await
-            .map_err(|e| ProviderError::TransferFailed(e.to_string()))?;
+            .map_err(|e| Self::classify_data_failure("reading", remote_path, e))?;
 
         // H2: Read with size cap to prevent OOM
         let mut data = Vec::new();
         let limit_usize = (limit + 1) as usize;
+        let mut watch_control = true;
         loop {
             let mut buf = [0u8; 8192];
-            let n = data_stream
-                .read(&mut buf)
-                .await
-                .map_err(|e| ProviderError::TransferFailed(e.to_string()))?;
+            let step = {
+                let control = self
+                    .stream
+                    .as_ref()
+                    .ok_or(ProviderError::NotConnected)?
+                    .get_ref();
+                Self::read_watching_control(&mut data_stream, control, &mut buf, &mut watch_control)
+                    .await?
+            };
+            let n = match step {
+                DataStep::Read(n) => n,
+                DataStep::ControlRefused => {
+                    let stream = self.stream.as_mut().ok_or(ProviderError::NotConnected)?;
+                    let refusal = stream
+                        .read_response_in(&[Status::ClosingDataConnection])
+                        .await
+                        .err()
+                        .unwrap_or(FtpError::BadResponse);
+                    return Err(Self::classify_data_failure("reading", remote_path, refusal));
+                }
+            };
             if n == 0 {
                 break;
             }
@@ -1289,7 +1389,7 @@ impl StorageProvider for FtpProvider {
                     .await?;
                 self.upload_single(local_path, remote_path, None).await
             }
-            Err(err) => Err(err),
+            Err(err) => Err(self.name_the_missing_parent(remote_path, err).await),
         }
     }
 
@@ -1523,7 +1623,7 @@ impl StorageProvider for FtpProvider {
         offset: u64,
         on_progress: Option<Box<dyn Fn(u64, u64) + Send>>,
     ) -> Result<(), ProviderError> {
-        use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt as _};
+        use tokio::io::{AsyncSeekExt, AsyncWriteExt as _};
 
         // PD-FTP-1: the transfer executor calls `resume_download()` instead of
         // `download()` whenever a retry carries a partial offset, so a resumed
@@ -1562,7 +1662,7 @@ impl StorageProvider for FtpProvider {
         let mut data_stream = stream
             .retr_as_stream(remote_path)
             .await
-            .map_err(|e| ProviderError::TransferFailed(e.to_string()))?;
+            .map_err(|e| Self::classify_data_failure("resuming", remote_path, e))?;
 
         // H3: Stream directly to file instead of buffering entire file in memory
         let mut file = tokio::fs::OpenOptions::new()
@@ -1581,11 +1681,33 @@ impl StorageProvider for FtpProvider {
         // Stream chunks from FTP data stream directly to disk
         let mut transferred = offset;
         let mut buf = vec![0u8; 64 * 1024]; // 64 KB chunks
+        let mut watch_control = true;
         loop {
-            let n = data_stream
-                .read(&mut buf)
-                .await
-                .map_err(|e| ProviderError::TransferFailed(e.to_string()))?;
+            let step = {
+                let control = self
+                    .stream
+                    .as_ref()
+                    .ok_or(ProviderError::NotConnected)?
+                    .get_ref();
+                Self::read_watching_control(&mut data_stream, control, &mut buf, &mut watch_control)
+                    .await?
+            };
+            let n = match step {
+                DataStep::Read(n) => n,
+                DataStep::ControlRefused => {
+                    let stream = self.stream.as_mut().ok_or(ProviderError::NotConnected)?;
+                    let refusal = stream
+                        .read_response_in(&[Status::ClosingDataConnection])
+                        .await
+                        .err()
+                        .unwrap_or(FtpError::BadResponse);
+                    return Err(Self::classify_data_failure(
+                        "resuming",
+                        remote_path,
+                        refusal,
+                    ));
+                }
+            };
             if n == 0 {
                 break;
             }
@@ -1823,8 +1945,6 @@ impl StorageProvider for FtpProvider {
         offset: u64,
         len: u64,
     ) -> Result<Vec<u8>, ProviderError> {
-        use tokio::io::AsyncReadExt;
-
         const MAX_READ_RANGE: u64 = 100 * 1024 * 1024; // 100 MB
         if len > MAX_READ_RANGE {
             return Err(ProviderError::Other(format!(
@@ -1855,16 +1975,43 @@ impl StorageProvider for FtpProvider {
         let mut data_stream = stream
             .retr_as_stream(path)
             .await
-            .map_err(|e| ProviderError::TransferFailed(e.to_string()))?;
+            .map_err(|e| Self::classify_data_failure("reading a range of", path, e))?;
 
         // Read exactly `len` bytes (or until EOF if file is shorter)
         let mut buf = vec![0u8; len as usize];
         let mut total_read = 0usize;
+        let mut watch_control = true;
         while total_read < len as usize {
-            let n = data_stream
-                .read(&mut buf[total_read..])
-                .await
-                .map_err(|e| ProviderError::TransferFailed(format!("Range read failed: {}", e)))?;
+            let step = {
+                let control = self
+                    .stream
+                    .as_ref()
+                    .ok_or(ProviderError::NotConnected)?
+                    .get_ref();
+                Self::read_watching_control(
+                    &mut data_stream,
+                    control,
+                    &mut buf[total_read..],
+                    &mut watch_control,
+                )
+                .await?
+            };
+            let n = match step {
+                DataStep::Read(n) => n,
+                DataStep::ControlRefused => {
+                    let stream = self.stream.as_mut().ok_or(ProviderError::NotConnected)?;
+                    let refusal = stream
+                        .read_response_in(&[Status::ClosingDataConnection])
+                        .await
+                        .err()
+                        .unwrap_or(FtpError::BadResponse);
+                    return Err(Self::classify_data_failure(
+                        "reading a range of",
+                        path,
+                        refusal,
+                    ));
+                }
+            };
             if n == 0 {
                 break;
             }
@@ -1918,7 +2065,107 @@ fn canonical_hash_key(server_algo: &str) -> String {
     .to_string()
 }
 
+/// How long a data transfer may go without a single byte arriving.
+///
+/// INACTIVITY, not total duration. A cap on the whole transfer would kill a
+/// legitimate multi-gigabyte download on a slow line, which is a worse defect
+/// than the one being removed and one we would hear about from a user rather
+/// than find ourselves.
+///
+/// The value and the shape both follow what this codebase already does:
+/// `providers::filen` and `providers::mega_native` build their HTTP clients
+/// with `read_timeout(1800)`, which is reqwest's between-reads limit. FTP was
+/// the only transfer path in the tree with no deadline of any kind, so this is
+/// not a new mechanism, it is the existing one reaching the provider that
+/// lacked it.
+const DATA_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1800);
+
+/// What one turn of a data-reading loop produced.
+enum DataStep {
+    /// Bytes from the data channel; `0` is end of stream.
+    Read(usize),
+    /// The server sent a negative reply on the CONTROL channel while we were
+    /// waiting for data. The reply is still in the socket, unread.
+    ControlRefused,
+}
+
 impl FtpProvider {
+    /// Read from the data channel while watching the control channel.
+    ///
+    /// A transfer that can never succeed used to wait for ever. Measured: a
+    /// `get` of a missing file over a real network left the control socket with
+    /// 55 unread bytes in `Recv-Q` and the data socket open with nothing ever
+    /// arriving, and neither socket had a timer armed, so no kernel event could
+    /// ever end it. The server had already said 550. The answer was inside our
+    /// own process, in our own socket buffer, and nobody was looking at it,
+    /// because reading the data channel means not reading the control channel.
+    ///
+    /// On loopback the same code returns in two seconds, because there the data
+    /// socket closes at once and the wait ends by itself. Same server, same
+    /// version, opposite outcome, decided by who closes first: a fixture cannot
+    /// exercise this, which is worth knowing before trusting a green test here.
+    ///
+    /// ONLY THE READINESS IS RACED, and that is a constraint rather than a
+    /// detail. `readable()` and `peek()` take `&self` and consume nothing:
+    /// `peek` is MSG_PEEK, so losing the race costs exactly nothing and the
+    /// bytes stay where they were. `read_response_in` is NOT cancellation-safe
+    /// (it reads lines from a `BufReader`, and dropping it mid-line leaves the
+    /// control channel misaligned), so it must never appear inside the select.
+    /// Moving it in here would look like a simplification and would replace a
+    /// control channel we ignore with a control channel we corrupt.
+    ///
+    /// A reply is only acted on when it is a refusal. 4yz and 5yz end the wait;
+    /// 2yz is the ordinary completion reply, which arrives on this channel too
+    /// and must be left alone for `finalize_retr_stream` to consume, or the
+    /// tail of a perfectly good transfer would be thrown away.
+    async fn read_watching_control<S>(
+        data: &mut S,
+        control: &tokio::net::TcpStream,
+        buf: &mut [u8],
+        watch_control: &mut bool,
+    ) -> Result<DataStep, ProviderError>
+    where
+        S: tokio::io::AsyncRead + Unpin,
+    {
+        if !*watch_control {
+            return Self::read_with_deadline(data, buf).await;
+        }
+        tokio::select! {
+            biased;
+            _ = control.readable() => {
+                let mut probe = [0u8; 1];
+                // Ready, so this returns at once; and it does not consume.
+                match control.peek(&mut probe).await {
+                    Ok(1) if probe[0] == b'4' || probe[0] == b'5' => Ok(DataStep::ControlRefused),
+                    // A completion reply, or nothing readable after all: stop
+                    // watching so the loop cannot spin on a socket that stays
+                    // ready, and let the data channel finish normally.
+                    _ => {
+                        *watch_control = false;
+                        Self::read_with_deadline(data, buf).await
+                    }
+                }
+            }
+            step = Self::read_with_deadline(data, buf) => step,
+        }
+    }
+
+    /// One data read that cannot wait for ever.
+    async fn read_with_deadline<S>(data: &mut S, buf: &mut [u8]) -> Result<DataStep, ProviderError>
+    where
+        S: tokio::io::AsyncRead + Unpin,
+    {
+        use tokio::io::AsyncReadExt;
+        match tokio::time::timeout(DATA_IDLE_TIMEOUT, data.read(buf)).await {
+            Ok(Ok(n)) => Ok(DataStep::Read(n)),
+            Ok(Err(e)) => Err(ProviderError::TransferFailed(e.to_string())),
+            Err(_) => Err(ProviderError::TransferFailed(format!(
+                "no data arrived for {}s",
+                DATA_IDLE_TIMEOUT.as_secs()
+            ))),
+        }
+    }
+
     /// One single-stream RETR attempt. Factored out of the trait `download` so
     /// it can be retried once after reconnecting a clean control session
     /// (reused-session recovery). `on_progress` is owned; the retry passes
@@ -1942,7 +2189,7 @@ impl FtpProvider {
         let mut data_stream = stream
             .retr_as_stream(remote_path)
             .await
-            .map_err(|e| ProviderError::TransferFailed(e.to_string()))?;
+            .map_err(|e| Self::classify_data_failure("downloading", remote_path, e))?;
 
         let mut atomic = super::atomic_write::AtomicFile::new(local_path)
             .await
@@ -1950,15 +2197,44 @@ impl FtpProvider {
 
         let mut chunk = vec![0u8; self.buffer_size];
         let mut transferred: u64 = 0;
+        let mut watch_control = true;
 
         loop {
-            let n = data_stream
-                .read(&mut chunk)
-                .await
-                .map_err(|e| ProviderError::TransferFailed(e.to_string()))?;
-            if n == 0 {
-                break;
-            }
+            let step = {
+                let control = self
+                    .stream
+                    .as_ref()
+                    .ok_or(ProviderError::NotConnected)?
+                    .get_ref();
+                Self::read_watching_control(
+                    &mut data_stream,
+                    control,
+                    &mut chunk,
+                    &mut watch_control,
+                )
+                .await?
+            };
+            let n = match step {
+                DataStep::Read(0) => break,
+                DataStep::Read(n) => n,
+                // The server refused while we were waiting for bytes that were
+                // never going to come. Its reply is still unread in the socket,
+                // so it is read HERE, outside the select, where cancelling it
+                // is not a possibility.
+                DataStep::ControlRefused => {
+                    let stream = self.stream.as_mut().ok_or(ProviderError::NotConnected)?;
+                    let refusal = stream
+                        .read_response_in(&[Status::ClosingDataConnection])
+                        .await
+                        .err()
+                        .unwrap_or(FtpError::BadResponse);
+                    return Err(Self::classify_data_failure(
+                        "downloading",
+                        remote_path,
+                        refusal,
+                    ));
+                }
+            };
             atomic
                 .write_all(&chunk[..n])
                 .await
@@ -2204,7 +2480,7 @@ async fn ftp_download_one_range(
         stream
             .retr_as_stream(&remote_path)
             .await
-            .map_err(|e| ProviderError::TransferFailed(e.to_string()))?
+            .map_err(|e| FtpProvider::classify_data_failure("checksumming", &remote_path, e))?
     };
 
     let mut out = tokio::fs::OpenOptions::new()
@@ -2498,12 +2774,26 @@ mod tests {
                 b"Permission denied".to_vec(),
             )),
         );
+        // The property this row exists for, unchanged: a refusal that says
+        // nothing about a missing path must not be reported as one.
         assert!(
-            matches!(denied, ProviderError::TransferFailed(_)),
+            !matches!(denied, ProviderError::NotFound(_)),
             "a refusal that is not about a missing path must not become NotFound: {denied:?}"
         );
+        // The variant DID change, from `TransferFailed` to `InvalidPath`, and
+        // this row is updated deliberately rather than relaxed. It used to pin
+        // the variant while its own message named the property, which is a
+        // narrower claim than intended: a 550 is permanent under RFC 959, so
+        // `TransferFailed` (exit 4, retryable) had it tried three times for
+        // nothing. Asserting the exit-code family rather than the variant is
+        // what the row was always about.
+        assert!(
+            matches!(denied, ProviderError::InvalidPath(_)),
+            "a permanent 5yz refusal must be non-retryable, not a retryable transfer failure: {denied:?}"
+        );
 
-        // A transport failure is not a classification question at all.
+        // A transport failure is not a classification question at all: no
+        // status code, so nothing to call permanent, and it stays retryable.
         let broken = FtpProvider::map_store_error("/srv/out/report.txt", FtpError::BadResponse);
         assert!(matches!(broken, ProviderError::TransferFailed(_)));
 
@@ -3129,5 +3419,122 @@ mod danger {
                 SignatureScheme::ED448,
             ]
         }
+    }
+}
+
+#[cfg(test)]
+mod data_channel_watch_tests {
+    use super::*;
+    use tokio::io::AsyncWriteExt;
+    use tokio::net::{TcpListener, TcpStream};
+
+    /// A data channel that is open and will never deliver a byte, which is the
+    /// shape measured on the wire: 388 bytes sent, nothing ever received, the
+    /// socket left open by both ends.
+    async fn silent_pair() -> (TcpStream, TcpStream) {
+        let l = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = l.local_addr().unwrap();
+        let client = TcpStream::connect(addr).await.unwrap();
+        let (server, _) = l.accept().await.unwrap();
+        (client, server)
+    }
+
+    /// The reply the server already sent ends the wait, instead of the wait
+    /// outliving the process.
+    ///
+    /// This cannot be reproduced against the docker fixture: on loopback the
+    /// data socket closes at once, the read returns, and the control reply is
+    /// found two seconds later by the ordinary path. The defect needs a data
+    /// channel that stays open and silent, so the test builds one rather than
+    /// pretending a passing fixture proves anything.
+    #[tokio::test]
+    async fn a_refusal_already_in_the_socket_ends_the_wait() {
+        let (mut data_client, _data_server_kept_open) = silent_pair().await;
+        let (control_client, mut control_server) = silent_pair().await;
+
+        // The 550 arrives while nobody is reading the control channel: exactly
+        // the 55 unread bytes seen in Recv-Q on the real failure.
+        control_server
+            .write_all(b"550 Failed to open file.\r\n")
+            .await
+            .unwrap();
+        control_server.flush().await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let mut buf = [0u8; 64];
+        let mut watch = true;
+        let step = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            FtpProvider::read_watching_control(
+                &mut data_client,
+                &control_client,
+                &mut buf,
+                &mut watch,
+            ),
+        )
+        .await
+        .expect("the wait did not end: the control reply was not noticed")
+        .expect("watching the control channel must not fail");
+
+        assert!(
+            matches!(step, DataStep::ControlRefused),
+            "a 550 sitting unread in the control socket has to stop the wait"
+        );
+        assert!(
+            watch,
+            "a refusal must not switch the watch off: the caller still has to read the reply"
+        );
+    }
+
+    /// A completion reply must NOT abort the transfer.
+    ///
+    /// 226 arrives on the same channel, and treating it like a refusal would
+    /// throw away the tail of a transfer that was working. The watch switches
+    /// itself off instead, so the loop cannot spin on a socket that stays
+    /// readable, and the reply is left in place for `finalize_retr_stream`.
+    #[tokio::test]
+    async fn a_completion_reply_is_left_alone_and_the_data_keeps_flowing() {
+        let (mut data_client, mut data_server) = silent_pair().await;
+        let (control_client, mut control_server) = silent_pair().await;
+
+        control_server
+            .write_all(b"226 Transfer complete.\r\n")
+            .await
+            .unwrap();
+        control_server.flush().await.unwrap();
+        data_server.write_all(b"tail-of-the-file").await.unwrap();
+        data_server.flush().await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let mut buf = [0u8; 64];
+        let mut watch = true;
+        let step = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            FtpProvider::read_watching_control(
+                &mut data_client,
+                &control_client,
+                &mut buf,
+                &mut watch,
+            ),
+        )
+        .await
+        .expect("a completion reply must not stall the read")
+        .expect("watching the control channel must not fail");
+
+        match step {
+            DataStep::Read(n) => assert_eq!(&buf[..n], b"tail-of-the-file"),
+            DataStep::ControlRefused => {
+                panic!("226 was treated as a refusal: the tail of a good transfer would be lost")
+            }
+        }
+        assert!(
+            !watch,
+            "after a non-refusal the watch has to stop, or the loop spins on a ready socket"
+        );
+
+        // And the reply is still there for the finalizer: peek did not eat it.
+        let mut left = [0u8; 3];
+        let seen = control_client.peek(&mut left).await.unwrap();
+        assert_eq!(&left[..seen], b"226", "the completion reply was consumed");
     }
 }


### PR DESCRIPTION
## What this fixes

A `get` of a file that is not there could wait for ever, and "for ever" is meant literally rather than as shorthand for slow.

Captured on the wire, twice, on a remote server, with a stable picture between the two snapshots:

```
ESTAB  Recv-Q=55  ->  <server>:21     (control)
ESTAB  Recv-Q=0   ->  <server>:30071  (data)
```

The control socket held 55 unread bytes with nothing received for 22 seconds. The data socket was open with 388 bytes sent and nothing ever coming back. Neither socket had a timer armed, and the timer column was verified to work by checking that 40 other sockets on the same machine did print one, so the emptiness is a fact rather than a limit of the tool. No kernel event could ever end that wait.

The server had already answered. Its `550` was sitting in the client's own receive buffer while the client waited on the data channel, because reading the data channel means not reading the control channel. The information was not on the wire and not in a struct: it was inside the client process, in the client's socket, and nothing was looking at it.

## Why the fixture cannot show it

On loopback the same code returns in two seconds. There the data socket closes at once, the wait ends by itself, and the ordinary path finds the `550` afterwards. Same server software, same version, opposite outcome, decided by which side closes first.

The docker fixture in this repo therefore cannot exercise this defect, and a green run against it proves nothing here. That is said next to the tests as well as in this description, because the tests are where somebody will read a green and draw a conclusion.

The two tests build the failing state instead: a data channel that is open and silent, plus a refusal already sitting unread in the control socket. Without the fix the first test times out; that was confirmed by removing the fix and watching it fail, not assumed.

## The part that was not in the plan

Noticing that the server spoke is not enough, and the obvious version of this change is dangerous.

The completion reply arrives on the same channel that is now being watched, so treating any reply as a refusal would abort a transfer that was working and truncate the file. The first digit is read with `peek`, which does not consume: `4` and `5` end the wait, anything else stops the watch and leaves the reply in place for `finalize_retr_stream`.

A remedy for a hang that silently truncated files would have been the worse defect of the two.

## Cancellation safety is load-bearing

Only the readiness is raced. `readable()` and `peek()` take `&self` and consume nothing, so losing the race costs nothing.

`read_response_in` is not cancellation-safe: it reads lines from a `BufReader`, and dropping it mid-line leaves the control channel misaligned. It is therefore called after the race, never inside it. Moving it into the `select!` would look like a simplification and would trade a control channel the client ignores for one it corrupts. That constraint is written above the function, not only here.

## An encrypted control channel

Reading the first byte of a reply only works in the clear, and that is the protocol rather than a limit found by measuring: a TLS record opens with a ContentType in 0x14..0x18, while ASCII `4` and `5` are 0x34 and 0x35, so the sets do not intersect and no server can put a reply's digits there. Under FTPS the classification above cannot fire, and the default TLS mode is the one most users get.

What survives encryption is the READINESS. The server spoke, even if what it said cannot be read from this side of the TLS layer, and during a healthy transfer it has no reason to: the preliminary reply was consumed when the data channel opened and the completion reply comes after the data are done.

So a reply arriving mid-transfer SHORTENS the deadline instead of ending the wait, from thirty minutes to thirty seconds, and when the shorter deadline expires the pending reply is read, so the user still gets the server's own words a few seconds later rather than a bare timeout. The difference between a clear and an encrypted control channel becomes the latency of the answer, not whether there is one.

It shortens rather than aborts on purpose, and the shortened deadline is inactivity rather than a grace period. A transfer that is ending well keeps delivering the bytes already in flight, each one resets the timer, and this never fires: it fires only when the server has spoken AND the data have stopped, which are never both true in a healthy transfer. Arming on readiness alone would cut short a transfer that was finishing.

## Leaving a transfer without leaving a mess

Every early exit from a data loop used to drop the `DataStream` without calling `finalize`, so inside the crate `data_connection_open` stayed true and the completion reply stayed unread. What that meant was decided by whatever came next: another data command is refused with "data connection is already open", which is recognised and reconnects, but a CONTROL command reads the stale `226 Transfer complete` as its own reply and fails while quoting the success of something else.

This is not a reading of a third-party crate. This product has had the defect and named it. `FtpManager` sends a NOOP before every LIST, and its comment says why: "drain any pending control-connection responses from a previous large transfer/listing. This prevents stale data from leaking into the next LIST response (phantom files bug)." That mitigation exists only on the twin. The path serving the GUI and the CLI has no equivalent.

Those exits were rare before this change and are not any more, because a deadline and a refusal were added to four loops. A defect made common by a change belongs to that change, so the eight exits now share one way out: `abort` under a five second budget, and if the server will not answer even that, the connection is dropped rather than reused. It reports which of the two happened, because `list_inner_opts` carries on to its LIST branch after MLSD fails, and a silently discarded session would turn a server that advertises MLSD without honouring it into `NotConnected`.

One reply needs naming, because reading it wrongly was about to cost a reconnect for every missing file. After a refusal has been read there is no transfer left to abort, and servers say so with 225: pyftpdlib answers "225 No transfer to abort." and vsftpd "225 No transfer to ABOR.", both measured. `abort` waits for 226 or 426, so it reports that as an error.

It is not one. `abort` sends ABOR, drops the stream, CLEARS the connection flag, and only then reads the reply, and the reader consumes the line before deciding whether to accept its code. On a 225 the flag is already down, the line is already gone, and the control channel is aligned: the session is clean. Treating every error from `abort` as a broken session would have discarded it, and on the pooled providers behind the GUI, the MCP server and the TUI that is a fresh TLS handshake per missing file, which is the commonest case this change touches.

That cost would have been introduced here rather than inherited, and it was nearly written into this description as a limitation of the crate with the remedy deferred. A limit recorded against someone else's library is one people stop looking at, with a clear conscience because the reason is written down, and this one was a single line in this change.

Curing it at the exit, rather than draining before the next question, is the difference from the NOOP. The NOOP is what has held this together until now.

`disconnect` is bounded for the same reason. It sends QUIT and then reads the reply with no deadline, and it is reached from seven places through `reconnect_after_data_error`, all of them after something has already gone wrong: on a server that had stopped answering, the remedy meant to throw away a poisoned connection hung on the goodbye instead. The `let _ =` in front of it discarded the result, not the wait. The twin has bounded this for a long time, with the same five seconds used here.

WHAT THE CLEANUP DOES NOT COVER, said plainly because a function that looks complete is read as complete: it runs on exits that RETURN. A future dropped from outside never reaches it, since dropping an async fn runs the destructors of its locals and none of the code that follows. The transfer executor wraps a download in `tokio::time::timeout` and lets the future fall on expiry, so on that path the session is left in exactly the state this exists to prevent. Moving that deadline inside the data loop would turn it into an ordinary error return and bring it back through here, which is where the shared primitive will put it anyway.

## What this does NOT close

This closes four of the five RETR loops this provider drives itself. It does not close the class, and three of the gaps are inside FTP rather than beyond it.

The fifth loop is `ftp_download_one_range`, the parallel range download. Its read sits in a `select!` with the cancellation token alone: no deadline, no control watching, no cleanup on the way out. It is the only one of the five that dials its own connection, created and dropped inside the function, so the stale-session problem below does not reach it; the unbounded wait does.

`STOR` is a loop this provider drives too, and it gets neither the deadline nor the watch here. The failure is the mirror image: the server stops reading, `write_all` blocks once the kernel buffer fills, and the reply sits unread. `APPE` is worse, because `resume_upload` still calls `append_file` with a bare `map_err`, so its message carries no path, its refusals get no permanence classification, and it has no deadline at all. That is the branch the transfer executor takes when it retries from a partial offset, which is exactly where a pointless retry costs most. Both are tracked, and both belong with the shared data-loop primitive rather than with a sixth loop rewritten inside this change.

The `LIST` data loop lives inside `suppaftp`: `list()` reaches `get_lines_from_stream`, which loops on `read_until` with no deadline and no control watching. The helper in this provider cannot reach it, because the loop belongs to the crate. `MLSD` reaches the same loop, and `MLSD` is the branch tried first.

That is not a guess about a related path. It is the same failure, measured on the same remote server, with the passive port opened by hand and the data channel inspected without blocking:

```
MLSD /nope-xyz    control: "501 No such directory."          instant   data: OPEN AND SILENT
RETR /nope.bin    control: "550 No such file or directory."  instant   data: OPEN AND SILENT
MLSD /            control: 125 then 226                                data: 250 bytes
```

The first two rows are one defect written twice. The reply is already on the control channel, the data channel is open and will never deliver anything, and nothing is watching. The second row is what this pull request closes. The first is not touched by it.

What prevents a user from hanging there today is one thing only: the MLST probe, which runs before MLSD and answers instantly on a missing path. Measured end to end against that server, `ls` on a directory that is not there returns in 0.48 seconds. But the probe is gated on `mlst_supported`, so a server that speaks MLSD and does not advertise MLST reaches the MLSD call, opens the data channel, and waits with neither of the two remedies in this change.

This was declared open in an earlier draft of this description as a matter of imprecise categorisation. That was an understatement, corrected here after measuring it: it is the same permanent hang, on the branch modern servers take first. It is pre-existing, this change does not make it worse, and it is tracked.

The anti-hang probe that covers listings is gated on `mlst_supported`, and vsftpd 3.0.5 answers `500 Unknown command` to `MLST` (measured). So on servers that do not advertise MLST the listing has no anti-hang defence at all. This is a pre-existing gap rather than something introduced here, and it was found by asking a server rather than by reading the code: the condition is written in plain sight, and what nobody had asked was how often it is false.

Neither fixture in this repository can exercise any of that, and this is measured rather than assumed. Both FTP containers are vsftpd, and `FEAT` on each answers with `MDTM` and `SIZE` only: no `MLSD`, no `MLST`. So the primary listing branch and the anti-hang probe that is supposed to cover it are both unreachable in the current lab, which is a large part of why this class survived. Closing it needs a ProFTPD or pure-ftpd fixture first, not code.

Whether a `LIST` actually hangs on such a server is NOT measured. I have no server that exercises it, and asserting it without having seen it would be the same overclaiming this branch has spent its time removing.

The remedy is plausibly small rather than structural, and three things about it are worth recording before anyone attempts it:

The reconnect machinery already exists and already wraps `list` and `list_for_delete`: `reconnect_after_data_error` disconnects and reconnects, so it discards a misaligned connection rather than reusing it. That was my main objection and it does not stand.

But `is_stale_data_connection_error` recognises staleness by SUBSTRING, not by type, so a timeout error saying "no data arrived" matches none of its needles and would fall through without ever reaching the reconnect. Making it match by adding a needle is the same text-matching class this branch has been removing in three other places.

And the reconnect retries once, so the real ceiling is twice the timeout, not once. For a listing a TOTAL cap is the right shape, the opposite of the choice made below for transfers, because the correct form follows from whether the operation has an intrinsic size bound: a listing does, a download does not.

## Retries

A refused data command is no longer retried when the refusal is permanent.

Measured against vsftpd 3.0.5: `put` into a directory that does not exist is refused with `553 Could not create file.` and `get` of a missing file with `550 Failed to open file.`, both instantly, and both were then attempted twice more for nothing.

The status decides permanence, not the text: RFC 959 makes 5yz permanent and 4yz transient, the same rule already applied to `CWD` on the branch below this one.

The obvious fix would have been wrong. Neither reply names a missing path: they say the operation did not happen, and a server sends them both for a path that is absent and for one it will not let you touch. Adding them to the missing-path vocabulary would state something the server did not, which is precisely the defect removed from the `550` on `CWD`.

## Messages

`put` says again what to do about a missing parent. The CLI used to check the parent before every upload and name the `mkdir -p` that would fix it; that check was removed when the provider began classifying these failures, and for the other four removed checks the reasoning held. Here it did not, because a classifier reads a reply while what was lost was a sentence the user could act on.

The parent is now asked about AFTER a permanent refusal rather than before every upload, so the successful path pays nothing, and it lives in the provider, so the GUI and the MCP server get the sentence the CLI-only check never gave them. If the parent turns out to exist, the original error is returned untouched.

All five `RETR` sites also name the path now. They were five identical copies of the same `map_err`, and none of them said which file had failed.

## One pinned expectation changed

`a_store_into_a_missing_directory_is_not_found_not_a_transfer_failure` said "must not become NotFound" in its message and asserted the `TransferFailed` variant, which is a narrower claim than the one it named. `InvalidPath` satisfies the property; the row now asserts both, and the reason the variant moved is recorded beside it.

It was sharpened rather than relaxed. Relaxing an assertion until it passes destroys the only record of what the test was for.

## One commit rather than three

The three parts are separable in principle, but they live in one file and reconstructing the intermediate trees by hand risks committing one that does not build, which costs more than the attribution gains. Each part is named in the commit message and commented where it lives.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved FTP transfer error messages with clearer operation and file path details.
  - More reliably detects refused transfers, timeouts, missing directories, and unreadable listings.
  - Improved downloads, uploads, resumed transfers, range requests, and hidden-file deletion.
  - Added safeguards to prevent transfers from hanging when servers stop responding.
  - FTP listings now explicitly report empty or inaccessible directory results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->