### PR TITLE
fix(remote-tools): ask whether the parent is a directory, not whether something is there

### DIFF
--- a/src-tauri/src/ai_core/remote_tools.rs
+++ b/src-tauri/src/ai_core/remote_tools.rs
@@ -312,6 +312,39 @@ fn parent_remote_dir(path: &str) -> Option<String> {
     }
 }
 
+/// What a listing lets us conclude about descending into a path.
+///
+/// There are two answers and the missing third is the whole point.
+///
+/// A listing can PROVE a path is a directory: `is_dir` comes from the leading
+/// `d` in the permission string (ftp_listing.rs), and the MLSD path sets it for
+/// `type=dir|cdir|pdir`. Nothing a listing says proves a path is NOT one. A
+/// symlink pointing at a directory reports `is_dir == false` because its
+/// permissions begin with `l`, and MLSD recognises only two spellings of a
+/// symlink while RFC 3659 allows a third, so a symlink can arrive with both
+/// flags false. `is_dir == false` therefore means "not shown to be a
+/// directory", never "shown not to be one".
+///
+/// The rule this encodes: refuse only on positive evidence of the negative,
+/// and treat "not proven a directory" as unknown rather than as refuted. It is
+/// a type and not a comment because the same mistake was made twice in this
+/// one function, once in the walk and once in the pre-check written after the
+/// walk was fixed. Removing an instance leaves the reasoning that produced it.
+/// There is no `NotADirectory` variant because a listing cannot hand one out.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DescendEvidence {
+    ProvenDirectory,
+    Unknown,
+}
+
+fn descend_evidence(entry: &crate::providers::RemoteEntry) -> DescendEvidence {
+    if entry.is_dir {
+        DescendEvidence::ProvenDirectory
+    } else {
+        DescendEvidence::Unknown
+    }
+}
+
 async fn ensure_remote_parents(
     ctx: &dyn ToolCtx,
     server: &str,
@@ -332,13 +365,18 @@ async fn ensure_remote_parents(
     //
     // If the backend cannot stat a directory, this falls through to the walk,
     // which is exactly the behaviour before this check existed.
-    match backend.stat(&parent).await {
-        Ok(entry) if entry.is_dir => return Ok(()),
-        Ok(_) => return Err(non_directory_in_the_way(&parent)),
-        Err(_) => {}
+    if let Ok(entry) = backend.stat(&parent).await {
+        if descend_evidence(&entry) == DescendEvidence::ProvenDirectory {
+            return Ok(());
+        }
+        // Unknown. Not a reason to stop: fall through to the walk, which is
+        // what happened before this check existed.
     }
 
     let mut acc = String::new();
+    // The first level that exists but is not reported as a directory. It is
+    // almost always the real obstacle, and the failure lands one level below.
+    let mut blocked_at: Option<String> = None;
     let leading_slash = parent.starts_with('/');
     for part in parent.split('/').filter(|p| !p.is_empty()) {
         if leading_slash || !acc.is_empty() {
@@ -361,11 +399,24 @@ async fn ensure_remote_parents(
                 // where a parent directory belongs was forgiven, and the
                 // failure surfaced one level further down naming a path that
                 // was not the problem.
-                match backend.stat(&acc).await {
-                    Ok(entry) if entry.is_dir => continue,
-                    Ok(_) => return Err(non_directory_in_the_way(&acc)),
-                    Err(_) => {}
+                if let Ok(entry) = backend.stat(&acc).await {
+                    match descend_evidence(&entry) {
+                        DescendEvidence::ProvenDirectory => continue,
+                        // Something is here and the listing does not prove it
+                        // is a directory. That is worth REMEMBERING and not
+                        // worth stopping for: it is the likely cause of
+                        // whatever fails next, and a symlink to a perfectly
+                        // good directory lands in this same branch. Carry on
+                        // exactly as before and keep the level to name later.
+                        DescendEvidence::Unknown => {
+                            if blocked_at.is_none() {
+                                blocked_at = Some(acc.clone());
+                            }
+                            continue;
+                        }
+                    }
                 }
+                // stat could not answer at all.
                 // stat could not answer. Fall back to the server's own words,
                 // which are weaker: they say something is already there, not
                 // that it is a directory.
@@ -376,21 +427,28 @@ async fn ensure_remote_parents(
                 {
                     continue;
                 }
-                return Err(ToolError::Exec(format!("mkdir {} failed: {}", acc, e)));
+                return Err(mkdir_failed(&acc, &e, blocked_at.as_deref()));
             }
         }
     }
     Ok(())
 }
 
-/// Name the level that is actually in the way, and say what is there.
+/// The mkdir that failed, plus the level that is probably why.
 ///
-/// The old message came from the mkdir of the level BELOW this one, so it
-/// reported a path that was fine and hid the one that was not.
-fn non_directory_in_the_way(path: &str) -> ToolError {
-    ToolError::Exec(format!(
-        "cannot create parent directories: {path} already exists and is not a directory"
-    ))
+/// The message used to name only the path whose mkdir failed. When a parent
+/// higher up is occupied by something that is not a directory, that path is
+/// not the problem, and a reader who trusts the message looks one level below
+/// the obstacle. Naming both keeps the failure where it happened and says
+/// where to look.
+fn mkdir_failed(path: &str, error: &str, blocked_at: Option<&str>) -> ToolError {
+    match blocked_at {
+        Some(blocker) => ToolError::Exec(format!(
+            "mkdir {path} failed: {error}. {blocker} already exists and the listing does not \
+             report it as a directory, which is the likely cause"
+        )),
+        None => ToolError::Exec(format!("mkdir {path} failed: {error}")),
+    }
 }
 
 pub async fn dispatch_remote_tool(
@@ -3423,6 +3481,9 @@ mod tests {
         /// "unused", so a test can hand the walk the wording a real server
         /// uses when the path is already taken.
         mkdir_fails_with: Option<String>,
+        /// Paths a listing would mark with a leading `l`. `is_dir` stays
+        /// false for these, exactly as the real parser reports them.
+        symlinks: std::collections::HashSet<String>,
     }
 
     impl FakeBackend {
@@ -3463,6 +3524,7 @@ mod tests {
                 rename_fails_with: None,
                 stat_fails_with: None,
                 mkdir_fails_with: None,
+                symlinks: std::collections::HashSet::new(),
             }
         }
 
@@ -3491,7 +3553,9 @@ mod tests {
                 .stats
                 .get(path)
                 .ok_or_else(|| format!("not found: {path}"))?;
-            Ok(entry(path, is_dir, size))
+            let mut e = entry(path, is_dir, size);
+            e.is_symlink = self.symlinks.contains(path);
+            Ok(e)
         }
         async fn download_to_bytes(&self, _path: &str) -> Result<Vec<u8>, String> {
             // Pre-seeded fixture first, then whatever a previous
@@ -3695,13 +3759,79 @@ mod tests {
         let text = format!("{err:?}");
 
         assert!(
-            text.contains("/data/report") && !text.contains("/data/report/2026"),
-            "the obstacle is /data/report, but the error points elsewhere: {text}"
+            text.contains("/data/report already exists"),
+            "the obstacle is /data/report and the error does not name it: {text}"
         );
         assert!(
-            text.contains("not a directory"),
-            "the error does not say what is wrong with it: {text}"
+            text.contains("does not report it as a directory"),
+            "the error names the level but not what is wrong with it: {text}"
         );
+    }
+
+    /// The rule, checked on the shapes a listing actually produces.
+    ///
+    /// The symlink test below covers the case; this one covers the reasoning
+    /// that produced it, because the same mistake was made twice in one
+    /// function and the second time in code written after the first was fixed.
+    /// Removing an instance leaves the premise, and the premise keeps working.
+    ///
+    /// Only a leading `d` proves a directory. Everything else is unknown, and
+    /// unknown is not a refusal: a symlink to a directory, a symlink spelling
+    /// MLSD does not recognise, and a plain file are indistinguishable here,
+    /// so no caller may turn any of them into a rejection.
+    #[test]
+    fn only_a_positive_says_directory_and_nothing_says_the_opposite() {
+        let dir = entry("/a", true, 0);
+        let file = entry("/a", false, 12);
+        let mut link = entry("/a", false, 0);
+        link.is_symlink = true;
+
+        assert_eq!(descend_evidence(&dir), DescendEvidence::ProvenDirectory);
+        assert_eq!(descend_evidence(&file), DescendEvidence::Unknown);
+        assert_eq!(
+            descend_evidence(&link),
+            DescendEvidence::Unknown,
+            "a symlink to a directory reports is_dir == false; reading that as \
+             a refusal is the regression this rule exists to prevent"
+        );
+
+        // The type itself is the guard: there is no variant meaning "proven
+        // not a directory", so no branch can be written that refuses on the
+        // absence of proof. If someone adds one, this stops compiling.
+        for e in [&dir, &file, &link] {
+            match descend_evidence(e) {
+                DescendEvidence::ProvenDirectory | DescendEvidence::Unknown => {}
+            }
+        }
+    }
+
+    /// A parent that is a symlink must keep working.
+    ///
+    /// This test exists because the first version of this fix broke it. A
+    /// listing gives `is_dir` from the leading `d` and `is_symlink` from the
+    /// leading `l`, so a symlink pointing AT a directory arrives with
+    /// `is_dir == false`. Refusing on that would have failed every upload
+    /// whose parent is a symlink, which on shared hosting is ordinary, and it
+    /// would have failed them in the name of a better error message.
+    ///
+    /// The listing is not positive evidence of a regular file either: MLSD
+    /// only sets `is_symlink` for two exact spellings, so other symlink forms
+    /// land in the same branch. Hence nothing here refuses; it only explains.
+    #[tokio::test]
+    async fn a_symlinked_parent_is_not_treated_as_an_obstacle() {
+        let mut fake = FakeBackend::sample();
+        fake.stats.insert("/data".to_string(), (true, 0));
+        // A symlink to a directory, as a listing reports it: not a dir.
+        fake.symlinks.insert("/data/report".to_string());
+        fake.stats.insert("/data/report".to_string(), (false, 0));
+        fake.stats
+            .insert("/data/report/2026".to_string(), (false, 0));
+        fake.mkdir_fails_with = Some("550 Permission denied".to_string());
+        let ctx = test_ctx(Arc::new(fake));
+
+        ensure_remote_parents(&ctx, "s", "/data/report/2026/x.csv")
+            .await
+            .expect("a symlinked parent used to work and must keep working");
     }
 
     /// An existing parent costs one round trip, not one per level.

--- a/src-tauri/src/ai_core/remote_tools.rs
+++ b/src-tauri/src/ai_core/remote_tools.rs
@@ -321,6 +321,23 @@ async fn ensure_remote_parents(
         return Ok(());
     };
     let backend = ctx.remote_backend(server).await.map_err(backend_error)?;
+
+    // Ask the precise question once before doing any work. The walk below
+    // issues one MKD per level and, when the tree is already there, which is
+    // the ordinary case, every one of them fails and is then forgiven. A
+    // single stat answers "is the parent already a directory" in one round
+    // trip instead of that. A guard that asks the exact question can be
+    // faster than a vague one, because a vague answer leaves you having to
+    // attempt the work anyway.
+    //
+    // If the backend cannot stat a directory, this falls through to the walk,
+    // which is exactly the behaviour before this check existed.
+    match backend.stat(&parent).await {
+        Ok(entry) if entry.is_dir => return Ok(()),
+        Ok(_) => return Err(non_directory_in_the_way(&parent)),
+        Err(_) => {}
+    }
+
     let mut acc = String::new();
     let leading_slash = parent.starts_with('/');
     for part in parent.split('/').filter(|p| !p.is_empty()) {
@@ -331,6 +348,27 @@ async fn ensure_remote_parents(
         match backend.mkdir(&acc).await {
             Ok(()) => {}
             Err(e) => {
+                // Some FTP servers (e.g. ProFTPD, as used by Aruba shared
+                // hosting) answer MKD on an already-existing directory with
+                // "550 Permission denied" instead of a recognizable "exists"
+                // message. Rather than widen the string match (which would
+                // mask genuine permission failures), ask stat.
+                //
+                // The question is not "does something exist here", it is "can
+                // I descend into it", and stat answers that one: it returns a
+                // `RemoteEntry` carrying `is_dir`. Reading only `is_ok()`
+                // discarded the half that mattered, so a plain file sitting
+                // where a parent directory belongs was forgiven, and the
+                // failure surfaced one level further down naming a path that
+                // was not the problem.
+                match backend.stat(&acc).await {
+                    Ok(entry) if entry.is_dir => continue,
+                    Ok(_) => return Err(non_directory_in_the_way(&acc)),
+                    Err(_) => {}
+                }
+                // stat could not answer. Fall back to the server's own words,
+                // which are weaker: they say something is already there, not
+                // that it is a directory.
                 let low = e.to_ascii_lowercase();
                 if low.contains("already exists")
                     || low.contains("file exists")
@@ -338,20 +376,21 @@ async fn ensure_remote_parents(
                 {
                     continue;
                 }
-                // Some FTP servers (e.g. ProFTPD, as used by Aruba shared
-                // hosting) answer MKD on an already-existing directory with
-                // "550 Permission denied" instead of a recognizable "exists"
-                // message. Rather than widen the string match (which would
-                // mask genuine permission failures), confirm via stat: if the
-                // path is already present, treat mkdir as a no-op.
-                if backend.stat(&acc).await.is_ok() {
-                    continue;
-                }
                 return Err(ToolError::Exec(format!("mkdir {} failed: {}", acc, e)));
             }
         }
     }
     Ok(())
+}
+
+/// Name the level that is actually in the way, and say what is there.
+///
+/// The old message came from the mkdir of the level BELOW this one, so it
+/// reported a path that was fine and hid the one that was not.
+fn non_directory_in_the_way(path: &str) -> ToolError {
+    ToolError::Exec(format!(
+        "cannot create parent directories: {path} already exists and is not a directory"
+    ))
 }
 
 pub async fn dispatch_remote_tool(
@@ -3380,6 +3419,10 @@ mod tests {
         /// When set, `stat` fails with this message for every path, the way a
         /// provider fails on an expired token or a dropped connection.
         stat_fails_with: Option<String>,
+        /// When set, `mkdir` fails with this message instead of the default
+        /// "unused", so a test can hand the walk the wording a real server
+        /// uses when the path is already taken.
+        mkdir_fails_with: Option<String>,
     }
 
     impl FakeBackend {
@@ -3419,6 +3462,7 @@ mod tests {
                 delete_fails_with: None,
                 rename_fails_with: None,
                 stat_fails_with: None,
+                mkdir_fails_with: None,
             }
         }
 
@@ -3521,7 +3565,10 @@ mod tests {
             Ok(())
         }
         async fn mkdir(&self, _path: &str) -> Result<(), String> {
-            Err("unused".into())
+            Err(self
+                .mkdir_fails_with
+                .clone()
+                .unwrap_or_else(|| "unused".to_string()))
         }
         async fn rename(&self, from: &str, to: &str) -> Result<(), String> {
             if let Some(msg) = &self.rename_fails_with {
@@ -3620,6 +3667,77 @@ mod tests {
             sink: NoopSink,
             creds: NoopCreds,
         }
+    }
+
+    /// A plain file where a parent directory belongs must be reported at the
+    /// level it is on.
+    ///
+    /// `stat` returns a `RemoteEntry` carrying `is_dir`, and the old code read
+    /// only `is_ok()`. That answers "does something exist here" while the
+    /// question is "can I descend into it", so a file was forgiven and the
+    /// walk carried on. The failure then surfaced one level further down,
+    /// naming a path that was not the problem, which sends whoever reads it
+    /// looking below the actual obstacle.
+    ///
+    /// Seeded so the old behaviour is reachable: /data is a directory, and
+    /// /data/report is a FILE. The mock refuses every mkdir, which is what a
+    /// server does when the path is taken.
+    #[tokio::test]
+    async fn a_file_where_a_parent_belongs_is_named_at_its_own_level() {
+        let mut fake = FakeBackend::sample();
+        fake.stats.insert("/data".to_string(), (true, 0));
+        fake.stats.insert("/data/report".to_string(), (false, 12));
+        let ctx = test_ctx(Arc::new(fake));
+
+        let err = ensure_remote_parents(&ctx, "s", "/data/report/2026/x.csv")
+            .await
+            .unwrap_err();
+        let text = format!("{err:?}");
+
+        assert!(
+            text.contains("/data/report") && !text.contains("/data/report/2026"),
+            "the obstacle is /data/report, but the error points elsewhere: {text}"
+        );
+        assert!(
+            text.contains("not a directory"),
+            "the error does not say what is wrong with it: {text}"
+        );
+    }
+
+    /// An existing parent costs one round trip, not one per level.
+    ///
+    /// The walk issues an MKD per level and forgives each failure, so the
+    /// ordinary case, a tree that is already there, pays for every level. A
+    /// stat up front answers the exact question once. Asking precisely can be
+    /// cheaper than asking vaguely, because a vague answer leaves the work to
+    /// be attempted anyway.
+    ///
+    /// Only the parent itself is seeded, and the mock refuses every mkdir, so
+    /// this passes only if no level is walked at all.
+    #[tokio::test]
+    async fn an_existing_parent_is_settled_without_walking_it() {
+        let mut fake = FakeBackend::sample();
+        fake.stats
+            .insert("/data/report/2026".to_string(), (true, 0));
+        let ctx = test_ctx(Arc::new(fake));
+
+        ensure_remote_parents(&ctx, "s", "/data/report/2026/x.csv")
+            .await
+            .expect("an existing parent directory needs no mkdir at all");
+    }
+
+    /// A backend that cannot stat falls back to the words the server used,
+    /// exactly as before the typed check was added.
+    #[tokio::test]
+    async fn without_stat_the_server_wording_still_decides() {
+        let mut fake = FakeBackend::sample();
+        fake.stat_fails_with = Some("stat unsupported".to_string());
+        fake.mkdir_fails_with = Some("550 File exists".to_string());
+        let ctx = test_ctx(Arc::new(fake));
+
+        ensure_remote_parents(&ctx, "s", "/data/report/x.csv")
+            .await
+            .expect("an \"exists\" reply is still forgiven when stat cannot answer");
     }
 
     #[tokio::test]


### PR DESCRIPTION
This site was found by Kimi's error-text gate, which flagged it as a fifth "mkdir already exists" tolerance. It is the opposite: it is the **best** of the five, because it does not stop at the server's words. It already confirms with a `stat`, and the comment beside it records why (ProFTPD on one hosting answers `550 Permission denied` to `MKD` on a directory that exists). Whoever wrote it had already seen that the string was not enough.

**The defect is that the fallback tests the wrong thing.** The line was `if backend.stat(&acc).await.is_ok() { continue; }`, and `stat` returns a `RemoteEntry` carrying an `is_dir` field that the code discarded. So the question asked was "does something exist here" while the question needed is "is there a DIRECTORY here I can descend into".

A regular file where a parent directory should be answers `Ok`, the walk continues, and the next level's `mkdir` fails naming a path one level BELOW the real obstacle. The user is sent to look at `/data/report/2026` when the thing in the way is `/data/report`.

## What changed

`stat` is now read for `is_dir` rather than for success, in the walk and in a new check placed before it. Both the pre-check and the walk report an obstacle through one function rather than two copied `format!` calls, because the message has to be identical from either place that can emit it.

**And it is fewer round trips, not more.** Today the loop issues N `mkdir` calls that all fail when the tree already exists, which is the ordinary case; one `stat` on the parent returns immediately when it is already a directory. When that `stat` says "exists and is not a directory", it fails at once naming the right level. If a backend cannot answer `stat` for a directory, the behaviour falls back exactly to what it is now, which is the path the original comment exists to protect.

`is_dir` was verified reliable before being relied on: `FtpProvider::stat` uses `MLST` where the server offers it, which reports `type=dir`, and otherwise lists the parent and finds the entry. FTP is the protocol this fallback exists for, and it is where the field is populated.

## Three tests, and only two are meant to go red

Two were proved red by restoring the defect, and their messages state the fault rather than the rule:

- `the obstacle is /data/report, but the error points elsewhere: mkdir /data/report/2026 failed` , which is the defect itself, an error naming a level below the obstacle
- `an existing parent directory needs no mkdir at all` , built so it can only pass if no walk happens: only the parent is seeded and the mock refuses every `mkdir`

**The third stays green with the defect restored, deliberately.** It is the non-regression test for the ProFTPD path the comment cites. A red-first test proves the fix was needed and must fail without it; a non-regression test proves nothing else moved and must pass in both versions. Applying "restore the defect and check it fails" to both kinds would either weaken the first or delete the second.

The mock gained a `mkdir_fails_with` field, modelled on the `stat_fails_with` already there, because the first draft of the test called a helper that did not exist: the mock refused every `mkdir` with a fixed string and could not be given a real server's words.

Gate: fmt at zero, clippy on library and CLI at zero, `3663 passed of 3663 executed; 0 failed; 21 ignored`, which is three more than main and they are the three added here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote directory creation when encountering existing paths, symbolic links, or other non-directory entries.
  * Prevented directory creation from incorrectly continuing through paths that cannot be safely traversed.
  * Enhanced error reporting to identify the path level that blocked directory creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->