### PR TITLE
fix(ftp): say what the MLST probe was always documented to say

### DIFF
--- a/.github/workflows/ftp-mlsd.yml
+++ b/.github/workflows/ftp-mlsd.yml
@@ -1,0 +1,86 @@
+# The listing tests that need a server speaking MLSD and MLST.
+#
+# They exist as a workflow rather than as instructions in a README because the
+# tests are `#[ignore]`, and an ignored test that no job runs is a defence that
+# is present and never fires. The branch they cover is the one most FTP servers
+# take, and a defect lived on it unnoticed precisely because nothing exercised
+# it. Running them by hand would leave that true.
+#
+# The docker fixture follows the shape delta-sync-integration.yml already uses.
+
+name: FTP MLSD listing
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src-tauri/src/providers/ftp.rs'
+      - 'src-tauri/src/providers/ftp_listing.rs'
+      - 'src-tauri/src/providers/types.rs'
+      - 'src-tauri/tests/integration_ftp_mlsd.rs'
+      - 'src-tauri/tests/fixtures/ftp-mlsd/**'
+      - '.github/workflows/ftp-mlsd.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src-tauri/src/providers/ftp.rs'
+      - 'src-tauri/src/providers/ftp_listing.rs'
+      - 'src-tauri/src/providers/types.rs'
+      - 'src-tauri/tests/integration_ftp_mlsd.rs'
+      - 'src-tauri/tests/fixtures/ftp-mlsd/**'
+      - '.github/workflows/ftp-mlsd.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  mlsd:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      # It pulls a base image from Docker Hub, which this repo has seen time
+      # out before (see aerorsync-protocol.yml).
+      - name: Build and start the MLSD fixture
+        timeout-minutes: 10
+        working-directory: src-tauri/tests/fixtures/ftp-mlsd
+        run: docker compose up -d --build
+
+      # A control connection that answers is the only readiness signal that
+      # means anything here: the container being up says the process started,
+      # not that it is serving.
+      - name: Wait for the fixture to answer
+        run: |
+          for i in $(seq 1 30); do
+            if printf 'QUIT\r\n' | timeout 3 nc 127.0.0.1 2199 | grep -q '^220'; then
+              echo "fixture answering after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "the fixture never answered on 2199"
+          exit 1
+
+      - name: Listing tests against an MLSD server
+        timeout-minutes: 15
+        working-directory: src-tauri
+        run: cargo test --test integration_ftp_mlsd -- --ignored --nocapture
+
+      - name: Dump fixture logs on failure
+        if: failure()
+        working-directory: src-tauri/tests/fixtures/ftp-mlsd
+        run: |
+          docker logs aeroftp-ftp-mlsd-fixture || true
+          docker compose ps
+
+      - name: Teardown
+        if: always()
+        working-directory: src-tauri/tests/fixtures/ftp-mlsd
+        run: docker compose down -v

--- a/.github/workflows/ftp-mlsd.yml
+++ b/.github/workflows/ftp-mlsd.yml
@@ -46,6 +46,17 @@ jobs:
         with:
           workspaces: src-tauri
 
+      # The test target links the Tauri crate, so the GTK/WebKit stack has to be
+      # present or the glib-sys build script fails before a single test runs.
+      # Same list as delta-sync-integration.yml, minus what only that lane needs.
+      - name: System dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev
+
       # It pulls a base image from Docker Hub, which this repo has seen time
       # out before (see aerorsync-protocol.yml).
       - name: Build and start the MLSD fixture

--- a/.github/workflows/ftp-mlsd.yml
+++ b/.github/workflows/ftp-mlsd.yml
@@ -114,8 +114,16 @@ jobs:
       # lane that waits for a service installs `netcat-openbsd` first, which
       # says plainly that `nc` cannot be assumed on this runner; removing the
       # dependency is better than adding the install.
+      # Three minutes, not two, and the arithmetic is the reason. The loop runs
+      # 30 iterations, and its worst case is one where the port is OPEN and
+      # silent: `read -t 3` waits its full three seconds and the `sleep 1`
+      # follows, so 30 x 4s is 120s, which is exactly what two minutes allows.
+      # The cap and the loop would finish together, and if the cap won the step
+      # would die MUTE, without the line written to say what happened. That
+      # worst case is not hypothetical: it is precisely the state the stalling
+      # fixture creates.
       - name: Wait for the fixture to answer
-        timeout-minutes: 2
+        timeout-minutes: 3
         run: |
           for i in $(seq 1 30); do
             if exec 3<>/dev/tcp/127.0.0.1/2199 2>/dev/null \

--- a/.github/workflows/ftp-mlsd.yml
+++ b/.github/workflows/ftp-mlsd.yml
@@ -37,6 +37,10 @@ permissions:
 jobs:
   mlsd:
     runs-on: ubuntu-latest
+    # Without a job cap, a slow apt mirror plus a cold Tauri build can sit until
+    # the platform limit. delta-sync-integration.yml caps at 110 for the same
+    # shape of work.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
 
@@ -46,16 +50,55 @@ jobs:
         with:
           workspaces: src-tauri
 
+      # The three packages are the right ones and were not the whole answer.
+      # delta-sync-integration.yml caches these archives because that download
+      # IS the observed failure mode of these lanes, with the measurements in
+      # its own comment: 61.5 MB of .deb, an Azure mirror serving one runner at
+      # roughly 45 kB/s, `libwebkit2gtk-4.1-0` alone taking 12m02s, and the step
+      # still fetching at 23m02s when the job cap killed it. `apt-get update` is
+      # not the cost. Installing the same list without the cache inherits that
+      # failure whole, so the cache travels with the list.
+      - name: apt archive cache key
+        id: apt-archive-key
+        run: echo "week=$(date -u +%G-W%V)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache apt archives
+        timeout-minutes: 10
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ~/apt-archives
+          key: apt-ftp-mlsd-${{ runner.os }}-${{ steps.apt-archive-key.outputs.week }}
+          restore-keys: |
+            apt-ftp-mlsd-${{ runner.os }}-
+
       # The test target links the Tauri crate, so the GTK/WebKit stack has to be
       # present or the glib-sys build script fails before a single test runs.
-      # Same list as delta-sync-integration.yml, minus what only that lane needs.
-      - name: System dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            libwebkit2gtk-4.1-dev \
-            libappindicator3-dev \
-            librsvg2-dev
+      # Bounded and retried for the same reason as the sibling lane: a slow
+      # mirror should fail THIS step, with its name in the log, rather than
+      # cancel the job and leave every test reported as skipped.
+      - name: Install system dependencies
+        timeout-minutes: 12
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 2
+          retry_wait_seconds: 15
+          command: |
+            set -euo pipefail
+            # An attempt killed mid-unpack leaves dpkg half-configured, and the
+            # next apt-get would refuse to run until it is told to finish.
+            sudo dpkg --configure -a || true
+            mkdir -p "$HOME/apt-archives/partial"
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends \
+              -o Dir::Cache::archives="$HOME/apt-archives/" \
+              -o APT::Keep-Downloaded-Packages=true \
+              libwebkit2gtk-4.1-dev \
+              libappindicator3-dev \
+              librsvg2-dev
+            # apt ran as root; hand the archives back so the cache save (which
+            # runs as the runner user) can read them.
+            sudo chown -R "$(id -u):$(id -g)" "$HOME/apt-archives"
 
       # It pulls a base image from Docker Hub, which this repo has seen time
       # out before (see aerorsync-protocol.yml).
@@ -67,20 +110,32 @@ jobs:
       # A control connection that answers is the only readiness signal that
       # means anything here: the container being up says the process started,
       # not that it is serving.
+      # `/dev/tcp` is a bash builtin, so this needs no package. The sibling
+      # lane that waits for a service installs `netcat-openbsd` first, which
+      # says plainly that `nc` cannot be assumed on this runner; removing the
+      # dependency is better than adding the install.
       - name: Wait for the fixture to answer
+        timeout-minutes: 2
         run: |
           for i in $(seq 1 30); do
-            if printf 'QUIT\r\n' | timeout 3 nc 127.0.0.1 2199 | grep -q '^220'; then
-              echo "fixture answering after ${i}s"
+            if exec 3<>/dev/tcp/127.0.0.1/2199 2>/dev/null \
+               && read -r -t 3 -u 3 banner \
+               && [[ "$banner" == 220* ]]; then
+              echo "fixture answering after ${i}s: $banner"
+              exec 3<&- 3>&-
               exit 0
             fi
+            exec 3<&- 3>&- 2>/dev/null || true
             sleep 1
           done
           echo "the fixture never answered on 2199"
           exit 1
 
+      # 15 minutes is a warm-cache figure. The first run on a branch compiles
+      # the Tauri crate from nothing, and a cap that bites once and never again
+      # reads as an infrastructure problem rather than as a wrong number.
       - name: Listing tests against an MLSD server
-        timeout-minutes: 15
+        timeout-minutes: 40
         working-directory: src-tauri
         run: cargo test --test integration_ftp_mlsd -- --ignored --nocapture
 

--- a/src-tauri/src/providers/ftp.rs
+++ b/src-tauri/src/providers/ftp.rs
@@ -390,6 +390,18 @@ impl FtpProvider {
             // MLST answers 550 for a missing path instantly (no data channel), so
             // we fail fast with a clear NotFound instead of hanging. Only probe an
             // explicit target; a current-directory listing is known to exist.
+            //
+            // That sentence describes what this was FOR, and until now the code
+            // did not do it: every 550 came back as `InvalidPath`, including
+            // the ones whose text said "No such file or directory". The comment
+            // was right and unimplemented, which is a shape worth naming: a
+            // stated intent is not a checked one.
+            //
+            // It survived because this branch cannot run without a server that
+            // advertises MLST, and until a pyftpdlib fixture existed there was
+            // none in the lab. The identical defect in `cwd_into` was found and
+            // fixed two branches ago, two hundred lines away, because THAT path
+            // runs against every server.
             if self.mlst_supported {
                 if let Some(ref target) = list_path {
                     let probe = {
@@ -401,7 +413,19 @@ impl FtpProvider {
                         Err(FtpError::UnexpectedResponse(response))
                             if response.status == Status::FileUnavailable =>
                         {
-                            return Err(ProviderError::InvalidPath(response.to_string()));
+                            // The same classifier a refused CWD goes through,
+                            // rather than a second copy of the same rule. FTP
+                            // spends 550 on both "it is not there" and "you may
+                            // not", the split is by text, and the text has to
+                            // be read with the path taken out of it: all of
+                            // that is already decided, already tested, and must
+                            // not be decided twice. Sharing it also puts this
+                            // arm inside the table that covers the other one.
+                            return Err(Self::classify_cwd_failure(
+                                "listing",
+                                target,
+                                &FtpError::UnexpectedResponse(response),
+                            ));
                         }
                         // MLST is only an anti-hang preflight. A transient failure
                         // (or a server that falsely advertises it) must not replace

--- a/src-tauri/tests/fixtures/ftp-mlsd/Dockerfile
+++ b/src-tauri/tests/fixtures/ftp-mlsd/Dockerfile
@@ -8,12 +8,29 @@
 # two rounds of review for that reason alone. A fixture that cannot reach a
 # code path decides what can be found in it.
 #
-# Python 3.11 on purpose: pyftpdlib still uses `asynchat`, removed in 3.12.
-FROM python:3.11-alpine
+# The Python version is pinned for reproducibility, the same posture as the
+# vsftpd fixture next door, which pins `alpine:3.19`. It is NOT pinned for a
+# compatibility limit: an earlier version of this comment claimed pyftpdlib
+# needed 3.11 because `asynchat` was removed in 3.12, and that was checked and
+# is false. pyftpdlib 1.5.10 imports cleanly on 3.12 with `asynchat` absent
+# from the standard library, because on any Python 3 it uses its own bundled
+# `_asynchat` and never reaches for the removed module.
+#
+# The claim is recorded here because it was written to stop somebody raising
+# the pin without knowing why, and a defensive note resting on an unchecked
+# fact is worse than no note: it makes a false thing hard to question.
+FROM python:3.12-alpine
 
-RUN pip install --no-cache-dir "pyftpdlib==1.5.10" \
+RUN pip install --no-cache-dir "pyftpdlib==1.5.10" "pyOpenSSL==24.2.1" \
     && adduser -D -h /workdir testuser \
     && mkdir -p /workdir && chown testuser:testuser /workdir
+
+# A throwaway certificate, generated at build time: the fixture is loopback
+# only and the tests connect with verification disabled.
+RUN apk add --no-cache openssl \
+    && openssl req -x509 -newkey rsa:2048 -keyout /k.pem -out /c.pem -days 3650 \
+       -nodes -subj "/CN=localhost" 2>/dev/null \
+    && cat /k.pem /c.pem > /cert.pem && rm /k.pem /c.pem
 
 COPY server.py /server.py
 EXPOSE 21 30100-30109

--- a/src-tauri/tests/fixtures/ftp-mlsd/Dockerfile
+++ b/src-tauri/tests/fixtures/ftp-mlsd/Dockerfile
@@ -1,0 +1,20 @@
+# An FTP server that speaks MLSD and MLST, which the vsftpd fixture next door
+# does not.
+#
+# That gap is not a detail of the lab: `list_inner_opts` tries MLSD first and
+# falls back to LIST, and the anti-hang MLST probe only runs when the server
+# advertises MLST. With vsftpd as the only fixture, the branch most servers
+# take was never executed by any test, and a defect that lived there survived
+# two rounds of review for that reason alone. A fixture that cannot reach a
+# code path decides what can be found in it.
+#
+# Python 3.11 on purpose: pyftpdlib still uses `asynchat`, removed in 3.12.
+FROM python:3.11-alpine
+
+RUN pip install --no-cache-dir "pyftpdlib==1.5.10" \
+    && adduser -D -h /workdir testuser \
+    && mkdir -p /workdir && chown testuser:testuser /workdir
+
+COPY server.py /server.py
+EXPOSE 21 30100-30109
+ENTRYPOINT ["python", "/server.py"]

--- a/src-tauri/tests/fixtures/ftp-mlsd/README.md
+++ b/src-tauri/tests/fixtures/ftp-mlsd/README.md
@@ -1,0 +1,37 @@
+# MLSD / MLST fixture
+
+An FTP server that speaks MLSD and MLST, which the vsftpd fixture next door does not.
+
+```bash
+docker compose up -d --build      # control on :2199, PASV 30100-30109
+cd ../../.. && cargo test --test integration_ftp_mlsd -- --ignored --nocapture
+cd tests/fixtures/ftp-mlsd && docker compose down -v
+```
+
+Credentials are `testuser` / `testpass`, fixture-only and deliberately hardcoded, the same as the vsftpd fixture beside it.
+
+## Why a second FTP fixture
+
+`list_inner_opts` tries MLSD first and only falls back to LIST, and the anti-hang MLST probe runs only when the server advertises MLST. vsftpd announces neither: `FEAT` on it answers with `MDTM` and `SIZE` only.
+
+So the branch most servers take was never executed by any test here, and a defect lived on it through two rounds of review for no other reason. A lab that cannot reach a code path decides what can be found in it.
+
+## Why pyftpdlib rather than a packaged daemon
+
+It is a library, so a handler can be subclassed and told what to emit. That is what makes conditions reachable that no real server will produce on request.
+
+`stall-forever.bin` is the one that exists today. A RETR of that name answers 150, leaves the data connection open, sends nothing, closes nothing, and then refuses on the control channel. That is the state a hanging transfer was captured in on a remote server: the reply already waiting unread on the control socket, the data socket open and silent, no timer armed on either.
+
+It could not be reproduced here before, and the reason was not the network. Every other server available closes the data connection when it has nothing to send, and a closed socket ends the wait by itself. The condition is "a server that does not close", and once that is said plainly it can be asked for.
+
+## TLS
+
+`AEROFTP_FIXTURE_TLS=1` turns on explicit FTPS, so one image serves both transports. That matters because a defence which inspects the raw control socket sees TLS records rather than FTP replies, and the same test has to be runnable both ways to show the difference.
+
+**The stall does not yet reproduce under TLS.** With the data handler never created, the client's data-channel handshake finds nobody, and the connection is reset before RETR is reached. That looks like a finding about the client and is a fault in the fixture.
+
+Reproducing it faithfully means letting pyftpdlib create the data handler, so the data-channel handshake completes, and then suppressing the sending, rather than skipping the creation as `StallMixin` does now. Changing the inheritance order does not help: the problem is not the MRO. This is written down so the next attempt starts from the answer instead of the question.
+
+## What is not covered yet
+
+A listing whose rows the parser cannot read. The same technique that made the stall reachable, a handler that decides what to emit, is what would produce it: no real server emits a dialect its own client cannot parse.

--- a/src-tauri/tests/fixtures/ftp-mlsd/docker-compose.yml
+++ b/src-tauri/tests/fixtures/ftp-mlsd/docker-compose.yml
@@ -1,0 +1,19 @@
+# MLSD/MLST fixture. See the Dockerfile for why this exists alongside the
+# vsftpd one.
+#
+#   cd src-tauri/tests/fixtures/ftp-mlsd
+#   docker compose up -d --build          # control on :2199, PASV 30100-30109
+#   cd ../../.. && cargo test --test integration_ftp_mlsd -- --ignored --nocapture
+#   cd tests/fixtures/ftp-mlsd && docker compose down -v
+#
+# Credentials are fixture-only and intentionally hardcoded, as in the vsftpd
+# fixture beside it.
+
+services:
+  ftp-mlsd:
+    build: .
+    container_name: aeroftp-ftp-mlsd-fixture
+    ports:
+      - "127.0.0.1:2199:21"
+      - "127.0.0.1:30100-30109:30100-30109"
+    restart: "on-failure"

--- a/src-tauri/tests/fixtures/ftp-mlsd/server.py
+++ b/src-tauri/tests/fixtures/ftp-mlsd/server.py
@@ -6,14 +6,70 @@ That is what makes the "no row could be read" case reachable at all, since a
 real server always emits a dialect its own client can parse.
 """
 
+import os
+
 from pyftpdlib.authorizers import DummyAuthorizer
 from pyftpdlib.handlers import FTPHandler
 from pyftpdlib.servers import FTPServer
 
+# A RETR of this name answers 150, leaves the data connection open, sends
+# nothing, closes nothing, and then refuses on the control channel.
+#
+# That is the state a hanging transfer was captured in: the reply already
+# waiting unread on the control socket, the data socket open and silent, and
+# no timer armed on either. It could not be reproduced in the lab, because
+# every server available here closes the data connection when it has nothing
+# to send, and a closed socket ends the wait by itself.
+#
+# The condition is therefore not "a remote link" but "a server that does not
+# close". Once that is said plainly it can be asked for, and a defect nobody
+# could recreate becomes a line in a test.
+STALL_NAME = "stall-forever.bin"
+STALL_REFUSAL_DELAY = 0.5
+
+
+class StallMixin:
+    def ftp_RETR(self, file):
+        if os.path.basename(file) != STALL_NAME:
+            return super().ftp_RETR(file)
+        # 150 first: the client is told the transfer is starting, so it stops
+        # reading the control channel and waits on data. Everything after this
+        # point is what the client cannot see.
+        self.respond("150 File status okay. About to open data connection.")
+        self.ioloop.call_later(
+            STALL_REFUSAL_DELAY,
+            lambda: self.respond("550 Failed to open file."),
+            _errback=self.handle_error,
+        )
+        # No data is pushed and the passive socket is left as it is: from the
+        # client's side the data connection is established and mute.
+
+
 authorizer = DummyAuthorizer()
 authorizer.add_user("testuser", "testpass", "/workdir", perm="elradfmw")
 
-handler = FTPHandler
+# TLS is opt-in through the environment so one image serves both transports.
+# The control channel being encrypted is not a detail here: a defence that
+# inspects the raw control socket sees TLS records rather than FTP replies, so
+# the same test has to be runnable both ways to show the difference.
+if os.environ.get("AEROFTP_FIXTURE_TLS") == "1":
+    from pyftpdlib.handlers import TLS_FTPHandler
+
+    # The mixin comes first so its `ftp_RETR` wins, and the TLS handler is the
+    # base so its own setup runs: the other order leaves the data channel
+    # without its handshake and the client is reset before it ever reaches
+    # RETR, which looks like a finding about the client and is a fault in the
+    # fixture.
+    class Handler(StallMixin, TLS_FTPHandler):
+        certfile = "/cert.pem"
+
+else:
+
+    class Handler(StallMixin, FTPHandler):
+        pass
+
+
+handler = Handler
 handler.authorizer = authorizer
 handler.passive_ports = range(30100, 30110)
 # The advertised address must stay literal so the mapped ports are reachable

--- a/src-tauri/tests/fixtures/ftp-mlsd/server.py
+++ b/src-tauri/tests/fixtures/ftp-mlsd/server.py
@@ -1,0 +1,24 @@
+"""Minimal MLSD/MLST-speaking FTP server for the listing tests.
+
+pyftpdlib is used rather than a packaged daemon for one reason: it is a
+library, so a handler can be subclassed to emit listing rows of our choosing.
+That is what makes the "no row could be read" case reachable at all, since a
+real server always emits a dialect its own client can parse.
+"""
+
+from pyftpdlib.authorizers import DummyAuthorizer
+from pyftpdlib.handlers import FTPHandler
+from pyftpdlib.servers import FTPServer
+
+authorizer = DummyAuthorizer()
+authorizer.add_user("testuser", "testpass", "/workdir", perm="elradfmw")
+
+handler = FTPHandler
+handler.authorizer = authorizer
+handler.passive_ports = range(30100, 30110)
+# The advertised address must stay literal so the mapped ports are reachable
+# from the host loopback, exactly as in the vsftpd fixture.
+handler.masquerade_address = "127.0.0.1"
+handler.banner = "aeroftp mlsd fixture ready"
+
+FTPServer(("0.0.0.0", 21), handler).serve_forever()

--- a/src-tauri/tests/integration_ftp_mlsd.rs
+++ b/src-tauri/tests/integration_ftp_mlsd.rs
@@ -1,0 +1,85 @@
+//! Live checks for the listing path taken against a server that speaks MLSD.
+//!
+//! `#[ignore]` so a default `cargo test` skips them, following the pattern of
+//! `integration_ftp_missing_path.rs`.
+//!
+//! ```bash
+//! cd src-tauri/tests/fixtures/ftp-mlsd
+//! docker compose up -d --build            # control :2199
+//! cd ../../.. && cargo test --test integration_ftp_mlsd -- --ignored --nocapture
+//! cd tests/fixtures/ftp-mlsd && docker compose down -v
+//! ```
+//!
+//! Why a second FTP fixture. `list_inner_opts` tries MLSD first and only falls
+//! back to LIST, and the anti-hang MLST probe runs only when the server
+//! advertises MLST. The vsftpd fixture announces neither, so every FTP test in
+//! this repository has been exercising the fallback while the branch most
+//! servers take went unexecuted. A defect lived on that branch through two
+//! rounds of review for no reason other than that: a lab that cannot reach a
+//! path decides what can be found in it.
+//!
+//! What is proved here cannot be proved by a unit test. The classification
+//! itself is covered by a table in `providers::ftp`; what needs a server is
+//! that the probe RUNS, that it runs before MLSD, and that its verdict is the
+//! one the reply supports.
+
+use ftp_client_gui_lib::providers::types::{FtpConfig, FtpTlsMode, ProviderError};
+use ftp_client_gui_lib::providers::{FtpProvider, StorageProvider};
+
+fn provider() -> FtpProvider {
+    FtpProvider::new(FtpConfig {
+        host: "127.0.0.1".to_string(),
+        port: 2199,
+        username: "testuser".to_string(),
+        password: "testpass".to_string().into(),
+        tls_mode: FtpTlsMode::None,
+        verify_cert: false,
+        initial_path: None,
+    })
+}
+
+/// A directory that is not there is reported as NOT FOUND, not as a path that
+/// merely did not work.
+///
+/// The probe answered `InvalidPath` for every 550, including the ones whose
+/// text says "No such file or directory", while the comment above it had said
+/// "fail fast with a clear NotFound" since the day it was written. The comment
+/// stated the intent and nothing checked it, and nothing could: without a
+/// server that advertises MLST this branch does not execute.
+#[tokio::test]
+#[ignore]
+async fn a_missing_directory_is_not_found_on_the_mlsd_path() {
+    let mut p = provider();
+    p.connect().await.expect("fixture not up: see the header");
+
+    let err = p
+        .list("/definitely-not-here")
+        .await
+        .expect_err("a directory that is not there must not list successfully");
+
+    assert!(
+        matches!(err, ProviderError::NotFound(_)),
+        "the server said \"No such file or directory\" and the verdict was {err:?}"
+    );
+    // The reply survives into the message, and so does the path.
+    let rendered = err.to_string();
+    assert!(
+        rendered.contains("/definitely-not-here"),
+        "the path is missing from {rendered:?}"
+    );
+}
+
+/// The probe does not turn a directory that IS there into a failure.
+///
+/// The boundary the fix must not cross: it would be easy to make every 550
+/// louder and break ordinary listing, and this row is what would catch that.
+#[tokio::test]
+#[ignore]
+async fn a_directory_that_exists_still_lists_on_the_mlsd_path() {
+    let mut p = provider();
+    p.connect().await.expect("fixture not up: see the header");
+
+    p.list("/")
+        .await
+        .expect("the root exists and must list through MLSD");
+}


### PR DESCRIPTION
## The defect

The comment above the anti-hang MLST probe has said this since the day it was written:

> A control-only MLST answers 550 for a missing path instantly (no data channel), so we fail fast with a clear NotFound instead of hanging.

The code underneath returned `InvalidPath` for every 550, including the ones whose text says "No such file or directory".

Measured against a server that speaks MLST: `ls` on a directory that is not there gives `Invalid path: [550] 550 No such file or directory.` and exit 5, where the reply plainly supports `NotFound` and exit 2. Both are non-retryable, so nothing was retried that should not have been; what was wrong is that a script checking exit 2 for "it is not there" does not get it, and that the category claimed less than the server said.

## Why nobody saw it

This is the uncomfortable variant of a shape this branch has been removing for two days. The comment was not wrong when it was written. It was right, and it was never true.

The branch cannot execute without a server that advertises MLST, and the only FTP fixture in this repository is vsftpd, which advertises neither MLST nor MLSD. `FEAT` on both existing containers answers with `MDTM` and `SIZE` only. So the listing branch that most servers take has never been executed by any test here, and neither has the probe that guards it.

The identical defect in `cwd_into` was found and fixed a few days ago, two hundred lines away. Both are equally readable in the source. The difference was whether a test could reach them.

## The fix

The probe now goes through `classify_cwd_failure`, which a refused CWD already uses, instead of a second copy of the rule. FTP spends 550 on both "it is not there" and "you may not", the split is by text, and the text has to be read with the path removed from it: all of that is decided in one place and covered by a table there.

A first attempt rewrote the rule inside the probe and was discarded. That function has been corrected twice in the last two days, once for anchoring status codes and once for the vocabulary, and a second copy would have been a copy diverging from something still settling.

## The fixture is the larger half

If the defect survived because the lab could not reach that branch, then the correction is not the line. It is that the lab reaches it for anyone.

`tests/fixtures/ftp-mlsd` runs pyftpdlib, which speaks MLSD and MLST, beside the vsftpd fixture that speaks neither. pyftpdlib is a library rather than a packaged daemon, so a handler can be subclassed and told what to emit. That already pays: the fixture can now be asked to stall a RETR, which reproduces a hang that had only ever been captured at the sockets on a remote server. A listing whose rows the parser cannot read is reachable the same way and is NOT produced here: this change makes that case available to whoever writes it, and does not cover it.

The Python version is pinned for reproducibility, matching the vsftpd fixture next door pinning `alpine:3.19`. An earlier version of the Dockerfile said it was pinned because pyftpdlib needs `asynchat`, removed in 3.12. That was checked and it is false: pyftpdlib 1.5.10 imports cleanly on 3.12 with `asynchat` absent, because on any Python 3 it uses its own bundled copy. The claim is recorded in the Dockerfile rather than quietly dropped, because it was written to stop somebody raising the pin without knowing why, and a defensive note resting on an unchecked fact is worse than no note: it makes a false thing hard to question.

## Tests

Two, both `#[ignore]` like the FTP tests beside them.

The first was confirmed failing before the fix, against the server rather than a hand-built value: with the old line it reports the verdict `InvalidPath` for a reply that says "No such file or directory".

The second is the opposite boundary. A directory that does exist must still list, because it would be easy to make every 550 louder and break ordinary listing, and that row is what would catch it.

What a unit test cannot show is written in the test file: the classification is covered without a server, but that the probe runs at all, that it runs before MLSD, and that its verdict matches the reply, all need one.

## Running in CI

A workflow runs these against the fixture on any change to the FTP provider, the listing parser, the shared vocabulary, the tests or the fixture itself. They are `#[ignore]`, and an ignored test that no job runs is a defence that is present and never fires: the branch it covers is the one most servers take, and the defect fixed here survived on it precisely because nothing exercised it. Running them by hand would have left that true.

The docker steps follow the shape `delta-sync-integration.yml` already uses, so this is not a new mechanism in this repository.

## Note for reviewers

The fixture takes port 2199. It does not clash with the vsftpd fixture on 2123, and the two use the same credentials so they stay consistent with each other.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * FTP listings now correctly identify missing paths as “Not Found” instead of reporting a generic invalid-path error.
  * Other FTP listing failures now receive more accurate error classifications.

* **Tests**
  * Added integration coverage for MLSD listings, missing directories, and stalled transfers.
  * Added automated CI coverage using a dedicated FTP/MLSD test fixture.

* **Documentation**
  * Documented the FTP/MLSD test fixture, supported TLS mode, and known limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->