### PR TITLE
fix(ftp): reject CR and LF in command lines, and type the refusal correctly

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10131,9 +10131,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "suppaftp"
-version = "10.0.0"
+version = "10.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b8286a5639930b8fc0400f8a5111439ffb57e5fba6e8276a8bce857ec47b18"
+checksum = "821001051ea3d12a60fb790b8c7cb9a6f5f8698dcfdca4cd533a025fefb0b5b8"
 dependencies = [
  "async-trait",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -59,7 +59,7 @@ tauri-plugin-fs = "2"
 tauri-plugin-dialog = "2"
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["io"] }
-suppaftp = { version = "=10.0.0", features = ["tokio", "tokio-rustls-aws-lc-rs", "deprecated"] }
+suppaftp = { version = "=10.0.2", features = ["tokio", "tokio-rustls-aws-lc-rs", "deprecated"] }
 rustls = { version = "0.23", features = ["aws-lc-rs"] }
 tokio-rustls = "0.26"
 rustls-pki-types = "1"

--- a/src-tauri/src/providers/ftp.rs
+++ b/src-tauri/src/providers/ftp.rs
@@ -879,6 +879,20 @@ impl FtpProvider {
         if let Some(missing) = Self::classify_missing_path(operation, path, &err) {
             return missing;
         }
+        // A command line the library refused to write, because the path carries
+        // CR or LF. Decided on the io KIND and not on the words: suppaftp
+        // reports it as `ConnectionError`, so passing its sentence through made
+        // the user read "Connection error" for something that is a property of
+        // the NAME, and made `sync::classify_sync_error` match "connection" and
+        // mark a permanent refusal retryable. Both follow from the type, so the
+        // type is where it is fixed; teaching the substring matcher another
+        // exception would leave the wrong noun in the sentence and would have to
+        // be taught again for the next caller that phrases it differently.
+        if let FtpError::ConnectionError(ref io) = err {
+            if io.kind() == std::io::ErrorKind::InvalidInput {
+                return ProviderError::InvalidPath(Self::doing(operation, path, io));
+            }
+        }
         if let FtpError::UnexpectedResponse(ref response) = err {
             let code = response.status as u32;
             if (500..600).contains(&code) {
@@ -3037,7 +3051,7 @@ impl FtpProvider {
                 &[suppaftp::Status::File, suppaftp::Status::CommandOk],
             )
             .await
-            .map_err(|e| ProviderError::ServerError(format!("Hash command failed: {}", e)))?;
+            .map_err(|e| Self::classify_data_failure("hashing", path, e))?;
 
         let body = String::from_utf8_lossy(&response.body).into_owned();
         let mut result = std::collections::HashMap::new();


### PR DESCRIPTION
Pins `suppaftp` to `10.0.2`, which refuses to write a command line containing CR or LF, and types the resulting refusal correctly on our side.

## The exposure, reproduced rather than inferred

With `10.0.0`, a `hashsum` given the path `/pippo.txt\r\nDELE /vittima.txt` made the server receive a second command. The fixture logs what it is asked, so this is the oracle rather than an argument:

```text
<- PWD
<- SIZE /pippo.txt
<- DELE /vittima.txt      <-- never requested by the user
```

With `10.0.2`, the same run reaches the server, completes `USER`/`PASS`/`TYPE`/`FEAT`/`PWD`/`PASV` and then quits. Zero `DELE`.

**The reachable vector is a path supplied by the caller**, from the CLI, a saved profile or an API. It is *not* a filename from a hostile server's listing: a listing is line-based, so a CR or LF inside a name splits the line and does not survive the parser. That was worth checking rather than claiming, because a PR is read later as a record of what was true.

## Why a patch bump carries a classification change

The bump alone would have replaced one defect with another. `suppaftp` reports the refusal as `ConnectionError` carrying `io::ErrorKind::InvalidInput`, so passing its words through produced:

```text
Transfer failed: Connection error: FTP command must not contain CR or LF
```

Two things follow from that sentence, and both are wrong. The user reads "connection" for something that is a property of the **path**. And `sync::classify_sync_error` matches on substrings, sees `connection`, and marks it `Network, retryable`: a refusal that can never succeed would have been attempted again to the retry limit, blaming the link for the name.

So the decision is made on the io **kind** rather than on the text, in `classify_data_failure`, which is the one place that already types these failures and serves reading, writing and opening alike. Teaching the substring matcher another exception would have left the wrong noun in the sentence and would have to be taught again for the next caller that phrases it differently.

```text
Invalid path: FTP command must not contain CR or LF (while reading …)
```

`invalid path` is already in the non-retryable branch, so the sentence and the retry decision are fixed by the same change.

## One wrong turn worth recording

The first attempt put the check at the checksum call site, where the path enters the `HASH` command. It compiled, and changed nothing the user sees: `cmd_hashsum` calls `checksum` inside an `if let Ok(...)`, swallows the failure and falls back to download-and-digest, so the error the user reads comes from the reading path. The defence sat on a path an earlier branch abandons before reaching it, which is a shape that passes every check that does not involve running it.

## Verified

Server as the oracle, with the fixture proven alive by a control listing first: `Invalid path` present, `Connection error` absent, zero `DELE` received, and two `USER` commands showing the client did reach the server, so the zero is not the zero of a client that never connected.

Local gate: `cargo fmt` clean, `cargo clippy --all-features --tests` with zero errors, `cargo test` 4201 passed and 0 failed across 23 test binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhB1WQp9kb1CXaCHSjsX5h


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - FTP paths containing unsupported carriage-return or line-feed characters are now correctly reported as invalid paths.
  - FTP checksum and hashing failures now receive more consistent and accurate error classification.
  - FTP server refusals unrelated to invalid paths are no longer incorrectly reported as path errors.
  - Improved FTP connection error handling provides more relevant feedback when commands cannot be sent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
