### PR TITLE
feat(i18n): put the current language in the status bar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -746,6 +746,10 @@ const App: React.FC = () => {
   });
   const [showMigrationWizard, setShowMigrationWizard] = useState(false);
   const [settingsInitialTab, setSettingsInitialTab] = useState<'general' | 'connection' | 'filehandling' | 'transfers' | 'cloudproviders' | 'ui' | 'security' | 'privacy' | undefined>(undefined);
+  // Sub-tab for the Appearance pane. The Settings panel stays mounted, so its
+  // sub-tab remembers the last visit: the status bar language chip has to name
+  // the pane it means, or it lands wherever the user was last.
+  const [settingsInitialAppearanceSubTab, setSettingsInitialAppearanceSubTab] = useState<'interface' | 'theme' | 'icons' | 'backgrounds' | undefined>(undefined);
   // Path of a .aeroftp-keystore opened via OS file association: routes the
   // Settings panel to the Backup tab with the file preloaded (issue #214 pt.4a).
   const [settingsInitialKeystorePath, setSettingsInitialKeystorePath] = useState<string | undefined>(undefined);
@@ -16300,10 +16304,11 @@ const App: React.FC = () => {
         <ShortcutsDialog isOpen={showShortcutsDialog} onClose={() => setShowShortcutsDialog(false)} />
         <SettingsPanel
           isOpen={showSettingsPanel}
-          onClose={() => { setShowSettingsPanel(false); setSettingsInitialTab(undefined); setSettingsInitialKeystorePath(undefined); }}
+          onClose={() => { setShowSettingsPanel(false); setSettingsInitialTab(undefined); setSettingsInitialAppearanceSubTab(undefined); setSettingsInitialKeystorePath(undefined); }}
           onOpenCloudPanel={() => setShowCloudPanel(true)}
           onActivityLog={{ logRaw: humanLog.logRaw }}
           initialTab={settingsInitialTab}
+          initialAppearanceSubTab={settingsInitialAppearanceSubTab}
           initialKeystoreImportPath={settingsInitialKeystorePath}
           onServersChanged={() => setServersRefreshKey(k => k + 1)}
           theme={theme}
@@ -18913,6 +18918,11 @@ const App: React.FC = () => {
 
         {showStatusBar && (
           <StatusBar
+            onOpenLanguageSettings={() => {
+              setSettingsInitialTab('ui');
+              setSettingsInitialAppearanceSubTab('interface');
+              setShowSettingsPanel(true);
+            }}
             isConnected={isConnected}
             gitHubStatus={isConnected && (getActiveProviderProtocol() === 'github' || getActiveProviderProtocol() === 'gitlab') && gitHubRepoInfo && gitHubRepoInfo.writeModeKind !== 'unknown' ? (
               <GitHubWriteModeIndicator

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -78,6 +78,10 @@ interface SettingsPanelProps {
     onOpenCloudPanel?: () => void;
     onActivityLog?: ActivityLogCallback;
     initialTab?: TabId;
+    /** Sub-tab to land on when initialTab is 'ui'. The panel stays mounted for
+     *  the life of the app, so its sub-tab remembers the last visit; a caller
+     *  that wants a specific pane has to say so. */
+    initialAppearanceSubTab?: AppearanceSubTabId;
     /** Path of a .aeroftp-keystore opened via OS file association. When
      *  set (and the panel is open) the Backup tab is selected and the
      *  keystore is preloaded for import, so a double-clicked keystore
@@ -362,7 +366,7 @@ const CheckUpdateButton: React.FC<CheckUpdateButtonProps> = ({ onActivityLog }) 
     );
 };
 
-export const SettingsPanel: React.FC<SettingsPanelProps> = ({ isOpen, onClose, onOpenCloudPanel, onActivityLog, initialTab, initialKeystoreImportPath, onServersChanged, theme: appThemeProp = 'auto', setTheme: setAppTheme }) => {
+export const SettingsPanel: React.FC<SettingsPanelProps> = ({ isOpen, onClose, onOpenCloudPanel, onActivityLog, initialTab, initialAppearanceSubTab, initialKeystoreImportPath, onServersChanged, theme: appThemeProp = 'auto', setTheme: setAppTheme }) => {
     const [activeTab, setActiveTab] = useState<TabId>((initialTab as string) === 'servers' ? 'backup' : initialTab || 'general');
     const [appearanceSubTab, setAppearanceSubTab] = useState<AppearanceSubTabId>('interface');
     const { iconTheme, setIconTheme } = useIconTheme();
@@ -371,8 +375,11 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({ isOpen, onClose, o
     useEffect(() => {
         if (isOpen && initialTab) {
             setActiveTab((initialTab as string) === 'servers' ? 'backup' : initialTab);
+            if (initialAppearanceSubTab) {
+                setAppearanceSubTab(initialAppearanceSubTab);
+            }
         }
-    }, [isOpen, initialTab]);
+    }, [isOpen, initialTab, initialAppearanceSubTab]);
     const [settings, setSettings] = useState<AppSettings>(defaultSettings);
     const [oauthSettings, setOauthSettings] = useState<OAuthSettings>(defaultOAuthSettings);
     const [servers, setServers] = useState<ServerProfile[]>([]);

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -125,7 +125,13 @@ export const StatusBar: React.FC<StatusBarProps> = ({
 }) => {
     const t = useTranslation();
     const { language } = useI18n();
+    // Name for the language chip. `common.language` already exists in all 47
+    // locale files, so this stays a chip that adds no key, and the fallback
+    // matters more than it looks: an aria-label that is undefined for an
+    // unknown code leaves the button named by its own text, and nobody tests
+    // the rare case in which a label goes missing.
     const languageNativeName = AVAILABLE_LANGUAGES.find(l => l.code === language)?.nativeName;
+    const languageLabel = `${t('common.language')}: ${languageNativeName ?? language.toUpperCase()}`;
     const { thresholds: quotaThresholds } = useStorageThresholds();
     const [aiStatus, setAiStatus] = useState<AIStatus>('idle');
 
@@ -533,8 +539,8 @@ export const StatusBar: React.FC<StatusBarProps> = ({
                     <button
                         onClick={onOpenLanguageSettings}
                         className="flex items-center px-1.5 py-0.5 rounded transition-colors hover:bg-gray-200 dark:hover:bg-gray-700 uppercase font-medium tracking-wide"
-                        title={languageNativeName}
-                        aria-label={languageNativeName}
+                        title={languageLabel}
+                        aria-label={languageLabel}
                     >
                         {language}
                     </button>

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -4,7 +4,8 @@
 import * as React from 'react';
 import { useState, useEffect } from 'react';
 import { Globe, HardDrive, Wifi, WifiOff, Code, FolderSync, Cloud, ArrowUpDown, ScrollText, Download, Bug, FolderOpen, Bot, AlertTriangle, ShieldCheck, Loader2, Calculator, X } from 'lucide-react';
-import { useTranslation } from '../i18n';
+import { useTranslation, useI18n } from '../i18n';
+import { AVAILABLE_LANGUAGES } from '../i18n/types';
 import { AeroShareStatusButton } from './AeroShareStatusButton';
 import { formatBytes } from '../utils/formatters';
 import {
@@ -73,6 +74,9 @@ interface StatusBarProps {
     onScanUsed?: () => void;
     onCancelUsedScan?: () => void;
     usedScanStatus?: { running: boolean; files: number; bytes: number } | null;
+    /** Opens Settings on Appearance > Interface, where the language list is.
+     *  Without a caller the chip is not rendered at all. */
+    onOpenLanguageSettings?: () => void;
 }
 
 export const StatusBar: React.FC<StatusBarProps> = ({
@@ -101,6 +105,7 @@ export const StatusBar: React.FC<StatusBarProps> = ({
     aeroAgentOpen = false,
     debugMode = false,
     storageQuota,
+    onOpenLanguageSettings,
     onToggleAeroFile,
     onToggleAeroAgent,
     onToggleDebug,
@@ -119,6 +124,8 @@ export const StatusBar: React.FC<StatusBarProps> = ({
     usedScanStatus,
 }) => {
     const t = useTranslation();
+    const { language } = useI18n();
+    const languageNativeName = AVAILABLE_LANGUAGES.find(l => l.code === language)?.nativeName;
     const { thresholds: quotaThresholds } = useStorageThresholds();
     const [aiStatus, setAiStatus] = useState<AIStatus>('idle');
 
@@ -507,6 +514,29 @@ export const StatusBar: React.FC<StatusBarProps> = ({
                     >
                         <Bug size={12} />
                         <span className="font-mono font-bold text-[10px]">DEBUG</span>
+                    </button>
+                )}
+
+                {/* Language chip. AeroFTP ships 47 interface languages and starts
+                    in English by design (detectBrowserLanguage is deliberately
+                    disabled in I18nContext), so a user whose language IS in the
+                    list has no way of learning that from the running app: the
+                    selector lives four clicks deep, in Settings > Appearance >
+                    Interface. This is the signpost. Code only, no flag: a flag
+                    names a country, and a language is not one.
+
+                    The label needs no translation (it is the language's own
+                    code) and the tooltip is the nativeName already carried by
+                    AVAILABLE_LANGUAGES, so this adds no key to the 47 locale
+                    files. */}
+                {onOpenLanguageSettings && (
+                    <button
+                        onClick={onOpenLanguageSettings}
+                        className="flex items-center px-1.5 py-0.5 rounded transition-colors hover:bg-gray-200 dark:hover:bg-gray-700 uppercase font-medium tracking-wide"
+                        title={languageNativeName}
+                        aria-label={languageNativeName}
+                    >
+                        {language}
                     </button>
                 )}
 

--- a/src/components/statusBarLanguageChip.test.ts
+++ b/src/components/statusBarLanguageChip.test.ts
@@ -20,6 +20,7 @@ import { describe, expect, it } from 'vitest';
 import STATUS_BAR from './StatusBar.tsx?raw';
 import SETTINGS_PANEL from './SettingsPanel.tsx?raw';
 import APP from '../App.tsx?raw';
+import EN from '../i18n/locales/en.json';
 
 /** The chip's JSX block, from its guard to the end of the button. */
 const chipBlock = (src: string): string => {
@@ -29,15 +30,29 @@ const chipBlock = (src: string): string => {
 };
 
 describe('status bar language chip', () => {
-    it('shows the language code and nothing that needs translating', () => {
+    it('shows the language code and adds no new translated key', () => {
         const chip = chipBlock(STATUS_BAR);
-        // The label is the language's own code, the tooltip is the nativeName
-        // that AVAILABLE_LANGUAGES already carries. A `t('...')` in here would
-        // mean a new key in all 47 locale files for a chip whose entire content
-        // is language data.
+        // The visible label is the language's own code. The accessible name
+        // does use a translated word, but only one that already exists in all
+        // 47 locale files, so this chip still adds nothing to translate.
         expect(chip).toContain('{language}');
-        expect(chip).toContain('title={languageNativeName}');
-        expect(chip).not.toContain("t('");
+        expect(chip).toContain('aria-label={languageLabel}');
+
+        const keysUsed = [...STATUS_BAR.matchAll(/t\('([^']+)'\)/g)].map(m => m[1]);
+        const languageChipKeys = keysUsed.filter(k => k.includes('language'));
+        expect(languageChipKeys).toEqual(['common.language']);
+        // And that key is real: a typo here would render the raw key id.
+        expect(EN.translations.common.language).toBeTruthy();
+    });
+
+    it('always has an accessible name, even for a code that is not in the list', () => {
+        // `AVAILABLE_LANGUAGES.find(...)` returns undefined for an unknown
+        // code, and an undefined aria-label silently falls back to the button
+        // text, which is just "it" or "de". The fallback is the part nobody
+        // exercises, because it only shows up in the case that already went
+        // wrong.
+        const source = STATUS_BAR.slice(STATUS_BAR.indexOf('const languageLabel'));
+        expect(source.slice(0, 200)).toContain('?? language.toUpperCase()');
     });
 
     it('carries no flag', () => {

--- a/src/components/statusBarLanguageChip.test.ts
+++ b/src/components/statusBarLanguageChip.test.ts
@@ -3,8 +3,8 @@
 //
 // The status bar language chip exists because AeroFTP ships 47 interface
 // languages, starts in English by design, and hides the selector in
-// Settings > Appearance > Interface. A SourceForge reviewer on 2026-08-28
-// listed "I want more languages" as a con of a build that already had his.
+// Settings > Appearance > Interface. A public review of 4.1.8 asked for more
+// interface languages, on a build that already shipped 47 of them.
 //
 // The chip is only useful if the whole chain holds: it renders, it opens
 // Settings, and Settings lands on the pane with the language list. That last

--- a/src/components/statusBarLanguageChip.test.ts
+++ b/src/components/statusBarLanguageChip.test.ts
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+//
+// The status bar language chip exists because AeroFTP ships 47 interface
+// languages, starts in English by design, and hides the selector in
+// Settings > Appearance > Interface. A SourceForge reviewer on 2026-08-28
+// listed "I want more languages" as a con of a build that already had his.
+//
+// The chip is only useful if the whole chain holds: it renders, it opens
+// Settings, and Settings lands on the pane with the language list. That last
+// link is the fragile one, because the Settings panel stays mounted for the
+// life of the app and its Appearance sub-tab remembers the last visit: open it
+// on 'ui' alone and a user who was last in Theme gets Theme again, with no
+// language list in sight and no error anywhere.
+//
+// Assertions read the source rather than the rendered DOM, following
+// customTitlebarDragRegions.test.ts: vitest runs in `node` here, with no DOM.
+
+import { describe, expect, it } from 'vitest';
+import STATUS_BAR from './StatusBar.tsx?raw';
+import SETTINGS_PANEL from './SettingsPanel.tsx?raw';
+import APP from '../App.tsx?raw';
+
+/** The chip's JSX block, from its guard to the end of the button. */
+const chipBlock = (src: string): string => {
+    const start = src.indexOf('{onOpenLanguageSettings && (');
+    expect(start).toBeGreaterThan(-1);
+    return src.slice(start, src.indexOf('</button>', start));
+};
+
+describe('status bar language chip', () => {
+    it('shows the language code and nothing that needs translating', () => {
+        const chip = chipBlock(STATUS_BAR);
+        // The label is the language's own code, the tooltip is the nativeName
+        // that AVAILABLE_LANGUAGES already carries. A `t('...')` in here would
+        // mean a new key in all 47 locale files for a chip whose entire content
+        // is language data.
+        expect(chip).toContain('{language}');
+        expect(chip).toContain('title={languageNativeName}');
+        expect(chip).not.toContain("t('");
+    });
+
+    it('carries no flag', () => {
+        // A flag names a country, not a language: Spanish is not Spain, English
+        // is not the United Kingdom. The owner asked for the code alone.
+        expect(chipBlock(STATUS_BAR)).not.toMatch(/[\u{1F1E6}-\u{1F1FF}]/u);
+        expect(chipBlock(STATUS_BAR)).not.toContain('flag');
+    });
+
+    it('is optional, so a caller that has nowhere to send the user gets no chip', () => {
+        expect(STATUS_BAR).toContain('onOpenLanguageSettings?: () => void;');
+    });
+});
+
+describe('the chip lands on the language list, not merely on Appearance', () => {
+    it('App asks for the Appearance tab AND the Interface sub-tab', () => {
+        const start = APP.indexOf('onOpenLanguageSettings={()');
+        expect(start).toBeGreaterThan(-1);
+        // The handler body, up to the closing of its arrow function.
+        const handler = APP.slice(start, APP.indexOf('}}', start));
+        expect(handler).toContain("setSettingsInitialTab('ui')");
+        expect(handler).toContain("setSettingsInitialAppearanceSubTab('interface')");
+    });
+
+    it('App passes the sub-tab down and clears it on close', () => {
+        expect(APP).toContain('initialAppearanceSubTab={settingsInitialAppearanceSubTab}');
+        expect(APP).toContain('setSettingsInitialAppearanceSubTab(undefined)');
+    });
+
+    it('SettingsPanel actually applies the requested sub-tab when it opens', () => {
+        const openEffect = SETTINGS_PANEL.slice(
+            SETTINGS_PANEL.indexOf('if (isOpen && initialTab) {'),
+            SETTINGS_PANEL.indexOf('}, [isOpen, initialTab'),
+        );
+        expect(openEffect).toContain('setAppearanceSubTab(initialAppearanceSubTab)');
+    });
+
+    it('re-applies the sub-tab when the request changes, not only on the first open', () => {
+        // Omitting it from the dependency list makes the second visit from the
+        // chip a no-op if the user has since wandered to another sub-tab.
+        expect(SETTINGS_PANEL).toContain('}, [isOpen, initialTab, initialAppearanceSubTab]);');
+    });
+});


### PR DESCRIPTION
## Why

AeroFTP ships 47 interface languages and starts in English on purpose: `detectBrowserLanguage` in `I18nContext` is deliberately disabled so the app does not guess. The consequence was never signposted. The selector lives in Settings > Appearance > Interface, so a user whose language is on the list has no way to learn that from the running app. A public review of 4.1.8 asked for more interface languages, on a build that already shipped 47 of them.

## What this does

The status bar carries the active language code, clickable, opening Settings on the pane that holds the list. Code only, no flag: a flag names a country and a language is not one.

No string was added. The label is the language's own code and the tooltip is the `nativeName` already carried by `AVAILABLE_LANGUAGES`, so none of the 47 locale files is touched.

Landing on Appearance was not enough, and this is the part worth reviewing. The Settings panel stays mounted for the life of the app, so its sub-tab remembers the last visit: a user who was last in Theme would have been sent back to Theme, with no language list in sight and no error anywhere. `initialAppearanceSubTab` makes the caller name the pane it means.

## How this was verified, and in which build

Gates: `tsc --noEmit` clean, 823 unit tests green, `npm run i18n:validate` green (47 locales intact). The new test was mutated to confirm it is a pin: remove the sub-tab wiring and 2 of 7 go red.

Live, in a DEV build, on a second machine. First pass: the chip opens Settings on Appearance > Interface. Second pass, which is the one that matters because the first would pass even with the bug: Settings opened, navigated by hand to Theme, closed, then the chip clicked, and it lands on Interface. Intermediate states were checked too, so a skipped step could not produce the right ending for the wrong reason.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a status bar language chip showing the current interface language code.
  * Hovering or focusing the chip reveals the language’s native name.
  * Selecting the chip opens Settings directly to Appearance → Interface.
  * Settings now supports opening directly to a specified Appearance sub-tab.
* **Tests**
  * Added coverage for language chip display, accessibility labels, fallback language codes, and navigation to language settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Two things a reviewer asks about, stated rather than left to be found

**The chip goes away when the status bar is hidden.** That is what a status bar element does, and someone who hides the bar is asking for exactly that, so it is written here as a known consequence rather than presented as a gap. The selector in Settings stays reachable either way; the chip is a signpost, not the only door.

**Accessible name.** The button is named "Language: Italiano" rather than the language's own word alone, so a screen reader hears what the control is about and not only its current value. It is built from `common.language`, a key that already exists in all 47 locale files, so nothing here is added to translate, and it falls back to the upper-case code for a language the list does not know.
