### PR TITLE
docs(tauri): the pin stays, its reason was wrong

### DIFF
--- a/src-tauri/.cargo/audit.toml
+++ b/src-tauri/.cargo/audit.toml
@@ -173,24 +173,49 @@ ignore = [
     # AeroFTP is NOT reachable through this vector:
     #
     #   1. AeroFTP's frontend is always served from the bundled localhost
-    #      server via `tauri-plugin-localhost` on `http://localhost:14321`.
-    #      We never load remote URLs into the main webview; there is no
-    #      `WebviewUrl::External` or `loadUrl` accepting attacker input.
-    #   2. The webview origin is `http://localhost:*`, not a custom scheme
+    #      server via `tauri-plugin-localhost` on `http://127.0.0.1:14321`.
+    #      `WebviewUrl::External` IS used, in four places, and an earlier
+    #      version of this note wrongly said it was not. Every one of them
+    #      parses a fixed `http://127.0.0.1:<port>/` URL built in our own
+    #      code (index, splash, extract); none takes a URL from a server, a
+    #      profile, a file or any other outside input, and there is no
+    #      `loadUrl` accepting attacker input. The property that matters for
+    #      this advisory is that no attacker-chosen URL reaches a webview,
+    #      and that holds; the absolute claim did not.
+    #   2. The webview origin is `http://127.0.0.1:*`, not a custom scheme
     #      mapped via `http://<scheme>.localhost/`, so the buggy first-dot
     #      check does not apply to our origin shape.
     #   3. Linux/macOS builds are not in the affected platform set at all.
     #
-    # The 2.11.1 fix is incompatible with our localhost-served frontend
-    # because it introduces a stricter `is_local_url()` that classifies
-    # `http://127.0.0.1:*` as remote and rejects every custom command
-    # without a full app ACL manifest. Migrating to 2.11.1 would require
-    # auditing and gating the entire invoke_handler surface behind an ACL
-    # capability scope, which is tracked separately and is unrelated to
-    # this CVE's attack surface.
+    # Why we cannot simply take the fix, stated correctly. 2.11.1 did NOT
+    # introduce a stricter `is_local_url()` that classifies
+    # `http://127.0.0.1:*` as remote; an earlier version of this note said so
+    # and it is wrong. Diffing the two published crates, the only edit to that
+    # function is inside `#[cfg(any(windows, target_os = "android"))]`, and
+    # neither version compares the host to 127.0.0.1 at all. The function
+    # already answered false for our origin under 2.11.0, because in
+    # production `get_app_url()` falls back to `tauri://localhost` whenever
+    # `frontendDist` is a directory, as ours is. What 2.11.1 changed is the
+    # IPC gate, which now enforces that answer on app commands as well:
+    # `if (plugin_command.is_some() || has_app_acl_manifest || !is_local)`.
     #
-    # The matching pin rationale lives inline on `tauri = "=2.11.0"` in
-    # src-tauri/Cargo.toml lines 44-50.
+    # The distinction is not academic. Under the old wording the fix looked
+    # like it could be met by changing the webview origin; it cannot. The only
+    # lever that makes `get_app_url()` return our HTTP URL is declaring
+    # `frontendDist` as a URL, and tauri-codegen maps `FrontendDist::Url` to an
+    # EMPTY embedded asset set, which is precisely what tauri-plugin-localhost
+    # serves. The remedy erases the content the server exists to serve.
+    #
+    # So migrating to 2.11.1 means giving all 1013 commands in the invoke
+    # handler an ACL. There is no `src-tauri/permissions/` today, so
+    # `has_app_manifest()` is false and they bypass ACL; adding one app
+    # permission flips it true and then ACL governs every command. The
+    # capability's `remote` block already lists `http://127.0.0.1:14321/*`, so
+    # that is not the missing piece. Tracked separately, and unrelated to this
+    # CVE's attack surface.
+    #
+    # The matching pin rationale lives inline on the `tauri` dependency in
+    # src-tauri/Cargo.toml (line numbers drift, search for "DO NOT BUMP").
     "GHSA-7gmj-67g7-phm9",  # Tauri Origin Confusion (not reachable, intentional pin)
 
     # ----------------------------------------------------------------

--- a/src-tauri/.cargo/audit.toml
+++ b/src-tauri/.cargo/audit.toml
@@ -172,19 +172,37 @@ ignore = [
     #
     # AeroFTP is NOT reachable through this vector:
     #
-    #   1. AeroFTP's frontend is always served from the bundled localhost
-    #      server via `tauri-plugin-localhost` on `http://127.0.0.1:14321`.
-    #      `WebviewUrl::External` IS used, in four places, and an earlier
-    #      version of this note wrongly said it was not. Every one of them
-    #      parses a fixed `http://127.0.0.1:<port>/` URL built in our own
-    #      code (index, splash, extract); none takes a URL from a server, a
-    #      profile, a file or any other outside input, and there is no
-    #      `loadUrl` accepting attacker input. The property that matters for
-    #      this advisory is that no attacker-chosen URL reaches a webview,
-    #      and that holds; the absolute claim did not.
-    #   2. The webview origin is `http://127.0.0.1:*`, not a custom scheme
-    #      mapped via `http://<scheme>.localhost/`, so the buggy first-dot
-    #      check does not apply to our origin shape.
+    #   1. The localhost server is a LINUX arrangement, and saying so makes
+    #      this ignore stronger rather than weaker. Each of the three windows
+    #      is built from a cfg triple, and the shipped arms are:
+    #
+    #        prod + linux      -> WebviewUrl::External("http://127.0.0.1:<port>/...")
+    #        prod + not linux  -> WebviewUrl::App(...)      i.e. the tauri:// protocol
+    #
+    #      So on Windows and macOS the app never loads an External URL in a
+    #      shipped build at all, and the origin this advisory abuses has no
+    #      entry point there. On Linux it does load one, from the bundled
+    #      `tauri-plugin-localhost` server, and Linux is not in the affected
+    #      platform set. Two legs, one per platform, both stated.
+    #
+    #      `WebviewUrl::External` IS used, and an earlier version of this note
+    #      wrongly said it was not. Its replacement said "four places", which
+    #      was true and still misleading twice over: it did not say on which
+    #      platform, and it counted a DEV-only site (the splash on the Vite
+    #      server at :5173) alongside three that ship. Shipped it is three, on
+    #      Linux: index, splash, extract. Every one parses a fixed
+    #      `http://127.0.0.1:<port>/` URL built in our own code; none takes a
+    #      URL from a server, a profile, a file or any other outside input,
+    #      and there is no `loadUrl` accepting attacker input.
+    #
+    #      The property that matters for this advisory is that no
+    #      attacker-chosen URL reaches a webview. That holds on every platform.
+    #      The absolute claim did not, and the unqualified count offered a
+    #      Linux fact as grounds for judging a Windows risk.
+    #   2. On Linux the webview origin is `http://127.0.0.1:*`, and on Windows
+    #      and macOS it is the `tauri://` App protocol. Neither is a custom
+    #      scheme mapped via `http://<scheme>.localhost/`, so the buggy
+    #      first-dot check does not apply to our origin shape on any platform.
     #   3. Linux/macOS builds are not in the affected platform set at all.
     #
     # Why we cannot simply take the fix, stated correctly. 2.11.1 did NOT

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -59,7 +59,10 @@ futures-util = "0.3"
 # Why it answers false: in production `get_app_url()` returns `frontendDist`
 # only when that is a URL. Ours is a directory, so it falls back to
 # `tauri_protocol_url()`, which off Windows and Android is `tauri://localhost`,
-# while the webview lives on `http://127.0.0.1:14321`. The schemes differ,
+# while the webview lives on `http://127.0.0.1:14321`. That second half is a
+# LINUX fact: only the Linux shipped build uses `WebviewUrl::External` on the
+# localhost server, and Windows and macOS use `WebviewUrl::App`, which is why
+# only Linux regressed. The schemes differ,
 # `make_relative` fails, and the third clause asks whether "http" is a
 # registered URI scheme, which it is not: tauri-plugin-localhost runs an HTTP
 # server rather than registering a scheme.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -41,18 +41,51 @@ toml = "1.1"
 log = "0.4"
 futures-util = "0.3"
 # DO NOT BUMP. Dependabot raised this to =2.11.1 (PR #201) and broke EVERY
-# Linux build: 2.11.1's GHSA-7gmj-67g7-phm9 fix added an `is_local_url()`
-# check that classifies the Linux production webview origin
-# `http://127.0.0.1:14321` as remote and rejects every custom command
-# ("not allowed by ACL": get_local_files, vault read, keystore, mount,
-# update) because default.json is not a full app ACL manifest. Windows/macOS
-# use the `tauri://` App protocol and are unaffected, which is why only
-# Linux regressed. The webview origin must stay on the localhost server so
-# upgrades preserve all WebKit origin-scoped state (localStorage, IndexedDB,
-# server filters, theme, etc.). The CVE vector requires loading
-# remote/untrusted content, which AeroFTP does not do, so the residual risk
-# is not applicable to our surface. Keep =2.11.0; ignore tauri 2.11.x in
-# dependabot.yml.
+# Linux build: every custom command started returning "not allowed by ACL"
+# (get_local_files, vault read, keystore, mount, update).
+#
+# What 2.11.1 changed is ONE line, and it is not the one this comment used
+# to name. The two crate sources differ in three files; in `is_local_url`
+# the only edit sits inside `#[cfg(any(windows, target_os = "android"))]`,
+# so the branch we compile on Linux is identical, and neither version
+# compares the host to 127.0.0.1 anywhere. The change is in the IPC gate:
+#
+#   -  if (plugin_command.is_some() || has_app_acl_manifest)
+#   +  if (plugin_command.is_some() || has_app_acl_manifest || !is_local)
+#
+# `is_local_url()` already answered false for our origin under 2.11.0. Only
+# the enforcement of that answer on app commands is new.
+#
+# Why it answers false: in production `get_app_url()` returns `frontendDist`
+# only when that is a URL. Ours is a directory, so it falls back to
+# `tauri_protocol_url()`, which off Windows and Android is `tauri://localhost`,
+# while the webview lives on `http://127.0.0.1:14321`. The schemes differ,
+# `make_relative` fails, and the third clause asks whether "http" is a
+# registered URI scheme, which it is not: tauri-plugin-localhost runs an HTTP
+# server rather than registering a scheme.
+#
+# The obvious remedy is self-defeating, which is worth writing down because it
+# looks correct. Making `get_app_url()` return the HTTP URL requires
+# `frontendDist` to be a URL, and tauri-codegen maps `FrontendDist::Url` to an
+# EMPTY embedded asset set, which is exactly what tauri-plugin-localhost serves
+# through `app.asset_resolver()`. The app would start and answer 404.
+#
+# Discarded alternative, recorded so it is not re-evaluated from scratch:
+# stop embedding the frontend and serve it from disk with our own server. That
+# makes the origins agree, and gives up single-binary packaging on every
+# platform to escape a pin. Not proportionate.
+#
+# What the bump actually costs: the invoke handler exposes 1013 commands and
+# there is no `src-tauri/permissions/`, so `has_app_manifest()` is false and
+# they bypass ACL today. Adding ONE app permission flips it true, and from that
+# moment ACL governs all 1013. The capability's `remote` block already lists
+# `http://127.0.0.1:14321/*`, so that is not the missing piece.
+#
+# The webview origin must stay on the localhost server so upgrades preserve all
+# WebKit origin-scoped state (localStorage, IndexedDB, server filters, theme).
+# The CVE vector requires loading remote/untrusted content, which AeroFTP does
+# not do, so the residual risk is not applicable to our surface.
+# Keep =2.11.0; ignore tauri 2.11.x in dependabot.yml.
 tauri = { version = "=2.11.0", features = ["tray-icon", "protocol-asset"] }
 tauri-plugin-log = "2"
 tauri-plugin-fs = "2"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -18889,12 +18889,20 @@ pub fn run() {
             // preserve every localStorage/IndexedDB value (theme, local tabs,
             // recent paths, etc.), which are origin-scoped in WebKit.
             //
-            // Tauri is pinned to 2.11.0 in Cargo.toml because 2.11.1's fix
-            // for GHSA-7gmj-67g7-phm9 introduced an `is_local_url()` check
-            // that classifies `http://127.0.0.1:*` as remote and rejects all
-            // custom commands without a full app ACL manifest. AeroFTP does
-            // not load remote/untrusted content, so the CVE vector does not
-            // apply to our surface.
+            // Tauri is pinned to 2.11.0 in Cargo.toml, and the reason is not
+            // the one stated here before: 2.11.1 did not introduce a check
+            // that classifies `http://127.0.0.1:*` as remote. Comparing the
+            // two crate sources, the only edit to `is_local_url()` is inside
+            // the Windows/Android cfg, and neither version ever compares the
+            // host to 127.0.0.1. `is_local_url()` already returned false for
+            // this origin under 2.11.0, because `get_app_url()` yields
+            // `tauri://localhost` when `frontendDist` is a directory; what
+            // 2.11.1 changed is that the IPC gate now enforces that answer on
+            // app commands (`|| !is_local`). AeroFTP does not load
+            // remote/untrusted content, so the CVE vector does not apply to
+            // our surface. The full derivation, including why the obvious
+            // remedy erases the assets this very server exists to serve, is
+            // inline on the `tauri` pin in Cargo.toml.
             //
             // Window is hidden until the frontend signals `app_ready` so the
             // splash can stay visible during initial load.


### PR DESCRIPTION
The `tauri = "=2.11.0"` pin stays. Its documented reason was wrong, and the wrong reason is what sent an outside reader looking for the remedy where it could not be.

## What the comment said, and what actually happened

`lib.rs` attributed the break to a check introduced in 2.11.1 "that classifies `http://127.0.0.1:*` as remote". Nothing of the kind was introduced. Both crate versions were extracted and diffed: **three files differ in total**, and `is_local_url` changed 12 lines, **all of them inside `#[cfg(any(windows, target_os = "android"))]`**. The Linux branch is identical character for character, and neither version names an address anywhere.

The real change is one line:

```
-    if (plugin_command.is_some() || has_app_acl_manifest)
+    if (plugin_command.is_some() || has_app_acl_manifest || !is_local)
```

`is_local_url` already returned `false` for us in 2.11.0. It simply was not applied to the app's own commands. **The verdict did not change; its use did.**

## Why it returns false here, verified against this tree rather than inferred

`get_app_url()` returns `tauri://localhost`: `frontendDist: "../dist"` is a `FrontendDist::Directory`, which falls to `_ => None` and then to the protocol URL. Our webview lives on `http://127.0.0.1:14321`, created with `WebviewUrl::External`. All three clauses fail: the scheme differs, `make_relative` cannot relate them, and `protocols.contains_key("http")` is false because `tauri-plugin-localhost` does not register a scheme, it opens an HTTP server.

## The obvious remedy dismantles its own precondition

Making the origins coincide requires declaring `frontendDist` as a `Url`. But `tauri-codegen/src/context.rs:184` reads `FrontendDist::Url(_url) => Default::default()`, that is, **empty embedded assets**, and those assets are exactly what `tauri-plugin-localhost` serves through `app.asset_resolver()`. The application would start and answer 404. This is invisible from outside the tree, because it depends on what our plugin serves rather than on what upstream does.

## Why it is all or nothing, with the number

The capability already grants the remote block for `http://127.0.0.1:14321/*`, so that is not the missing piece. What is missing is permissions for our OWN commands: all 30 present are plugin permissions, `src-tauri/permissions/` does not exist, and `has_app_manifest()` is false. The `invoke_handler` registers **1013 commands**, and adding one permission file flips that flag, after which the ACL governs all 1013.

The only path that would genuinely make the origins agree is to stop embedding the assets and serve them from disk, giving up the single-binary packaging on every platform. It is recorded in the comment as a rejected alternative **with its reason**, so it is not rediscovered and re-evaluated from scratch.

## A false absolute in the auditors' document

`.cargo/audit.toml` is the file external reviewers read, and it carried a claim unrelated to the pin: "there is no `WebviewUrl::External`". There are **four**. All four parse a fixed `http://127.0.0.1:<port>/` built in our own code, and none takes a URL from a server, a profile or a file, so the property that matters for the advisory holds. The absolute did not.

An absolute in a document written for reviewers is the first thing checked, because it is the only claim falsifiable with a single grep. The rewritten note states the property that is true and records that the previous wording was wrong.

Comments only: verified with a diff excluding comment lines, **zero code lines changed**, the pin and the ignore both untouched.

Gate: fmt, clippy on library and CLI at zero, `3660 passed; 0 failed; 21 ignored`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified security advisory notes and the application’s local URL behavior across supported platforms.
  - Expanded documentation explaining the pinned framework version and Linux-specific localhost handling.
  - Added platform-specific context for IPC command authorization and the relevance of the reported security issue.
  - Corrected details about shipped windows, development-only behavior, and the application’s use of locally generated URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->