### PR TITLE
ci(aerorsync): fail the live lane when it runs fewer tests than it selects

### DIFF
--- a/.github/workflows/aerorsync-protocol.yml
+++ b/.github/workflows/aerorsync-protocol.yml
@@ -320,9 +320,27 @@ jobs:
           RSNP_TEST_REAL_LOCAL_DOWNLOAD_FILE_MD4: /tmp/aerorsync-lane/local_MD4.bin
           RSNP_TEST_REAL_LOCAL_DOWNLOAD_FILE_SHA1: /tmp/aerorsync-lane/local_SHA1.bin
         # --test-threads=1: the checksum override is a process-global env var.
+        #
+        # The count check is not belt-and-braces. This selects tests BY NAME and
+        # only the ignored ones, and `cargo test` prints "test result: ok" and
+        # exits 0 when a filter matches nothing. So renaming the module, or
+        # removing `#[ignore]` from these tests to make them run more often,
+        # would turn this lane green having executed NOTHING, and the second one
+        # looks like an improvement while doing it. `set -o pipefail` matters for
+        # the same reason: without it the exit status would be tee's, not cargo's.
         run: |
+          set -o pipefail
           cargo test --features aerorsync --lib aerorsync::live_tests -- \
-            --ignored --nocapture --test-threads=1
+            --ignored --nocapture --test-threads=1 | tee /tmp/aerorsync-live.log
+          ran=$(grep -oE '^test result: ok\. [0-9]+ passed' /tmp/aerorsync-live.log \
+                | grep -oE '[0-9]+' | head -1)
+          echo "aerorsync live tests executed: ${ran:-none}"
+          if [ -z "${ran}" ] || [ "${ran}" -lt 8 ]; then
+            echo "::error::this lane executed ${ran:-0} live tests, expected at least 8."
+            echo "::error::a green here with fewer tests means the filter stopped matching,"
+            echo "::error::not that the protocol got simpler. Fix the filter, not this check."
+            exit 1
+          fi
       - name: Tear down harness
         if: always()
         working-directory: src-tauri/src/aerorsync/capture

--- a/.github/workflows/aerorsync-protocol.yml
+++ b/.github/workflows/aerorsync-protocol.yml
@@ -332,8 +332,14 @@ jobs:
           set -o pipefail
           cargo test --features aerorsync --lib aerorsync::live_tests -- \
             --ignored --nocapture --test-threads=1 | tee /tmp/aerorsync-live.log
+          # `|| true` is load-bearing: GitHub runs a step with no `shell:` as
+          # `bash -e {0}`, and under -e an assignment from a pipeline that
+          # matches nothing ends the script right here, silently. The check
+          # would still fail, but with no message, which is the exact shape
+          # this step exists to remove. `shell: bash` does NOT fix it: that is
+          # `bash -eo pipefail`, so -e is still on.
           ran=$(grep -oE '^test result: ok\. [0-9]+ passed' /tmp/aerorsync-live.log \
-                | grep -oE '[0-9]+' | head -1)
+                | grep -oE '[0-9]+' | head -1 || true)
           echo "aerorsync live tests executed: ${ran:-none}"
           if [ -z "${ran}" ] || [ "${ran}" -lt 8 ]; then
             echo "::error::this lane executed ${ran:-0} live tests, expected at least 8."


### PR DESCRIPTION
**This lane can go green having executed nothing, and today nothing would say so.** It selects its tests by name and takes only the ignored ones (`--lib aerorsync::live_tests -- --ignored`), and `cargo test` prints `test result: ok` and exits 0 when a filter matches no tests. I hit that shape by accident on my own machine earlier today: a filtered run reported `test result: ok. 0 passed` with exit 0 because the file it named had been restored out from under it, and the only reason I noticed was that I had reason to be suspicious.

**Two ways in, and the second is the one that will actually happen.** Renaming the module empties the filter, but whoever renames a module knows they are changing something and may go looking for references. Removing `#[ignore]` from those eight tests also empties it, because `--ignored` selects only ignored tests, and there is no moment in that edit where anyone would get a doubt: it looks like making the tests run more often. A well-intentioned improvement switches the lane off.

**The existing defence sits on the wrong side of the fault.** `RSNP_TEST_REAL_REQUIRED=1` makes these tests fail rather than skip when the Docker harness is unreachable, which is right and stays. But it is a guard inside the tests against something that happens before them: if no test is selected, nothing reads that variable. A guard placed after the point where control is lost is not a weak guard, it is zero.

**Why a count and not `0 passed`.** Failing only on zero would let a partial loss through: three tests surviving out of eight passes a zero check and is just as much a hole. The step reads the number executed and fails under eight, and prints it either way, so the log says what ran rather than that something did.

Verified against five inputs rather than trusting the shape, **run under `bash -e`, which is how GitHub executes a step with no `shell:`**: `8 passed` passes; `0 passed`, `3 passed`, a log with no result line at all, and a log that was never written each fail, and each says what it counted. `set -o pipefail` is what makes the compile-failure case reachable at all: piping into `tee` without it would hand the step tee's exit status instead of cargo's, which is the same class of mistake the check exists to catch.

The first version of this check was validated under a plain `bash`, and that was not good enough: under `-e`, an assignment from a pipeline matching nothing ends the script at that line, so the branch printing "executed: none" could never be reached. The step still failed, but mutely, which is precisely the shape being removed here. Found by review, fixed with `|| true` on the assignment. `shell: bash` would not have fixed it, because GitHub runs that as `bash -eo pipefail` and `-e` stays on; both forms were measured before choosing. The lesson is narrower than "test your script": the logic was right and the logic-as-executed was not, and those are two different questions.

Expected count is eight, checked rather than assumed: all eight tests in `aerorsync/live_tests.rs` are `#[tokio::test]` + `#[ignore]`, with no `cfg` gating that could vary the number under `--features aerorsync`. The bound is `-lt 8` rather than `== 8` so that adding a ninth test does not fail the lane; removing one still does.

No Rust changed, so the fmt/clippy/test gate is whatever `main` already is.
