### PR TITLE
fix(transfer): cap what a segmented download holds, not just one request of it

### DIFF
--- a/src-tauri/src/provider_transfer_executor.rs
+++ b/src-tauri/src/provider_transfer_executor.rs
@@ -99,6 +99,55 @@ const SEGMENTED_DOWNLOAD_MIN_CHUNK_SIZE: u64 = 1024 * 1024;
 /// unbounded on very large files.
 const SEGMENTED_DOWNLOAD_SUB_READ_SIZE: u64 = 64 * 1024 * 1024;
 
+/// Ceiling on the bytes all window workers may hold at once.
+///
+/// `read_range` returns a `Vec`, so a sub-read is materialised whole before it
+/// is written. The per-request cap above bounds ONE of those and says so, and
+/// that was read as bounding the download. It does not: the workers run
+/// concurrently, `max_parallel` equals the segment count, and the peak is their
+/// product.
+///
+/// The arithmetic is worse below the cap than above it. A sub-read is
+/// `min(window, 64 MiB)` and a window is the file divided by the segments, so
+/// under a gigabyte the sub-read IS the window and every worker holds a
+/// sixteenth of the file. A 500 MB download peaks near 500 MB, a 200 MB one
+/// near 200 MB, and only past a gigabyte does the per-request cap begin to
+/// bite. The protection starts exactly where the ratio stops being surprising.
+///
+/// So the aggregate is capped too, and the per-request cap stays for what it
+/// was always for. What this buys is paid in round trips: on FTP each sub-read
+/// is a REST plus RETR on a new data connection, with a TLS handshake when the
+/// channel is protected, so a smaller sub-read means more of them. The number
+/// below is therefore a starting point that wants measuring on a real link, not
+/// a tuned value, and the direction of doubt is stated: too small costs speed
+/// on every large download, too large costs memory on every concurrent one.
+const SEGMENTED_DOWNLOAD_TOTAL_READ_BUDGET: u64 = 128 * 1024 * 1024;
+
+/// Bytes a single `read_range` may ask for, given how many windows are running.
+///
+/// Separated from the loop so the memory a download plans to use can be
+/// checked without running one: the peak is decided here, by arithmetic, and a
+/// test that asserts it does not scale with the file is a statement about the
+/// property rather than about one observed run.
+pub fn segmented_sub_read_size(segments: usize, window_len: u64) -> u64 {
+    let share = SEGMENTED_DOWNLOAD_TOTAL_READ_BUDGET / (segments.max(1) as u64);
+    window_len
+        .min(SEGMENTED_DOWNLOAD_SUB_READ_SIZE)
+        .min(share.max(SEGMENTED_DOWNLOAD_MIN_CHUNK_SIZE))
+}
+
+/// What a segmented download of `file_size` plans to hold in memory at once.
+///
+/// Zero when the file is not segmented at all.
+pub fn segmented_planned_peak_bytes(file_size: u64, requested: u32, max_workers: usize) -> u64 {
+    let segments = provider_segmented_effective_count(file_size, requested).min(max_workers.max(1));
+    if segments < 2 {
+        return 0;
+    }
+    let window = file_size / segments as u64;
+    segmented_sub_read_size(segments, window) * segments as u64
+}
+
 /// Effective segment count after the anti-fragmentation rule
 /// (`SEGMENTED_DOWNLOAD_MIN_CHUNK_SIZE`). Mirrors `pget_effective_segments`
 /// in `bin/aeroftp_cli.rs`. Returns 0 to signal "do not segment".
@@ -308,7 +357,8 @@ pub async fn run_provider_segmented_download(
                         "Transfer cancelled by user".to_string(),
                     ));
                 }
-                let sub_len = (window_len - written).min(SEGMENTED_DOWNLOAD_SUB_READ_SIZE);
+                let sub_len =
+                    (window_len - written).min(segmented_sub_read_size(segments, window_len));
                 let data = provider
                     .read_range(&remote, start_off + written, sub_len)
                     .await
@@ -1784,6 +1834,77 @@ async fn transfer_entry_upload_size(entry: &TransferEntry) -> u64 {
 
 #[cfg(test)]
 mod tests {
+    /// The memory a segmented download plans to hold does not grow with the
+    /// file.
+    ///
+    /// Two sizes, not one, and the assertion is that the peak does NOT scale.
+    /// A single figure, however small, is a statement about that one run; the
+    /// question the defect asks is whether the number follows the input.
+    ///
+    /// It followed it. `read_range` returns a `Vec`, so a sub-read is held
+    /// whole, the workers run concurrently with `max_parallel` equal to the
+    /// segment count, and the peak is their product. The per-request cap of
+    /// 64 MiB bounds one of them and reads as though it bounded the download.
+    ///
+    /// Below a gigabyte it never applied at all: the sub-read is
+    /// `min(window, 64 MiB)` and the window is the file over the segments, so
+    /// each worker held a sixteenth of the file and the peak was the whole
+    /// thing. A 200 MB download planned 200 MB, a 500 MB one planned 500 MB,
+    /// and nobody would look for a memory defect at those sizes.
+    #[test]
+    fn the_planned_peak_does_not_follow_the_file_size() {
+        const MB: u64 = 1024 * 1024;
+        let peak = |size: u64| segmented_planned_peak_bytes(size, 16, 16);
+
+        let small = peak(200 * MB);
+        let large = peak(25 * 1024 * MB);
+
+        assert!(
+            small > 0 && large > 0,
+            "both sizes must actually segment, or this compares nothing: {small} and {large}"
+        );
+        assert!(
+            large <= small.saturating_mul(2),
+            "the peak follows the input: {} MB of file plans {} MB, {} MB of file plans {} MB",
+            200,
+            small / MB,
+            25 * 1024,
+            large / MB
+        );
+        assert!(
+            large <= SEGMENTED_DOWNLOAD_TOTAL_READ_BUDGET,
+            "the aggregate exceeds its own budget: {} MB",
+            large / MB
+        );
+
+        // The size that used to be exactly the file: 500 MB over 16 windows is
+        // 31 MB each, under the per-request cap, so the cap never saw it.
+        let mid = peak(500 * MB);
+        assert!(
+            mid <= SEGMENTED_DOWNLOAD_TOTAL_READ_BUDGET,
+            "a 500 MB download plans {} MB, which is the whole file",
+            mid / MB
+        );
+    }
+
+    /// The floor still holds, so the budget cannot split a download into
+    /// pathologically small requests.
+    ///
+    /// The cost of the cap is paid in round trips, and on FTP each sub-read is
+    /// a REST plus RETR on a fresh data connection. Dividing the budget by the
+    /// segments must not drive the request below the size this file already
+    /// refuses to go under for exactly that reason.
+    #[test]
+    fn the_budget_never_asks_for_less_than_the_minimum_chunk() {
+        for segments in [2usize, 4, 8, 16, 64] {
+            let sub = segmented_sub_read_size(segments, 4 * 1024 * 1024 * 1024);
+            assert!(
+                sub >= SEGMENTED_DOWNLOAD_MIN_CHUNK_SIZE,
+                "{segments} segments planned a {sub}-byte request, under the floor"
+            );
+        }
+    }
+
     use super::*;
     use crate::transfer_dag::SessionLeaseKind;
 

--- a/src-tauri/src/provider_transfer_executor.rs
+++ b/src-tauri/src/provider_transfer_executor.rs
@@ -1954,13 +1954,36 @@ mod tests {
              arithmetic this note describes has changed"
         );
 
-        // The count the code actually reaches, and the distance to the edge.
-        let clamped = provider_segmented_effective_count(4 * 1024 * 1024 * 1024, 64);
+        // The count the code actually reaches, held a declared distance from
+        // that edge rather than merely inside it.
+        //
+        // This assertion is a tripwire, and it is deliberately strung at the
+        // current value, so it fires at the first movement. That means it
+        // fires LONG BEFORE anything breaks: the edge is 128 segments, and a
+        // clamp of 24 would still plan well inside the budget while failing
+        // here. So the message has to say that it is the declared margin that
+        // was crossed and not the budget, and print both numbers, or it sends
+        // whoever raised the clamp for a good reason looking for a fault that
+        // is not there.
+        //
+        // The margin is stated against the edge and not against the budget on
+        // purpose. Both are eight times the same arithmetic today, but raising
+        // the budget alone would widen the permitted clamp by itself, with
+        // nobody having decided to; written this way the widening at least
+        // reads as a change to how far from the edge we insist on staying.
+        const EDGE_SEGMENTS: u64 =
+            SEGMENTED_DOWNLOAD_TOTAL_READ_BUDGET / SEGMENTED_DOWNLOAD_MIN_CHUNK_SIZE;
+        const DECLARED_MARGIN: u64 = 8;
+        let clamped = provider_segmented_effective_count(4 * 1024 * 1024 * 1024, 64) as u64;
         assert!(
-            clamped as u64 * SEGMENTED_DOWNLOAD_MIN_CHUNK_SIZE
-                <= SEGMENTED_DOWNLOAD_TOTAL_READ_BUDGET / 8,
-            "the clamp no longer keeps the segment count clear of the edge: \
-             {clamped} segments"
+            clamped * DECLARED_MARGIN <= EDGE_SEGMENTS,
+            "the segment count is no longer {DECLARED_MARGIN} times clear of the edge: \
+             {clamped} segments against an edge of {EDGE_SEGMENTS}. This is the declared \
+             margin, NOT the budget: a peak of {} bytes is still inside the {} byte budget, \
+             and nothing is broken. Either restore the margin or decide, in writing, that \
+             a smaller one is the one being defended.",
+            clamped * SEGMENTED_DOWNLOAD_MIN_CHUNK_SIZE,
+            SEGMENTED_DOWNLOAD_TOTAL_READ_BUDGET
         );
     }
 

--- a/src-tauri/src/provider_transfer_executor.rs
+++ b/src-tauri/src/provider_transfer_executor.rs
@@ -121,6 +121,18 @@ const SEGMENTED_DOWNLOAD_SUB_READ_SIZE: u64 = 64 * 1024 * 1024;
 /// below is therefore a starting point that wants measuring on a real link, not
 /// a tuned value, and the direction of doubt is stated: too small costs speed
 /// on every large download, too large costs memory on every concurrent one.
+///
+/// One caveat belongs here rather than in whoever reads it later. This is a
+/// ceiling only while the floor below it does not win: `segmented_sub_read_size`
+/// raises the per-segment share back up to `SEGMENTED_DOWNLOAD_MIN_CHUNK_SIZE`
+/// when the division falls under it, so the aggregate stays inside the budget
+/// only while `segments * MIN_CHUNK_SIZE` still fits, that is up to 128
+/// segments. Past that the floor wins and the peak grows with the count again.
+/// The count is clamped to 16 in `provider_segmented_effective_count`, eight
+/// times clear of that edge, so today the ceiling is real. It stops being real
+/// if that clamp is raised or if `max_workers` is allowed to exceed it, and
+/// that constant lives in another function, which is why the dependency is
+/// written down here and asserted in `segmented_planned_peak_bytes`.
 const SEGMENTED_DOWNLOAD_TOTAL_READ_BUDGET: u64 = 128 * 1024 * 1024;
 
 /// Bytes a single `read_range` may ask for, given how many windows are running.
@@ -145,7 +157,18 @@ pub fn segmented_planned_peak_bytes(file_size: u64, requested: u32, max_workers:
         return 0;
     }
     let window = file_size / segments as u64;
-    segmented_sub_read_size(segments, window) * segments as u64
+    let peak = segmented_sub_read_size(segments, window) * segments as u64;
+    // The budget is a ceiling only while the minimum-chunk floor does not
+    // overrule it, which it starts doing past 128 segments. Fail loudly here if
+    // the clamp that keeps us clear of that edge ever moves, rather than
+    // letting the peak quietly grow with the segment count again.
+    debug_assert!(
+        peak <= SEGMENTED_DOWNLOAD_TOTAL_READ_BUDGET,
+        "the aggregate budget no longer holds: {segments} segments plan {peak} bytes, \
+         over the {SEGMENTED_DOWNLOAD_TOTAL_READ_BUDGET} budget, because the minimum chunk \
+         size now overrules the share"
+    );
+    peak
 }
 
 /// Effective segment count after the anti-fragmentation rule
@@ -1903,6 +1926,42 @@ mod tests {
                 "{segments} segments planned a {sub}-byte request, under the floor"
             );
         }
+    }
+
+    /// Where the budget stops being a ceiling, stated instead of discovered.
+    ///
+    /// The floor overrules the share, so the aggregate stays inside the budget
+    /// only while `segments * MIN_CHUNK_SIZE` still fits: at 128 segments the
+    /// product is exactly the budget, and past that the floor wins and the peak
+    /// grows with the count again. The segment count is clamped to 16 elsewhere,
+    /// so the margin today is eightfold. This test exists because that clamp is
+    /// in another function: it pins where the edge is, so raising the clamp past
+    /// it fails here rather than silently uncapping every large download.
+    #[test]
+    fn the_budget_holds_only_while_the_floor_does_not_overrule_it() {
+        let aggregate = |segments: usize| {
+            segmented_sub_read_size(segments, 4 * 1024 * 1024 * 1024) * segments as u64
+        };
+
+        assert_eq!(
+            aggregate(128),
+            SEGMENTED_DOWNLOAD_TOTAL_READ_BUDGET,
+            "128 segments is the last count the budget still bounds"
+        );
+        assert!(
+            aggregate(129) > SEGMENTED_DOWNLOAD_TOTAL_READ_BUDGET,
+            "past the edge the floor is supposed to win; if it does not, the \
+             arithmetic this note describes has changed"
+        );
+
+        // The count the code actually reaches, and the distance to the edge.
+        let clamped = provider_segmented_effective_count(4 * 1024 * 1024 * 1024, 64);
+        assert!(
+            clamped as u64 * SEGMENTED_DOWNLOAD_MIN_CHUNK_SIZE
+                <= SEGMENTED_DOWNLOAD_TOTAL_READ_BUDGET / 8,
+            "the clamp no longer keeps the segment count clear of the edge: \
+             {clamped} segments"
+        );
     }
 
     use super::*;


### PR DESCRIPTION
## The cap that never applied where it mattered

`read_range` returns a `Vec`, so each sub-read is materialised whole before it is written. The per-request cap of 64 MiB bounds one of those, and its comment says it stops a single range request growing unbounded on very large files. That is true, and it reads as though it bounded the download.

It does not. The window workers run concurrently, `max_parallel` equals the segment count, and the peak is their product.

The arithmetic is worse below the cap than above it, which is why nobody had met it. A sub-read is `min(window, 64 MiB)`, and a window is the file divided by the segments, so under a gigabyte the sub-read IS the window and every worker holds a sixteenth of the file:

```
    file   segments   window   sub-read   planned peak
  200 MB         16      12M        12M         200 MB
  500 MB         16      31M        31M         500 MB
    1 GB         16      64M        64M           1 GB
   25 GB         16    1600M        64M           1 GB
```

The planned peak is `min(file size, 1 GiB)`. A 200 MB download holds 200 MB of it in memory, and nobody goes looking for a memory defect at that size. The protection starts exactly where the ratio stops being surprising.

## What changes

The aggregate is capped as well as the request. The per-request cap stays for what it was always for.

It is paid for in round trips. On FTP each sub-read is a REST plus RETR on a fresh data connection, with a TLS handshake when the channel is protected, so a smaller sub-read means more of them. **The budget is a starting point, not a tuned value**, and the direction of doubt is written next to it: too small costs speed on every large download, too large costs memory on every concurrent one. It wants measuring on a real link before anyone treats the number as settled.

The existing minimum chunk size floors the division, so dividing a budget among many segments can never ask for a pathologically small request. That is asserted separately.

## The test

The peak is now decided by arithmetic in one place, so it can be checked without running a download.

It uses **two sizes** and asserts the peak does not follow the file. A single figure, however small, is a statement about one run; the question a memory defect asks is whether the number tracks the input.

It did. With the aggregate cap removed, the row reports 200 MB of file planning 200 MB and 25 GB planning 1 GB, which is the defect stated in its own numbers. That was confirmed before the fix was kept.

## What this does not resolve

There are two segmented download engines in this tree with opposite memory policies. `ftp_download_one_range` reads into a fixed buffer and writes with seek plus write_all, so its memory does not depend on the window; the generic path goes through `read_range` and materialises. Both serve FTP, and which one runs depends on the surface the download came from.

Removing that split means changing what `read_range` returns, which is a trait shape with eleven implementations. It is not attempted here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced peak memory usage during segmented downloads by applying an aggregate 128 MiB memory budget across concurrent download segments.
  * Improved download stability for large files while preserving a minimum read size for efficient transfers.
* **Tests**
  * Added coverage verifying memory usage remains bounded and behaves correctly across different file sizes and segment counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->