### PR TITLE
test(ftp-fixture): count command verbs so a test can assert what was asked

### DIFF
--- a/src-tauri/tests/fixtures/ftp/README-slowftp.md
+++ b/src-tauri/tests/fixtures/ftp/README-slowftp.md
@@ -593,3 +593,29 @@ Note that the deadline has to be shorter than `--hang`, and `--hang` now default
 to 420 for the reasons in the defaults audit above. For this scenario set it
 explicitly to something just above the deadline you are testing, so the reply is
 late but the test is not slow.
+
+## Asserting what the server was asked, by name
+
+The status file counts every command verb the server received:
+
+```text
+"commands": {"FEAT": 1, "PASS": 1, "PWD": 1, "SIZE": 1, "TYPE": 2, "USER": 1}
+```
+
+A test driving the client cannot see this server's log, and the client is the
+wrong end to ask questions like "was a second command injected": it is exactly
+the side that does not know. Counted per verb rather than as a total, because
+the assertion is "`DELE` was never asked" and a total cannot say which verb is
+missing.
+
+Validated against the fault it exists to report, which is the only check that
+makes a counter a guard:
+
+| binary | `DELE` | `USER` | `DELE == 0` |
+|---|---|---|---|
+| before the CR/LF refusal | **1** | 1 | fails |
+| after | **0** | 1 | passes |
+
+The `USER` count is the control in the same reading. Without it a `DELE` of zero
+could equally mean the client never reached the server, and the assertion would
+pass for the wrong reason.

--- a/src-tauri/tests/fixtures/ftp/slowftp.py
+++ b/src-tauri/tests/fixtures/ftp/slowftp.py
@@ -56,6 +56,7 @@ class Counters:
         self.unsolicited_sent = 0
         self.pasv_announced = 0
         self.data_accepted = 0
+        self.commands = {}
         self.write()
 
     def write(self):
@@ -63,10 +64,11 @@ class Counters:
             return
         tmp = self.path + ".tmp"
         with open(tmp, "w") as fh:
+            cmds = ", ".join('"%s": %d' % (k, v) for k, v in sorted(self.commands.items()))
             fh.write('{"abor_read": %d, "stor_bytes": %d, "unsolicited_sent": %d, '
-                     '"pasv_announced": %d, "data_accepted": %d}\n'
+                     '"pasv_announced": %d, "data_accepted": %d, "commands": {%s}}\n'
                      % (self.abor_read, self.stor_bytes, self.unsolicited_sent,
-                        self.pasv_announced, self.data_accepted))
+                        self.pasv_announced, self.data_accepted, cmds))
         os.replace(tmp, self.path)  # atomic: a reader never sees a half file
 
     def bump_abor(self):
@@ -84,6 +86,20 @@ class Counters:
         """
         with self.lock:
             self.unsolicited_sent += 1
+            self.write()
+
+    def note_command(self, verb):
+        """Count every command verb the server was asked, by name.
+
+        A test that drives the client cannot see this server's log, so without
+        this it can only assert on what the client printed. That is the wrong
+        end for questions like "was a second command injected": the client is
+        exactly the side that does not know. Counted per verb rather than as a
+        total, because the assertion is "DELE was never asked", and a total
+        cannot say which verb is missing.
+        """
+        with self.lock:
+            self.commands[verb] = self.commands.get(verb, 0) + 1
             self.write()
 
     def bump(self, field):
@@ -412,6 +428,7 @@ class Session(threading.Thread):
                 continue
             cmd, _, arg = line.partition(" ")
             cmd = cmd.upper()
+            self.counters.note_command(cmd)
             log("<- %s" % line)
 
             if cmd == "USER":   self.send("331 Please specify the password.")


### PR DESCRIPTION
The fixture's status file now carries a per-verb count of every command the server received.

```text
"commands": {"FEAT": 1, "PASS": 1, "PWD": 1, "SIZE": 1, "TYPE": 2, "USER": 1}
```

## Why the client is the wrong end to ask

A test that drives our client cannot see the fixture's log. For a question like *was a second command injected*, the client is exactly the side that does not know: the injected command leaves it and never comes back. The server is the only end that can answer, so the answer has to be readable from the server without parsing a log, which is fragile in a test.

Counted per verb rather than as a total, because the assertion is that `DELE` was never asked, and a total cannot say which verb is missing.

## Validated against the fault it reports

A counter that has never been seen to go red for the fault it exists to report is a counter, not a guard. This one was run against both binaries:

| binary | `DELE` | `USER` | assertion `DELE == 0` |
|---|---|---|---|
| still allows CR/LF injection | **1** | 1 | **fails** |
| with the refusal in place | **0** | 1 | passes |

The `USER` count in the same reading is the control. Without it a `DELE` of zero could equally mean the client never reached the server at all, and the assertion would pass for the wrong reason: the two zeroes are the same digit.

## Scope

Test fixture and its README only. No product code. It unblocks writing the CR/LF injection regression in Rust, which currently exists only as a manual reproduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhB1WQp9kb1CXaCHSjsX5h


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved FTP fixture diagnostics by recording counts for each command received.
  * Added validation that command counts remain accurate during line-ending refusal scenarios.
  * Documented the new command-count information available in fixture status output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->