### PR TITLE
fix(errors): one vocabulary per question, not one per caller

### DIFF
--- a/src-tauri/src/ai_core/mcp_impl.rs
+++ b/src-tauri/src/ai_core/mcp_impl.rs
@@ -147,13 +147,40 @@ pub struct McpRemoteBackend {
 /// app refreshes the token in the vault the pooled provider keeps presenting
 /// the stale one. Dropping the pooled entry forces `create_provider_from_vault`
 /// to re-read the fresh token from disk.
+/// Is this failure the kind a fresh credential could fix?
+///
+/// It gates one hot-reload from the vault and a single retry, so the two
+/// directions cost differently and that decides how wide it should be. A miss
+/// means a user sees a failure that reloading would have repaired; a false
+/// positive costs one wasted round trip. Wider is the cheap side here, which is
+/// the opposite of most guards in this file.
+///
+/// UNDERSCORES ARE NORMALISED TO SPACES before matching, and that is the fix
+/// rather than a tidy-up. `yandex_disk.rs` emits `invalid_token`; this list
+/// carried `invalid token`, and one does not contain the other, so a revoked
+/// Yandex token reached the pool and never triggered the reload that exists for
+/// exactly that case. Adding the second spelling would have fixed one wording
+/// and left the next one to be discovered; normalising means neither spelling
+/// of any needle can be the one that was not thought of.
+///
+/// `revoked` belongs here even though a revoked token cannot be refreshed. The
+/// retry does not refresh anything: it re-reads the vault, which the desktop
+/// app may have repopulated by a full re-authentication. A revoked token is
+/// therefore precisely a case where the stored credential may already be good
+/// again. Note that `yandex_disk.rs` asks the OPPOSITE question of the same
+/// words, whether an auth failure is terminal for its own retry loop, so the
+/// two lists must not be merged however alike they look.
 fn looks_like_auth_failure(msg: &str) -> bool {
-    let m = msg.to_ascii_lowercase();
+    let m = msg.to_ascii_lowercase().replace('_', " ");
     m.contains("401")
         || m.contains("unauthorized")
         || m.contains("access token")
-        || m.contains("invalid_grant")
+        || m.contains("invalid grant")
         || m.contains("invalid token")
+        || m.contains("invalid oauth")
+        || m.contains("token is invalid")
+        || m.contains("token not valid")
+        || m.contains("revoked")
         || m.contains("token expired")
         || m.contains("expired token")
         || m.contains("authentication failed")
@@ -416,6 +443,15 @@ mod tests {
             "invalid_grant",
             "the access token expired",
             "Box API: invalid token",
+            // Every wording `yandex_disk.rs` produces for a dead token. None
+            // of these matched before: `invalid_token` is not `invalid token`
+            // once the underscore is in the way, and the two word orders below
+            // are not the phrase this list knew either.
+            "invalid_token",
+            "OAuth token is invalid",
+            "token not valid",
+            "The OAuth token has been revoked",
+            "invalid oauth token",
         ] {
             assert!(looks_like_auth_failure(s), "should be auth-class: {s}");
         }
@@ -426,6 +462,10 @@ mod tests {
             "404 Not Found",
             "directory not found",
             "connection refused",
+            // Widening for the underscore must not reach past auth: a expired
+            // certificate is not a credential the vault can replace.
+            "certificate expired",
+            "the cached listing is invalid",
         ] {
             assert!(!looks_like_auth_failure(s), "should NOT be auth-class: {s}");
         }

--- a/src-tauri/src/ai_core/remote_tools.rs
+++ b/src-tauri/src/ai_core/remote_tools.rs
@@ -86,23 +86,6 @@ fn backend_error(e: String) -> ToolError {
     }
 }
 
-/// True when a `RemoteBackend` error means "the path is not there", as opposed
-/// to "the lookup did not complete" (auth, connection, provider 5xx, unsupported
-/// operation). `RemoteBackend` errors are opaque `String`s, so this is a string
-/// probe; it mirrors `is_not_found_error` on the `ProviderError` side of the CLI.
-///
-/// Callers that use a failed `stat` as permission to write MUST go through this:
-/// treating every error as "absent" is fail-open, and on a transient error it
-/// hands out a write on a path that may hold user data.
-fn stat_error_is_not_found(e: &str) -> bool {
-    let msg = e.to_ascii_lowercase();
-    msg.contains("not found")
-        || msg.contains("no such")
-        || msg.contains("does not exist")
-        || msg.contains("doesn't exist")
-        || msg.contains("404")
-}
-
 /// Hard cap per pagina per `aeroftp_list_files` / `aeroftp_search_files`.
 /// Se l'agente passa un `limit` superiore, viene clampato a questo valore.
 const MAX_LIST_PAGE: usize = 5_000;
@@ -809,7 +792,7 @@ async fn preview_delete(
     let (is_dir, root_size): (bool, u64) = match backend.stat(path).await {
         Ok(r) => (r.is_dir, r.size),
         Err(e) => {
-            if recursive && stat_error_is_not_found(&e) {
+            if recursive && crate::providers::types::message_names_a_missing_path(&e) {
                 // Assume pseudo-directory for recursive preview; contents will
                 // be discovered by list below.
                 (true, 0)
@@ -2506,7 +2489,10 @@ async fn speed(ctx: &dyn ToolCtx, args: &Value) -> Result<Value, ToolError> {
                 ),
             });
         }
-        Err(e) if path_is_caller_named && !stat_error_is_not_found(&e) => {
+        Err(e)
+            if path_is_caller_named
+                && !crate::providers::types::message_names_a_missing_path(&e) =>
+        {
             return Err(ToolError::InvalidArgs {
                 tool: "aeroftp_speed".to_string(),
                 reason: format!(

--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -32438,16 +32438,21 @@ enum DryRunOutcome {
 /// Some providers (FTP, WebDAV) answer a missing path with `ServerError`
 /// instead of `NotFound`, so the message has to be sniffed too. Shared by the
 /// real delete and by `--dry-run`, which must agree on what "absent" means.
+/// The typed variant first, and the shared vocabulary for everything else.
+///
+/// The list that used to be inline here matched a bare `404`, three digits
+/// anywhere in the message. `message_names_a_missing_path` carries the record
+/// of why that is wrong and the note that the needle came FROM this file; the
+/// tightening was made there and never came back. Asking that function is what
+/// stops the two from drifting apart again.
+///
+/// The variant gate stays: only a `ServerError` or an `Other` has a message
+/// worth reading, and letting every variant's text be searched would find
+/// "not found" inside errors that are about something else entirely.
 fn is_not_found_error(e: &ProviderError) -> bool {
     matches!(e, ProviderError::NotFound(_))
-        || (matches!(e, ProviderError::ServerError(_) | ProviderError::Other(_)) && {
-            let msg = e.to_string().to_ascii_lowercase();
-            msg.contains("not found")
-                || msg.contains("no such file")
-                || msg.contains("doesn't exist")
-                || msg.contains("does not exist")
-                || msg.contains("404")
-        })
+        || (matches!(e, ProviderError::ServerError(_) | ProviderError::Other(_))
+            && ftp_client_gui_lib::providers::types::message_names_a_missing_path(&e.to_string()))
 }
 
 /// The delete scope of `rm`/`purge`, assembled from the GLOBAL filter flags:

--- a/src-tauri/src/ftp_transfer_executor.rs
+++ b/src-tauri/src/ftp_transfer_executor.rs
@@ -279,7 +279,8 @@ impl TransferExecutor for FtpDownloadExecutor {
                 Err(error) => {
                     last_error = error;
 
-                    if self.cancel_token.is_cancelled() || last_error.contains("cancelled by user")
+                    if self.cancel_token.is_cancelled()
+                        || crate::transfer_dag::error::message_names_a_cancellation(&last_error)
                     {
                         break;
                     }
@@ -301,7 +302,9 @@ impl TransferExecutor for FtpDownloadExecutor {
             }
         }
 
-        let failure = if self.cancel_token.is_cancelled() || last_error.contains("cancelled") {
+        let failure = if self.cancel_token.is_cancelled()
+            || crate::transfer_dag::error::message_names_a_cancellation(&last_error)
+        {
             TransferFailure::new(
                 TransferFailureKind::Cancelled,
                 "Transfer cancelled by user",
@@ -535,7 +538,8 @@ impl TransferExecutor for FtpUploadExecutor {
                 Err(error) => {
                     last_error = error;
 
-                    if self.cancel_token.is_cancelled() || last_error.contains("cancelled by user")
+                    if self.cancel_token.is_cancelled()
+                        || crate::transfer_dag::error::message_names_a_cancellation(&last_error)
                     {
                         break;
                     }
@@ -557,7 +561,9 @@ impl TransferExecutor for FtpUploadExecutor {
             }
         }
 
-        let failure = if self.cancel_token.is_cancelled() || last_error.contains("cancelled") {
+        let failure = if self.cancel_token.is_cancelled()
+            || crate::transfer_dag::error::message_names_a_cancellation(&last_error)
+        {
             TransferFailure::new(
                 TransferFailureKind::Cancelled,
                 "Transfer cancelled by user",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11594,14 +11594,6 @@ fn sync_ec_message(status: SyncEcStatus, message: impl Into<String>) -> SyncEcCo
     }
 }
 
-fn remote_missing_error_text(error: &str) -> bool {
-    let lower = error.to_ascii_lowercase();
-    lower.contains("not found")
-        || lower.contains("no such file")
-        || lower.contains("does not exist")
-        || lower.contains("550")
-}
-
 async fn sync_ec_use_provider(
     provider_state: &provider_commands::ProviderState,
     is_provider: Option<bool>,
@@ -11656,14 +11648,18 @@ async fn sync_ec_download_remote_bytes(
                 .map(Some)
                 .map_err(|e| format!("read AeroSync EC temp download: {e}")),
             Err(crate::providers::ProviderError::NotFound(_)) => Ok(None),
-            Err(e) if remote_missing_error_text(&e.to_string()) => Ok(None),
+            Err(e) if crate::providers::types::message_names_a_missing_path(&e.to_string()) => {
+                Ok(None)
+            }
             Err(e) => Err(e.to_string()),
         }
     } else {
         let mut ftp_manager = state.ftp_manager.lock().await;
         match ftp_manager.download_to_bytes(remote_path).await {
             Ok(bytes) => Ok(Some(bytes)),
-            Err(e) if remote_missing_error_text(&e.to_string()) => Ok(None),
+            Err(e) if crate::providers::types::message_names_a_missing_path(&e.to_string()) => {
+                Ok(None)
+            }
             Err(e) => Err(e.to_string()),
         }
     }

--- a/src-tauri/src/provider_commands.rs
+++ b/src-tauri/src/provider_commands.rs
@@ -3467,7 +3467,7 @@ pub async fn provider_download_file(
 
     // Partial local target is not a valid whole file after cancel (MTP has no resume).
     if let Err(ref err) = result {
-        if err.to_string().contains("cancelled by user") {
+        if crate::transfer_dag::error::message_names_a_cancellation(&err.to_string()) {
             let _ = tokio::fs::remove_file(&local_path).await;
         }
     }
@@ -3504,7 +3504,7 @@ pub async fn provider_download_file(
             info!("Download completed: {}", filename);
             Ok(format!("Downloaded: {}", filename))
         }
-        Err(e) if e.to_string().contains("cancelled by user") => {
+        Err(e) if crate::transfer_dag::error::message_names_a_cancellation(&e.to_string()) => {
             // Cancel path already emitted a transfer_event above.
             Err(format!("Download cancelled by user: {}", filename))
         }
@@ -4997,7 +4997,7 @@ pub async fn provider_upload_file(
     // MTP honesty: cancelled whole-file upload may leave a partial object.
     // Delete it when the backend allows; never claim resume.
     if let Err(ref err) = result {
-        if err.contains("cancelled by user")
+        if crate::transfer_dag::error::message_names_a_cancellation(err)
             && provider.provider_type() == crate::providers::types::ProviderType::Mtp
         {
             if let Err(del_err) = provider.delete(&remote_path).await {
@@ -5035,7 +5035,7 @@ pub async fn provider_upload_file(
             info!("Upload completed: {}", filename);
             Ok(format!("Uploaded: {}", filename))
         }
-        Err(e) if e.contains("cancelled by user") => {
+        Err(e) if crate::transfer_dag::error::message_names_a_cancellation(e) => {
             // Cancel path already emitted a transfer_event above.
             Err(e.clone())
         }

--- a/src-tauri/src/provider_transfer_executor.rs
+++ b/src-tauri/src/provider_transfer_executor.rs
@@ -1133,7 +1133,9 @@ impl ProviderDownloadExecutor {
     fn failed_download(&self, entry: TransferEntry, last_error: String) -> TransferOutcome {
         // Classify from the raw provider string once; domain carrier keeps
         // typed congestion / Retry-After while the public event stays redacted.
-        let failure = if self.cancel_token.is_cancelled() || last_error.contains("cancelled") {
+        let failure = if self.cancel_token.is_cancelled()
+            || crate::transfer_dag::error::message_names_a_cancellation(&last_error)
+        {
             TransferFailure::new(
                 crate::transfer_domain::TransferFailureKind::Cancelled,
                 "Transfer cancelled by user",
@@ -1442,7 +1444,9 @@ impl ProviderUploadExecutor {
     }
 
     fn failed_upload(&self, entry: TransferEntry, last_error: String) -> TransferOutcome {
-        let failure = if self.cancel_token.is_cancelled() || last_error.contains("cancelled") {
+        let failure = if self.cancel_token.is_cancelled()
+            || crate::transfer_dag::error::message_names_a_cancellation(&last_error)
+        {
             TransferFailure::new(
                 crate::transfer_domain::TransferFailureKind::Cancelled,
                 "Transfer cancelled by user",

--- a/src-tauri/src/providers/types.rs
+++ b/src-tauri/src/providers/types.rs
@@ -1675,14 +1675,48 @@ impl RemoteEntry {
 /// question answered in two places is the defect being removed, a second
 /// vocabulary is the same defect in miniature, so there is one list and both
 /// ask it.
+///
+/// THAT SENTENCE WAS TRUE OF TWO READERS AND THERE WERE FIVE. Three more asked
+/// the same question with three more lists: the CLI's `--force` delete path,
+/// the AI remote tools' stat probe, and the library's existence probe. None was
+/// a superset of another, and the divergences were not academic. `cannot find`
+/// lived only here, and it is the wording Windows itself uses ("The system
+/// cannot find the file specified"), so on Windows three of the five did not
+/// recognise the operating system's own message. `doesn't exist` lived only in
+/// the other two. And the library's list carried a bare `550`, which is the
+/// same defect this function's own comment below describes for `404`, one
+/// protocol over: FTP spends 550 on "file unavailable", which covers a missing
+/// file AND a refused one, so a permission denial was read as an absence.
+///
+/// The repair recorded below never travelled to the list it came FROM. The
+/// comment says the `404` needle came from the CLI; the CLI kept the untightened
+/// version. A fix that stays where it was made is how one vocabulary becomes
+/// five, so the three lists are gone and their callers ask this.
+///
+/// THE CONTRACT ONE OF THE ABSORBED LISTS CARRIED, kept because it belongs to
+/// whichever function answers this question. This says "the path is not there",
+/// NOT "the lookup did not complete": auth, connection, a provider 5xx and an
+/// unsupported operation are all failures to find out, and none of them is an
+/// absence. Callers that treat a failed lookup as permission to WRITE must go
+/// through here, because reading every error as "absent" is fail-open, and on a
+/// transient error it hands out a write on a path that may hold user data.
 pub fn message_names_a_missing_path(message: &str) -> bool {
     let lowered = message.to_ascii_lowercase();
     if [
-        "no such file",
-        "no such directory",
+        // "no such" rather than the two longer forms it replaces: it also
+        // covers "no such object", "no such bucket" and "no such key", which
+        // are how object stores phrase the same fact.
+        "no such",
         "not found",
         "does not exist",
+        // The contracted form, which two of the absorbed lists had and this
+        // one did not. A vocabulary that knows one spelling of a phrase and
+        // not the other is the divergence in miniature.
+        "doesn't exist",
         "file not exists",
+        // Windows' own wording, and the reason this list has to be the only
+        // one: it lived here alone while three other readers answered the same
+        // question, so a missing file on Windows was invisible to them.
         "cannot find",
     ]
     .iter()
@@ -1766,6 +1800,68 @@ mod missing_path_vocabulary_tests {
         ] {
             assert!(message_names_a_missing_path(message), "{message:?}");
         }
+    }
+
+    /// The wordings the four absorbed lists disagreed about.
+    ///
+    /// Each row was recognised by SOME reader of this question and not by
+    /// others, which is what made the answer depend on which caller asked. The
+    /// Windows row is the one that mattered in practice: `cannot find` lived in
+    /// this list alone while three other readers answered the same question, so
+    /// the operating system's own phrase for a missing file was invisible to
+    /// them.
+    #[test]
+    fn every_wording_the_separate_lists_disagreed_about() {
+        for message in [
+            // Windows, verbatim. Known only here before the merge.
+            "The system cannot find the file specified. (os error 2)",
+            "The system cannot find the path specified.",
+            // The contracted spelling. Known to the CLI delete path and the
+            // stat probe, not to this list nor to the existence probe.
+            "The remote object doesn't exist",
+            // Object stores, which say "no such X" for three different X.
+            "NoSuchKey: The specified key does not exist",
+            "no such bucket",
+            "no such object",
+        ] {
+            assert!(
+                message_names_a_missing_path(message),
+                "{message:?} is a missing path to at least one of the lists this replaced"
+            );
+        }
+    }
+
+    /// A bare `550` is not an absence, and one of the absorbed lists said it was.
+    ///
+    /// FTP spends 550 on "requested action not taken: file unavailable", which
+    /// covers a file that is not there AND a file the server refuses to give,
+    /// so the code alone cannot tell absence from refusal. The library's
+    /// existence probe matched it and turned a permission denial into "the file
+    /// is not there", which is the same defect as the digits-in-a-path case
+    /// above, one protocol over.
+    ///
+    /// Nothing is lost by dropping it. `sync.rs` pins that on FTP every 550
+    /// reaching classification is permission denied whatever the text says, and
+    /// a genuinely missing path arrives here as `ProviderError::NotFound`,
+    /// whose Display is "Path not found", matched by the words.
+    #[test]
+    fn a_bare_550_is_not_an_absence() {
+        for message in [
+            "550 Permission denied",
+            "550 Failed to change directory.",
+            "Server error: 550",
+        ] {
+            assert!(
+                !message_names_a_missing_path(message),
+                "{message:?} was read as a missing path from the status code alone"
+            );
+        }
+
+        // The refusal that also SAYS it is missing still matches, on the words.
+        assert!(message_names_a_missing_path(
+            "550 No such file or directory"
+        ));
+        assert!(message_names_a_missing_path("Path not found: /nope"));
     }
 }
 

--- a/src-tauri/src/transfer_dag/error.rs
+++ b/src-tauri/src/transfer_dag/error.rs
@@ -268,17 +268,45 @@ fn default_idempotent_for(kind: TransferErrorKind) -> bool {
     )
 }
 
+/// Does this message say the operation was cancelled?
+///
+/// Five readers asked this with THREE different needles, and the answer to the
+/// same message depended on which layer was asking. `transfer_multipart` used
+/// bare `cancel`; the FTP and provider executors used `cancelled`, except for
+/// one site four lines from its twin that used `cancelled by user`; this file
+/// and `provider_commands` used `cancelled by user`. A provider error phrased
+/// "request cancelled" was therefore a cancellation to two layers and an
+/// ordinary failure to the other two, and cleanup and event emission followed
+/// different answers to one question.
+///
+/// `cancelled` is the level both extremes were wrong about, and consolidating
+/// moves two sites in each direction rather than widening everything to the
+/// loosest. Bare `cancel` also matched "failed to cancel" and "cancellation
+/// refused", which are the opposite of a cancellation; `cancelled by user`
+/// missed every cancellation the user did not personally cause, which includes
+/// a parent task cancelling its children.
+///
+/// The American spelling is here because none of the five had it, and nothing
+/// guarantees that every library and provider in the dependency tree spells it
+/// the way this codebase does.
+pub fn message_names_a_cancellation(message: &str) -> bool {
+    let lowered = message.to_ascii_lowercase();
+    lowered.contains("cancelled") || lowered.contains("canceled")
+}
+
 /// Classify a free-form error string once at the adapter boundary.
 ///
 /// This is the only place that may inspect message text for transfer-DAG
 /// scheduling decisions. The controller must use [`TransferErrorKind`].
+///
+/// The claim above is about SCHEDULING and it holds; it was never a claim that
+/// no other file reads message text, and four of them read it for cancellation
+/// alone. They now ask [`message_names_a_cancellation`], which lives here so
+/// that the sentence is true of the vocabulary as well as of the scheduling.
 fn classify_raw_message(raw: &str) -> TransferErrorKind {
     let lower = raw.to_lowercase();
 
-    if lower.contains("cancelled by user")
-        || lower.contains("transfer cancelled")
-        || lower == "transfer cancelled"
-    {
+    if message_names_a_cancellation(&lower) {
         return TransferErrorKind::Cancelled;
     }
     if lower.contains("503") || lower.contains("service unavailable") {

--- a/src-tauri/src/transfer_dag_single_file.rs
+++ b/src-tauri/src/transfer_dag_single_file.rs
@@ -2375,8 +2375,9 @@ mod tests {
         assert!(res.is_err(), "a cancelled transfer must return an error");
         let msg = res.unwrap_err().to_string().to_lowercase();
         assert!(
-            msg.contains("cancel"),
-            "error should mention cancellation, got: {msg}"
+            crate::transfer_dag::error::message_names_a_cancellation(&msg),
+            "the error must be one PRODUCTION would classify as cancelled, not \
+             merely one containing the letters: got {msg}"
         );
         assert!(
             !*completed.lock().unwrap(),
@@ -2490,8 +2491,9 @@ mod tests {
         assert!(res.is_err(), "a cancelled multipart upload must fail");
         let msg = res.unwrap_err().to_string().to_lowercase();
         assert!(
-            msg.contains("cancel"),
-            "error should mention cancellation, got: {msg}"
+            crate::transfer_dag::error::message_names_a_cancellation(&msg),
+            "the error must be one PRODUCTION would classify as cancelled, not \
+             merely one containing the letters: got {msg}"
         );
         assert!(
             part_started.load(Ordering::SeqCst) >= 1,

--- a/src-tauri/src/transfer_multipart.rs
+++ b/src-tauri/src/transfer_multipart.rs
@@ -640,7 +640,7 @@ pub fn clone_multipart_worker(provider: &dyn StorageProvider) -> Option<Box<dyn 
 /// Classification happens once at this adapter boundary (via the shared
 /// [`TransferError`] taxonomy). Controllers later read only machine fields.
 pub fn transfer_failure_from_message(message: &str, _path_hint: Option<&str>) -> TransferFailure {
-    if message.to_lowercase().contains("cancel") {
+    if crate::transfer_dag::error::message_names_a_cancellation(message) {
         return cancelled_failure();
     }
     // Lift typed congestion / Retry-After from the raw message before the


### PR DESCRIPTION
Three questions were each answered in several places with vocabularies that had drifted apart, so the answer depended on which caller asked. Each is consolidated onto one predicate, and each consolidation moves at least one site in both directions rather than widening everything to the loosest reading.

## One vocabulary for "is this path missing", not five

The doc on `message_names_a_missing_path` recorded that two readers had once had different lists and that there was now one both would ask. That was true of two readers and there were five: the CLI's `--force` delete path, the AI remote tools' stat probe and the library's existence probe each kept their own, and none was a superset of another.

The divergences were not academic. `cannot find` lived only in the shared list, and it is the wording **Windows itself uses**, so on Windows three of the five did not recognise the operating system's own phrase for a missing file. `doesn't exist` lived only in the other two. And the library's list carried a bare `550`, which is the same defect the shared list had already documented for `404`, one protocol over: FTP spends 550 on "file unavailable", covering a file that is absent AND one the server refuses, so a permission denial was read as an absence.

**The repair never travelled back to the list it came from.** The comment explaining why a bare `404` is wrong says the needle came from the CLI, and the CLI kept the untightened version. A fix that stays where it was made is how one vocabulary becomes five.

The two `&str` lists are deleted and their callers ask the shared function; the CLI's keeps its typed pre-check and delegates the text. The safety contract one of the deleted functions carried, that a failed lookup used as permission to write must not treat every error as absence, moves onto the function that now answers the question.

## One predicate for "does this message say cancelled"

Five readers, three needles: bare `cancel` in `transfer_multipart`, `cancelled` in the executors except for one site four lines from its twin, and `cancelled by user` in the DAG classifier and `provider_commands`. A provider error phrased "request cancelled" was a cancellation to two layers and an ordinary failure to the other two, and cleanup and event emission followed different answers.

`cancelled` is the level both extremes were wrong about. Bare `cancel` also matched "failed to cancel" and "cancellation refused", which are the opposite of a cancellation; `cancelled by user` missed every cancellation the user did not personally cause, including a parent task cancelling its children. The American spelling is added because none of the five had it.

Two test assertions that used `contains("cancel")` now call the same predicate: they were asserting **less** than production requires, so "cancel requested" would have satisfied the test while production would not have classified it.

## Underscores normalised before deciding a failure is an auth failure

`looks_like_auth_failure` gates one hot-reload of credentials from the vault and a single retry. It matched `invalid token`; `yandex_disk.rs` emits `invalid_token`, and neither string contains the other, so a revoked Yandex token never triggered the reload that exists for that case.

Adding the second spelling would have repaired one wording and left the next to be discovered, so underscores are normalised to spaces before matching. `revoked`, `invalid oauth`, `token is invalid` and `token not valid` join the list. `revoked` belongs even though a revoked token cannot be refreshed, because the retry re-reads the **vault**, which the desktop app may have repopulated by a full re-authentication.

The two lists are deliberately not merged: `is_yandex_terminal_auth_message` asks the opposite question of the same words, whether an auth failure is terminal for its own retry loop, so a shared list would have made one of them answer backwards.

## Gate

`cargo fmt --all`, `cargo clippy --lib --all-features --tests` with zero warnings, and the library suite at `3651 passed; 0 failed; 20 ignored`.

The suite has an intermittent test unrelated to this branch: three complete runs today across two branches gave 3649/2, 3650/1 and 3651/0 against the same total of 3651. It is being identified separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of authentication failures, including revoked and invalid OAuth tokens.
  * More reliably identifies missing files and folders across different server and operating-system error messages.
  * Improved transfer cancellation detection, including both American and British spellings.
  * Prevents ambiguous server errors from being incorrectly treated as missing paths.
* **Tests**
  * Expanded coverage for authentication, missing-path, and cancellation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->