### PR TITLE
feat(ftp): bound opening a data channel, where the wait actually lives

### DIFF
--- a/.github/workflows/ftp-mlsd.yml
+++ b/.github/workflows/ftp-mlsd.yml
@@ -19,6 +19,7 @@ on:
       - 'src-tauri/src/providers/types.rs'
       - 'src-tauri/tests/integration_ftp_mlsd.rs'
       - 'src-tauri/tests/fixtures/ftp-mlsd/**'
+      - 'src-tauri/tests/fixtures/ftp/**'
       - '.github/workflows/ftp-mlsd.yml'
   pull_request:
     branches: [main]
@@ -28,6 +29,7 @@ on:
       - 'src-tauri/src/providers/types.rs'
       - 'src-tauri/tests/integration_ftp_mlsd.rs'
       - 'src-tauri/tests/fixtures/ftp-mlsd/**'
+      - 'src-tauri/tests/fixtures/ftp/**'
       - '.github/workflows/ftp-mlsd.yml'
   workflow_dispatch:
 
@@ -158,3 +160,82 @@ jobs:
         if: always()
         working-directory: src-tauri/tests/fixtures/ftp-mlsd
         run: docker compose down -v
+
+  # A listing that times out must not hand the session on. This runs the guard
+  # for that as its own job rather than inside `mlsd`, because it needs a
+  # different server: `slowftp.py --feat mlsd-hang` accepts MLSD and then says
+  # nothing, which the docker fixture above cannot do.
+  listing-timeout:
+    runs-on: ubuntu-latest
+    # The test itself waits out LIST_BUDGET, which is 300s and not injectable,
+    # and a cold Tauri build precedes it. 90 is the same cap the job above uses
+    # for the same shape of work, and it is not tight: the wait is five minutes
+    # of the ninety.
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      # 420s of hanging, not 90: the fixture must outlast the 300s budget under
+      # test. At the old default of 90 the fixture gave up first, and a test that
+      # believed it was measuring the cap measured the fixture and passed.
+      - name: Start the hanging-MLSD fixture
+        working-directory: src-tauri/tests/fixtures/ftp
+        run: |
+          python3 slowftp.py --port 2140 --feat mlsd-hang --hang 420 \
+            > /tmp/slowftp-mlsd-hang.log 2>&1 &
+          echo $! > /tmp/slowftp.pid
+
+      # The banner, not the process: a pid says the interpreter started, not that
+      # it is serving. 20 iterations worst case is 20 x (3s read + 1s sleep) =
+      # 80s, comfortably inside the two-minute cap, so the loop finishes before
+      # the cap and the step cannot die mute.
+      - name: Wait for the fixture to answer
+        timeout-minutes: 2
+        run: |
+          for i in $(seq 1 20); do
+            if exec 3<>/dev/tcp/127.0.0.1/2140 2>/dev/null \
+               && read -r -t 3 -u 3 banner \
+               && [[ "$banner" == 220* ]]; then
+              echo "fixture answering after ${i}s: $banner"
+              exec 3<&- 3>&-
+              exit 0
+            fi
+            exec 3<&- 3>&- 2>/dev/null || true
+            sleep 1
+          done
+          echo "the fixture never answered on 2140"
+          exit 1
+
+      # The count is checked because this selects by NAME with `--lib`, the shape
+      # that prints "test result: ok" and exits 0 when the filter matches
+      # nothing. Exactly one, not "at least one": this step promises to run one
+      # named test, so a second arriving here is a change to what the job does
+      # and should be said out loud. The sibling aerorsync lane uses `-lt`
+      # instead, and correctly: it collects a whole module, which may grow.
+      - name: The session must not survive a timed-out listing
+        timeout-minutes: 40
+        working-directory: src-tauri
+        run: |
+          set -o pipefail
+          cargo test --lib providers::ftp::live_listing_timeout -- \
+            --ignored --nocapture | tee /tmp/listing-timeout.log
+          ran=$(grep -oE '^test result: ok\. [0-9]+ passed' /tmp/listing-timeout.log \
+                | grep -oE '[0-9]+' | head -1 || true)
+          echo "live listing-timeout tests executed: ${ran:-none}"
+          if [ "${ran:-0}" -ne 1 ]; then
+            echo "::error::expected exactly 1 test, ran ${ran:-0}: the filter stopped matching,"
+            echo "::error::which is a green that executed nothing. Fix the filter, not this check."
+            exit 1
+          fi
+
+      - name: Fixture log on failure
+        if: failure()
+        run: cat /tmp/slowftp-mlsd-hang.log || true
+
+      - name: Teardown
+        if: always()
+        run: kill "$(cat /tmp/slowftp.pid)" 2>/dev/null || true

--- a/.github/workflows/ftp-mlsd.yml
+++ b/.github/workflows/ftp-mlsd.yml
@@ -179,6 +179,56 @@ jobs:
         with:
           workspaces: src-tauri
 
+      # The three steps below are copied from the `mlsd` job, deliberately and
+      # in full. This job was added beside that one and inherits nothing from
+      # it: without them `cargo` reaches `glib-sys`, cannot find `glib-2.0`, and
+      # fails with exit 101 before a single test runs, which is what happened on
+      # the first attempt. The fixture had started correctly; the build never
+      # got to it.
+      #
+      # Copying only the install would have been worse than copying nothing,
+      # because the failure would have moved instead of going away: that mirror
+      # serves about 45 kB/s, `libwebkit2gtk-4.1-0` alone took 12m02s once and
+      # was still fetching at 23m02s when a job cap killed it. The lane would
+      # have become slow and intermittent rather than red, which is harder to
+      # diagnose than a clean failure.
+      #
+      # The cache KEY is the sibling's, not a new one. The package list is
+      # identical, so a separate key would pay the same 61.5 MB twice and the
+      # two jobs would never help each other; sharing it means whichever runs
+      # first fills it for the other.
+      - name: apt archive cache key
+        id: apt-archive-key
+        run: echo "week=$(date -u +%G-W%V)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache apt archives
+        timeout-minutes: 10
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ~/apt-archives
+          key: apt-ftp-mlsd-${{ runner.os }}-${{ steps.apt-archive-key.outputs.week }}
+          restore-keys: |
+            apt-ftp-mlsd-${{ runner.os }}-
+
+      - name: Install system dependencies
+        timeout-minutes: 12
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 2
+          retry_wait_seconds: 15
+          command: |
+            set -euo pipefail
+            sudo dpkg --configure -a || true
+            mkdir -p "$HOME/apt-archives/partial"
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends \
+              -o Dir::Cache::archives="$HOME/apt-archives/" \
+              -o APT::Keep-Downloaded-Packages=true \
+              libwebkit2gtk-4.1-dev \
+              libappindicator3-dev \
+              librsvg2-dev
+
       # 420s of hanging, not 90: the fixture must outlast the 300s budget under
       # test. At the old default of 90 the fixture gave up first, and a test that
       # believed it was measuring the cap measured the fixture and passed.

--- a/src-tauri/src/providers/ftp.rs
+++ b/src-tauri/src/providers/ftp.rs
@@ -2499,11 +2499,21 @@ impl FtpProvider {
                 // "aligned" in exactly the case it was added to catch, and a
                 // fixture sending the two in separate writes would make that
                 // green. Segmentation is not ours to control.
-                // The cost is bounded and that is why it is acceptable here: a
-                // queued `421` reaches the next command as a reply it did not
-                // expect, and `421` is never among any command's expected codes,
-                // so it surfaces as an error rather than as data. This is not
-                // the phantom-files class.
+                // THE COST IS NOT BOUNDED, and an earlier version of this
+                // comment said it was. Measured, not reasoned: a server
+                // answering `RETR` with `550` and `421` in ONE write leaves
+                // nothing on the socket, and the next command, a `PWD`, receives
+                // "421 Service not available" as ITS OWN reply. An operation
+                // fails citing an answer caused by the command before it, which
+                // IS the phantom-files class, the one this whole line of work
+                // exists to remove.
+                // The first version of that claim checked the VALUE (an error,
+                // not data) and not the ATTRIBUTION (the error of the wrong
+                // command), which is the same mistake in prose that the code is
+                // here to prevent on the wire.
+                // Tracked separately rather than patched here: the fix is not a
+                // comment, and it does not belong in a change about bounding the
+                // open.
                 //
                 // Both are named rather than claimed closed: a condition that
                 // looks total has been wrong four times, and each time it was

--- a/src-tauri/src/providers/ftp.rs
+++ b/src-tauri/src/providers/ftp.rs
@@ -2462,8 +2462,32 @@ impl FtpProvider {
                 // `4xx` and `5xx` are the only replies that are both final and
                 // legitimately here: after one of those, nothing more is owed
                 // for that command, so the control channel really is aligned.
+                //
+                // `421` is excluded and it is the fourth narrowing of this arm.
+                // It is a `4xx`, final, and legitimately here, so every earlier
+                // version of this condition kept the session; but it says
+                // "service not available, CLOSING CONTROL CONNECTION". The
+                // server is announcing that the channel is going away, and the
+                // next command would take a session already closed. It is the
+                // only status in this range that carries that meaning: `426`
+                // closes the DATA connection and `221` is a `2xx`, outside it.
+                //
+                // ON WHICH PROPERTY IS THIS ONE STILL SILENT? Each version of
+                // this condition was right about the property it was chosen for
+                // and said nothing about the next: any error at all was mute on
+                // whether a whole reply arrived, the VARIANT was mute on
+                // finality, the STATUS CLASS was mute on the connection
+                // surviving. This one is mute on WHOSE reply it is. FTP carries
+                // no request identifier, so a reply queued here could in
+                // principle belong to an earlier command whose answer came late,
+                // and consuming it as ours would leave our own reply still
+                // owed. Nothing in reach distinguishes them, so it is named
+                // rather than claimed closed: a condition that looks total has
+                // been wrong four times, and each time it was total with
+                // respect to one property.
                 Ok(FtpError::UnexpectedResponse(reply))
-                    if (400..600).contains(&reply.status.code()) =>
+                    if (400..600).contains(&reply.status.code())
+                        && reply.status != Status::NotAvailable =>
                 {
                     return Self::classify_data_failure(
                         operation,

--- a/src-tauri/src/providers/ftp.rs
+++ b/src-tauri/src/providers/ftp.rs
@@ -2481,10 +2481,33 @@ impl FtpProvider {
                 // no request identifier, so a reply queued here could in
                 // principle belong to an earlier command whose answer came late,
                 // and consuming it as ours would leave our own reply still
-                // owed. Nothing in reach distinguishes them, so it is named
-                // rather than claimed closed: a condition that looks total has
-                // been wrong four times, and each time it was total with
-                // respect to one property.
+                // owed. FTP carries no identifier, so nothing distinguishes
+                // them.
+                //
+                // AND ON A SECOND ONE, mute for a different reason: whether
+                // ANOTHER reply follows the one just read. `read_response_in`
+                // consumes exactly one, and a server that refuses and then hangs
+                // up sends `550` and then `421`, in that order, because the
+                // refusal answers the command and the goodbye comes after. Read
+                // the `550` and this arm keeps the session with the `421` still
+                // queued.
+                // It is named rather than fixed because the fix that suggests
+                // itself does not work: a second peek looks at `get_ref()`,
+                // which is the bare socket UNDER the `BufReader`, so when both
+                // replies arrive in one segment the `421` is already in the
+                // buffer and the socket shows nothing. The peek would report
+                // "aligned" in exactly the case it was added to catch, and a
+                // fixture sending the two in separate writes would make that
+                // green. Segmentation is not ours to control.
+                // The cost is bounded and that is why it is acceptable here: a
+                // queued `421` reaches the next command as a reply it did not
+                // expect, and `421` is never among any command's expected codes,
+                // so it surfaces as an error rather than as data. This is not
+                // the phantom-files class.
+                //
+                // Both are named rather than claimed closed: a condition that
+                // looks total has been wrong four times, and each time it was
+                // total with respect to one property.
                 Ok(FtpError::UnexpectedResponse(reply))
                     if (400..600).contains(&reply.status.code())
                         && reply.status != Status::NotAvailable =>

--- a/src-tauri/src/providers/ftp.rs
+++ b/src-tauri/src/providers/ftp.rs
@@ -440,7 +440,7 @@ impl FtpProvider {
             }
             let mlsd_result = {
                 let stream = self.stream_mut()?;
-                stream.mlsd(list_path.as_deref()).await
+                Self::list_with_cap(stream.mlsd(list_path.as_deref())).await
             };
 
             match mlsd_result {
@@ -477,7 +477,7 @@ impl FtpProvider {
             // entries that `-a` adds are dropped by the listing parsers.
             let saved_cwd = self.cwd_into(&base_path).await?;
             let stream = self.stream_mut()?;
-            let listed = stream.list(Some("-a")).await;
+            let listed = Self::list_with_cap(stream.list(Some("-a"))).await;
             let restored = self.restore_cwd(&saved_cwd).await;
             // Both are reported when both fail. Propagating the listing error
             // first would swallow the restore failure exactly when it matters
@@ -502,8 +502,7 @@ impl FtpProvider {
             }
         } else {
             let stream = self.stream_mut()?;
-            stream
-                .list(list_path.as_deref())
+            Self::list_with_cap(stream.list(list_path.as_deref()))
                 .await
                 .map_err(|e| ProviderError::ServerError(e.to_string()))?
         };
@@ -1352,10 +1351,13 @@ impl StorageProvider for FtpProvider {
             .map_err(|e| ProviderError::ServerError(e.to_string()))?;
 
         // Download using retr_as_stream
-        let data_stream = stream
-            .retr_as_stream(remote_path)
+        let opened = Self::open_with_cap(stream.retr_as_stream(remote_path))
             .await
             .map_err(|e| Self::classify_data_failure("reading", remote_path, e))?;
+        let data_stream = match opened {
+            Some(data_stream) => data_stream,
+            None => return Err(self.after_timed_out_open("reading", remote_path).await),
+        };
 
         // H2: Read with size cap to prevent OOM
         let mut data = Vec::new();
@@ -1690,10 +1692,13 @@ impl StorageProvider for FtpProvider {
             .map_err(|e| ProviderError::TransferFailed(format!("REST failed: {}", e)))?;
 
         // Retrieve from offset
-        let data_stream = stream
-            .retr_as_stream(remote_path)
+        let opened = Self::open_with_cap(stream.retr_as_stream(remote_path))
             .await
             .map_err(|e| Self::classify_data_failure("resuming", remote_path, e))?;
+        let data_stream = match opened {
+            Some(data_stream) => data_stream,
+            None => return Err(self.after_timed_out_open("resuming", remote_path).await),
+        };
 
         // H3: Stream directly to file instead of buffering entire file in memory
         let mut file = tokio::fs::OpenOptions::new()
@@ -1985,10 +1990,13 @@ impl StorageProvider for FtpProvider {
             .await
             .map_err(|e| ProviderError::TransferFailed(format!("REST failed: {}", e)))?;
 
-        let data_stream = stream
-            .retr_as_stream(path)
+        let opened = Self::open_with_cap(stream.retr_as_stream(path))
             .await
             .map_err(|e| Self::classify_data_failure("reading a range of", path, e))?;
+        let data_stream = match opened {
+            Some(data_stream) => data_stream,
+            None => return Err(self.after_timed_out_open("reading a range of", path).await),
+        };
 
         // Read exactly `len` bytes (or until EOF if file is shorter).
         //
@@ -2066,6 +2074,35 @@ fn canonical_hash_key(server_algo: &str) -> String {
 /// the only transfer path in the tree with no deadline of any kind, so this is
 /// not a new mechanism, it is the existing one reaching the provider that
 /// lacked it.
+/// How long OPENING a data channel may take before we stop waiting.
+///
+/// Total, not inactivity: an open has no bytes to be idle about, and its whole
+/// job is bounded work. Thirty seconds sits far from both edges of what has been
+/// measured. A healthy open against the lab completes in 0.116s, three orders of
+/// magnitude below this; the hang was still unresolved at 120s, which was the
+/// probe's own cap rather than a limit of the wait. A cap near the first would
+/// turn a slow-but-working handshake into a failure; one near the second would
+/// take minutes to say what it can say in seconds. Written here rather than
+/// inlined because the next person to change it needs the two numbers it sits
+/// between.
+const OPEN_BUDGET: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Total cap on a whole listing, and total is the point.
+///
+/// A transfer wants an INACTIVITY bound, because a large file legitimately takes
+/// hours and a total cap would kill it. A listing is the opposite: it has an
+/// intrinsic size, so an inactivity bound would never fire against a server that
+/// dribbles a row at a time, and a total one is the only kind that can.
+///
+/// Five minutes is a LIVENESS limit, not a performance one: anything under it is
+/// allowed, and the number exists so that a listing which will never finish stops
+/// instead of waiting forever. It is deliberately far above the twin's
+/// `list_timeout` of 30s in `src/ftp.rs`, which is a total cap too and may well be
+/// truncating legitimate listings of large directories on slow links. That is an
+/// open question with its own measurement, and copying the number would have
+/// inherited the answer without asking it.
+const LIST_BUDGET: std::time::Duration = std::time::Duration::from_secs(300);
+
 const DATA_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1800);
 
 /// How long the data may stay silent AFTER the server has spoken on control.
@@ -2337,6 +2374,110 @@ impl<'p, S> Drop for DataChannel<'p, S> {
 }
 
 impl FtpProvider {
+    /// A cap on OPENING a data channel, which is where the wait actually lives.
+    ///
+    /// Measured on `main`: a `RETR` against a server that refuses hangs before
+    /// the read loop is ever entered, inside the data connection's TLS
+    /// handshake. `read_watching_control` guards the loop, and the loop is not
+    /// reached. Two awaits in `data_command` are unbounded, and BOTH need this:
+    /// the passive connect, which is the only one of the two on a plaintext
+    /// session, and the TLS upgrade, which is the one that was measured.
+    ///
+    /// Returns `Ok(None)` when the budget expires, so the caller can realign
+    /// with the borrow of the control stream already released. Realignment is
+    /// deliberately NOT done here: the future being dropped is the crate's, and
+    /// the drop has to happen before anything else touches the session.
+    /// A total cap on a listing, shaped so every caller keeps its own handling.
+    ///
+    /// The expiry is returned as an `FtpError`, not as a separate variant, so the
+    /// three listing sites match on it exactly as they already match on a server
+    /// that refused: `MLSD` still marks itself broken and falls through to
+    /// `LIST`, which gets its own cap, and `LIST` still maps to a `ServerError`.
+    async fn list_with_cap(
+        fut: impl std::future::Future<Output = suppaftp::FtpResult<Vec<String>>>,
+    ) -> suppaftp::FtpResult<Vec<String>> {
+        match tokio::time::timeout(LIST_BUDGET, fut).await {
+            Ok(result) => result,
+            Err(_) => Err(FtpError::ConnectionError(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                format!("no listing within {}s", LIST_BUDGET.as_secs()),
+            ))),
+        }
+    }
+
+    /// Bounds, and does nothing else. The failure is handed back RAW so each
+    /// caller keeps the mapping it already had: `STOR` classifies with
+    /// `map_store_error` and the others with `classify_data_failure`, and a
+    /// helper that classified on their behalf would quietly change one of them.
+    async fn open_with_cap<T>(
+        fut: impl std::future::Future<Output = suppaftp::FtpResult<T>>,
+    ) -> Result<Option<T>, FtpError> {
+        match tokio::time::timeout(OPEN_BUDGET, fut).await {
+            Ok(Ok(opened)) => Ok(Some(opened)),
+            Ok(Err(err)) => Err(err),
+            Err(_) => Ok(None),
+        }
+    }
+
+    /// What to do after an opening that never finished.
+    ///
+    /// The command is already on the wire and its reply unread: `pasv()` reads
+    /// its own `227`, but `perform(cmd)` reads nothing, so the control channel
+    /// is one reply behind. The likely case is that the reply is a REFUSAL that
+    /// arrived long ago, which is why the server never serviced the data port;
+    /// on the lab that reply was sitting in the socket while the handshake hung.
+    /// So this looks before it concludes, and returns the server's own reason
+    /// when there is one instead of a timeout that says nothing.
+    ///
+    /// When nothing is queued, the session is taken: the reply is still owed,
+    /// and a session one answer behind hands the next question somebody else's
+    /// answer.
+    async fn after_timed_out_open(&mut self, operation: &'static str, path: &str) -> ProviderError {
+        let queued = match self.stream.as_ref() {
+            Some(stream) => {
+                let control = stream.get_ref();
+                let mut probe = [0u8; 1];
+                let mut got = tokio::io::ReadBuf::new(&mut probe);
+                std::future::poll_fn(|cx| {
+                    std::task::Poll::Ready(match control.poll_peek(cx, &mut got) {
+                        std::task::Poll::Ready(Ok(bytes)) => bytes,
+                        _ => 0,
+                    })
+                })
+                .await
+            }
+            None => 0,
+        };
+        if queued > 0 {
+            match self.read_queued_refusal().await {
+                // A reply was parsed, so it was consumed whole and the control
+                // channel is aligned again: the session survives.
+                Ok(refusal @ FtpError::UnexpectedResponse(_)) => {
+                    return Self::classify_data_failure(operation, path, refusal)
+                }
+                // Anything else means the collection produced no complete reply,
+                // and `read_response_in` is not cancellation-safe: it may have
+                // been dropped mid-line. The error is still the best thing to
+                // report, but the session cannot be handed on.
+                Ok(other) => {
+                    self.stream = None;
+                    return Self::classify_data_failure(operation, path, other);
+                }
+                Err(err) => {
+                    self.stream = None;
+                    return err;
+                }
+            }
+        }
+        self.stream = None;
+        ProviderError::TransferFailed(format!(
+            "Opening the data channel for {} {} got no answer within {}s",
+            operation,
+            path,
+            OPEN_BUDGET.as_secs()
+        ))
+    }
+
     /// Read the refusal the server has queued, without waiting for one that
     /// may not be there.
     ///
@@ -2543,10 +2684,13 @@ impl FtpProvider {
             .map_err(|e| ProviderError::ServerError(e.to_string()))?;
 
         // Download using retr_as_stream: stream directly to disk (no full-file RAM buffer)
-        let data_stream = stream
-            .retr_as_stream(remote_path)
+        let opened = Self::open_with_cap(stream.retr_as_stream(remote_path))
             .await
             .map_err(|e| Self::classify_data_failure("downloading", remote_path, e))?;
+        let data_stream = match opened {
+            Some(data_stream) => data_stream,
+            None => return Err(self.after_timed_out_open("downloading", remote_path).await),
+        };
 
         let mut atomic = super::atomic_write::AtomicFile::new(local_path)
             .await
@@ -2618,11 +2762,16 @@ impl FtpProvider {
             .map_err(ProviderError::IoError)?;
         let total_size = file.metadata().await.map_err(ProviderError::IoError)?.len();
 
-        // Open streaming upload channel (PASV + STOR)
-        let mut data_stream = stream
-            .put_with_stream(remote_path)
+        // Open streaming upload channel (PASV + STOR), under the same cap as the
+        // reads: the two unbounded awaits live in `data_command`, which every
+        // verb goes through.
+        let opened = Self::open_with_cap(stream.put_with_stream(remote_path))
             .await
             .map_err(|e| Self::map_store_error(remote_path, e))?;
+        let mut data_stream = match opened {
+            Some(data_stream) => data_stream,
+            None => return Err(self.after_timed_out_open("uploading", remote_path).await),
+        };
 
         // Write in 64KB chunks for optimal throughput
         let mut chunk = [0u8; 65536];
@@ -2806,11 +2955,21 @@ async fn ftp_download_one_range(
             .map_err(|e| ProviderError::TransferFailed(format!("REST failed: {}", e)))?;
     }
 
-    let mut data_stream = {
+    let opened = {
         let stream = worker.stream_mut()?;
-        stream.retr_as_stream(&remote_path).await.map_err(|e| {
-            FtpProvider::classify_data_failure("downloading a range of", &remote_path, e)
-        })?
+        FtpProvider::open_with_cap(stream.retr_as_stream(&remote_path))
+            .await
+            .map_err(|e| {
+                FtpProvider::classify_data_failure("downloading a range of", &remote_path, e)
+            })?
+    };
+    let mut data_stream = match opened {
+        Some(data_stream) => data_stream,
+        None => {
+            return Err(worker
+                .after_timed_out_open("downloading a range of", &remote_path)
+                .await)
+        }
     };
 
     let mut out = tokio::fs::OpenOptions::new()

--- a/src-tauri/src/providers/ftp.rs
+++ b/src-tauri/src/providers/ftp.rs
@@ -4304,3 +4304,91 @@ mod data_channel_watch_tests {
         assert_eq!(&left[..seen], b"226", "the completion reply was consumed");
     }
 }
+
+/// Live regression for the one thing a timed-out listing must not do: hand the
+/// session on.
+///
+/// **Why this cannot be a unit test.** The defect is a relation between two
+/// commands on one control channel, so it needs a server that accepts `MLSD`
+/// and then says nothing. `slowftp.py --feat mlsd-hang` is that server.
+///
+/// **What it asserts, and what it deliberately does not.** Not the duration: a
+/// released client re-dials, so the elapsed time is multiplied by the retry
+/// count and says nothing. Not that the listing failed: it fails either way.
+/// It asserts ATTRIBUTION, which is the only thing that separates the two
+/// worlds. Without the fix the session survives with the listing's reply still
+/// owed, and the next command collects it: measured, a `PWD` receives
+/// "425 Cannot open data connection." and the `257` it was owed arrives one
+/// place later. With the fix the session is gone, so the same `PWD` can only
+/// report `NotConnected`.
+///
+/// The probe is a `PWD` and not a `LIST` on purpose: an empty listing and a
+/// misattributed one look alike, so the assertion could not tell them apart,
+/// while `PWD` has one known right answer and anything else is unambiguous.
+///
+/// **It takes five minutes, and that is declared rather than discovered.**
+/// `LIST_BUDGET` is 300s and is not injectable, so the wait is real. The fixture
+/// hangs for 420s by default, chosen to outlast it: at the earlier default of
+/// 90s the fixture gave up first, and a test that believed it was measuring the
+/// cap was measuring the fixture, and passed. If this is ever wanted faster the
+/// way is to make the budget injectable, never to shorten it, because a
+/// production constant lowered for the convenience of a test turns the measured
+/// thing into one that resembles it.
+///
+/// ```bash
+/// cd src-tauri/tests/fixtures/ftp
+/// ./slowftp.py --port 2140 --feat mlsd-hang --hang 420 &
+/// cd ../../.. && cargo test --lib providers::ftp::live_listing_timeout -- --ignored --nocapture
+/// ```
+#[cfg(test)]
+mod live_listing_timeout {
+    use super::*;
+
+    fn fixture_port() -> u16 {
+        std::env::var("AEROFTP_MLSD_HANG_PORT")
+            .ok()
+            .and_then(|p| p.parse().ok())
+            .unwrap_or(2140)
+    }
+
+    #[tokio::test]
+    #[ignore = "live: needs slowftp.py --feat mlsd-hang, and waits out LIST_BUDGET"]
+    async fn a_listing_that_timed_out_does_not_hand_the_session_on() {
+        let mut provider = FtpProvider::new(FtpConfig {
+            host: "127.0.0.1".to_string(),
+            port: fixture_port(),
+            username: "u".to_string(),
+            password: "p".to_string().into(),
+            tls_mode: FtpTlsMode::None,
+            verify_cert: false,
+            initial_path: None,
+        });
+        provider
+            .connect()
+            .await
+            .expect("the mlsd-hang fixture must be up");
+
+        let started = std::time::Instant::now();
+        let listing = provider.list("/").await;
+        eprintln!(
+            "MEASURED listing after {:?}: {listing:?}",
+            started.elapsed()
+        );
+        assert!(
+            listing.is_err(),
+            "a server that accepts MLSD and never answers must not produce a listing"
+        );
+
+        // The whole test is this line. The listing failed in both worlds; only
+        // here do they differ.
+        match provider.pwd().await {
+            Err(ProviderError::NotConnected) => {}
+            other => panic!(
+                "after a timed-out listing the session must not be reusable, so this PWD should \
+                 have found no session at all. Got {other:?}. If that mentions 425 or a data \
+                 connection, the session was kept and the PWD collected the listing's reply \
+                 instead of its own, which is the defect this guards."
+            ),
+        }
+    }
+}

--- a/src-tauri/src/providers/ftp.rs
+++ b/src-tauri/src/providers/ftp.rs
@@ -2450,21 +2450,39 @@ impl FtpProvider {
         };
         if queued > 0 {
             match self.read_queued_refusal().await {
-                // A reply was parsed, so it was consumed whole and the control
-                // channel is aligned again: the session survives.
-                Ok(refusal @ FtpError::UnexpectedResponse(_)) => {
-                    return Self::classify_data_failure(operation, path, refusal)
+                // A reply was parsed AND it is FINAL. Parsed alone is not
+                // enough, and that distinction is the whole of this arm: a
+                // `1xx` is preliminary and another reply follows it, so
+                // consuming it and keeping the session leaves the completion in
+                // the pipe for the next command to read as its own. That is the
+                // phantom-files class, entering through the branch that exists
+                // to prevent it. A `3xx` is intermediate for the same reason,
+                // and an unexpected `2xx` in this position is strange enough
+                // that guessing is worse than dialling again.
+                // `4xx` and `5xx` are the only replies that are both final and
+                // legitimately here: after one of those, nothing more is owed
+                // for that command, so the control channel really is aligned.
+                Ok(FtpError::UnexpectedResponse(reply))
+                    if (400..600).contains(&reply.status.code()) =>
+                {
+                    return Self::classify_data_failure(
+                        operation,
+                        path,
+                        FtpError::UnexpectedResponse(reply),
+                    )
                 }
                 // EVERYTHING else, and the catch-all is the point rather than a
-                // shorthand. `BadResponse` says the collection produced nothing
-                // readable; a connection error says something else again; a
-                // variant added by a future version of the crate says something
-                // nobody here has considered. What they share is not a meaning,
-                // it is the ABSENCE of one: none of them establishes that the
-                // control channel is aligned, and `read_response_in` is not
-                // cancellation-safe, so it may have been dropped mid-line.
-                // The default is therefore to discard, because the safe side is
-                // the one that does not assume. The error is still the best
+                // shorthand. It now holds two kinds of case. Some say nothing
+                // about alignment: `BadResponse` means the collection produced
+                // nothing readable, a connection error means something else
+                // again, and a variant added by a later crate version means
+                // something nobody here has considered. Others say the wrong
+                // thing: a parsed but non-final reply proves the channel is
+                // mid-exchange rather than aligned. Neither group establishes
+                // that the session can be handed on, and `read_response_in` is
+                // not cancellation-safe, so it may also have been dropped
+                // mid-line. The default discards because the safe side is the
+                // one that makes the smaller claim. The error is still the best
                 // thing to report; the session is not.
                 Ok(other) => {
                     self.stream = None;

--- a/src-tauri/src/providers/ftp.rs
+++ b/src-tauri/src/providers/ftp.rs
@@ -445,7 +445,21 @@ impl FtpProvider {
 
             let mlsd_result = match mlsd_result {
                 Ok(Some(lines)) => Ok(lines),
-                Ok(None) => return Err(self.listing_timed_out(&base_path)),
+                Ok(None) => {
+                    // The session goes, but this flag is PROVIDER state and
+                    // outlives it: `connect` re-reads it as
+                    // `mlsd_supported = server_supports_mlsd && !mlsd_broken`,
+                    // so it is what stops the next attempt from paying the whole
+                    // budget again. A server that advertises MLSD and then never
+                    // answers it is exactly the server this flag exists for, and
+                    // the ordinary failure path below sets it for the same
+                    // reason. Returning early without it would leave the
+                    // provider permanently SLOW instead of permanently STUCK,
+                    // which is better and is not the point.
+                    self.mlsd_broken = true;
+                    self.mlsd_supported = false;
+                    return Err(self.listing_timed_out(&base_path));
+                }
                 Err(err) => Err(err),
             };
             match mlsd_result {

--- a/src-tauri/src/providers/ftp.rs
+++ b/src-tauri/src/providers/ftp.rs
@@ -487,7 +487,8 @@ impl FtpProvider {
                 Err(err) => {
                     let provider_err = ProviderError::ServerError(err.to_string());
                     tracing::debug!(
-                        "[FTP] MLSD failed for {}: {}. Disabling MLSD fallback for this session.",
+                        "[FTP] MLSD failed for {}: {}. Disabling MLSD for this provider: the \
+                         flag outlives the session and is re-read on reconnect.",
                         base_path,
                         provider_err
                     );

--- a/src-tauri/src/providers/ftp.rs
+++ b/src-tauri/src/providers/ftp.rs
@@ -456,6 +456,20 @@ impl FtpProvider {
                     // reason. Returning early without it would leave the
                     // provider permanently SLOW instead of permanently STUCK,
                     // which is better and is not the point.
+                    // Said, and said DIFFERENTLY from the failure path below,
+                    // which logs the same flag being set. Two identical lines
+                    // would give a log that cannot tell a server which REFUSES
+                    // from one which goes SILENT, and separating those two is
+                    // most of what this work has been about. Without any line at
+                    // all, the log would show "disabling MLSD" when MLSD errors
+                    // and show nothing when it expires, while the effect on the
+                    // provider is the same.
+                    tracing::debug!(
+                        "[FTP] MLSD produced nothing for {} within {}s. Disabling MLSD for this \
+                         provider: it answered the command and then went silent.",
+                        base_path,
+                        LIST_BUDGET.as_secs()
+                    );
                     self.mlsd_broken = true;
                     self.mlsd_supported = false;
                     return Err(self.listing_timed_out(&base_path));

--- a/src-tauri/src/providers/ftp.rs
+++ b/src-tauri/src/providers/ftp.rs
@@ -2455,10 +2455,17 @@ impl FtpProvider {
                 Ok(refusal @ FtpError::UnexpectedResponse(_)) => {
                     return Self::classify_data_failure(operation, path, refusal)
                 }
-                // Anything else means the collection produced no complete reply,
-                // and `read_response_in` is not cancellation-safe: it may have
-                // been dropped mid-line. The error is still the best thing to
-                // report, but the session cannot be handed on.
+                // EVERYTHING else, and the catch-all is the point rather than a
+                // shorthand. `BadResponse` says the collection produced nothing
+                // readable; a connection error says something else again; a
+                // variant added by a future version of the crate says something
+                // nobody here has considered. What they share is not a meaning,
+                // it is the ABSENCE of one: none of them establishes that the
+                // control channel is aligned, and `read_response_in` is not
+                // cancellation-safe, so it may have been dropped mid-line.
+                // The default is therefore to discard, because the safe side is
+                // the one that does not assume. The error is still the best
+                // thing to report; the session is not.
                 Ok(other) => {
                     self.stream = None;
                     return Self::classify_data_failure(operation, path, other);

--- a/src-tauri/src/providers/ftp.rs
+++ b/src-tauri/src/providers/ftp.rs
@@ -2419,25 +2419,20 @@ impl<'p, S> Drop for DataChannel<'p, S> {
 }
 
 impl FtpProvider {
-    /// A cap on OPENING a data channel, which is where the wait actually lives.
+    /// A total cap on a listing, whose expiry every caller must handle.
     ///
-    /// Measured on `main`: a `RETR` against a server that refuses hangs before
-    /// the read loop is ever entered, inside the data connection's TLS
-    /// handshake. `read_watching_control` guards the loop, and the loop is not
-    /// reached. Two awaits in `data_command` are unbounded, and BOTH need this:
-    /// the passive connect, which is the only one of the two on a plaintext
-    /// session, and the TLS upgrade, which is the one that was measured.
+    /// The expiry is `Ok(None)` and NOT an error, and that is the whole shape.
+    /// An earlier version returned it as an `FtpError`, which made it
+    /// indistinguishable from a reply the server had actually sent: the three
+    /// listing sites treated it as one more server failure and carried on using
+    /// a session whose listing reply was still owed. `MLSD` fell through to
+    /// `LIST` on it, the `-a` path called `restore_cwd` on it, and the late
+    /// reply answered the wrong command.
     ///
-    /// Returns `Ok(None)` when the budget expires, so the caller can realign
-    /// with the borrow of the control stream already released. Realignment is
-    /// deliberately NOT done here: the future being dropped is the crate's, and
-    /// the drop has to happen before anything else touches the session.
-    /// A total cap on a listing, shaped so every caller keeps its own handling.
-    ///
-    /// The expiry is returned as an `FtpError`, not as a separate variant, so the
-    /// three listing sites match on it exactly as they already match on a server
-    /// that refused: `MLSD` still marks itself broken and falls through to
-    /// `LIST`, which gets its own cap, and `LIST` still maps to a `ServerError`.
+    /// As `Ok(None)` the compiler forces each of the three to say what it does,
+    /// and all three take the session. Nothing here is matched on the text of a
+    /// message, which is what the existing reconnect guard does and why it never
+    /// fired for this.
     async fn list_with_cap(
         fut: impl std::future::Future<Output = suppaftp::FtpResult<Vec<String>>>,
     ) -> suppaftp::FtpResult<Option<Vec<String>>> {
@@ -2471,6 +2466,20 @@ impl FtpProvider {
         ))
     }
 
+    /// A cap on OPENING a data channel, which is where the wait actually lives.
+    ///
+    /// Measured on `main`: a `RETR` against a server that refuses hangs before
+    /// the read loop is ever entered, inside the data connection's TLS
+    /// handshake. `read_watching_control` guards the loop, and the loop is not
+    /// reached. Two awaits in `data_command` are unbounded, and BOTH need this:
+    /// the passive connect, which is the only one of the two on a plaintext
+    /// session, and the TLS upgrade, which is the one that was measured.
+    ///
+    /// Returns `Ok(None)` when the budget expires, so the caller can realign
+    /// with the borrow of the control stream already released. Realignment is
+    /// deliberately NOT done here: the future being dropped is the crate's, and
+    /// the drop has to happen before anything else touches the session.
+    ///
     /// Bounds, and does nothing else. The failure is handed back RAW so each
     /// caller keeps the mapping it already had: `STOR` classifies with
     /// `map_store_error` and the others with `classify_data_failure`, and a

--- a/src-tauri/src/providers/ftp.rs
+++ b/src-tauri/src/providers/ftp.rs
@@ -443,6 +443,11 @@ impl FtpProvider {
                 Self::list_with_cap(stream.mlsd(list_path.as_deref())).await
             };
 
+            let mlsd_result = match mlsd_result {
+                Ok(Some(lines)) => Ok(lines),
+                Ok(None) => return Err(self.listing_timed_out(&base_path)),
+                Err(err) => Err(err),
+            };
             match mlsd_result {
                 Ok(lines) => {
                     let entries: Vec<RemoteEntry> = lines
@@ -478,6 +483,13 @@ impl FtpProvider {
             let saved_cwd = self.cwd_into(&base_path).await?;
             let stream = self.stream_mut()?;
             let listed = Self::list_with_cap(stream.list(Some("-a"))).await;
+            // Restoring the directory on a session whose listing timed out is
+            // the exact defect this guards: the late reply would answer the
+            // `CWD` instead. So the expiry is handled before anything else
+            // touches the stream.
+            if matches!(listed, Ok(None)) {
+                return Err(self.listing_timed_out(&base_path));
+            }
             let restored = self.restore_cwd(&saved_cwd).await;
             // Both are reported when both fail. Propagating the listing error
             // first would swallow the restore failure exactly when it matters
@@ -485,13 +497,15 @@ impl FtpProvider {
             // and of the pair it is the unrestored directory that outlives the
             // call and misdirects everything after it.
             match (listed, restored) {
-                (Ok(lines), Ok(())) => lines,
+                (Ok(Some(lines)), Ok(())) => lines,
+                // Unreachable: the expiry returned above.
+                (Ok(None), _) => return Err(self.listing_timed_out(&base_path)),
                 (Err(list_err), Ok(())) => {
                     return Err(ProviderError::ServerError(Self::doing(
                         "listing", &base_path, list_err,
                     )))
                 }
-                (Ok(_), Err(restore_err)) => return Err(restore_err),
+                (Ok(Some(_)), Err(restore_err)) => return Err(restore_err),
                 (Err(list_err), Err(restore_err)) => {
                     return Err(ProviderError::ServerError(Self::doing(
                         "listing",
@@ -502,9 +516,11 @@ impl FtpProvider {
             }
         } else {
             let stream = self.stream_mut()?;
-            Self::list_with_cap(stream.list(list_path.as_deref()))
-                .await
-                .map_err(|e| ProviderError::ServerError(e.to_string()))?
+            match Self::list_with_cap(stream.list(list_path.as_deref())).await {
+                Ok(Some(lines)) => lines,
+                Ok(None) => return Err(self.listing_timed_out(&base_path)),
+                Err(e) => return Err(ProviderError::ServerError(e.to_string())),
+            }
         };
 
         let listing =
@@ -2395,14 +2411,35 @@ impl FtpProvider {
     /// `LIST`, which gets its own cap, and `LIST` still maps to a `ServerError`.
     async fn list_with_cap(
         fut: impl std::future::Future<Output = suppaftp::FtpResult<Vec<String>>>,
-    ) -> suppaftp::FtpResult<Vec<String>> {
+    ) -> suppaftp::FtpResult<Option<Vec<String>>> {
         match tokio::time::timeout(LIST_BUDGET, fut).await {
-            Ok(result) => result,
-            Err(_) => Err(FtpError::ConnectionError(std::io::Error::new(
-                std::io::ErrorKind::TimedOut,
-                format!("no listing within {}s", LIST_BUDGET.as_secs()),
-            ))),
+            Ok(result) => result.map(Some),
+            Err(_) => Ok(None),
         }
+    }
+
+    /// The session cannot survive a listing that timed out, and returning the
+    /// expiry as an ordinary error was not enough to say so.
+    ///
+    /// The dropped future was inside `read_response_in`, which is not
+    /// cancellation-safe, and the reply to `MLSD` or `LIST` is still owed. Every
+    /// caller here goes on to use the same session: `MLSD` falls through to
+    /// `LIST` by design, and the `-a` path calls `restore_cwd` on that stream,
+    /// so the late listing reply would be read as the answer to the `CWD`.
+    ///
+    /// The reconnect that looks like it would cover this does not fire.
+    /// `is_stale_data_connection_error` matches on SUBSTRINGS of the message,
+    /// and none of its six covers a timeout phrased here, so widening that list
+    /// would silence the symptom and keep the mechanism that produced the hole.
+    /// The session is taken instead, which costs a re-dial on a path that has
+    /// already spent the whole budget.
+    fn listing_timed_out(&mut self, path: &str) -> ProviderError {
+        self.stream = None;
+        ProviderError::TransferFailed(format!(
+            "Listing {} produced nothing within {}s",
+            path,
+            LIST_BUDGET.as_secs()
+        ))
     }
 
     /// Bounds, and does nothing else. The failure is handed back RAW so each


### PR DESCRIPTION
**The wait was never in the loop.** Measured on `main`, three runs of three against the FTPS lab: a download of a file the server refuses hangs with the control socket holding an unread reply and the data socket showing `bytes_sent 388`, `bytes_received 0`. 388 out and none back is a TLS ClientHello nobody answered, so the wait is inside the data connection's handshake, which happens BEFORE the first read. `read_watching_control` guards the read loop, and the loop is never reached. #660 gave nine sites a guarded loop; this gives them a guarded opening, which is where the defect lives.

**Two unbounded awaits, and both are covered.** In the crate's `data_command`, active mode is bounded by `active_timeout`, but the passive connect (`passive_stream_builder`) and the TLS upgrade (`tls_ctx.connect`) are not. Only the second was measured. The first is the one that matters on a **plaintext** session, where there is no handshake to hang in, and no measurement in this campaign has ever exercised the plaintext path: it is not that there are no defects there, it is that nobody has looked. Bounding only the measured one would have closed the case we had seen and left the case we had not.

**`open_with_cap` bounds and does nothing else, and that is a correction.** The first version classified the failure too. Writing the SECOND caller showed why that was wrong: `STOR` maps with `map_store_error` and the others with `classify_data_failure`, so a helper that classified would have changed that site's behaviour silently. It is the second consumer that reveals an abstraction doing one thing too many; the first cannot, because whatever the helper does is what that caller wanted.

**What happens when the cap expires, and why the session usually survives.** The command is already on the wire and its reply unread: `pasv()` reads its own `227`, but `perform(cmd)` reads nothing. So `after_timed_out_open` looks before it concludes. The `Recv-Q` of 55 during the measured hang decomposes exactly as a TLS 1.2 AES-GCM record carrying `550 Failed to open file.\r\n`: 5 header + 8 nonce + 26 payload + 16 tag. Consistent, not proof, but it says the likely case is that the server refused long ago, which is precisely why it never serviced the data port. So the cap does not produce a quick failure; it produces the server's own reason, which was there to be read.

**Four conditions, and a named silence.** The session is kept only when the reply is parsed WHOLE, is FINAL, belongs HERE, and does not announce the channel closing. That last one is `421`, "service not available, closing control connection": a `4xx`, final, legitimately present, and kept by every earlier version of this condition, while the server was saying the channel was going away.

This arm has now been narrowed four times, and the sequence is the useful part. Keeping on any error was right about "something failed" and silent on whether a whole reply arrived. Keeping on the error VARIANT was right about that and silent on finality. Keeping on the STATUS CLASS was right about finality and silent on the connection surviving. **Each discriminant was correct for the property it was chosen for and mute on the next**, which is why it looked total every time: totality is answered with respect to one property at a time.

So the question that matters for the fifth round is not "does this cover every case" but **"which property is this discriminant silent about"**. This one is silent about WHOSE reply it is: FTP carries no request identifier, so a reply queued here could belong to an earlier command answered late, and consuming it as ours would leave our own still owed. Nothing in reach distinguishes them, so it is named in the code rather than claimed closed.

**And the session is discarded whenever it cannot be handed on**, which is what makes the cap safe:

- a complete reply was parsed: it was consumed whole, the control channel is aligned again, the session survives;
- the collection produced nothing readable: `read_response_in` is not cancellation-safe and may have been dropped mid-line, so the session goes;
- nothing was queued at all: the reply is still owed, and a session one answer behind hands the next question somebody else's answer. The session goes.

The second of those is a CATCH-ALL, not a third named case, and that is deliberate. `BadResponse`, a connection error, and any variant a later version of the crate might add do not share a meaning; they share the absence of one, since none of them establishes that the control channel is aligned. So the default discards, because the safe side is the one that does not assume. It is the same asymmetry as the write-side record types with the sign reversed: there the safe default was to keep writing, here it is to throw the session away, and in both the safe default is the branch that claims to know least.

**Listings get a TOTAL cap, not an inactivity one.** A transfer wants inactivity, because a large file legitimately takes hours and a total cap would kill it. A listing has an intrinsic size, so an inactivity bound would never fire against a server that dribbles a row at a time. The expiry is returned as an `FtpError` so the three listing sites treat it exactly as they already treat a refusal: `MLSD` marks itself broken and falls through to `LIST`, which has its own cap.

**The two numbers, with what they rest on.** `OPEN_BUDGET` is 30s, chosen to sit far from both measured edges: a healthy open against the lab completes in 0.116s and the hang was still unresolved at 120s, which was the probe's cap rather than a limit of the wait. `LIST_BUDGET` is 300s and is **reasoned, not measured**: it is a liveness limit, not a performance one, and it has NOT been checked against a pathological listing such as a hundred thousand entries over a slow link. Raising it is safe; lowering it is not. If a truncated listing is ever reported, this is the first place to look, not the network. It deliberately does not copy the twin's `list_timeout` of 30s in `src/ftp.rs`, which is the number we suspect may already be truncating legitimate listings there: copying it would have inherited the answer without asking the question.

**This bounds ONE opening, and a transfer makes as many as the caller asks for.** Measured against a permanent stall (23), counting openings while varying `--retries`: 0 gives 2, 1 gives 2, 2 gives 4, 3 gives 6, 5 gives 10. So the count is `2 x max(1, retries)`: two openings per attempt, times the attempts the caller chose. The 6 first observed was simply 2 x 3, the default, and quoting it as a constant would have made a caller's setting look like a property of the client.

The user-visible worst case is therefore `2 x retries x OPEN_BUDGET`: about 180s at the default, 600s with `--retries 10`. That multiplier is literally a knob the user turns, which settles where the number belongs: the cap is the only one of the two that does not depend on the caller, so lowering it to make the total tolerable would be answering a retry question with a transport constant, at the wrong layer. It is stated because whoever tunes `OPEN_BUDGET` is not setting one sixth of the worst case, they are setting a fraction that is not fixed, and a budget sized once against a user's patience does not stay sized. Either way it is bounded now, and it was not before: the same download did not finish at all.

**Divergence on the four sites #660 called almost-no-op.** `download_to_bytes`, `resume_download`, `read_range` and `download_single` gain the opening cap here. Anyone who read #660 has "those four are unchanged" in mind, and nobody re-reads a closed pull request, so it is stated rather than left to be deduced. The five that had nothing gain it too, and `ftp_download_one_range`, which had a cancel token and no deadline at all, gains its first bound.

**Out of scope, deliberately.** Driving the `LIST` loop ourselves and giving `STOR` its own surveillance are new behaviour with no inherited tests, and they answer a different question: this pull request asks "does the opening have a limit?", which is mechanical and uniform across nine sites, while that one asks "is the new behaviour right?". They are separated for the same reason #660 was separated from this.

**Gate.** `cargo fmt`; `clippy --all-features --tests` clean; 36 `providers::ftp` tests pass. The live proof needs the stalling fixture, which is #662 and not yet on `main`; the lane that runs it comes with the test, and no code here depends on it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added time limits for FTP file transfers and directory listings.
  * Improved handling of stalled or unresponsive FTP operations, including directory listing and resumed or ranged transfers.
  * FTP sessions are now safely closed when recovery is not possible, reducing hangs and inconsistent connection states.
  * Prevented delayed server responses from interfering with subsequent FTP commands.
  * Improved recovery from failed data-channel connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->