### PR TITLE
fix(sync): a connection the server closed is not a disk failure

### DIFF
--- a/src-tauri/src/providers/types.rs
+++ b/src-tauri/src/providers/types.rs
@@ -1892,37 +1892,52 @@ impl ProviderError {
     }
 }
 
-/// Heuristic check for transport-level errors that indicate the session
-/// was closed by the peer (server idle timeout, NAT eviction, network
-/// blip), as opposed to a logical "path not found" or permission error.
+/// Message fragments that mean the peer tore the session down: a server idle
+/// timeout, a NAT eviction, a network blip, as opposed to a logical "path not
+/// found" or a permission error.
 ///
-/// Used to upgrade misclassified errors (e.g. russh returning a generic
-/// error string when the SFTP channel is dead) into [`ProviderError::ConnectionLost`]
+/// This is a `const` and not a literal inside the function below so that other
+/// layers can be checked against the real list instead of against a copy. A
+/// copy is how this tree came to hold four different opinions about what a dead
+/// connection looks like, and the copies did not agree: the sync taxonomy filed
+/// "broken pipe" as a disk error and refused to retry it.
+pub const SESSION_CLOSED_NEEDLES: &[&str] = &[
+    "session closed",
+    "channel closed",
+    "channel is closed",
+    "stream closed",
+    "broken pipe",
+    "connection reset",
+    "connection aborted",
+    "connection closed",
+    "unexpected eof",
+    "early eof",
+    // What `std` itself prints for these kinds, which is not what the OS
+    // prints and not what anyone writing this list by hand guessed:
+    // ErrorKind::UnexpectedEof renders "unexpected end of file", and
+    // ErrorKind::NotConnected renders "not connected", which also subsumes the
+    // OS wording "transport endpoint is not connected". Verified by printing
+    // them, and pinned by a test that iterates the kinds rather than a copy of
+    // these strings.
+    "unexpected end of file",
+    "not connected",
+    "epipe",
+    "econnreset",
+    "econnaborted",
+    "the remote host closed the connection",
+    "operation timed out",
+    "ssh disconnect",
+    "remote disconnected",
+];
+
+/// True when the message says the session was closed by the peer.
+///
+/// Used to upgrade misclassified errors (e.g. russh returning a generic error
+/// string when the SFTP channel is dead) into [`ProviderError::ConnectionLost`]
 /// so the command layer can attempt a silent reconnect.
 pub fn is_session_closed_error_message(msg: &str) -> bool {
     let m = msg.to_lowercase();
-    [
-        "session closed",
-        "channel closed",
-        "channel is closed",
-        "stream closed",
-        "broken pipe",
-        "connection reset",
-        "connection aborted",
-        "connection closed",
-        "unexpected eof",
-        "early eof",
-        "transport endpoint is not connected",
-        "epipe",
-        "econnreset",
-        "econnaborted",
-        "the remote host closed the connection",
-        "operation timed out",
-        "ssh disconnect",
-        "remote disconnected",
-    ]
-    .iter()
-    .any(|p| m.contains(p))
+    SESSION_CLOSED_NEEDLES.iter().any(|p| m.contains(p))
 }
 
 /// Storage quota information
@@ -2096,6 +2111,43 @@ impl TransferProgressInfo {
 
 #[cfg(test)]
 mod tests {
+    /// The needles must match the strings `std` actually prints for a socket
+    /// that has died, not the ones they sound like.
+    ///
+    /// The corpus is the `ErrorKind` set itself and the text comes from
+    /// `Error::from(kind).to_string()`, so `std` is the authority on its own
+    /// wording rather than a list someone typed. That mattered: the list held
+    /// "unexpected eof" while `std` prints "unexpected end of file", and it
+    /// held the OS wording "transport endpoint is not connected" while `std`
+    /// prints "not connected". Both gaps were invisible to a reader and to
+    /// every test written from the same guesses.
+    #[test]
+    fn the_needles_match_what_std_prints_for_a_dead_socket() {
+        use std::io::{Error, ErrorKind};
+
+        let kinds = [
+            ErrorKind::BrokenPipe,
+            ErrorKind::ConnectionReset,
+            ErrorKind::ConnectionAborted,
+            ErrorKind::NotConnected,
+            ErrorKind::UnexpectedEof,
+        ];
+        let mut missed = Vec::new();
+        for kind in kinds {
+            let text = Error::from(kind).to_string();
+            if !is_session_closed_error_message(&text) {
+                missed.push(format!("{kind:?} prints {text:?}"));
+            }
+        }
+        assert!(
+            missed.is_empty(),
+            "{} of {} socket error kinds print something no needle matches, so \
+             the layer above cannot tell the connection is gone: {missed:?}",
+            missed.len(),
+            kinds.len()
+        );
+    }
+
     use super::*;
     use std::collections::HashMap;
 

--- a/src-tauri/src/sync.rs
+++ b/src-tauri/src/sync.rs
@@ -3356,11 +3356,35 @@ pub fn classify_sync_error(raw: &str, file_path: Option<&str>) -> SyncErrorInfo 
         (SyncErrorKind::Auth, false)
     } else if lower.contains("locked") || lower.contains("in use") {
         (SyncErrorKind::FileLocked, true)
-    } else if lower.contains("disk full")
-        || lower.contains("no space")
-        || lower.contains("i/o error")
-        || lower.contains("broken pipe")
-    {
+    } else if crate::providers::types::is_session_closed_error_message(&lower) {
+        // The peer tore the session down mid-flight. That question already has
+        // an answer in this tree: `is_session_closed_error_message` is the list
+        // the reconnect path consults, so it is asked here rather than answered
+        // a second time with a different list.
+        //
+        // This branch sits above the disk one on purpose. "broken pipe" used to
+        // fall into it, filed under "Disk full or I/O error" together with the
+        // genuinely local ones, and a broken pipe is not a disk: it is a write
+        // to a socket whose peer has gone. Filed as a disk error it came out
+        // non-retryable, so the single most ordinary way a server drops a
+        // transfer, an idle timeout or a NAT eviction, was the one failure the
+        // executors refused to retry even once.
+        (SyncErrorKind::Network, true)
+    } else if lower.contains("disk full") || lower.contains("no space") {
+        // Only symptoms of an actual disk belong here. "i/o error" used to be
+        // in this list and is not one: it is the label a wrapper prints in
+        // front of the real error. quick-xml renders "I/O error: {e}" and is
+        // the parser behind WebDAV, S3, Azure and Swift, and zip renders
+        // "i/o error: {e}". So a connection dying mid-response arrived here as
+        // "I/O error: Connection reset by peer" and was declared a permanent
+        // disk failure on four providers at once.
+        //
+        // Dropping the wrapper label does not lose the disk cases: they say so
+        // themselves through the needles that remain, wrapped or not. What it
+        // gives up is a guess about errors that name no cause, and those now
+        // land in Unknown, which is retryable. That direction is deliberate.
+        // Calling a dead socket permanent loses the file in silence; calling a
+        // full disk retryable spends a few retries and then reports it.
         (SyncErrorKind::DiskError, false)
     } else if lower.contains("connection")
         || lower.contains("network")
@@ -5754,14 +5778,81 @@ mod tests {
     /// "drop anything with a separator" would delete the reason along with the
     /// path and send those failures to `Unknown`, which is retryable, with
     /// every test above still green.
+    /// Every message the reconnect path calls a dead session must be retryable
+    /// here, and none of them may be filed as a disk error.
+    ///
+    /// The corpus is `SESSION_CLOSED_NEEDLES` itself, not a copy of it. A copy
+    /// is what this test exists to prevent: the tree held four separate lists
+    /// deciding whether a connection was gone, and they disagreed. "broken
+    /// pipe" was in every one of them EXCEPT this taxonomy, where it sat under
+    /// "Disk full or I/O error" and came out non-retryable, so the executors,
+    /// which break on `!retryable`, refused to retry the most ordinary way a
+    /// server drops a transfer. Deriving the corpus from the real list means a
+    /// needle added there is checked here without anyone remembering to.
+    #[test]
+    fn a_closed_session_is_never_a_permanent_failure() {
+        let needles = crate::providers::types::SESSION_CLOSED_NEEDLES;
+        assert!(
+            needles.len() >= 18,
+            "read only {} needles: the list moved, or it was not read at all",
+            needles.len()
+        );
+
+        let mut refused = Vec::new();
+        let mut called_disk = Vec::new();
+        for needle in needles {
+            let info = classify_sync_error(needle, None);
+            if matches!(info.kind, SyncErrorKind::DiskError) {
+                called_disk.push(*needle);
+            }
+            if !info.retryable {
+                refused.push((*needle, info.kind));
+            }
+        }
+        assert!(
+            refused.is_empty(),
+            "{} of {} closed-session messages are classified as permanent, so a \
+             transfer that hits one is abandoned without a retry: {refused:?}",
+            refused.len(),
+            needles.len()
+        );
+        assert!(
+            called_disk.is_empty(),
+            "a dropped connection is not a disk problem, but {called_disk:?} is \
+             filed as one, which is also how it became non-retryable"
+        );
+    }
+
     #[test]
     fn stripping_paths_leaves_the_reasons_intact() {
         let cases: &[(&str, Option<&str>, SyncErrorKind, bool)] = &[
+            // A real disk symptom, which names itself and survives the strip.
             (
-                "Transfer failed: i/o error (while uploading /home/a/b.txt)",
+                "Transfer failed: no space left on device (while uploading /home/a/b.txt)",
                 Some("/home/a/b.txt"),
                 SyncErrorKind::DiskError,
                 false,
+            ),
+            // This row used to expect DiskError, and that expectation was the
+            // defect written down: "i/o error" is the label a wrapper prints in
+            // front of the real error, not a symptom of a disk. quick-xml, the
+            // parser behind WebDAV, S3, Azure and Jottacloud, renders
+            // "I/O error: {e}", so a socket dying mid-response was declared a
+            // permanent disk failure and abandoned without a retry. Naming no
+            // cause now means Unknown, which is retryable.
+            (
+                "Transfer failed: i/o error (while uploading /home/a/b.txt)",
+                Some("/home/a/b.txt"),
+                SyncErrorKind::Unknown,
+                true,
+            ),
+            // And the case that motivated the change: the wrapper in front of a
+            // dead socket must reach the transport branch, not the disk one.
+            (
+                "I/O error: Connection reset by peer (os error 104)",
+                None,
+                SyncErrorKind::Network,
+                true,
             ),
             // The word still decides when it is the SERVER saying it.
             (


### PR DESCRIPTION
A transfer the server tore down was abandoned without a single retry, and the user was told the disk had failed.

`classify_sync_error` filed `broken pipe` under "Disk full or I/O error", which is `retryable = false`. Four sites consume that verdict as `if attempt >= max_retries || !retryable { break; }`: `provider_transfer_executor` at 839 and 1269, `ftp_transfer_executor` at 289 and 545. So the single most ordinary way a server drops a transfer, an idle timeout or a NAT eviction, was the one failure the executors refused to retry even once, and the diagnosis sent the user to look at their disk.

**And `i/o error` was in the same branch, which is worse, because it is not a symptom at all.** It is the label a wrapper prints in front of the real error. `quick-xml` renders `"I/O error: {e}"` and is the parser behind WebDAV, S3, Azure and Jottacloud; `zip` renders `"i/o error: {e}"`. So `"I/O error: Connection reset by peer"`, which is what a connection dying mid-response looks like, was declared a permanent disk failure. That is the normal path of every XML provider, not an edge case.

**The user-facing surface is wider than the four provider files.** WebDAV and S3 are transports, not services: the factory routes `ProviderType::WebDav` and `ProviderType::S3`, so every service configured over them crosses the same line, Nextcloud, ownCloud, MinIO, Wasabi, Storj and the Discover presets included.

## What changed

A branch above the disk one asks `is_session_closed_error_message`, which is the list the reconnect path already consults, rather than answering the same question a second time with a different vocabulary. `i/o error` leaves the disk branch; real disk cases still name themselves through `disk full` and `no space`, wrapped or not, and `"No space left on device"` is verified to stay `DiskError`.

What is given up is guessing about errors that name no cause, and those now land in `Unknown`, which is retryable. **The direction is deliberate and is the argument for the change rather than a footnote: calling a dead socket permanent loses the file in silence, while calling a full disk retryable spends a few retries and then reports it.** Retrying is safe here because `download_attempt` and `upload_attempt` restart the attempt rather than resuming from an offset, so moving from never to once does not open a duplication window.

## Two things the tests do that a hand-written test would not

`SESSION_CLOSED_NEEDLES` is now a public `const` and the sync-side test iterates **that list**, not a copy of it. A copy is how this tree came to hold four different opinions about what a dead connection looks like. The test also asserts the list is at least 18 entries long, so it cannot pass having read nothing.

And the needles were wrong about what `std` prints. The list held `unexpected eof` while `ErrorKind::UnexpectedEof` renders `unexpected end of file`, and held the OS wording while `NotConnected` renders `not connected`. So `"I/O error: unexpected end of file"` was a permanent disk error that none of the four lists recognised. The new test iterates the `ErrorKind` set and takes each string from `Error::from(kind).to_string()`, putting `std` in charge of its own wording; proved red by removing the two needles, reporting `2 of 5 socket error kinds print something no needle matches`. A corpus typed by hand would have encoded the same wrong guesses and been green against both gaps.

## Declared limits

`failed to fill whole buffer` and `failed to write whole buffer` are produced by both a dead socket and a full disk, so they are deliberately left out: including them would buy one fault at the price of the other. They land in `Unknown` and retryable today, which costs nothing.

`io::Error::new(kind, msg)` does not print the kind, so a `BrokenPipe` constructed with a custom message emits only that message and no string list can see it. That is material for structured errors, recorded as a limit rather than as remaining work.

`operation timed out` is in the needle list but continues to classify as `Timeout`, because the timeout branch is the first in the chain; verified, and retryable either way.

## Gate

`cargo fmt`, clippy on the library and the CLI at zero, suite `3651 passed; 0 failed; 20 ignored`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of interrupted or closed connections during synchronization.
  * Connection-related errors are now recognized more consistently, including broken pipes, connection resets, and unexpected end-of-file conditions.
  * Retry behavior is improved by preventing connection issues from being incorrectly treated as permanent disk failures.
  * Genuine disk-space errors continue to be reported as disk-related failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->