### PR TITLE
fix(providers): delete the loose disjunct sitting beside the exact one

### DIFF
--- a/src-tauri/src/providers/filelu.rs
+++ b/src-tauri/src/providers/filelu.rs
@@ -528,7 +528,6 @@ impl FileLuProvider {
             || lower.contains("http 503")
             || lower.contains("http 504")
             || lower.starts_with("api error 5")
-            || lower.contains(" 500")
             || lower.contains("internal server error")
             || lower.contains("bad gateway")
             || lower.contains("service unavailable")
@@ -2261,6 +2260,18 @@ mod tests {
         assert!(FileLuProvider::is_filelu_transient_5xx(
             &ProviderError::ServerError("API error 503".into())
         ));
+    }
+
+    #[test]
+    fn test_is_filelu_transient_5xx_rejects_numbers_that_only_start_with_500() {
+        for message in ["Upload contains 5000 chunks", "Remaining quota: 500 MB"] {
+            assert!(
+                !FileLuProvider::is_filelu_transient_5xx(&ProviderError::ServerError(
+                    message.into()
+                )),
+                "one quoted quantity is not one HTTP 500 response: {message}"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/providers/mega_df.rs
+++ b/src-tauri/src/providers/mega_df.rs
@@ -299,7 +299,7 @@ pub(crate) fn classify_mega_webdav_result(
         return Ok(());
     }
     let lower = combined.to_ascii_lowercase();
-    if lower.contains("already") || lower.contains("serving") || lower.contains("served") {
+    if lower.contains("already being served at") && parse_mega_webdav_url(combined).is_some() {
         return Ok(());
     }
     if lower.contains("not logged in")
@@ -602,6 +602,18 @@ Total size taken up by file versions:     31457280 bytes (30.0 MB)
             "/: already being served at http://127.0.0.1:4443/"
         )
         .is_ok());
+    }
+
+    #[test]
+    fn mega_webdav_failure_with_incidental_already_is_not_success() {
+        let result = classify_mega_webdav_result(
+            false,
+            "Failed to initialize WebDAV: port 4443 is already allocated",
+        );
+        assert!(
+            matches!(result, Err(ProviderError::ServerError(_))),
+            "one incidental word must not erase one failed command"
+        );
     }
 
     #[test]

--- a/src-tauri/src/providers/s3.rs
+++ b/src-tauri/src/providers/s3.rs
@@ -2591,6 +2591,13 @@ fn extract_s3_error(body: &str) -> String {
     }
 }
 
+/// Whether an S3 authentication failure is evidence that the signing clock is
+/// wrong. Kept pure so retry classification cannot be widened unnoticed.
+fn is_s3_clock_skew_error(error_msg: &str, body: &str) -> bool {
+    let lower = error_msg.to_lowercase();
+    lower.contains("expired") || body.contains("RequestTimeTooSkewed")
+}
+
 #[async_trait]
 impl StorageProvider for S3Provider {
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
@@ -2706,13 +2713,8 @@ impl StorageProvider for S3Provider {
                 let body = response.text().await.unwrap_or_default();
                 let error_msg = extract_s3_error(&body);
 
-                // Detect clock skew: error mentions "time" or "expired" and we haven't retried yet
-                let is_time_error = {
-                    let lower = error_msg.to_lowercase();
-                    lower.contains("time")
-                        || lower.contains("expired")
-                        || body.contains("RequestTimeTooSkewed")
-                };
+                // Detect the exact S3 clock-skew code or an expired signed request.
+                let is_time_error = is_s3_clock_skew_error(&error_msg, &body);
 
                 if is_time_error {
                     // Try server Date header first, then <ServerTime> from XML body
@@ -5802,6 +5804,19 @@ fn parse_object_versions_page(xml_str: &str) -> Result<VersionsPage, ProviderErr
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn clock_skew_classifier_rejects_an_ordinary_timeout() {
+        assert!(is_s3_clock_skew_error(
+            "The difference between the request time and the server time is too large",
+            "<Code>RequestTimeTooSkewed</Code>"
+        ));
+        assert!(is_s3_clock_skew_error("Request has expired", ""));
+        assert!(
+            !is_s3_clock_skew_error("Connection timeout while reading response", ""),
+            "one ordinary timeout has zero clock-skew signals and must not spend a re-sign retry"
+        );
+    }
 
     #[test]
     fn list_buckets_parser_ignores_owner_name_and_sorts_targets() {

--- a/src-tauri/src/server_health.rs
+++ b/src-tauri/src/server_health.rs
@@ -8,6 +8,7 @@
 // Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
 
 use serde::Serialize;
+use std::error::Error as StdError;
 use std::net::SocketAddr;
 use std::time::{Duration, Instant};
 use tokio::net::TcpStream;
@@ -267,6 +268,24 @@ async fn check_tcp(host: &str, port: u16) -> CheckDetail {
     }
 }
 
+fn is_connection_refused_error(is_connect: bool, error: &(dyn StdError + 'static)) -> bool {
+    if !is_connect {
+        return false;
+    }
+
+    let mut current = Some(error);
+    while let Some(source) = current {
+        if source
+            .downcast_ref::<std::io::Error>()
+            .is_some_and(|io_error| io_error.kind() == std::io::ErrorKind::ConnectionRefused)
+        {
+            return true;
+        }
+        current = source.source();
+    }
+    false
+}
+
 /// Perform TLS handshake timing via HTTPS HEAD request.
 /// Uses a shorter timeout (5s) since we only care about the TLS negotiation,
 /// not the full HTTP response.
@@ -303,7 +322,7 @@ async fn check_tls(host: &str, port: u16) -> CheckDetail {
         Err(e) => {
             let elapsed = start.elapsed();
             let msg = format!("{}", e);
-            if msg.contains("Connection refused") {
+            if is_connection_refused_error(e.is_connect(), &e) {
                 CheckDetail {
                     name: "tls_handshake".into(),
                     status: "skip".into(),
@@ -708,6 +727,21 @@ pub async fn server_health_check_batch(
 mod tests {
     use super::*;
 
+    #[derive(Debug)]
+    struct LocalizedConnectError(std::io::Error);
+
+    impl std::fmt::Display for LocalizedConnectError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "Verbindung abgelehnt")
+        }
+    }
+
+    impl StdError for LocalizedConnectError {
+        fn source(&self) -> Option<&(dyn StdError + 'static)> {
+            Some(&self.0)
+        }
+    }
+
     fn check(name: &str, status: &str, latency_ms: Option<f64>) -> CheckDetail {
         CheckDetail {
             name: name.into(),
@@ -774,6 +808,17 @@ mod tests {
         assert!(should_check_tls("s3", 443));
         // Known cloud protocols
         assert!(should_check_tls("googledrive", 443));
+    }
+
+    #[test]
+    fn tls_refusal_uses_typed_io_kind_not_localized_display_text() {
+        let error =
+            LocalizedConnectError(std::io::Error::from(std::io::ErrorKind::ConnectionRefused));
+        assert!(
+            is_connection_refused_error(true, &error),
+            "one typed ConnectionRefused source must skip TLS even when zero English words match"
+        );
+        assert!(!is_connection_refused_error(false, &error));
     }
 
     #[test]


### PR DESCRIPTION
Four guards decided control flow on a substring of an error message, and in two of them the exact, correct test was already present, one `||` away from a loose one. A guard is as wide as its widest disjunct, so the precise needle could never change an outcome the loose one had not already decided: it was decorative. That is why reading the list does not catch this. The eye lands on `RequestTimeTooSkewed` or `http 500`, recognises the right signal, and reads the rest as reinforcement, when the rest is the whole behaviour.

The repair is therefore subtraction rather than addition, which makes it unusual: the correct guard already existed and the work was deleting what sat beside it.

**`providers/s3.rs`** treated any error message containing the four letters `time` as evidence that the signing clock was wrong, so an ordinary connection timeout spent a re-sign retry against server time. The classification moves into a pure `is_s3_clock_skew_error`, which makes the branch reachable by a test without issuing a request, and keeps the exact `RequestTimeTooSkewed` code and the `expired` case.

**`providers/filelu.rs`** matched `" 500"`, which also matches `" 5000"` and `" 500 MB"` inside any message quoting a size or a count, next to the exact `http 500` it made redundant.

**`providers/mega_df.rs`** turned a FAILED command into `Ok(())` whenever its output contained `already`, `serving` or `served`. This was the only one of the four that lost errors rather than spending retries: a genuine failure reading `port 4443 is already allocated` was reported upstream as success. It now requires the complete phrase `already being served at` together with a parseable URL.

**`server_health.rs`** matched `Connection refused` in English, so the TLS-skip branch never fired where the operating system string is localised. It now walks the error source chain for a typed `io::ErrorKind::ConnectionRefused`, gated on `is_connect()`.

Each fix has a test that was **red first** against the original guard, stating the defect in its own terms rather than asserting the new behaviour: an ordinary timeout consuming the clock-skew path, `Upload contains 5000 chunks` classified as an HTTP 500, `port 4443 is already allocated` returning success, and a typed `ConnectionRefused` behind German display text failing the English string.

**A declared limit on the MEGAcmd tolerance, carried here deliberately.** Current upstream MEGAcmd, read at `6505327a5a7a0e94f26f611f83b024aeeb63582c`, emits `Serving via webdav <path>: <url>` on success, and no current non-zero wording for the idempotent case could be pinned. The `already being served at` phrase is retained as repository compatibility evidence, not as a claim about current upstream behaviour. So the failure mode has moved rather than gone: instead of an unrelated real failure swallowed as success, wording drift would now surface a repeated serve as a failure. That is the better direction of the two, and it is written down here because a tolerance that tolerates nothing is not visible from its own code.

Gate: `cargo fmt --all -- --check`, the full `npm run ci:pre-push` at exit 0, with 3660 Rust library tests, 509 CLI, 826 frontend, typecheck, i18n 46/46 with zero placeholders, and the RustSec audit.
