### PR TITLE
test(ftp): add a configurable FTP fixture for hard-to-reach branches

### DIFF
--- a/src-tauri/tests/fixtures/ftp/README-slowftp.md
+++ b/src-tauri/tests/fixtures/ftp/README-slowftp.md
@@ -460,7 +460,33 @@ is a false green on a test you believe is measuring a hang.
 Verified independent: `--pending-hold 6 --stor-stop-hold 60` holds each hang 6s,
 and `--stor-stop-hold 6 --pending-hold 60` lingers 6s on the stopped socket.
 
-### The default is long on purpose
+### No default may win a race against the thing under test
+
+Every timing default here either is `0`, meaning the behaviour is off and cannot
+race anything, or is long enough to lose on purpose. That is not decoration: a
+default does not appear on a command line, so when a default decides an outcome,
+the number that decided it is absent from the file someone reads to understand
+the test.
+
+Audited against the deadlines they run beside:
+
+| option | was | now | races |
+|---|---|---|---|
+| `--pending-hold` | 30 | 120 | `OPEN_BUDGET` = 30, the same number |
+| `--stor-stop-hold` | 30 | 120 | `DATA_IDLE_AFTER_CONTROL_SPOKE` = 30, the same number |
+| `--hang` | 90 | 420 | `LIST_BUDGET` = 300, which the old default never reached |
+
+The last one is the one worth staring at, because it lost the race by
+**surrendering** rather than by resisting. At 90 the fixture gave up first and a
+300 second listing budget was never reached, so a test believing it measured
+that budget measured this number instead, and passed. A default can decide an
+outcome by being too short just as easily as by being too long.
+
+The options that default to `0` are safe for a different reason worth stating:
+off cannot race. When a new timing knob is added here, defaulting it off is the
+cheapest way to keep this property.
+
+### The pending hold is long on purpose
 
 `--pending-hold` defaults to **120 seconds**, which is far longer than any
 deadline likely to be under test. That is the point. If the hold and the

--- a/src-tauri/tests/fixtures/ftp/README-slowftp.md
+++ b/src-tauri/tests/fixtures/ftp/README-slowftp.md
@@ -474,3 +474,31 @@ should, instead of when a garbage collector decides.
 One consequence to expect when reading a timing: a client that is released this
 way may reconnect and hit the same wall again. Against `--pending-hold 6` our
 client takes about 12s in total, which is two hangs of 6s and not one of 12.
+
+## How many openings a client attempts, measured
+
+A deadline on opening a data channel bounds one opening. It does not bound a
+command, because the client retries. Against this fixture with
+`--pasv-no-accept tls-silent --pending-hold 5`:
+
+| command | openings the server saw | total |
+|---|---|---|
+| `ls` | 2 | 10.2s |
+| `get` | 6 | 32.4s |
+
+So a per-opening budget of N seconds is worth up to 6N on a download. Anyone
+sizing such a budget against a user's patience should size it for the total, not
+for one attempt.
+
+### The bound was missing on exactly the path that needed it most
+
+This was measured, not assumed, and the first measurement was the interesting
+one: `get` sat for the full 400s ceiling having announced **one** opening, while
+`ls` against the same fixture came back after two holds.
+
+`RETR` takes an earlier branch that never calls `accept_data()`, so the
+`if c is None` guard was unreachable there and `--pending-hold` bounded nothing
+on the download path. That is the same shape as the crash documented above, a
+guard placed on a path an earlier branch returns before reaching, and it was
+introduced by the fix for that crash. Both openings now go through
+`hold_unserved()`, which is the one place that holds and releases.

--- a/src-tauri/tests/fixtures/ftp/README-slowftp.md
+++ b/src-tauri/tests/fixtures/ftp/README-slowftp.md
@@ -446,7 +446,7 @@ When two ends disagree, the end you are not measuring is the one to believe.
 --stor-stop-hold N   seconds a STOPPED socket lingers after the server stops
                      reading a refused STOR
 --pending-hold N     seconds a LIST, RETR or STOR is held pending when
-                     tls-silent leaves no usable data channel
+                     tls-silent leaves no usable data channel (default 120)
 ```
 
 **The last two were one option, and separating them was worth doing.** One
@@ -459,6 +459,19 @@ is a false green on a test you believe is measuring a hang.
 
 Verified independent: `--pending-hold 6 --stor-stop-hold 60` holds each hang 6s,
 and `--stor-stop-hold 6 --pending-hold 60` lingers 6s on the stopped socket.
+
+### The default is long on purpose
+
+`--pending-hold` defaults to **120 seconds**, which is far longer than any
+deadline likely to be under test. That is the point. If the hold and the
+deadline are close, the outcome is decided by a few milliseconds: sometimes the
+deadline fires, sometimes this fixture's EOF arrives first, and the test passes
+either way without saying which one it measured.
+
+Worse, that collision is invisible in the test. A default does not appear in the
+command line, so the number that decided the race is absent from the file
+someone reads to understand the test. It defaults long so that whatever is under
+test wins the race, and a deliberately short hold has to be asked for.
 
 ### `--pending-hold` ends the hang by closing, and that is deliberate
 

--- a/src-tauri/tests/fixtures/ftp/README-slowftp.md
+++ b/src-tauri/tests/fixtures/ftp/README-slowftp.md
@@ -484,11 +484,28 @@ command, because the client retries. Against this fixture with
 | command | openings the server saw | total |
 |---|---|---|
 | `ls` | 2 | 10.2s |
-| `get` | 6 | 32.4s |
+| `get`, default `--retries 3` | 6 | 32.4s |
 
-So a per-opening budget of N seconds is worth up to 6N on a download. Anyone
-sizing such a budget against a user's patience should size it for the total, not
-for one attempt.
+The six is not a constant. Counted against the same permanent stall:
+
+| `--retries` | openings |
+|---|---|
+| `0` | 2 |
+| `1` | 2 |
+| `2` | 4 |
+| `3` | 6 |
+| `5` | 10 |
+
+So `openings = 2 x max(1, --retries)`: two openings per attempt, multiplied by
+the caller's own retry setting. A per-opening budget of N seconds is therefore
+worth `2 x retries x N` to the person waiting, which at the default is 6N and at
+`--retries 10` is 20N.
+
+That matters more than the single number: the multiplier is a knob the caller
+turns, so a budget sized against a user's patience cannot be sized once. The
+budget is still the right mechanism and belongs where it is, since it is what
+turns an unbounded wait into a bounded one; what cannot be read off the constant
+or its call sites is what it is being multiplied by.
 
 ### The bound was missing on exactly the path that needed it most
 

--- a/src-tauri/tests/fixtures/ftp/README-slowftp.md
+++ b/src-tauri/tests/fixtures/ftp/README-slowftp.md
@@ -1,0 +1,395 @@
+# slowftp: the FTP server for the branches a real server hides
+
+`slowftp.py` is a hand-written FTP server, no dependencies. It exists because the
+branches we need to test are decided by exactly what the server says and when it
+says it, and a real server will not say those things on demand.
+
+Run it, point a client at `127.0.0.1:<port>`, any username and password.
+
+## The three FEAT positions
+
+The listing branch is chosen by the server, so it takes a server to switch it.
+
+| `--feat` | What the server does | What our client does |
+|---|---|---|
+| `nomlsd` | FEAT omits MLSD | falls back to `LIST` |
+| `mlsd` | FEAT advertises MLSD, MLSD works | takes the MLSD branch |
+| `mlsd-hang` | FEAT advertises MLSD, MLSD never answers | marks it broken, reconnects, and runs `LIST` inside the same call |
+
+All three verified against `aeroftp-cli ls`, entries checked, not just the path.
+The third opens two data channels in one `list()` and has no test today.
+
+## The include_hidden axis is not the server's
+
+`LIST -a` versus `LIST` is our own parameter, not a server capability, so it is
+exercised by calling two of our own operations against one server. This fixture
+serves the dotfiles only when the client asks with `-a`, so the difference is
+visible instead of assumed. Both operations verified against one running server:
+
+```
+aeroftp-cli ls    ->  LIST                    2 entries, no dotfiles
+aeroftp-cli rm -r ->  CWD /sub
+                      LIST -a                 4 entries, dotfiles included
+                      CWD /
+                      DELE /sub/.hidden-a
+                      DELE /sub/.hidden-b
+                      DELE /sub/file-000.txt
+                      DELE /sub/file-001.txt
+                      RMD  /sub
+```
+
+That is the `CWD` in, bare `LIST -a`, restore-the-working-directory sequence
+`providers/ftp.rs:622-632` describes, doing what it says: without the `-a` the
+two dotfiles would survive and the final `RMD` would fail on a directory the
+client believed was empty.
+
+## The late reply, and why the fixture must not tear down
+
+`--late-final N` makes the server finish its work and send the closing `226`
+N seconds late, **without closing the control connection**. That reply is then
+sitting in the socket when the next command asks its own question, and the next
+command reads it as its own answer. This is the "phantom files" defect that
+`src/ftp.rs:218-221` already documents and already patches with a pre-LIST NOOP.
+
+A fixture that closed at the deadline could not produce this case, and the green
+it returned would only be saying "the fixture closed".
+
+## Reaching that defect on the main road: RETR, not LIST
+
+`providers/ftp.rs` (the GUI and CLI path) has **no listing timeout at all**, so a
+slow listing cannot strand a reply there. A download can:
+`provider_transfer_executor.rs` races each download against the user cancel token
+and a per-file timeout and drops the future mid-`RETR`. The `FtpProvider`
+survives with its control stream mid-reply, and the retry loop reuses that same
+instance for the next attempt.
+
+So the stall belongs on `RETR`:
+
+```
+--retr-stall N       hold the data channel open and silent for N seconds,
+                     to outlast the per-file download timeout
+--retr-before-stall  bytes handed over before the stall (default 4096)
+--late-final N       then pay the 226 N seconds late, connection still open
+```
+
+## Sitting on a threshold
+
+`--list-total S` spreads the listing over S seconds, so a run can be placed just
+under or just over a deadline without recomputing a per-row delay. The rows are
+real and correct throughout: what a total timeout costs here is real data, not
+an error.
+
+## The two numbers without which this fixture reproduces nothing
+
+The stall has to end **after** the client's per-file timeout fires and **before**
+the client gives up on the entry altogether. Against the 30s default:
+
+| `--retr-stall` | per-file timeout | what you see |
+|---|---|---|
+| `35` | 30s | the late `226` lands while a retry is waiting: the desync |
+| `45` | 30s | all three retries are exhausted first: **nothing at all** |
+
+Same code, same path, same fixture. The 45s run looks clean and proves nothing.
+This is the single easiest thing to lose from this file.
+
+## Surviving the broken pipe, which is the half hour you do not have to repeat
+
+When the client's timeout fires it drops its end of the **data** channel. The
+server is still mid-`sendall`, so the write raises `BrokenPipeError`. Left
+alone, that exception kills the session thread, and a dead thread never sends
+the late reply.
+
+The result is a run that looks completely clean and reproduces nothing, and the
+trace from the client's side is **identical** to a correct run in which the
+server simply had nothing more to say. "The server stopped talking" and "the
+server had nothing left to say" are the same bytes at the client. It cost half
+an hour and was found only by reading the **server** log.
+
+So the fixture catches `BrokenPipeError` and `ConnectionResetError` in three
+places, and none of them is optional:
+
+- around the `RETR` body, so an aborted download still owes its `226`;
+- around the listing loop, for the same reason on the `LIST` path;
+- around the whole session loop, so a client that drops the **control**
+  connection closes one session instead of taking the handler down.
+
+The general form, worth more than the three catches: **a fixture that falls over
+and a fixture that closes on purpose tear down at the same instant and produce
+the same clean trace.** Whenever the instrument is a dialogue between two ends,
+read the outcome from the end you are NOT measuring. The end you measure always
+shows you a coherent trace, including when the other one is dead.
+
+## Does #655 make this obsolete? No, and #655 says so itself
+
+`#655` adds `abandon_transfer`, which cleans the session up on the way out of a
+failed transfer. It would be reasonable to assume that closes the desync above
+and retires this fixture. It does not, and the PR states the limit in its own
+doc comment rather than leaving it to be discovered:
+
+> It runs on exits that RETURN. A future dropped from outside never reaches it:
+> dropping an async fn runs the destructors of its locals and none of the code
+> that follows. The transfer executor wraps a download in `tokio::time::timeout`
+> and lets the future fall on expiry, so on that path the session is left exactly
+> as this function exists to prevent, and the retry that follows reuses the same
+> connection.
+
+So the reproduction stays live after `#655` lands, with the same two numbers.
+It closes when the deadline moves **inside** the data loop, where expiry becomes
+an ordinary error return and passes through the cleanup like every other exit.
+That is where the shared data-loop primitive will put it, and this fixture is
+the instrument for checking that it actually got there.
+
+## One thing this fixture cannot do, from the same PR
+
+> On loopback the same code returns in two seconds, because there the data
+> socket closes at once and the wait ends by itself. Same server, same version,
+> opposite outcome, decided by who closes first: a fixture cannot exercise this,
+> which is worth knowing before trusting a green test here.
+
+That is about the hanging download of a missing file (F9), not about the desync.
+This fixture runs on loopback, so it is the wrong instrument for that one and a
+green here would mean nothing. F9 is measured against a real remote.
+
+## Two anomalies on the control channel while the data channel is open
+
+Both were asked for by the session working on `STOR`, and they are one handler
+because they are the same shape: an unusual reply, or an unusual silence, on the
+control channel during a transfer.
+
+### `--abor-silent`: take the ABOR and say nothing
+
+The server reads the `ABOR` and sends neither `226` nor `426`, so the client's
+abort stays pending inside its own budget. That is the only state in which a
+future dropped mid-abort can be observed at all.
+
+Verified: `<- (during transfer) ABOR` in the server log, and no reply at the
+client after 8s.
+
+The first version passed this test while being wrong. It never read the `ABOR`
+at all, it merely never answered, and at the client those are the same silence.
+Reading it required the stalls to keep watching the control channel, which is
+what `wait_watching_control` is for: a bare `time.sleep` makes the fixture deaf.
+
+### `--stor-refuse-after N`, with `--stor-after-refuse drain|stop`
+
+Mid-`STOR` the server sends `552` on the control channel and then either keeps
+draining the data channel (`drain`) or stops reading with the socket still open
+(`stop`). Closing it instead would deliver `EPIPE`, a different failure that
+answers a question nobody asked.
+
+`--stor-read-rate BYTES_PER_SEC` throttles the server's reading, and on loopback
+it is **not optional**: without it the client writes the whole file into the
+socket buffers before the refusal can matter, so "it uploaded everything" would
+be a property of the buffers rather than of the client.
+
+Measured with the read throttled to 16 KB/s, a 300000 byte file, refusal at
+65536 bytes:
+
+| mode | bytes the server received after refusing | what ended the client |
+|---|---|---|
+| `drain` | **all 300000** | still running at the 300s ceiling |
+| `stop` | 65536 | the data socket closing, not the `552` |
+
+So neither half of the assumption holds up: refusing on the control channel does
+not, by itself, end the upload. In `drain` the whole file goes up after the
+refusal even with the write genuinely blocked. In `stop` the write does jam, but
+the client waits for the socket rather than acting on a refusal it already has.
+
+### `poll_control` peeks, it never reads
+
+It uses `MSG_PEEK` and consumes only an `ABOR`, leaving every other byte where
+it was. An earlier version read whatever had arrived, which swallowed the
+ordinary commands a client sends during a transfer and answered none of them.
+
+## Asserting what the fixture actually did, not what it looks like
+
+A test that drives the client cannot see this server's log. Without something
+more, such a test would stay green if this fixture regressed to never reading
+the `ABOR` at all, because at the client "took it and said nothing" and "never
+read it" are the same silence. That regression is not hypothetical: this fixture
+shipped it once.
+
+Two ways to close it, use whichever the harness can reach:
+
+```
+--status-file PATH      the fixture rewrites PATH with what it did:
+                        {"abor_read": 1, "stor_bytes": 0}
+SITE STATUS             the same counters in-band: 211 abor_read=1 stor_bytes=0
+```
+
+The file is rewritten **at startup**, so a stale file from an earlier run can
+never be read as this run's result, and it is replaced atomically, so a reader
+never sees a half-written file.
+
+Assert `abor_read == 1`, not `>= 1`: the exact count also catches the client
+sending more `ABOR`s than it should.
+
+**What this counter does not cover, said here because it was already read as
+covering it.** It increments in exactly one place: when the server *reads an
+`ABOR` sent by the client*. It counts commands travelling one way. A client that
+speculatively consumes a server *reply* it should have left alone does so
+entirely on its own side of the socket, takes nothing away from what the server
+reads, and moves no counter here. That is a different property and needs a
+different instrument: speculative consumption is not observable as consumption,
+only as its consequence, a session shifted by one reply from then on.
+
+### Verified against the failure it exists to catch
+
+The counter was checked by rebuilding the deaf regression on purpose (the stall
+reverted to a bare `time.sleep`) and running the identical probe against both:
+
+| fixture | what the client saw | `abor_read` |
+|---|---|---|
+| correct | silence for 6s | `1` |
+| deaf (regression) | silence for 6s | `0` |
+
+Same silence at the client, different counter. An instrument that has never been
+shown to go red for the fault it is meant to report is a counter, not a guard.
+
+## `--unsolicited-refusal-after N`: a refusal nobody asked for
+
+The path where a client is meant to *peek* at the control channel and consume a
+reply only once it has decided to fail. Mid-`RETR`, after N bytes of data, the
+server sends a refusal on the control channel unasked:
+
+```
+550 SLOWFTP-INJECTED unsolicited refusal at 4096 bytes
+```
+
+The `SLOWFTP-INJECTED` marker is not decoration. When a test goes red here the
+first question is whether the reply that got consumed was this one or an
+ordinary one, and a bare `550` cannot answer it. `--unsolicited-code` changes
+the code if 550 collides with something real.
+
+**How the test reads it.** Speculative consumption cannot be caught in the act:
+the read happens entirely on the client's side of the socket. It is caught by
+what comes next. So the assertion is a question with a known answer, asked
+afterwards, on a file whose size cannot coincide with anything else in play:
+
+```
+--file-size 40961      ->  SIZE must answer exactly "213 40961"
+```
+
+Not 0, not 65536, not a round number: if the assertion fails, a strange number
+says immediately whether the answer belongs to this question or to a previous
+one. A red on a *value* says what happened; a red on a timeout says only that
+something did not arrive.
+
+**Assert `unsolicited_sent == 1` as well.** If the injection never fired, a test
+checking "the size is still right afterwards" would pass without exercising
+anything at all. That is the same green-and-empty failure this fixture keeps
+walking into, so the counter is in the status file next to the others.
+
+Verified: injection fires at 4096 bytes of a 40961 byte transfer, the whole file
+still arrives on the data channel, and `SIZE` afterwards answers `213 40961`.
+
+## `--pasv-no-accept`: announce a data port and then fail to serve it
+
+Three ways the data connection can fail to happen. They are **not**
+interchangeable: the client sees a different failure in each, and the wait sits
+at a different depth.
+
+| mode | what the client sees | verified |
+|---|---|---|
+| `tls-silent` | `connect()` succeeds, then nothing ever comes back | connect in 0.00s, zero data bytes |
+| `connect-hang` | `connect()` itself never returns | stalled past 8s |
+| `refuse` | `connect()` gets RST at once | refused in 0.00s |
+
+`connect-hang` fills the listening socket's accept queue so the kernel drops the
+SYN. Without that the kernel completes the handshake on its own and `connect()`
+returns, which is a different case wearing the same name.
+
+`refuse` is not padding: it is the contrast that shows the other two really are
+hangs and not just slow.
+
+**`--refuse-before-data`** sends `550 Failed to open file.` on the control
+channel *before* the data phase, so the refusal is already queued while the
+client waits on a data channel that will never work. That is the shape measured
+live: the answer was in our own socket buffer and nobody was looking at it.
+
+### The byte count will not match the live one, and here is why
+
+Live, the control channel held **55** unread bytes. This fixture speaks
+plaintext, so the same refusal queues **26**:
+
+```
+"550 Failed to open file.\r\n"                     26 bytes
+inside a TLS 1.2 AES-GCM record: 5 + 8 + 26 + 16 = 55 bytes
+```
+
+The shape is identical and the arithmetic accounts for the difference exactly,
+but a test asserting `Recv-Q == 55` against this fixture will fail. Assert the
+behaviour, not the byte count, or run the case over a real FTPS server.
+
+### Guards on the fact, not just the effect
+
+`pasv_announced` and `data_accepted` are in the status file. Expect `1` and `0`:
+without them the test would also pass against a server that refused the `PASV`
+itself, which is a different fault entirely.
+
+## What this fixture CANNOT reproduce: the live hang
+
+Measured, not assumed. Against this fixture in `--refuse-before-data
+--pasv-no-accept tls-silent`, our own client fails **correctly in 0.113s**:
+
+```
+Error: Download failed: Invalid path: [550] 550 Failed to open file.
+```
+
+Against the live FTPS lab, the same binary hangs indefinitely on the same
+scenario.
+
+The reason is the transport. This fixture speaks **plaintext**, so there is no
+TLS handshake on the data channel: the client goes straight to reading, enters
+the loop, `read_watching_control` does its job, sees the `550` and fails. Live it
+is FTPS, and the wait lives entirely inside the data channel's TLS handshake,
+which happens *before* the loop.
+
+**So this fixture exercises the path that is already fixed, not the broken one.**
+A test built here to prove that a deadline on the *opening* surfaces the queued
+`550` would be green before that change and green after it: it can never go red,
+which is the exact shape this file keeps warning about.
+
+**This is now closed: the fixture speaks FTPS.** Pass `--tls-cert` and
+`--tls-key` and it offers `AUTH TLS`, `PBSZ` and `PROT` in `FEAT`, upgrades the
+control channel, and under `--pasv-no-accept tls-silent` leaves the data
+channel's handshake unanswered, which is the live case.
+
+Measured, same fixture, same options, only the transport differs:
+
+| transport | result |
+|---|---|
+| plaintext | fails correctly in **0.116s** |
+| FTPS | **hangs to the 120s ceiling** |
+
+That contrast is also an independent confirmation of where the wait lives: not
+in the read loop, which the plaintext run reaches and survives, but in the data
+channel's TLS handshake, which only the FTPS run gets to.
+
+Running it needs a certificate the client will accept, and `--insecure` is
+refused by design in unattended use, so trust the certificate rather than
+disabling the check. A CA plus a leaf (`CA:FALSE`, `subjectAltName=IP:127.0.0.1`)
+works; a bare self-signed `openssl req -x509` does not, rustls rejects it with
+`CaUsedAsEndEntity`:
+
+```
+SSL_CERT_FILE=<ca.pem> aeroftp-cli --tls explicit get ftp://u:p@127.0.0.1:PORT/...
+```
+
+Under TLS the `ABOR` case does not work: `MSG_PEEK` cannot see through TLS
+framing, so `poll_control` returns early and `abor_read` stays `0`. Declared
+rather than silently skipped, so nobody reads that zero as a regression.
+
+**What that limit does NOT mean.** It applies to reading the *content* of a
+record, which is what `poll_control` needs: it has to know the command is `ABOR`.
+The first byte of a TLS record, the content type, is *not* encrypted: `0x17` is
+application data, `0x16` a handshake message, `0x15` an alert. A design that
+watches the control channel by looking at the record type rather than the
+payload is unaffected by this limit, and the limit is in fact the reason to
+prefer it. Spelled out here because two READMEs read in sequence would otherwise
+suggest the same wall stops both, and it does not.
+
+This is #655's own warning arriving from the opposite side. There: "on loopback
+the same code returns in two seconds, a fixture cannot exercise this". Here: in
+plaintext the fix works, so the fixture cannot exercise the gap. Twice the same
+limit, and both times the risk was publishing a green obtained on the wrong path.

--- a/src-tauri/tests/fixtures/ftp/README-slowftp.md
+++ b/src-tauri/tests/fixtures/ftp/README-slowftp.md
@@ -436,3 +436,25 @@ Python evaluates the `%` expression before calling `rd()`, so the timestamp was
 taken before the blocking read rather than after it. The reading was resolved by
 timestamping the **server** log, which showed the hold running its full 8.0s.
 When two ends disagree, the end you are not measuring is the one to believe.
+
+## The plumbing options, and one of them is load-bearing
+
+```
+--port N        where to listen (default 2130)
+--lines N       how many files the listing contains
+--hang N        seconds MLSD stays silent in the mlsd-hang position
+--stor-stop-hold N   see below
+```
+
+`--stor-stop-hold` does more than its name says, and that is worth knowing
+before setting it. It was added for the `stop` half of a refused `STOR`, where
+it is how long the server keeps a socket open after it stops reading. It is now
+**also** how long the server holds a `LIST`, `RETR` or `STOR` pending when
+`--pasv-no-accept tls-silent` leaves no usable data channel, which is the hang
+this fixture exists to produce.
+
+So lowering it to shorten a `STOR` test also shortens every deliberate hang, and
+a client that then returns looks like a client that recovered. The name is
+narrower than the behaviour: it is documented rather than renamed because tests
+are already being written against these flags, and a rename would break them for
+a cosmetic gain.

--- a/src-tauri/tests/fixtures/ftp/README-slowftp.md
+++ b/src-tauri/tests/fixtures/ftp/README-slowftp.md
@@ -373,8 +373,14 @@ works; a bare self-signed `openssl req -x509` does not, rustls rejects it with
 `CaUsedAsEndEntity`:
 
 ```
-SSL_CERT_FILE=<ca.pem> aeroftp-cli --tls explicit get ftp://u:p@127.0.0.1:PORT/...
+AEROFTP_PASSWORD=<pw> SSL_CERT_FILE=<ca.pem> \
+  aeroftp-cli --tls explicit get ftp://<user>@127.0.0.1:PORT/...
 ```
+
+The password goes in the environment (or `--password-stdin`), not in the URL.
+The client warns about a URL-embedded password every time it sees one, and a
+documented example is the fastest way for that habit to spread out of a fixture
+and into a real profile.
 
 Under TLS the `ABOR` case does not work: `MSG_PEEK` cannot see through TLS
 framing, so `poll_control` returns early and `abor_read` stays `0`. Declared

--- a/src-tauri/tests/fixtures/ftp/README-slowftp.md
+++ b/src-tauri/tests/fixtures/ftp/README-slowftp.md
@@ -437,24 +437,40 @@ taken before the blocking read rather than after it. The reading was resolved by
 timestamping the **server** log, which showed the hold running its full 8.0s.
 When two ends disagree, the end you are not measuring is the one to believe.
 
-## The plumbing options, and one of them is load-bearing
+## The plumbing options
 
 ```
---port N        where to listen (default 2130)
---lines N       how many files the listing contains
---hang N        seconds MLSD stays silent in the mlsd-hang position
---stor-stop-hold N   see below
+--port N          where to listen (default 2130)
+--lines N         how many files the listing contains
+--hang N          seconds MLSD stays silent in the mlsd-hang position
+--stor-stop-hold N   seconds a STOPPED socket lingers after the server stops
+                     reading a refused STOR
+--pending-hold N     seconds a LIST, RETR or STOR is held pending when
+                     tls-silent leaves no usable data channel
 ```
 
-`--stor-stop-hold` does more than its name says, and that is worth knowing
-before setting it. It was added for the `stop` half of a refused `STOR`, where
-it is how long the server keeps a socket open after it stops reading. It is now
-**also** how long the server holds a `LIST`, `RETR` or `STOR` pending when
-`--pasv-no-accept tls-silent` leaves no usable data channel, which is the hang
-this fixture exists to produce.
+**The last two were one option, and separating them was worth doing.** One
+number governed both how long a stopped socket lingers and how long a deliberate
+hang lasts. Those are different scenarios with different natural durations, and
+wanting one short and the other long is ordinary. The way it broke was the worst
+kind: lowering it to shorten a `STOR` test also shortened every deliberate hang,
+and a client that then returned looked like a client that had recovered, which
+is a false green on a test you believe is measuring a hang.
 
-So lowering it to shorten a `STOR` test also shortens every deliberate hang, and
-a client that then returns looks like a client that recovered. The name is
-narrower than the behaviour: it is documented rather than renamed because tests
-are already being written against these flags, and a rename would break them for
-a cosmetic gain.
+Verified independent: `--pending-hold 6 --stor-stop-hold 60` holds each hang 6s,
+and `--stor-stop-hold 6 --pending-hold 60` lingers 6s on the stopped socket.
+
+### `--pending-hold` ends the hang by closing, and that is deliberate
+
+Holding the handler is not enough. The client is stuck in a TLS handshake on the
+data socket, and letting a server-side wait expire does nothing to it: measured,
+the handler released after 6s and the client was still waiting at 40. So the
+hold ends the only way the client can observe, by closing the socket.
+
+That closure is an EOF, which everywhere else in this file is the accident to
+avoid. The difference is that here it happens exactly when the option says it
+should, instead of when a garbage collector decides.
+
+One consequence to expect when reading a timing: a client that is released this
+way may reconnect and hit the same wall again. Against `--pending-hold 6` our
+client takes about 12s in total, which is two hangs of 6s and not one of 12.

--- a/src-tauri/tests/fixtures/ftp/README-slowftp.md
+++ b/src-tauri/tests/fixtures/ftp/README-slowftp.md
@@ -26,7 +26,7 @@ exercised by calling two of our own operations against one server. This fixture
 serves the dotfiles only when the client asks with `-a`, so the difference is
 visible instead of assumed. Both operations verified against one running server:
 
-```
+```text
 aeroftp-cli ls    ->  LIST                    2 entries, no dotfiles
 aeroftp-cli rm -r ->  CWD /sub
                       LIST -a                 4 entries, dotfiles included
@@ -65,7 +65,7 @@ instance for the next attempt.
 
 So the stall belongs on `RETR`:
 
-```
+```text
 --retr-stall N       hold the data channel open and silent for N seconds,
                      to outlast the per-file download timeout
 --retr-before-stall  bytes handed over before the stall (default 4096)
@@ -211,7 +211,7 @@ shipped it once.
 
 Two ways to close it, use whichever the harness can reach:
 
-```
+```text
 --status-file PATH      the fixture rewrites PATH with what it did:
                         {"abor_read": 1, "stor_bytes": 0}
 SITE STATUS             the same counters in-band: 211 abor_read=1 stor_bytes=0
@@ -252,7 +252,7 @@ The path where a client is meant to *peek* at the control channel and consume a
 reply only once it has decided to fail. Mid-`RETR`, after N bytes of data, the
 server sends a refusal on the control channel unasked:
 
-```
+```text
 550 SLOWFTP-INJECTED unsolicited refusal at 4096 bytes
 ```
 
@@ -266,7 +266,7 @@ the read happens entirely on the client's side of the socket. It is caught by
 what comes next. So the assertion is a question with a known answer, asked
 afterwards, on a file whose size cannot coincide with anything else in play:
 
-```
+```text
 --file-size 40961      ->  SIZE must answer exactly "213 40961"
 ```
 
@@ -312,7 +312,7 @@ live: the answer was in our own socket buffer and nobody was looking at it.
 Live, the control channel held **55** unread bytes. This fixture speaks
 plaintext, so the same refusal queues **26**:
 
-```
+```text
 "550 Failed to open file.\r\n"                     26 bytes
 inside a TLS 1.2 AES-GCM record: 5 + 8 + 26 + 16 = 55 bytes
 ```
@@ -332,7 +332,7 @@ itself, which is a different fault entirely.
 Measured, not assumed. Against this fixture in `--refuse-before-data
 --pasv-no-accept tls-silent`, our own client fails **correctly in 0.113s**:
 
-```
+```text
 Error: Download failed: Invalid path: [550] 550 Failed to open file.
 ```
 
@@ -372,7 +372,7 @@ disabling the check. A CA plus a leaf (`CA:FALSE`, `subjectAltName=IP:127.0.0.1`
 works; a bare self-signed `openssl req -x509` does not, rustls rejects it with
 `CaUsedAsEndEntity`:
 
-```
+```text
 AEROFTP_PASSWORD=<pw> SSL_CERT_FILE=<ca.pem> \
   aeroftp-cli --tls explicit get ftp://<user>@127.0.0.1:PORT/...
 ```
@@ -439,7 +439,7 @@ When two ends disagree, the end you are not measuring is the one to believe.
 
 ## The plumbing options
 
-```
+```text
 --port N          where to listen (default 2130)
 --lines N         how many files the listing contains
 --hang N          seconds MLSD stays silent in the mlsd-hang position

--- a/src-tauri/tests/fixtures/ftp/README-slowftp.md
+++ b/src-tauri/tests/fixtures/ftp/README-slowftp.md
@@ -558,3 +558,38 @@ on the download path. That is the same shape as the crash documented above, a
 guard placed on a path an earlier branch returns before reaching, and it was
 introduced by the fix for that crash. Both openings now go through
 `hold_unserved()`, which is the one place that holds and releases.
+
+## Testing attribution: does the next command read the previous one's reply?
+
+`mlsd-hang` is documented above as the position that forces a reconnection and a
+second data channel. It serves a second purpose that is not obvious from that
+description, so it is stated here rather than left to be rediscovered: it is also
+how you make a reply arrive **late enough to be misattributed**.
+
+The server accepts `MLSD` and then says nothing for `--hang` seconds before
+answering `425`. Set `--hang` longer than the deadline under test and the client
+abandons the listing while the `425` is still owed. The reply then arrives on a
+connection where the next question has already been asked.
+
+Measured with `--hang 6` and a probe that gives up after 2s:
+
+```text
+MLSD sent, abandoned after 2s
+PWD sent           (its own correct answer is 257)
+PWD received       425 Cannot open data connection.
+                   257 "/" is the current directory
+```
+
+The `257` is there, one place too late. Every reply from that point belongs to
+the previous question.
+
+**The assertion is on attribution, not duration.** A test here should not check
+how long anything took: it should ask a question with a known answer and check
+that it got *that* answer. `PWD` and a `SIZE` on a file of a distinctive size
+both work; a listing does not, because an empty result and a misattributed one
+can look alike.
+
+Note that the deadline has to be shorter than `--hang`, and `--hang` now defaults
+to 420 for the reasons in the defaults audit above. For this scenario set it
+explicitly to something just above the deadline you are testing, so the reply is
+late but the test is not slow.

--- a/src-tauri/tests/fixtures/ftp/README-slowftp.md
+++ b/src-tauri/tests/fixtures/ftp/README-slowftp.md
@@ -399,3 +399,40 @@ This is #655's own warning arriving from the opposite side. There: "on loopback
 the same code returns in two seconds, a fixture cannot exercise this". Here: in
 plaintext the fix works, so the fixture cannot exercise the gap. Twice the same
 limit, and both times the risk was publishing a green obtained on the wrong path.
+
+## Every option has been exercised where its mechanism runs
+
+Not merely switched on. A mode enabled on a path that returns before its
+mechanism executes is untested, and looks tested. That is how the `tls-silent`
+crash survived review here: it had only been run on the `RETR` path together
+with `--refuse-before-data`, which returns before `accept_data()` is ever
+called, so the mode was on and its code never ran.
+
+| option | exercised by | evidence |
+|---|---|---|
+| `--feat` (3 positions) | `ls` on each | correct entries, and the reconnection path taken |
+| include_hidden | `ls` and `rm -r` on one server | `LIST` vs `CWD` + `LIST -a` |
+| `--list-delay` | slow `ls` | 5 rows at 1s took 5.1s, all 5 arrived |
+| `--list-total` | slow `ls` | 10 rows over a 6s budget took 6.1s |
+| `--late-final` | raw probe on `LIST` | `226` arrived at 8.0s, server held 8.0s |
+| `--retr-stall` | `get -r` | the stale-reply desync |
+| `--abor-silent` | raw probe mid-transfer | `abor_read` 1, no reply for 8s |
+| `--stor-refuse-after` | `put`, both halves | 300000 bytes drained / 65536 then stopped |
+| `--stor-read-rate` | `put` throttled | made the drain case measurable at all |
+| `--unsolicited-refusal-after` | raw probe mid-`RETR` | injected at 4096 bytes, `unsolicited_sent` 1 |
+| `--pasv-no-accept` (3 modes) | raw probe | silent, hung, refused: three different failures |
+| `--tls-cert` | our own client | plaintext 0.116s vs FTPS to the ceiling |
+
+### One of those checks was wrong, and the fixture was right
+
+Measuring `--late-final` first suggested the `226` arrived immediately, which
+would have made this file's central claim false. The fault was in the probe:
+
+```python
+print("226 at %.1fs" % (time.time() - t0), rd())   # wrong
+```
+
+Python evaluates the `%` expression before calling `rd()`, so the timestamp was
+taken before the blocking read rather than after it. The reading was resolved by
+timestamping the **server** log, which showed the hold running its full 8.0s.
+When two ends disagree, the end you are not measuring is the one to believe.

--- a/src-tauri/tests/fixtures/ftp/slowftp.py
+++ b/src-tauri/tests/fixtures/ftp/slowftp.py
@@ -34,7 +34,8 @@ be saying "the fixture closed", which is the earlier trap wearing a new face.
 import argparse, os, select, socket, ssl, threading, time, sys
 
 def log(msg):
-    sys.stderr.write("[slowftp] %s\n" % msg); sys.stderr.flush()
+    sys.stderr.write("[slowftp] %s\n" % msg)
+    sys.stderr.flush()
 
 class Counters:
     """What the fixture actually DID, in a form a test can assert on.
@@ -106,6 +107,7 @@ class Session(threading.Thread):
         self.cwd = "/"
         self.tls = False
         self.prot_private = False
+        self.pending_silent = []
 
     def send(self, line):
         self.f.write((line + "\r\n").encode())
@@ -229,7 +231,8 @@ class Session(threading.Thread):
                         the contrast that shows the other two ARE hangs.
         """
         mode = self.cfg.pasv_no_accept
-        s = socket.socket(); s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        s = socket.socket()
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         s.bind(("127.0.0.1", 0))
         port = s.getsockname()[1]
         if mode == "refuse":
@@ -242,7 +245,8 @@ class Session(threading.Thread):
             # its own and connect() would return, which is a different case.
             filler = socket.socket()
             try:
-                filler.settimeout(1); filler.connect(("127.0.0.1", port))
+                filler.settimeout(1)
+                filler.connect(("127.0.0.1", port))
             except Exception:
                 pass
             self.data_sock = s
@@ -270,6 +274,11 @@ class Session(threading.Thread):
         self.counters.bump("data_accepted")
         if self.tls and self.prot_private:
             if self.cfg.pasv_no_accept == "tls-silent":
+                # Keep a reference. Dropping this socket has it garbage
+                # collected and closed, so the client gets EOF on its handshake
+                # and fails FAST, which is the opposite of what this mode is for
+                # and still looks like a working fixture.
+                self.pending_silent.append(c)
                 log("data channel accepted, TLS handshake deliberately NOT answered")
                 return None  # held open, silent: the live hang
             ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
@@ -285,6 +294,15 @@ class Session(threading.Thread):
         it a 226. Delivering that debt late is what plants the stale reply.
         """
         c = self.accept_data()
+        if c is None:
+            # tls-silent: there is no usable data channel by design.
+            # Touching it here raised AttributeError and killed the
+            # session thread, which is the same failure as the broken
+            # pipe: the fixture dies and the client gets a prompt EOF
+            # instead of the wait it is supposed to see.
+            log("no data channel by design, holding %ss" % self.cfg.stor_stop_hold)
+            self.wait_watching_control(self.cfg.stor_stop_hold)
+            return
         try:
             per_row = self.cfg.list_delay
             if self.cfg.list_total and lines:
@@ -297,7 +315,9 @@ class Session(threading.Thread):
             except (BrokenPipeError, ConnectionResetError):
                 log("LIST: client dropped the data channel, still owing a reply")
         finally:
-            c.close(); self.data_sock.close(); self.data_sock = None
+            c.close()
+            self.data_sock.close()
+            self.data_sock = None
         if self.cfg.late_final:
             log("data done, holding the 226 for %ss (client has probably given up)"
                 % self.cfg.late_final)
@@ -383,6 +403,15 @@ class Session(threading.Thread):
                 # in a PR body.
                 self.send("150 Ok to send data.")
                 c = self.accept_data()
+                if c is None:
+                    # tls-silent: there is no usable data channel by design.
+                    # Touching it here raised AttributeError and killed the
+                    # session thread, which is the same failure as the broken
+                    # pipe: the fixture dies and the client gets a prompt EOF
+                    # instead of the wait it is supposed to see.
+                    log("no data channel by design, holding %ss" % self.cfg.stor_stop_hold)
+                    self.wait_watching_control(self.cfg.stor_stop_hold)
+                    continue
                 total = 0
                 refused = False
                 try:
@@ -425,7 +454,9 @@ class Session(threading.Thread):
                 except (BrokenPipeError, ConnectionResetError):
                     log("STOR: client dropped the data channel after %d bytes" % total)
                 finally:
-                    c.close(); self.data_sock.close(); self.data_sock = None
+                    c.close()
+                    self.data_sock.close()
+                    self.data_sock = None
                 log("STOR: %d bytes read, refused=%s" % (total, refused))
                 self.counters.set_stor_bytes(total)
                 if not refused:
@@ -469,13 +500,23 @@ class Session(threading.Thread):
                         % self.cfg.pasv_no_accept)
                     continue
                 c = self.accept_data()
+                if c is None:
+                    # tls-silent: there is no usable data channel by design.
+                    # Touching it here raised AttributeError and killed the
+                    # session thread, which is the same failure as the broken
+                    # pipe: the fixture dies and the client gets a prompt EOF
+                    # instead of the wait it is supposed to see.
+                    log("no data channel by design, holding %ss" % self.cfg.stor_stop_hold)
+                    self.wait_watching_control(self.cfg.stor_stop_hold)
+                    continue
                 try:
                     sent = 0
                     injected = False
                     chunk = b"x" * 1024
                     while sent < self.cfg.retr_before_stall:
                         n = min(len(chunk), self.cfg.retr_before_stall - sent)
-                        c.sendall(chunk[:n]); sent += n
+                        c.sendall(chunk[:n])
+                        sent += n
                         injected = self.maybe_inject(sent, injected)
                     self.poll_control()
                     if self.cfg.retr_stall:
@@ -486,7 +527,9 @@ class Session(threading.Thread):
                     try:
                         while rest > 0:
                             n = min(len(chunk), rest)
-                            c.sendall(chunk[:n]); rest -= n; sent += n
+                            c.sendall(chunk[:n])
+                            rest -= n
+                            sent += n
                             injected = self.maybe_inject(sent, injected)
                     except (BrokenPipeError, ConnectionResetError):
                         # The client gave up and dropped its end of the DATA
@@ -498,13 +541,16 @@ class Session(threading.Thread):
                         # accidental one, and it silently removes the case.
                         log("RETR: client dropped the data channel, still owing a reply")
                 finally:
-                    c.close(); self.data_sock.close(); self.data_sock = None
+                    c.close()
+                    self.data_sock.close()
+                    self.data_sock = None
                 if self.cfg.late_final:
                     log("RETR data done, holding the 226 for %ss" % self.cfg.late_final)
                     time.sleep(self.cfg.late_final)
                 self.send("226 Transfer complete.")
             elif cmd in ("QUIT",):
-                self.send("221 Goodbye."); return
+                self.send("221 Goodbye.")
+                return
             elif cmd == "SITE" and arg.strip().upper() == "STATUS":
                 # In-band twin of --status-file, for a test that can send a raw
                 # command but cannot read a file (or the other way round).
@@ -572,8 +618,10 @@ def main():
                         "is still owed when the next command asks its own question")
     cfg = p.parse_args()
     counters = Counters(cfg.status_file)
-    srv = socket.socket(); srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    srv.bind(("127.0.0.1", cfg.port)); srv.listen(5)
+    srv = socket.socket()
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(("127.0.0.1", cfg.port))
+    srv.listen(5)
     log("listening on 127.0.0.1:%d feat=%s delay=%ss total=%ss late_final=%ss lines=%d"
         % (cfg.port, cfg.feat, cfg.list_delay, cfg.list_total, cfg.late_final, cfg.lines))
     while True:

--- a/src-tauri/tests/fixtures/ftp/slowftp.py
+++ b/src-tauri/tests/fixtures/ftp/slowftp.py
@@ -641,7 +641,11 @@ def main():
     p.add_argument("--feat", choices=["nomlsd", "mlsd", "mlsd-hang"], default="nomlsd")
     p.add_argument("--list-delay", type=float, default=0.0, help="seconds between listing rows")
     p.add_argument("--lines", type=int, default=5)
-    p.add_argument("--hang", type=float, default=90.0, help="seconds MLSD stays silent in mlsd-hang")
+    p.add_argument("--hang", type=float, default=420.0,
+                   help="seconds MLSD stays silent in the mlsd-hang position. Defaults LONG "
+                        "(420) so it outlasts a listing deadline under test: at the old 90 "
+                        "the fixture gave up first, so a test believing it measured a 300s "
+                        "listing budget measured this number instead, and passed")
     p.add_argument("--list-total", type=float, default=0.0,
                    help="spread the listing over this many seconds total, to sit just "
                         "under or just over a client deadline")
@@ -686,9 +690,12 @@ def main():
                    help="CASE B: bytes per second the server reads from the data channel "
                         "(0 = as fast as possible). Needed on loopback, where otherwise the "
                         "client finishes writing before the refusal can matter")
-    p.add_argument("--stor-stop-hold", type=float, default=30.0,
+    p.add_argument("--stor-stop-hold", type=float, default=120.0,
                    help="CASE B only: seconds the STOPPED socket is held open after the "
-                        "server stops reading a refused STOR")
+                        "server stops reading a refused STOR. Defaults LONG (120) for the "
+                        "same reason as --pending-hold: at the old 30 it was the same number "
+                        "as the idle deadline it races, and the winner was decided by "
+                        "milliseconds with the test passing either way")
     p.add_argument("--pending-hold", type=float, default=120.0,
                    help="seconds a LIST, RETR or STOR is held pending when tls-silent "
                         "leaves no usable data channel. Separate from --stor-stop-hold on "

--- a/src-tauri/tests/fixtures/ftp/slowftp.py
+++ b/src-tauri/tests/fixtures/ftp/slowftp.py
@@ -182,6 +182,18 @@ class Session(threading.Thread):
             except OSError:
                 pass
         self.pending_silent = []
+        # And the listener this path opened in order to accept. Closing what was
+        # accepted and leaving open what was opened to accept it is the same
+        # omission this function was written to fix, one object further out: the
+        # listener survives until the control session ends or the next PASV
+        # overwrites the reference, so several data operations on one session
+        # accumulate them. Measured: 2 sockets before, 4 after one cycle.
+        if self.data_sock is not None:
+            try:
+                self.data_sock.close()
+            except OSError:
+                pass
+            self.data_sock = None
 
     def wait_watching_control(self, seconds):
         """Sleep, but keep taking commands that arrive meanwhile.
@@ -318,7 +330,17 @@ class Session(threading.Thread):
         looking like it exercised the broken one.
         """
         self.data_sock.settimeout(20)
-        c, _ = self.data_sock.accept()
+        try:
+            c, _ = self.data_sock.accept()
+        except (socket.timeout, TimeoutError, OSError):
+            # A client that asks for PASV and then never connects is a legitimate
+            # thing for a server to survive. Letting this propagate killed the
+            # session thread, which is the same failure this file keeps meeting:
+            # the fixture dies and everything after it looks like a server that
+            # stopped answering. Treated as "no data channel", which the callers
+            # already know how to hold and release.
+            log("nobody connected to the data port, treating as no data channel")
+            return None
         self.counters.bump("data_accepted")
         if self.tls and self.prot_private:
             if self.cfg.pasv_no_accept == "tls-silent":

--- a/src-tauri/tests/fixtures/ftp/slowftp.py
+++ b/src-tauri/tests/fixtures/ftp/slowftp.py
@@ -135,6 +135,26 @@ class Session(threading.Thread):
             % (self.cfg.unsolicited_code, sent))
         return True
 
+    def release_pending(self):
+        """End a deliberate hang by closing the sockets nobody ever answered.
+
+        Holding the handler is not enough: the client is stuck in a TLS
+        handshake on the DATA socket, and letting the server-side wait expire
+        does nothing to it. Measured: the handler released after 6s and the
+        client was still waiting at 40. So the hold has to end the way the
+        client can observe, which is the socket closing.
+
+        The closure is an EOF, which elsewhere in this fixture is the accident
+        to avoid. Here it is the intended end of a bounded hang, and the
+        difference is only that it happens when the option says it should.
+        """
+        for s in self.pending_silent:
+            try:
+                s.close()
+            except OSError:
+                pass
+        self.pending_silent = []
+
     def wait_watching_control(self, seconds):
         """Sleep, but keep taking commands that arrive meanwhile.
 
@@ -300,8 +320,9 @@ class Session(threading.Thread):
             # session thread, which is the same failure as the broken
             # pipe: the fixture dies and the client gets a prompt EOF
             # instead of the wait it is supposed to see.
-            log("no data channel by design, holding %ss" % self.cfg.stor_stop_hold)
-            self.wait_watching_control(self.cfg.stor_stop_hold)
+            log("no data channel by design, holding %ss" % self.cfg.pending_hold)
+            self.wait_watching_control(self.cfg.pending_hold)
+            self.release_pending()
             return
         try:
             per_row = self.cfg.list_delay
@@ -410,8 +431,9 @@ class Session(threading.Thread):
                     # session thread, which is the same failure as the broken
                     # pipe: the fixture dies and the client gets a prompt EOF
                     # instead of the wait it is supposed to see.
-                    log("no data channel by design, holding %ss" % self.cfg.stor_stop_hold)
-                    self.wait_watching_control(self.cfg.stor_stop_hold)
+                    log("no data channel by design, holding %ss" % self.cfg.pending_hold)
+                    self.wait_watching_control(self.cfg.pending_hold)
+                    self.release_pending()
                     continue
                 total = 0
                 refused = False
@@ -507,8 +529,9 @@ class Session(threading.Thread):
                     # session thread, which is the same failure as the broken
                     # pipe: the fixture dies and the client gets a prompt EOF
                     # instead of the wait it is supposed to see.
-                    log("no data channel by design, holding %ss" % self.cfg.stor_stop_hold)
-                    self.wait_watching_control(self.cfg.stor_stop_hold)
+                    log("no data channel by design, holding %ss" % self.cfg.pending_hold)
+                    self.wait_watching_control(self.cfg.pending_hold)
+                    self.release_pending()
                     continue
                 try:
                     sent = 0
@@ -612,7 +635,14 @@ def main():
                         "(0 = as fast as possible). Needed on loopback, where otherwise the "
                         "client finishes writing before the refusal can matter")
     p.add_argument("--stor-stop-hold", type=float, default=30.0,
-                   help="CASE B: seconds the stopped socket is held open before closing")
+                   help="CASE B only: seconds the STOPPED socket is held open after the "
+                        "server stops reading a refused STOR")
+    p.add_argument("--pending-hold", type=float, default=30.0,
+                   help="seconds a LIST, RETR or STOR is held pending when tls-silent "
+                        "leaves no usable data channel. Separate from --stor-stop-hold on "
+                        "purpose: one is how long a stopped socket lingers, the other is how "
+                        "long a deliberate hang lasts, and wanting one short and the other "
+                        "long is legitimate")
     p.add_argument("--late-final", type=float, default=0.0,
                    help="after the data channel closes, wait this long before sending the "
                         "closing 226, WITHOUT closing the control connection, so the reply "

--- a/src-tauri/tests/fixtures/ftp/slowftp.py
+++ b/src-tauri/tests/fixtures/ftp/slowftp.py
@@ -34,7 +34,7 @@ be saying "the fixture closed", which is the earlier trap wearing a new face.
 import argparse, os, select, socket, ssl, threading, time, sys
 
 def log(msg):
-    sys.stderr.write("[slowftp] %s\n" % msg)
+    sys.stderr.write("[slowftp %.2f] %s\n" % (time.time() % 1000, msg))
     sys.stderr.flush()
 
 class Counters:
@@ -322,6 +322,7 @@ class Session(threading.Thread):
             log("data done, holding the 226 for %ss (client has probably given up)"
                 % self.cfg.late_final)
             self.wait_watching_control(self.cfg.late_final)
+            log("hold finished, the 226 goes out now")
 
     def run(self):
         try:

--- a/src-tauri/tests/fixtures/ftp/slowftp.py
+++ b/src-tauri/tests/fixtures/ftp/slowftp.py
@@ -1,0 +1,584 @@
+#!/usr/bin/env python3
+"""Minimal FTP server for exercising the branches a real server hides.
+
+Written by hand rather than on pyftpdlib for one reason: every branch this has
+to reach is decided by exactly what the server says and when it says it, so the
+fixture has to own every byte and every pause. Subclassing a library to make it
+slow enough, and to make one command hang while the rest works, is more fiddly
+than writing the twelve replies the client actually needs.
+
+Three FEAT positions, because the listing branch is chosen by the server:
+  nomlsd     FEAT omits MLSD          -> client must fall back to LIST
+  mlsd       FEAT advertises MLSD     -> client takes the MLSD branch
+  mlsd-hang  FEAT advertises MLSD and then never serves it
+             -> the client marks it broken, may reconnect, and continues to
+                LIST inside the SAME call: one list() opening two data channels.
+                That path has no test today.
+
+The include_hidden axis is NOT the server's: it is our own `LIST -a`, so this
+serves dotfiles only when the client asks for them, and the two branches are
+exercised by calling two different operations against one server.
+
+--list-delay makes the listing arrive slowly without ever failing, so a total
+(not idle) timeout can be tested for truncation: the rows are real and correct,
+they simply take longer than the limit. What is lost is real data.
+
+--late-final is the part that makes the third case possible, and it is the whole
+point. When our client gives up reading, this server does NOT close and does NOT
+cancel: it finishes its work and sends the closing 226 late, on the same control
+connection. That reply is then sitting in the socket when the NEXT command asks
+its own question, and the next command reads it as its own answer. A fixture that
+tears down at the deadline cannot produce this: the green it returns would only
+be saying "the fixture closed", which is the earlier trap wearing a new face.
+"""
+import argparse, os, select, socket, ssl, threading, time, sys
+
+def log(msg):
+    sys.stderr.write("[slowftp] %s\n" % msg); sys.stderr.flush()
+
+class Counters:
+    """What the fixture actually DID, in a form a test can assert on.
+
+    A test that drives the client cannot see the server log, so without this it
+    would stay green if the fixture regressed to never reading the ABOR at all:
+    at the client, "took it and said nothing" and "never read it" are the same
+    silence. That regression is not hypothetical, this fixture had it.
+
+    The file is rewritten at startup, so a stale file from an earlier run can
+    never be mistaken for this run's result.
+    """
+    def __init__(self, path):
+        self.path = path
+        self.lock = threading.Lock()
+        self.abor_read = 0
+        self.stor_bytes = 0
+        self.unsolicited_sent = 0
+        self.pasv_announced = 0
+        self.data_accepted = 0
+        self.write()
+
+    def write(self):
+        if not self.path:
+            return
+        tmp = self.path + ".tmp"
+        with open(tmp, "w") as fh:
+            fh.write('{"abor_read": %d, "stor_bytes": %d, "unsolicited_sent": %d, '
+                     '"pasv_announced": %d, "data_accepted": %d}\n'
+                     % (self.abor_read, self.stor_bytes, self.unsolicited_sent,
+                        self.pasv_announced, self.data_accepted))
+        os.replace(tmp, self.path)  # atomic: a reader never sees a half file
+
+    def bump_abor(self):
+        with self.lock:
+            self.abor_read += 1
+            self.write()
+
+    def bump_unsolicited(self):
+        """Counted for the same reason `abor_read` is.
+
+        If the injection never fired, a test asserting "the size is still right
+        afterwards" would pass without ever having exercised anything. Asserting
+        `unsolicited_sent == 1` is what stops that test from being green and
+        empty, which is the failure this whole fixture keeps running into.
+        """
+        with self.lock:
+            self.unsolicited_sent += 1
+            self.write()
+
+    def bump(self, field):
+        with self.lock:
+            setattr(self, field, getattr(self, field) + 1)
+            self.write()
+
+    def set_stor_bytes(self, n):
+        with self.lock:
+            self.stor_bytes = n
+            self.write()
+
+
+class Session(threading.Thread):
+    def __init__(self, conn, addr, cfg, counters):
+        super().__init__(daemon=True)
+        self.conn, self.addr, self.cfg = conn, addr, cfg
+        self.counters = counters
+        self.f = conn.makefile("rwb", buffering=0)
+        self.data_sock = None
+        self.cwd = "/"
+        self.tls = False
+        self.prot_private = False
+
+    def send(self, line):
+        self.f.write((line + "\r\n").encode())
+
+    def maybe_inject(self, sent, already):
+        """Send a refusal on the control channel NOBODY ASKED FOR.
+
+        This is the path where a client is supposed to peek at the control
+        channel and consume the reply only once it has decided to fail. A client
+        that consumes it speculatively cannot be caught in the act, because the
+        read happens entirely on its own side of the socket: it is caught by
+        what comes next, a session shifted by one reply.
+        """
+        if already or not self.cfg.unsolicited_refusal_after:
+            return already
+        if sent < self.cfg.unsolicited_refusal_after:
+            return already
+        # The marker matters: if a test ever goes red here, the first question is
+        # whether the reply that got consumed was THIS one or an ordinary one,
+        # and a generic 550 cannot answer it.
+        self.send("%d SLOWFTP-INJECTED unsolicited refusal at %d bytes"
+                  % (self.cfg.unsolicited_code, sent))
+        self.counters.bump_unsolicited()
+        log("INJECTED %d SLOWFTP-INJECTED after %d bytes, unasked"
+            % (self.cfg.unsolicited_code, sent))
+        return True
+
+    def wait_watching_control(self, seconds):
+        """Sleep, but keep taking commands that arrive meanwhile.
+
+        A bare `time.sleep` here makes the fixture DEAF: an ABOR sent during a
+        stall would sit unread, and the client cannot tell "the server took my
+        command and said nothing" from "the server never read it". Those are
+        the same silence at one end and two different servers at the other, and
+        this fixture exists to be the second end.
+        """
+        end = time.time() + seconds
+        while True:
+            left = end - time.time()
+            if left <= 0:
+                return
+            r, _, _ = select.select([self.conn], [], [], min(left, 0.2))
+            if r:
+                self.poll_control()
+
+    def poll_control(self):
+        """Consume a command that arrives WHILE a data transfer is running.
+
+        Both anomalies 25 asked for are a reply (or a silence) on the control
+        channel while the data channel is open, and this server is otherwise
+        strictly sequential: without this, an ABOR sent mid-transfer would sit
+        unread until the handler returned, which is not what a real server does.
+
+        Note for anyone tempted to drop this and rely on the socket buffer: at
+        the client the two are indistinguishable, because bytes land in the
+        receive buffer whether or not anyone reads them. It is kept because the
+        fixture should do what it claims, not merely look the same from one end.
+        """
+        r, _, _ = select.select([self.conn], [], [], 0)
+        if not r:
+            return None
+        # PEEK, never a bare read. Consuming whatever turned up would swallow
+        # the ordinary commands a client sends while a transfer is in flight,
+        # and then answer none of them. It also destroys the stale-reply case:
+        # the retry's SIZE would be eaten here instead of arriving after the
+        # late 226, and the desync this fixture exists to show would vanish.
+        # Verified the hard way: an earlier version read unconditionally and
+        # the reproduction stopped reproducing.
+        if self.tls:
+            # MSG_PEEK cannot see through TLS framing, and reading here would
+            # consume commands this fixture must leave alone. Declared rather
+            # than silently skipped: under TLS the ABOR case does not work, and
+            # `abor_read` staying 0 is the honest answer, not a regression.
+            return None
+        try:
+            peeked = self.conn.recv(512, socket.MSG_PEEK)
+        except (BlockingIOError, ConnectionResetError):
+            return None
+        if b"\n" not in peeked:
+            return None
+        line = peeked.split(b"\n", 1)[0].decode("utf-8", "replace").strip()
+        cmd = line.split(" ")[0].upper()
+        if cmd != "ABOR":
+            # Not ours: leave every byte where it was for the normal loop.
+            return None
+        self.f.readline()  # now consume it, it really is an ABOR
+        self.counters.bump_abor()
+        log("<- (during transfer) %s" % line)
+        if cmd == "ABOR":
+            if self.cfg.abor_silent:
+                # CASE A: take the command and say NOTHING. The client's abort
+                # stays pending inside its own budget, which is the only state
+                # in which a future dropped mid-abort can be observed.
+                log("ABOR received: staying silent on purpose")
+            else:
+                self.send("226 Abort successful.")
+        return cmd
+
+    def entries(self, show_hidden):
+        n = self.cfg.lines
+        names = ["file-%03d.txt" % i for i in range(n)]
+        if show_hidden:
+            names = [".hidden-a", ".hidden-b"] + names
+        return names
+
+    def open_pasv(self):
+        """Announce a data port, and optionally never serve it.
+
+        Three ways a data connection can fail to happen, and they are NOT
+        interchangeable: the client sees a different failure in each.
+
+          tls-silent    accept the TCP and then answer nothing. This is the one
+                        measured live: the client sends a TLS ClientHello and
+                        gets zero bytes back. Needs no TLS here, since the point
+                        is that nothing ever answers.
+          connect-hang  listen with a full accept queue, so the kernel drops the
+                        SYN and connect() itself hangs. This is the plaintext
+                        case, where the wait is one step earlier still.
+          refuse        announce a port with nothing listening: connect() gets
+                        RST and fails at once. Not a hang, and worth having as
+                        the contrast that shows the other two ARE hangs.
+        """
+        mode = self.cfg.pasv_no_accept
+        s = socket.socket(); s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        s.bind(("127.0.0.1", 0))
+        port = s.getsockname()[1]
+        if mode == "refuse":
+            s.close()  # the port is announced, nothing is listening on it
+            self.data_sock = None
+        elif mode == "connect-hang":
+            s.listen(0)
+            # Fill the accept queue so the next SYN is dropped rather than
+            # completed. Without this the kernel would finish the handshake on
+            # its own and connect() would return, which is a different case.
+            filler = socket.socket()
+            try:
+                filler.settimeout(1); filler.connect(("127.0.0.1", port))
+            except Exception:
+                pass
+            self.data_sock = s
+            self._filler = filler
+        else:
+            s.listen(1)
+            self.data_sock = s
+        self.counters.bump("pasv_announced")
+        log("PASV announced port %d (mode=%s)" % (port, mode))
+        self.send("227 Entering Passive Mode (127,0,0,1,%d,%d)." % (port >> 8, port & 0xFF))
+
+    def accept_data(self):
+        """Accept the data connection, and wrap it in TLS unless told not to.
+
+        `--pasv-no-accept tls-silent` with TLS on is the live case and the whole
+        reason this fixture learned to speak TLS: the TCP is accepted, so the
+        client's connect() succeeds, and then the handshake is never answered.
+        The client sits inside the handshake, which is BEFORE the first data
+        read, so a guard placed on the read loop never runs. In plaintext this
+        case cannot exist, and the fixture would exercise the fixed path while
+        looking like it exercised the broken one.
+        """
+        self.data_sock.settimeout(20)
+        c, _ = self.data_sock.accept()
+        self.counters.bump("data_accepted")
+        if self.tls and self.prot_private:
+            if self.cfg.pasv_no_accept == "tls-silent":
+                log("data channel accepted, TLS handshake deliberately NOT answered")
+                return None  # held open, silent: the live hang
+            ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+            ctx.load_cert_chain(self.cfg.tls_cert, self.cfg.tls_key)
+            c = ctx.wrap_socket(c, server_side=True)
+        return c
+
+    def serve_lines(self, lines):
+        """Serve the data channel, then close the FINAL reply late if asked.
+
+        The control connection is never touched here: whatever the client does
+        with its own deadline, this side keeps the session alive and still owes
+        it a 226. Delivering that debt late is what plants the stale reply.
+        """
+        c = self.accept_data()
+        try:
+            per_row = self.cfg.list_delay
+            if self.cfg.list_total and lines:
+                per_row = self.cfg.list_total / float(len(lines))
+            try:
+                for ln in lines:
+                    c.sendall((ln + "\r\n").encode())
+                    if per_row:
+                        time.sleep(per_row)
+            except (BrokenPipeError, ConnectionResetError):
+                log("LIST: client dropped the data channel, still owing a reply")
+        finally:
+            c.close(); self.data_sock.close(); self.data_sock = None
+        if self.cfg.late_final:
+            log("data done, holding the 226 for %ss (client has probably given up)"
+                % self.cfg.late_final)
+            self.wait_watching_control(self.cfg.late_final)
+
+    def run(self):
+        try:
+            self.serve()
+        except (BrokenPipeError, ConnectionResetError):
+            log("control connection dropped by the client")
+
+    def serve(self):
+        self.send("220 (slowftp fixture)")
+        while True:
+            raw = self.f.readline()
+            if not raw:
+                return
+            line = raw.decode("utf-8", "replace").strip()
+            if not line:
+                continue
+            cmd, _, arg = line.partition(" ")
+            cmd = cmd.upper()
+            log("<- %s" % line)
+
+            if cmd == "USER":   self.send("331 Please specify the password.")
+            elif cmd == "PASS": self.send("230 Login successful.")
+            elif cmd == "AUTH":
+                if not self.cfg.tls_cert:
+                    self.send("500 AUTH not available, fixture started without --tls-cert")
+                elif arg.strip().upper() not in ("TLS", "TLS-C", "SSL"):
+                    self.send("504 Unsupported AUTH type.")
+                else:
+                    self.send("234 AUTH TLS OK, starting TLS.")
+                    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+                    ctx.load_cert_chain(self.cfg.tls_cert, self.cfg.tls_key)
+                    self.conn = ctx.wrap_socket(self.conn, server_side=True)
+                    self.f = self.conn.makefile("rwb", buffering=0)
+                    self.tls = True
+                    log("control channel upgraded to TLS")
+            elif cmd == "PBSZ": self.send("200 PBSZ=0")
+            elif cmd == "PROT":
+                self.prot_private = arg.strip().upper() == "P"
+                self.send("200 PROT now %s." % ("P" if self.prot_private else "C"))
+            elif cmd == "SYST": self.send("215 UNIX Type: L8")
+            elif cmd == "TYPE": self.send("200 Switching to Binary mode.")
+            elif cmd == "PWD":  self.send('257 "%s" is the current directory' % self.cwd)
+            elif cmd == "CWD":
+                self.cwd = arg if arg.startswith("/") else self.cwd.rstrip("/") + "/" + arg
+                self.send("250 Directory successfully changed.")
+            elif cmd == "FEAT":
+                feats = ["211-Features:", " EPSV", " PASV", " SIZE", " TVFS", " UTF8"]
+                if self.cfg.tls_cert and not self.tls:
+                    feats[1:1] = [" AUTH TLS", " PBSZ", " PROT"]
+                if self.cfg.feat in ("mlsd", "mlsd-hang"):
+                    feats.insert(1, " MLSD")
+                feats.append("211 End")
+                for x in feats: self.send(x)
+            elif cmd == "PASV": self.open_pasv()
+            elif cmd == "MLSD":
+                if self.cfg.feat == "mlsd-hang":
+                    # Announced and then not served. The control channel stays
+                    # silent: no 150, no error, nothing to read.
+                    log("MLSD requested: hanging on purpose, no reply")
+                    time.sleep(self.cfg.hang)
+                    self.send("425 Cannot open data connection.")
+                else:
+                    self.send("150 Here comes the directory listing.")
+                    rows = ["type=dir;sizd=4096; ." , "type=pdir;sizd=4096; .."]
+                    rows += ["type=file;size=10; %s" % n for n in self.entries(True)]
+                    self.serve_lines(rows)
+                    self.send("226 Directory send OK.")
+            elif cmd == "LIST":
+                show_hidden = "-a" in arg.split()
+                self.send("150 Here comes the directory listing.")
+                rows = ["-rw-r--r--    1 u  g  10 Aug 30 01:00 %s" % n
+                        for n in self.entries(show_hidden)]
+                self.serve_lines(rows)
+                self.send("226 Directory send OK.")
+            elif cmd == "STOR":
+                # CASE B: does a server that refuses a STOR also stop reading?
+                # Nothing in the protocol says so. This server can do either,
+                # so the assumption becomes a measurement instead of a sentence
+                # in a PR body.
+                self.send("150 Ok to send data.")
+                c = self.accept_data()
+                total = 0
+                refused = False
+                try:
+                    while True:
+                        self.poll_control()
+                        if self.cfg.stor_read_rate:
+                            # Without this the case is not measurable on
+                            # loopback: the client writes the whole file into
+                            # the socket buffers before the refusal can matter,
+                            # so "it uploaded everything" would be a property of
+                            # the buffers and not of the client. Throttling the
+                            # READ makes the client's writes actually block, and
+                            # only then does it mean something that it did or did
+                            # not notice the 552 while writing.
+                            time.sleep(65536.0 / self.cfg.stor_read_rate)
+                        chunk = c.recv(65536)
+                        if not chunk:
+                            break
+                        total += len(chunk)
+                        if (self.cfg.stor_refuse_after
+                                and not refused
+                                and total >= self.cfg.stor_refuse_after):
+                            refused = True
+                            log("STOR: refusing after %d bytes (%s)"
+                                % (total, self.cfg.stor_after_refuse))
+                            self.send("552 Requested file action aborted: "
+                                      "exceeded storage allocation.")
+                            if self.cfg.stor_after_refuse == "stop":
+                                # Stop reading but leave the socket OPEN, so the
+                                # client's writes fill the window and block.
+                                # Closing here would deliver EPIPE instead, which
+                                # is a different failure and would answer a
+                                # question nobody asked.
+                                log("STOR: no longer reading, socket left open %ss"
+                                    % self.cfg.stor_stop_hold)
+                                self.wait_watching_control(self.cfg.stor_stop_hold)
+                                break
+                            # else: keep draining to the end, which is the half
+                            # where the whole file goes up for nothing.
+                except (BrokenPipeError, ConnectionResetError):
+                    log("STOR: client dropped the data channel after %d bytes" % total)
+                finally:
+                    c.close(); self.data_sock.close(); self.data_sock = None
+                log("STOR: %d bytes read, refused=%s" % (total, refused))
+                self.counters.set_stor_bytes(total)
+                if not refused:
+                    self.send("226 Transfer complete.")
+            elif cmd == "ABOR":
+                self.counters.bump_abor()
+                if self.cfg.abor_silent:
+                    log("ABOR received outside a transfer: staying silent")
+                else:
+                    self.send("226 Abort successful.")
+            elif cmd in ("DELE", "RMD", "MKD"):
+                # Enough for the recursive delete to run end to end, which is
+                # how the include_hidden axis gets exercised: that operation
+                # passes include_hidden and issues `LIST -a`, a plain listing
+                # does not, and this server serves the dotfiles only to `-a`.
+                self.send("250 Requested file action okay, completed.")
+            elif cmd == "SIZE":
+                self.send("213 %d" % self.cfg.file_size)
+            elif cmd == "RETR":
+                # The route that actually reaches the stale reply on the main
+                # road. providers/ftp.rs has no list timeout at all, so a slow
+                # listing cannot strand a reply there; a download can. The
+                # per-file timeout in provider_transfer_executor.rs drops the
+                # download future mid-RETR, the FtpProvider survives with its
+                # control stream intact, and the retry loop immediately reuses
+                # it for the next attempt. So: hand out part of the file, stall
+                # past their deadline, then pay the 226 late into a connection
+                # they are already asking the next question on.
+                if self.cfg.refuse_before_data:
+                    # The refusal is ALREADY on the control channel while the
+                    # client is still waiting on a data channel that will never
+                    # work. That is the live signature: the answer was in our
+                    # own socket buffer and nobody was looking at it.
+                    self.send("550 Failed to open file.")
+                    log("RETR refused up front; data channel deliberately not served")
+                    if self.cfg.pasv_no_accept != "none":
+                        continue  # do not touch the data channel at all
+                self.send("150 Opening BINARY mode data connection.")
+                if self.cfg.pasv_no_accept != "none":
+                    log("RETR: data channel announced but not served (%s)"
+                        % self.cfg.pasv_no_accept)
+                    continue
+                c = self.accept_data()
+                try:
+                    sent = 0
+                    injected = False
+                    chunk = b"x" * 1024
+                    while sent < self.cfg.retr_before_stall:
+                        n = min(len(chunk), self.cfg.retr_before_stall - sent)
+                        c.sendall(chunk[:n]); sent += n
+                        injected = self.maybe_inject(sent, injected)
+                    self.poll_control()
+                    if self.cfg.retr_stall:
+                        log("RETR: %d bytes out, stalling %ss with the channel open"
+                            % (sent, self.cfg.retr_stall))
+                        self.wait_watching_control(self.cfg.retr_stall)
+                    rest = self.cfg.file_size - sent
+                    try:
+                        while rest > 0:
+                            n = min(len(chunk), rest)
+                            c.sendall(chunk[:n]); rest -= n; sent += n
+                            injected = self.maybe_inject(sent, injected)
+                    except (BrokenPipeError, ConnectionResetError):
+                        # The client gave up and dropped its end of the DATA
+                        # channel. A real server does not die here: it notes the
+                        # aborted transfer and goes on serving the CONTROL
+                        # connection, which is the whole point of this fixture.
+                        # Letting the thread fall over on this write is itself a
+                        # way of tearing down at the deadline, just an
+                        # accidental one, and it silently removes the case.
+                        log("RETR: client dropped the data channel, still owing a reply")
+                finally:
+                    c.close(); self.data_sock.close(); self.data_sock = None
+                if self.cfg.late_final:
+                    log("RETR data done, holding the 226 for %ss" % self.cfg.late_final)
+                    time.sleep(self.cfg.late_final)
+                self.send("226 Transfer complete.")
+            elif cmd in ("QUIT",):
+                self.send("221 Goodbye."); return
+            elif cmd == "SITE" and arg.strip().upper() == "STATUS":
+                # In-band twin of --status-file, for a test that can send a raw
+                # command but cannot read a file (or the other way round).
+                self.send("211 abor_read=%d stor_bytes=%d"
+                          % (self.counters.abor_read, self.counters.stor_bytes))
+            elif cmd in ("OPTS", "NOOP"): self.send("200 Ok.")
+            else: self.send("502 Command not implemented.")
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--port", type=int, default=2130)
+    p.add_argument("--feat", choices=["nomlsd", "mlsd", "mlsd-hang"], default="nomlsd")
+    p.add_argument("--list-delay", type=float, default=0.0, help="seconds between listing rows")
+    p.add_argument("--lines", type=int, default=5)
+    p.add_argument("--hang", type=float, default=90.0, help="seconds MLSD stays silent in mlsd-hang")
+    p.add_argument("--list-total", type=float, default=0.0,
+                   help="spread the listing over this many seconds total, to sit just "
+                        "under or just over a client deadline")
+    p.add_argument("--file-size", type=int, default=1048576,
+                   help="size RETR/SIZE report and serve")
+    p.add_argument("--retr-before-stall", type=int, default=4096,
+                   help="bytes handed over before RETR stalls")
+    p.add_argument("--retr-stall", type=float, default=0.0,
+                   help="seconds RETR holds the data channel open and silent, to outlast "
+                        "the per-file download timeout")
+    p.add_argument("--tls-cert", default=None,
+                   help="PEM certificate: enables AUTH TLS / PBSZ / PROT, so the data "
+                        "channel can accept the TCP and then never answer the handshake, "
+                        "which is the live case and cannot exist in plaintext")
+    p.add_argument("--tls-key", default=None, help="PEM private key for --tls-cert")
+    p.add_argument("--pasv-no-accept", choices=["none", "tls-silent", "connect-hang", "refuse"],
+                   default="none",
+                   help="announce a PASV port and then fail to serve it, three different ways")
+    p.add_argument("--refuse-before-data", action="store_true",
+                   help="send 550 on the control channel BEFORE the data phase, so the "
+                        "refusal is already queued while the client waits on the data channel")
+    p.add_argument("--unsolicited-refusal-after", type=int, default=0,
+                   help="bytes of RETR data after which the server sends a refusal on the "
+                        "control channel WITHOUT being asked (0 = never). Exercises the "
+                        "peek-do-not-consume path directly")
+    p.add_argument("--unsolicited-code", type=int, default=550,
+                   help="status code of the injected refusal (default 550)")
+    p.add_argument("--status-file", default=None,
+                   help="path this fixture rewrites with what it actually did "
+                        '(\'{"abor_read": N, "stor_bytes": N}\'), so a test that drives '
+                        "the client can assert the server read the ABOR instead of "
+                        "trusting it. Rewritten at startup, so a stale file cannot pass.")
+    p.add_argument("--abor-silent", action="store_true",
+                   help="CASE A: accept ABOR and send no reply at all, so the abort stays "
+                        "pending inside its budget")
+    p.add_argument("--stor-refuse-after", type=int, default=0,
+                   help="CASE B: bytes after which STOR is refused with 552 (0 = never)")
+    p.add_argument("--stor-after-refuse", choices=["drain", "stop"], default="drain",
+                   help="CASE B: after the 552, keep draining the data channel (drain) or "
+                        "stop reading with the socket still open (stop)")
+    p.add_argument("--stor-read-rate", type=int, default=0,
+                   help="CASE B: bytes per second the server reads from the data channel "
+                        "(0 = as fast as possible). Needed on loopback, where otherwise the "
+                        "client finishes writing before the refusal can matter")
+    p.add_argument("--stor-stop-hold", type=float, default=30.0,
+                   help="CASE B: seconds the stopped socket is held open before closing")
+    p.add_argument("--late-final", type=float, default=0.0,
+                   help="after the data channel closes, wait this long before sending the "
+                        "closing 226, WITHOUT closing the control connection, so the reply "
+                        "is still owed when the next command asks its own question")
+    cfg = p.parse_args()
+    counters = Counters(cfg.status_file)
+    srv = socket.socket(); srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(("127.0.0.1", cfg.port)); srv.listen(5)
+    log("listening on 127.0.0.1:%d feat=%s delay=%ss total=%ss late_final=%ss lines=%d"
+        % (cfg.port, cfg.feat, cfg.list_delay, cfg.list_total, cfg.late_final, cfg.lines))
+    while True:
+        c, a = srv.accept()
+        Session(c, a, cfg, counters).start()
+
+if __name__ == "__main__":
+    main()

--- a/src-tauri/tests/fixtures/ftp/slowftp.py
+++ b/src-tauri/tests/fixtures/ftp/slowftp.py
@@ -135,6 +135,34 @@ class Session(threading.Thread):
             % (self.cfg.unsolicited_code, sent))
         return True
 
+    def hold_unserved(self, what):
+        """Hold an opening that was announced and never accepted, then release it.
+
+        There are two ways this fixture leaves a client waiting on a data
+        channel, and only one of them had a bound. When `accept_data()` runs and
+        returns nothing, the `if c is None` guard holds and releases. But RETR
+        takes an earlier branch that never calls `accept_data()` at all, so that
+        guard was unreachable there and `--pending-hold` bounded nothing on the
+        download path: measured, a `get` sat for the full 400s ceiling while a
+        `ls` against the same fixture came back in two holds.
+
+        That is the same shape as the crash this file already documents: a guard
+        placed on a path an earlier branch returns before reaching. It was
+        introduced by the fix for that crash, which is worth saying plainly.
+
+        Here the client is parked in the listening socket's backlog rather than
+        on an accepted socket, so the release is closing the listener.
+        """
+        log("%s: holding the unserved opening %ss" % (what, self.cfg.pending_hold))
+        self.wait_watching_control(self.cfg.pending_hold)
+        if self.data_sock is not None:
+            try:
+                self.data_sock.close()
+            except OSError:
+                pass
+            self.data_sock = None
+        self.release_pending()
+
     def release_pending(self):
         """End a deliberate hang by closing the sockets nobody ever answered.
 
@@ -516,11 +544,13 @@ class Session(threading.Thread):
                     self.send("550 Failed to open file.")
                     log("RETR refused up front; data channel deliberately not served")
                     if self.cfg.pasv_no_accept != "none":
+                        self.hold_unserved("RETR refused up front")
                         continue  # do not touch the data channel at all
                 self.send("150 Opening BINARY mode data connection.")
                 if self.cfg.pasv_no_accept != "none":
                     log("RETR: data channel announced but not served (%s)"
                         % self.cfg.pasv_no_accept)
+                    self.hold_unserved("RETR")
                     continue
                 c = self.accept_data()
                 if c is None:

--- a/src-tauri/tests/fixtures/ftp/slowftp.py
+++ b/src-tauri/tests/fixtures/ftp/slowftp.py
@@ -689,12 +689,14 @@ def main():
     p.add_argument("--stor-stop-hold", type=float, default=30.0,
                    help="CASE B only: seconds the STOPPED socket is held open after the "
                         "server stops reading a refused STOR")
-    p.add_argument("--pending-hold", type=float, default=30.0,
+    p.add_argument("--pending-hold", type=float, default=120.0,
                    help="seconds a LIST, RETR or STOR is held pending when tls-silent "
                         "leaves no usable data channel. Separate from --stor-stop-hold on "
                         "purpose: one is how long a stopped socket lingers, the other is how "
-                        "long a deliberate hang lasts, and wanting one short and the other "
-                        "long is legitimate")
+                        "long a deliberate hang lasts. Defaults LONG (120) so that whatever "
+                        "deadline is under test wins the race by default: a hold equal to "
+                        "that deadline decides the outcome by a few milliseconds and passes "
+                        "either way without saying which won")
     p.add_argument("--late-final", type=float, default=0.0,
                    help="after the data channel closes, wait this long before sending the "
                         "closing 226, WITHOUT closing the control connection, so the reply "


### PR DESCRIPTION
Adds a dependency-free FTP server, `src-tauri/tests/fixtures/ftp/slowftp.py`, that can be told to behave in the ways a real server will not on demand. No CI lane here on purpose: the lane comes with the first test that uses it, so neither change has to wait for the other.

## What it can do

**Three FEAT positions**, because the listing branch is the server's choice and not ours: MLSD absent so the client falls back to `LIST`; MLSD advertised and working; MLSD advertised and then never served, which makes a single `list()` open two data channels with a reconnection in between. That third path has no test today.

**The `include_hidden` axis is ours**, not a server capability, so it is exercised by running two of our own operations against one server. Verified: `ls` sends `LIST` and sees two entries, `rm -r` sends `CWD` plus a bare `LIST -a`, sees four, and removes the dotfiles too.

**Five ways the control channel can misbehave while a data channel is open**: a closing reply paid late without closing the session; a refusal nobody asked for; an `ABOR` that is read and deliberately not answered; a `STOR` refused midway that either keeps draining or stops reading with the socket still open; and a `PASV` port announced and then never served in three distinct ways (accepted and silent, `connect` never completing, refused outright).

**A status file** recording what the fixture actually did: `ABOR`s read, bytes taken by a refused `STOR`, unsolicited replies sent, `PASV` ports announced, data connections accepted. Rewritten at startup and replaced atomically, so neither a stale file nor a half-written one can be read as this run's result.

## Why FTPS support is not a convenience

The fixture speaks explicit FTPS when given a certificate, and without that it exercises the wrong path. Same fixture, same options, only the transport differs:

| transport | result |
|---|---|
| plaintext | client fails correctly in **0.116s** |
| FTPS | client waits to a **120s ceiling** |

In plaintext there is no handshake on the data channel, so the client reaches the read loop and the existing guard does its job. Over FTPS the wait lives inside the data channel's handshake, which is before the loop. A plaintext-only fixture would therefore exercise the path that is already fixed while looking like it exercised the broken one, and a test built on it would be green before a fix and green after it.

The 120s is a ceiling I set. The measurement is "no reply within 120s", not "never".

## What it cannot do, stated so nobody builds on it

Under TLS the `ABOR` case does not work: `MSG_PEEK` cannot see through TLS framing, so the fixture cannot tell that the command is an `ABOR`, and `abor_read` stays `0`. That limit is about reading a record's *content*; the first byte of a TLS record, the content type, is not encrypted, so a design that watches the record type rather than the payload is unaffected. `ABOR` cases run in plaintext, hang cases run under TLS, and this fixture does not do both at once.

Running the FTPS cases needs a certificate the client will accept. `--insecure` is refused by design in unattended use and should not be worked around: trust the certificate instead, with a CA plus a leaf (`CA:FALSE`, `subjectAltName=IP:127.0.0.1`). A bare self-signed `openssl req -x509` is rejected by rustls with `CaUsedAsEndEntity`.

## Verified

Every behaviour above was checked by running it, not by reading it, and the three FEAT positions were re-checked after each later change. The fixture was also run against our own client and not only against a hand-written probe, which is how the plaintext limit was found: the probe said the scenario was there, the client said the path was elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhB1WQp9kb1CXaCHSjsX5h


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a configurable FTP test server fixture for simulating slow transfers, delayed listings, connection failures, TLS scenarios, passive-mode failures, and control-channel anomalies.
  * Added bounded handling for stalled downloads and data-channel connections.
  * Added status tracking to verify fixture behavior during automated tests.
* **Documentation**
  * Documented supported FTP behavior modes, configuration options, limitations, reproducibility considerations, and safer FTPS authentication examples.
  * Added guidance for diagnosing connection hangs, transfer timing, and retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->