### PR TITLE
fix(errors): close the four review findings on the vocabulary consolidation

### DIFF
--- a/src-tauri/src/ai_core/remote_tools.rs
+++ b/src-tauri/src/ai_core/remote_tools.rs
@@ -792,7 +792,7 @@ async fn preview_delete(
     let (is_dir, root_size): (bool, u64) = match backend.stat(path).await {
         Ok(r) => (r.is_dir, r.size),
         Err(e) => {
-            if recursive && crate::providers::types::message_names_a_missing_path(&e) {
+            if recursive && crate::providers::types::message_names_a_missing_path_for(&e, path) {
                 // Assume pseudo-directory for recursive preview; contents will
                 // be discovered by list below.
                 (true, 0)
@@ -2491,7 +2491,7 @@ async fn speed(ctx: &dyn ToolCtx, args: &Value) -> Result<Value, ToolError> {
         }
         Err(e)
             if path_is_caller_named
-                && !crate::providers::types::message_names_a_missing_path(&e) =>
+                && !crate::providers::types::message_names_a_missing_path_for(&e, &remote_path) =>
         {
             return Err(ToolError::InvalidArgs {
                 tool: "aeroftp_speed".to_string(),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11648,7 +11648,12 @@ async fn sync_ec_download_remote_bytes(
                 .map(Some)
                 .map_err(|e| format!("read AeroSync EC temp download: {e}")),
             Err(crate::providers::ProviderError::NotFound(_)) => Ok(None),
-            Err(e) if crate::providers::types::message_names_a_missing_path(&e.to_string()) => {
+            Err(e)
+                if crate::providers::types::message_names_a_missing_path_for(
+                    &e.to_string(),
+                    remote_path,
+                ) =>
+            {
                 Ok(None)
             }
             Err(e) => Err(e.to_string()),
@@ -11657,7 +11662,12 @@ async fn sync_ec_download_remote_bytes(
         let mut ftp_manager = state.ftp_manager.lock().await;
         match ftp_manager.download_to_bytes(remote_path).await {
             Ok(bytes) => Ok(Some(bytes)),
-            Err(e) if crate::providers::types::message_names_a_missing_path(&e.to_string()) => {
+            Err(e)
+                if crate::providers::types::message_names_a_missing_path_for(
+                    &e.to_string(),
+                    remote_path,
+                ) =>
+            {
                 Ok(None)
             }
             Err(e) => Err(e.to_string()),

--- a/src-tauri/src/provider_transfer_executor.rs
+++ b/src-tauri/src/provider_transfer_executor.rs
@@ -904,7 +904,7 @@ impl ProviderDownloadExecutor {
                 }
                 Err(error) => {
                     last_error = error;
-                    if self.cancel_token.is_cancelled() {
+                    if attempt_is_over(self.cancel_token.is_cancelled(), &last_error) {
                         break;
                     }
                     let err_info =
@@ -1336,7 +1336,7 @@ impl ProviderUploadExecutor {
                 }
                 Err(error) => {
                     last_error = error;
-                    if self.cancel_token.is_cancelled() {
+                    if attempt_is_over(self.cancel_token.is_cancelled(), &last_error) {
                         break;
                     }
                     let err_info =
@@ -1859,8 +1859,45 @@ async fn transfer_entry_upload_size(entry: &TransferEntry) -> u64 {
     }
 }
 
+/// Is this attempt over, whoever stopped it?
+///
+/// Split out because it is the only part that decides anything, and inside the
+/// loop it cannot be reached without a provider, a runtime and a live socket. A
+/// branch that changes behaviour and cannot be reached by a test is where a
+/// regression hides.
+///
+/// It answers ONE question with both available sources. The loop used to
+/// consult only the local flag while the failure built at the end consulted the
+/// message too, so a cancellation the PROVIDER reported was retried to the
+/// policy limit and only then labelled cancelled: two readers of the same
+/// question, disagreeing, with the wasteful answer running first.
+fn attempt_is_over(locally_cancelled: bool, last_error: &str) -> bool {
+    locally_cancelled || crate::transfer_dag::error::message_names_a_cancellation(last_error)
+}
+
 #[cfg(test)]
 mod tests {
+
+    /// A cancellation the provider reported ends the attempt, like our own flag.
+    ///
+    /// Before, only the local flag was consulted here while the failure built
+    /// at the end consulted the message as well, so a provider cancellation was
+    /// retried to the policy limit and only then labelled cancelled. The retry
+    /// was wasted work against an operation nobody wanted finished.
+    #[test]
+    fn a_cancellation_ends_the_attempt_whichever_side_reported_it() {
+        assert!(super::attempt_is_over(true, "connection reset by peer"));
+        assert!(super::attempt_is_over(false, "request cancelled"));
+        assert!(super::attempt_is_over(false, "Transfer cancelled by user"));
+
+        // An ordinary failure still gets its retries.
+        assert!(!super::attempt_is_over(false, "connection reset by peer"));
+        // And a NEGATED cancellation is an ordinary failure, so it keeps them.
+        assert!(!super::attempt_is_over(
+            false,
+            "the transfer could not be cancelled"
+        ));
+    }
     /// The memory a segmented download plans to hold does not grow with the
     /// file.
     ///

--- a/src-tauri/src/providers/ftp.rs
+++ b/src-tauri/src/providers/ftp.rs
@@ -690,45 +690,6 @@ impl FtpProvider {
         format!("{reply} (while {operation} {path})")
     }
 
-    /// The part of a server reply that is the reason, with the path taken out.
-    ///
-    /// FTP servers quote back the path they were given, so the reply carries
-    /// both a reason the server chose and a name the user chose, and the
-    /// missing-path vocabulary reads the two as one string. Every word it looks
-    /// for is a legal path component: `550 /public_html/404.html: Permission
-    /// denied` was read as a missing file, and a refusal for permission came
-    /// back as a file that is not there. That is the exact mistake the doc
-    /// comment below warns about, arriving through the vocabulary rather than
-    /// through the status.
-    ///
-    /// The path we sent is what the server is quoting, so it is removed here,
-    /// where it is known, rather than guessed at from the shape of the text.
-    /// This is the same split as `sync::classification_text` and for the same
-    /// reason: only the reason is evidence, and the name never was.
-    ///
-    /// It is not a complete separation and does not need to be. A server may
-    /// echo a path it resolved differently from the one we sent, and then the
-    /// removal does nothing; the vocabulary's own token boundary still keeps
-    /// `404.html` from counting. The reply the CALLER is shown is untouched:
-    /// only the reading of it changes.
-    fn reason_without_the_path(reply: &str, path: &str) -> String {
-        // A one-character path carries no information and removing it damages
-        // the text instead: a failed CWD to "/" would take every slash out of
-        // the reply.
-        //
-        // No test covers this and that is deliberate rather than an omission.
-        // None of the current needles contains a separator, so today the
-        // mangling changes no verdict and any test would pass with the guard
-        // deleted. It is here against the needle somebody adds later, and it is
-        // said out loud so nobody reads it as a checked rule: the class it
-        // belongs to is `i/o error` in `sync::looks_like_a_path`, where a rule
-        // written to remove noise removed the signal instead.
-        if path.len() < 2 {
-            return reply.to_string();
-        }
-        reply.replace(path, " ")
-    }
-
     /// Decide what a refused CWD means, without claiming more than the reply says.
     ///
     /// The reply carries two independent facts and they must not be collapsed:
@@ -777,8 +738,7 @@ impl FtpProvider {
         // NotFound turns an inaccessible directory into a nonexistent one,
         // which is the mistake this change already made once on mkdir and had
         // corrected by a live server.
-        if super::types::message_names_a_missing_path(&Self::reason_without_the_path(&text, target))
-        {
+        if super::types::message_names_a_missing_path_for(&text, target) {
             ProviderError::NotFound(Self::doing(operation, target, &text))
         } else {
             ProviderError::InvalidPath(Self::doing(operation, target, &text))
@@ -830,7 +790,7 @@ impl FtpProvider {
             return None;
         }
         let text = response.to_string();
-        super::types::message_names_a_missing_path(&Self::reason_without_the_path(&text, path))
+        super::types::message_names_a_missing_path_for(&text, path)
             .then(|| ProviderError::NotFound(Self::doing(operation, path, &text)))
     }
 

--- a/src-tauri/src/providers/types.rs
+++ b/src-tauri/src/providers/types.rs
@@ -1700,13 +1700,55 @@ impl RemoteEntry {
 /// absence. Callers that treat a failed lookup as permission to WRITE must go
 /// through here, because reading every error as "absent" is fail-open, and on a
 /// transient error it hands out a write on a path that may hold user data.
+/// The same question, asked after removing the caller's own path from the text.
+///
+/// EVERY needle in the list below is a legal path component, and a server reply
+/// carries the reason and the path in one string, so matching over the whole of
+/// it cannot tell which half spoke. `404.html` is the case already recorded
+/// below; `/no such/keep.txt` and `/not found/report.pdf` are the same defect
+/// with a different needle, and a directory called `not found` is not exotic on
+/// a machine where somebody was looking for something.
+///
+/// Callers that know which path they asked about should use this rather than
+/// the bare function. The FTP provider has stripped the path since the needle
+/// was tightened for `404`; the others did not, and the tightening did not
+/// reach them, which is the same failure to travel that this whole function
+/// exists to record.
+pub fn message_names_a_missing_path_for(message: &str, echoed_path: &str) -> bool {
+    message_names_a_missing_path(&reason_without_the_echoed_path(message, echoed_path))
+}
+
+/// Remove the caller's path from a server reply so only the reason is matched.
+///
+/// A one-character path carries no information and removing it damages the text
+/// instead: stripping "/" from a reply would take every separator out of it.
+///
+/// No test covers that guard and the omission is deliberate rather than an
+/// oversight. None of the current needles contains a separator, so today the
+/// mangling changes no verdict and a test would pass with the guard deleted. It
+/// is here against the needle somebody adds later, and it is said out loud so
+/// nobody reads it as a checked rule.
+pub fn reason_without_the_echoed_path(reply: &str, path: &str) -> String {
+    if path.len() < 2 {
+        return reply.to_string();
+    }
+    reply.replace(path, " ")
+}
+
 pub fn message_names_a_missing_path(message: &str) -> bool {
     let lowered = message.to_ascii_lowercase();
     if [
-        // "no such" rather than the two longer forms it replaces: it also
-        // covers "no such object", "no such bucket" and "no such key", which
-        // are how object stores phrase the same fact.
-        "no such",
+        // The specific forms rather than a bare "no such". The bare version was
+        // wider by one word and that word was the whole safety margin: a server
+        // reply quotes the user's path back, so "550 /no such/keep.txt:
+        // Permission denied" matched on the PATH and a refusal was read as an
+        // absence. The object-store phrasings are named individually instead,
+        // which is what the bare form was reaching for.
+        "no such file",
+        "no such directory",
+        "no such object",
+        "no such bucket",
+        "no such key",
         "not found",
         "does not exist",
         // The contracted form, which two of the absorbed lists had and this
@@ -1751,7 +1793,10 @@ pub fn message_names_a_missing_path(message: &str) -> bool {
 
 #[cfg(test)]
 mod missing_path_vocabulary_tests {
-    use super::message_names_a_missing_path;
+    use super::{
+        message_names_a_missing_path, message_names_a_missing_path_for,
+        reason_without_the_echoed_path,
+    };
 
     /// A path that merely contains "404" is not a missing path.
     ///
@@ -1829,6 +1874,74 @@ mod missing_path_vocabulary_tests {
                 "{message:?} is a missing path to at least one of the lists this replaced"
             );
         }
+    }
+
+    /// The needle matched on the PATH, not on the reason.
+    ///
+    /// Every needle in this vocabulary is a legal path component, and a server
+    /// reply carries the reason and the path in one string. `404.html` was the
+    /// case that tightened the digits; these are the same defect with the word
+    /// needles, and the one that matters is the `speed` tool's overwrite guard:
+    /// it treats "the path is not there" as permission to write and then
+    /// delete, so a refusal read as an absence destroys a real file.
+    #[test]
+    fn a_needle_inside_the_users_own_path_is_not_a_reason() {
+        // Bare matching cannot tell which half of the reply spoke, so this is
+        // recorded as the limit of the unscoped function rather than as a pass.
+        assert!(message_names_a_missing_path(
+            "550 /no such file/keep.txt: Permission denied"
+        ));
+
+        // But the needles stay as narrow as the vocabulary allows, because the
+        // callers that cannot pass a path depend on that margin. A bare "no
+        // such" would match every one of these, and each is a plausible
+        // directory on a machine where somebody was looking for something.
+        for message in [
+            "550 /no such/keep.txt: Permission denied",
+            "550 /no such thing/report.pdf: Permission denied",
+            "550 /archive/no such/a.bin: Permission denied",
+        ] {
+            assert!(
+                !message_names_a_missing_path(message),
+                "{message:?} matched on a path fragment: the needle is wider than the vocabulary"
+            );
+        }
+
+        // Given the path the caller asked about, the reason is read alone.
+        for (reply, path) in [
+            (
+                "550 /no such file/keep.txt: Permission denied",
+                "/no such file/keep.txt",
+            ),
+            (
+                "550 /not found/report.pdf: Permission denied",
+                "/not found/report.pdf",
+            ),
+            (
+                "550 /does not exist/a.bin: Permission denied",
+                "/does not exist/a.bin",
+            ),
+        ] {
+            assert!(
+                !message_names_a_missing_path_for(reply, path),
+                "{reply:?} was read as an absence because the PATH carried the needle"
+            );
+        }
+
+        // And a genuine absence still reads as one once the path is removed.
+        assert!(message_names_a_missing_path_for(
+            "550 /srv/data/keep.txt: No such file or directory",
+            "/srv/data/keep.txt"
+        ));
+    }
+
+    /// A one-character path is left alone, or stripping it would gut the reply.
+    #[test]
+    fn a_single_character_path_is_not_stripped() {
+        assert_eq!(
+            reason_without_the_echoed_path("550 /: Permission denied", "/"),
+            "550 /: Permission denied"
+        );
     }
 
     /// A bare `550` is not an absence, and one of the absorbed lists said it was.

--- a/src-tauri/src/providers/yandex_disk.rs
+++ b/src-tauri/src/providers/yandex_disk.rs
@@ -294,12 +294,31 @@ fn resource_to_entry(res: &YdResource) -> RemoteEntry {
     }
 }
 
+/// The user-facing sentence for an auth failure, which is NOT the same question
+/// as whether the failure is terminal.
+///
+/// Both were answered by one predicate, so every terminal condition came out as
+/// "token revoked or expired: regenerate the OAuth token". A SCOPE problem is
+/// terminal, correctly, and it is not a dead token: telling its owner to
+/// regenerate a token that is perfectly valid sends them to repair the one
+/// thing that is not broken, and the real cause, a missing permission on the
+/// application, is not mentioned at all.
+///
+/// The retry decision is unchanged and still asks
+/// [`is_yandex_terminal_auth_message`]. Only the sentence splits.
 fn yandex_auth_message(description: &str) -> String {
     let clean = if description.trim().is_empty() {
         "Unauthorized"
     } else {
         description.trim()
     };
+    let lower = clean.to_ascii_lowercase();
+    if lower.contains("scope") {
+        return format!(
+            "Yandex refused the token's permissions: {}. The token itself is valid; the application is missing a scope, so re-authorise it with Disk access rather than regenerating the token.",
+            clean
+        );
+    }
     if is_yandex_terminal_auth_message(clean) {
         format!(
             "Yandex token revoked or expired: {}. Regenerate the OAuth token at oauth.yandex.com and re-add the server.",
@@ -1912,6 +1931,36 @@ impl StorageProvider for YandexDiskProvider {
 
 #[cfg(test)]
 mod tests {
+
+    /// A scope problem is terminal, and it is not a dead token.
+    ///
+    /// One predicate answered both "should this be retried" and "what do we
+    /// tell the user", so every terminal condition came out as "token revoked
+    /// or expired: regenerate the OAuth token". Sending the owner of a valid
+    /// token to regenerate it is repairing the one thing that works, while the
+    /// real cause, a permission the application was never granted, is not
+    /// mentioned.
+    #[test]
+    fn a_scope_refusal_does_not_tell_the_user_to_regenerate_the_token() {
+        let msg = super::yandex_auth_message("invalid OAuth scope");
+        assert!(
+            !msg.contains("Regenerate the OAuth token"),
+            "a scope problem sent the user to regenerate a valid token: {msg}"
+        );
+        assert!(msg.contains("scope"), "the real cause is not named: {msg}");
+
+        // The dead-token sentence is unchanged for a dead token.
+        let dead = super::yandex_auth_message("token has been revoked");
+        assert!(dead.contains("Regenerate the OAuth token"), "{dead}");
+
+        // And the RETRY decision is untouched: both are still terminal.
+        assert!(super::is_yandex_terminal_auth_message(
+            "invalid OAuth scope"
+        ));
+        assert!(super::is_yandex_terminal_auth_message(
+            "token has been revoked"
+        ));
+    }
     use super::*;
 
     #[test]

--- a/src-tauri/src/transfer_dag/error.rs
+++ b/src-tauri/src/transfer_dag/error.rs
@@ -291,6 +291,30 @@ fn default_idempotent_for(kind: TransferErrorKind) -> bool {
 /// the way this codebase does.
 pub fn message_names_a_cancellation(message: &str) -> bool {
     let lowered = message.to_ascii_lowercase();
+    // A NEGATED cancellation is not a cancellation, and substring matching says
+    // it is. "could not be cancelled" and "the request was not canceled" both
+    // contain the word, and reading them as a cancellation suppresses the
+    // retries and reports an ordinary failure as something the user asked for.
+    //
+    // The earlier reasoning stopped one form short. Choosing `cancelled` over a
+    // bare `cancel` was done precisely to exclude "failed to cancel", and it
+    // does; what it does not exclude is the PASSIVE negation, where the word
+    // keeps its participle form and the negation sits in front of it.
+    const NEGATIONS: &[&str] = &[
+        "not cancelled",
+        "not canceled",
+        "never cancelled",
+        "never canceled",
+        "cannot be cancelled",
+        "cannot be canceled",
+        "could not be cancelled",
+        "could not be canceled",
+        "unable to cancel",
+        "failed to cancel",
+    ];
+    if NEGATIONS.iter().any(|n| lowered.contains(n)) {
+        return false;
+    }
     lowered.contains("cancelled") || lowered.contains("canceled")
 }
 
@@ -348,6 +372,43 @@ fn classify_network_message(raw: &str) -> TransferErrorKind {
 
 #[cfg(test)]
 mod tests {
+
+    /// A negated cancellation is not a cancellation.
+    ///
+    /// Substring matching says it is: "could not be cancelled" contains the
+    /// word. Read as a cancellation it suppresses the retries and reports an
+    /// ordinary failure as something the user asked for, which is a wrong
+    /// answer in the direction that also hides itself, because a transfer the
+    /// user believes they stopped is not investigated.
+    ///
+    /// The earlier reasoning stopped one form short. Choosing `cancelled` over
+    /// bare `cancel` excluded "failed to cancel" and does; it did not exclude
+    /// the passive negation, where the participle survives and the negation
+    /// sits in front of it.
+    #[test]
+    fn a_negated_cancellation_is_not_a_cancellation() {
+        for message in [
+            "the transfer could not be cancelled",
+            "the request was not canceled",
+            "cannot be cancelled once committed",
+            "unable to cancel the running job",
+            "failed to cancel: server refused",
+        ] {
+            assert!(
+                !super::message_names_a_cancellation(message),
+                "{message:?} was read as a cancellation because it contains the word"
+            );
+        }
+
+        // The real thing still reads as the real thing, in both spellings.
+        for message in [
+            "Transfer cancelled by user",
+            "request cancelled",
+            "operation canceled",
+        ] {
+            assert!(super::message_names_a_cancellation(message), "{message:?}");
+        }
+    }
     use super::*;
     use crate::transfer_dag::adaptive::embed_retry_after_marker;
 

--- a/src-tauri/src/transfer_dag/error.rs
+++ b/src-tauri/src/transfer_dag/error.rs
@@ -300,6 +300,27 @@ pub fn message_names_a_cancellation(message: &str) -> bool {
     // bare `cancel` was done precisely to exclude "failed to cancel", and it
     // does; what it does not exclude is the PASSIVE negation, where the word
     // keeps its participle form and the negation sits in front of it.
+    //
+    // CONTRACTIONS ARE EXPANDED FIRST, and that is the fix rather than a tidy-up.
+    // The list below was written by enumerating phrases, and enumeration is what
+    // it exists to correct: "couldn't be canceled" and "wasn't cancelled" are the
+    // same negations with an apostrophe, and a list of spellings will always be
+    // one spelling short. The same mistake was avoided two functions away, where
+    // underscores are normalised rather than spelled out, and made again here.
+    //
+    // BOTH apostrophes are handled. A message composed in a user interface
+    // carries U+2019, the typographic one, and a message from an operating
+    // system or a protocol carries U+0027; the two are different characters and
+    // matching one of them is the same defect one layer down.
+    let lowered = lowered
+        .replace('\u{2019}', "'")
+        .replace("couldn't", "could not")
+        .replace("wasn't", "was not")
+        .replace("weren't", "were not")
+        .replace("isn't", "is not")
+        .replace("didn't", "did not")
+        .replace("won't", "will not")
+        .replace("can't", "cannot");
     const NEGATIONS: &[&str] = &[
         "not cancelled",
         "not canceled",
@@ -311,6 +332,12 @@ pub fn message_names_a_cancellation(message: &str) -> bool {
         "could not be canceled",
         "unable to cancel",
         "failed to cancel",
+        "will not cancel",
+        "did not cancel",
+        "is not cancelled",
+        "is not canceled",
+        "was not cancelled",
+        "was not canceled",
     ];
     if NEGATIONS.iter().any(|n| lowered.contains(n)) {
         return false;
@@ -393,6 +420,17 @@ mod tests {
             "cannot be cancelled once committed",
             "unable to cancel the running job",
             "failed to cancel: server refused",
+            // The CONTRACTED forms. The list of negations was written by
+            // enumerating phrases, so it was one apostrophe short of complete,
+            // which is what enumeration always is.
+            "the request couldn't be canceled",
+            "the request wasn't cancelled",
+            "it can't be cancelled at this stage",
+            "the job didn't cancel",
+            // And with the TYPOGRAPHIC apostrophe, which is what a message
+            // composed in a user interface actually carries.
+            "the request couldn\u{2019}t be canceled",
+            "the request wasn\u{2019}t cancelled",
         ] {
             assert!(
                 !super::message_names_a_cancellation(message),


### PR DESCRIPTION
CodeRabbit reviewed the exact head that merged as #666 and **the review was not read before merging**. All four findings were real, and three of them were introduced by that change.

## The one that mattered

`message_names_a_missing_path` was widened to a bare `no such`, one word shorter than the forms it replaced, and that word was the whole safety margin. A server reply carries the reason AND the user's path in one string, so `550 /no such/keep.txt: Permission denied` matched on the **path** and a refusal was read as an absence.

The function's own comment records exactly this hazard for the `404` needle, three lines above where the widening was made. And the site that makes it serious is the speed tool's overwrite guard, whose comment says it "fails CLOSED on a caller-named path" because it treats absence as permission to write and then delete: a refusal read as an absence would have destroyed a real file.

Narrowing alone would only move the hazard to the next needle, since every one of them is a legal path component. So the remedy is to remove the caller's path before matching. `message_names_a_missing_path_for` does that, and the four callers that know which path they asked about now use it. The FTP provider had been stripping the path since the `404` tightening, in a private copy of the helper; that copy is gone, and the tightening reaching only one of five callers is the same failure to travel the consolidation was about.

## The other three

**A negated cancellation is not a cancellation.** `could not be cancelled` and `the request was not canceled` both contain the word, and reading them as cancellation suppresses the retries and reports an ordinary failure as something the user asked for. Choosing `cancelled` over a bare `cancel` excluded "failed to cancel" and did nothing about the passive form.

**The retry loop and the failure it builds now ask one question.** The loop consulted only the local cancel flag while the failure consulted the message as well, so a cancellation the PROVIDER reported was retried to the policy limit and only then labelled cancelled. The decision moves into `attempt_is_over`, because inside the loop it cannot be reached without a provider, a runtime and a live socket.

**Yandex stops telling users to regenerate a token that works.** One predicate answered both "is this terminal" and "what do we tell them", so a missing OAuth scope came out as `token revoked or expired: regenerate the OAuth token`. That sends the owner of a valid token to repair the one thing that is not broken while the real cause, a permission the application was never granted, is not mentioned. The retry decision is unchanged and still terminal; only the sentence splits.

## On the Major finding, where I disagree with part of it

The review's stated consequence was a duplicated mutation, and that does not follow: a scope refusal means the mutation did not happen, so the retry costs a round trip and duplicates nothing. Its proposed remedy, scoping the predicate to token phrases, also does not fix the case it names, because Yandex writes `token revoked` into the wrapper for **every** terminal auth condition including a scope error. The defect underneath was real and is fixed at the source instead.

## Red first

Every test was proved red by restoring the defect, not written after the fix:

- `"550 /no such/keep.txt: Permission denied" matched on a path fragment: the needle is wider than the vocabulary`
- `"the transfer could not be cancelled" was read as a cancellation because it contains the word`
- `a scope problem sent the user to regenerate a valid token: Yandex token revoked or expired: invalid OAuth scope. Regenerate the OAuth token at oauth.yandex.com and re-add the server.`

Gate: `cargo fmt`, `clippy --all-features --tests` at zero, `3665 passed; 0 failed`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of file and directory errors to prevent unrelated messages from being misclassified as missing paths.
  * Transfers now stop retrying promptly when cancellation is reported by the provider.
  * Prevented messages such as “not cancelled” from being treated as cancellations.
  * Improved FTP and cloud storage error interpretation for more accurate transfer results.

* **User Experience**
  * Added a clearer authentication message when a Yandex Disk token is valid but lacks required permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->