### PR TITLE
chore(deps): russh 0.63.1, for three client-side advisories cargo audit cannot see

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -8611,9 +8611,9 @@ dependencies = [
 
 [[package]]
 name = "russh"
-version = "0.62.5"
+version = "0.63.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da7c230e0ed9cbeb92fbad6c8848985d6df2a1464c0dc247a021abd666e9005e"
+checksum = "35bab1b87d915817d5d9cc352637cd40d5f0b298a48c6309af9156a4addc3031"
 dependencies = [
  "aes 0.9.1",
  "aws-lc-rs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -142,7 +142,7 @@ mime_guess = "2"
 
 # SFTP Support (Sprint 3 - v1.3.0)
 # SFTP channel writes: see sftp-upload-0byte-bug.md in memory
-russh = { version = "0.62.5", features = ["ring"] }
+russh = { version = "0.63.1", features = ["ring"] }
 russh-sftp = "2.1"
 ssh2 = { version = "0.9.5", features = ["vendored-openssl"] }
 
@@ -351,7 +351,20 @@ unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(mtp_libmtp)',
 ] }
 
-# russh 0.62.5 closes the three advisories that 0.61.2 carried plus
+# russh 0.63.1 closes GHSA-47hw-gvq5-r2gm (High, CVSS 7.5, published 2026-08-23),
+# which is a CLIENT-side defect and therefore ours: a hostile or compromised
+# server can fire channel-scoped `Handler` callbacks for channel IDs the client
+# never opened, giving panics, forged exit statuses and desynchronised channel
+# state. It also closes GHSA-w3jg-pjxf-73p4 (Moderate), the missing X25519
+# zero-point validation in the hybrid ML-KEM768+X25519 key exchange, fixed in
+# 0.63.0 only.
+#
+# There is no backport on the 0.62 line, and that is arithmetic rather than a
+# reading of a changelog: 0.62.7 was published 2026-08-17, four days BEFORE
+# 0.63.0 and six before 0.63.1, so it cannot contain a fix for advisories
+# published after it. `cargo update` stays on 0.62 and stays vulnerable.
+#
+# 0.62.5 closed the three advisories that 0.61.2 carried plus
 # GHSA-m65r-rprj-r5rg, which affects channel-scoped server callbacks through
 # 0.62.4. The earlier advisories are GHSA-g9hv-x236-4qp3
 # and GHSA-5xvq-cp9x-6p6r (pre-auth panics, the first on every SFTP connection

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -375,7 +375,7 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 #
 # The bump is not resolvable without this patch. n0-mainline 0.5.0, reached
 # through aeroftp-peer-l0 -> iroh-mainline-address-lookup 0.4.0, pins
-# `ed25519-dalek = "=3.0.0-rc.0"`, while russh 0.62.5 asks for `^3`. A caret
+# `ed25519-dalek = "=3.0.0-rc.0"`, while russh 0.63.1 asks for `^3`. A caret
 # requirement does not match a pre-release and cargo treats 3.0.0-rc.0 and
 # 3.0.0 as one compatibility range, so the two are disjoint rather than merely
 # duplicated: cargo cannot satisfy both and refuses the graph.

--- a/src-tauri/src/aerorsync/russh_session_transport.rs
+++ b/src-tauri/src/aerorsync/russh_session_transport.rs
@@ -94,9 +94,15 @@ impl Handler for RusshHandler {
         // and both take `host_key_certificates` from the default. The one that
         // does override `key` lists Ed25519, three ECDSA curves and two RSA
         // hashes, every one of them a plain-key algorithm, so it does not
-        // reopen the door either. The arm goes live if a third `Preferred`
-        // fills that list, or if a `key` list gains a `*-cert-v01@openssh.com`
-        // algorithm, and neither of those edits is in this file.
+        // reopen the door either. The arm goes live if any `Preferred` fills
+        // that list, or if a `key` list gains a `*-cert-v01@openssh.com`
+        // algorithm. Both of those edits are named by path on purpose, because
+        // this paragraph is repeated in three handlers and "not in this file"
+        // would be true in one of them and reassuring in exactly the file that
+        // owns the dangerous line: today they are `providers/sftp.rs` and
+        // `aerorsync/russh_session_transport.rs`, the two that build a
+        // `Preferred`, the second holding the only `key` override, plus
+        // wherever a new `Preferred` is added.
         //
         // WHOEVER ENABLES HOST CERTIFICATES MUST COME BACK TO ALL FOUR
         // HANDLERS FIRST. Filling that list makes this arm live, and accepting

--- a/src-tauri/src/aerorsync/russh_session_transport.rs
+++ b/src-tauri/src/aerorsync/russh_session_transport.rs
@@ -87,9 +87,20 @@ impl Handler for RusshHandler {
         // one. It is refused rather than left to a wildcard so that the answer
         // is a decision instead of an accident.
         //
+        // The default holding is the second half of that claim, and it was
+        // checked rather than assumed: this tree builds a `Preferred` of its
+        // own in exactly two places, `providers/sftp.rs` (compression only) and
+        // `aerorsync/russh_session_transport.rs` (host-key algorithms only),
+        // and both take `host_key_certificates` from the default. The one that
+        // does override `key` lists Ed25519, three ECDSA curves and two RSA
+        // hashes, every one of them a plain-key algorithm, so it does not
+        // reopen the door either. The arm goes live if a third `Preferred`
+        // fills that list, or if a `key` list gains a `*-cert-v01@openssh.com`
+        // algorithm, and neither of those edits is in this file.
+        //
         // WHOEVER ENABLES HOST CERTIFICATES MUST COME BACK TO ALL FOUR
-        // HANDLERS FIRST. Filling
-        // that list makes this arm live, and accepting a certificate is a trust
+        // HANDLERS FIRST. Filling that list makes this arm live, and accepting
+        // a certificate is a trust
         // policy nobody has discussed: it would mean trusting a CA to vouch for
         // hosts, which is a different model from the known-hosts and pinned
         // fingerprint checks below. Refusing keeps today's behaviour exactly,

--- a/src-tauri/src/aerorsync/russh_session_transport.rs
+++ b/src-tauri/src/aerorsync/russh_session_transport.rs
@@ -13,7 +13,9 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use russh::client::{self, AuthResult, Config, Handle, Handler, Msg};
-use russh::keys::{self, Algorithm, EcdsaCurve, HashAlg, PrivateKeyWithHashAlg, PublicKey};
+use russh::keys::{
+    self, Algorithm, EcdsaCurve, HashAlg, PrivateKeyWithHashAlg, PublicKey, PublicKeyOrCertificate,
+};
 use russh::Preferred;
 use russh::{Channel, ChannelMsg};
 use secrecy::ExposeSecret;
@@ -76,8 +78,32 @@ impl Handler for RusshHandler {
 
     async fn check_server_key(
         &mut self,
-        server_public_key: &PublicKey,
+        server_public_key: &PublicKeyOrCertificate,
     ) -> Result<bool, Self::Error> {
+        // russh 0.63 presents either a bare key or a host CERTIFICATE here.
+        // The certificate arm is unreachable as this client is configured:
+        // `Preferred::host_key_certificates` defaults to an empty list, so no
+        // certificate algorithm is ever offered and a server cannot present
+        // one. It is refused rather than left to a wildcard so that the answer
+        // is a decision instead of an accident.
+        //
+        // WHOEVER ENABLES HOST CERTIFICATES MUST COME BACK TO ALL FOUR
+        // HANDLERS FIRST. Filling
+        // that list makes this arm live, and accepting a certificate is a trust
+        // policy nobody has discussed: it would mean trusting a CA to vouch for
+        // hosts, which is a different model from the known-hosts and pinned
+        // fingerprint checks below. Refusing keeps today's behaviour exactly,
+        // because today the case cannot arise.
+        let server_public_key = match server_public_key {
+            PublicKeyOrCertificate::PublicKey { key, .. } => key,
+            PublicKeyOrCertificate::Certificate(_) => {
+                tracing::warn!(
+                    "SSH: refusing a host certificate; certificate algorithms are not offered \
+                     by this client, so this should be unreachable"
+                );
+                return Ok(false);
+            }
+        };
         match &self.policy {
             SshHostKeyPolicy::AcceptAny => Ok(true),
             SshHostKeyPolicy::PinnedFingerprintSha256 { sha256_hex } => {
@@ -850,6 +876,17 @@ impl crate::aerorsync::transport::BidirectionalByteStream for RusshUnusedStream 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// russh 0.63 hands the handler a key OR a certificate. These tests are
+    /// about the key policy, so they present a key; the certificate arm is
+    /// unreachable while no certificate algorithm is offered, and it has its
+    /// own refusal in the handler.
+    fn presented(key: &PublicKey) -> PublicKeyOrCertificate {
+        PublicKeyOrCertificate::PublicKey {
+            key: key.clone(),
+            hash_alg: None,
+        }
+    }
     use secrecy::SecretString;
 
     fn dummy_config() -> SshTransportConfig {
@@ -1141,13 +1178,13 @@ mod tests {
         });
 
         assert!(
-            h.check_server_key(&pinned)
+            h.check_server_key(&presented(&pinned))
                 .await
                 .expect("no transport error"),
             "the pinned key must be accepted"
         );
         assert!(
-            !h.check_server_key(&impostor)
+            !h.check_server_key(&presented(&impostor))
                 .await
                 .expect("a mismatch is a rejection, not a transport error"),
             "a server key we did not pin MUST be rejected: this is the man-in-the-middle case"
@@ -1167,7 +1204,7 @@ mod tests {
         });
 
         assert!(
-            h.check_server_key(&pinned)
+            h.check_server_key(&presented(&pinned))
                 .await
                 .expect("no transport error"),
             "an uppercase pin must match the same key"
@@ -1184,7 +1221,7 @@ mod tests {
         let (_, unknown) = two_distinct_host_keys();
         let mut h = RusshHandler::new(SshHostKeyPolicy::AcceptAny);
         assert!(
-            h.check_server_key(&unknown)
+            h.check_server_key(&presented(&unknown))
                 .await
                 .expect("no transport error"),
             "AcceptAny is the bootstrap hatch and accepts an unvouched key by design"

--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -29809,10 +29809,19 @@ mod serve_sftp {
                 russh::MethodSet::from(&[russh::MethodKind::Password][..])
             } else {
                 // russh 0.63 removed `all()` and split it by side. This is a
-                // `server::Config`, so `server_supported()` is the one, and the
-                // two return the identical list: None, Password, PublicKey,
-                // HostBased, KeyboardInteractive. Checked against both crates
-                // rather than assumed from the name.
+                // `server::Config`, so `server_supported()` is the one, and it
+                // is `all()` and `server_supported()` that return the identical
+                // list: None, Password, PublicKey, HostBased,
+                // KeyboardInteractive. Checked against both crates rather than
+                // assumed from the name.
+                //
+                // Not the two SIDES. `client_supported()` returns those five
+                // plus GssapiWithMic, so it is not a drop-in here: russh 0.63.1
+                // ships no gssapi implementation in its server module, and a
+                // `server::Config` built from it would advertise a method it
+                // cannot honour. The equality that makes this substitution
+                // behaviour-preserving is with the OLD `all()`, not with the
+                // client side.
                 russh::MethodSet::server_supported()
             },
             keys: vec![key],

--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -29808,7 +29808,12 @@ mod serve_sftp {
             methods: if auth_credentials.is_some() {
                 russh::MethodSet::from(&[russh::MethodKind::Password][..])
             } else {
-                russh::MethodSet::all()
+                // russh 0.63 removed `all()` and split it by side. This is a
+                // `server::Config`, so `server_supported()` is the one, and the
+                // two return the identical list: None, Password, PublicKey,
+                // HostBased, KeyboardInteractive. Checked against both crates
+                // rather than assumed from the name.
+                russh::MethodSet::server_supported()
             },
             keys: vec![key],
             ..Default::default()

--- a/src-tauri/src/host_key_check.rs
+++ b/src-tauri/src/host_key_check.rs
@@ -7,7 +7,7 @@
 // Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
 
 use russh::client::{self, Config, Handler};
-use russh::keys::{self, known_hosts, HashAlg, PublicKey};
+use russh::keys::{self, known_hosts, HashAlg, PublicKey, PublicKeyOrCertificate};
 use serde::Serialize;
 use std::collections::HashMap;
 use std::sync::{Arc, LazyLock, Mutex};
@@ -56,8 +56,32 @@ impl Handler for ProbeHandler {
 
     async fn check_server_key(
         &mut self,
-        server_public_key: &PublicKey,
+        server_public_key: &PublicKeyOrCertificate,
     ) -> Result<bool, Self::Error> {
+        // russh 0.63 presents either a bare key or a host CERTIFICATE here.
+        // The certificate arm is unreachable as this client is configured:
+        // `Preferred::host_key_certificates` defaults to an empty list, so no
+        // certificate algorithm is ever offered and a server cannot present
+        // one. It is refused rather than left to a wildcard so that the answer
+        // is a decision instead of an accident.
+        //
+        // WHOEVER ENABLES HOST CERTIFICATES MUST COME BACK TO ALL FOUR
+        // HANDLERS FIRST. Filling
+        // that list makes this arm live, and accepting a certificate is a trust
+        // policy nobody has discussed: it would mean trusting a CA to vouch for
+        // hosts, which is a different model from the known-hosts and pinned
+        // fingerprint checks below. Refusing keeps today's behaviour exactly,
+        // because today the case cannot arise.
+        let server_public_key = match server_public_key {
+            PublicKeyOrCertificate::PublicKey { key, .. } => key,
+            PublicKeyOrCertificate::Certificate(_) => {
+                tracing::warn!(
+                    "SSH: refusing a host certificate; certificate algorithms are not offered \
+                     by this client, so this should be unreachable"
+                );
+                return Ok(false);
+            }
+        };
         let fingerprint = server_public_key.fingerprint(HashAlg::Sha256).to_string();
         let algorithm = server_public_key.algorithm().as_str().to_string();
 

--- a/src-tauri/src/host_key_check.rs
+++ b/src-tauri/src/host_key_check.rs
@@ -65,9 +65,20 @@ impl Handler for ProbeHandler {
         // one. It is refused rather than left to a wildcard so that the answer
         // is a decision instead of an accident.
         //
+        // The default holding is the second half of that claim, and it was
+        // checked rather than assumed: this tree builds a `Preferred` of its
+        // own in exactly two places, `providers/sftp.rs` (compression only) and
+        // `aerorsync/russh_session_transport.rs` (host-key algorithms only),
+        // and both take `host_key_certificates` from the default. The one that
+        // does override `key` lists Ed25519, three ECDSA curves and two RSA
+        // hashes, every one of them a plain-key algorithm, so it does not
+        // reopen the door either. The arm goes live if a third `Preferred`
+        // fills that list, or if a `key` list gains a `*-cert-v01@openssh.com`
+        // algorithm, and neither of those edits is in this file.
+        //
         // WHOEVER ENABLES HOST CERTIFICATES MUST COME BACK TO ALL FOUR
-        // HANDLERS FIRST. Filling
-        // that list makes this arm live, and accepting a certificate is a trust
+        // HANDLERS FIRST. Filling that list makes this arm live, and accepting
+        // a certificate is a trust
         // policy nobody has discussed: it would mean trusting a CA to vouch for
         // hosts, which is a different model from the known-hosts and pinned
         // fingerprint checks below. Refusing keeps today's behaviour exactly,

--- a/src-tauri/src/host_key_check.rs
+++ b/src-tauri/src/host_key_check.rs
@@ -72,9 +72,15 @@ impl Handler for ProbeHandler {
         // and both take `host_key_certificates` from the default. The one that
         // does override `key` lists Ed25519, three ECDSA curves and two RSA
         // hashes, every one of them a plain-key algorithm, so it does not
-        // reopen the door either. The arm goes live if a third `Preferred`
-        // fills that list, or if a `key` list gains a `*-cert-v01@openssh.com`
-        // algorithm, and neither of those edits is in this file.
+        // reopen the door either. The arm goes live if any `Preferred` fills
+        // that list, or if a `key` list gains a `*-cert-v01@openssh.com`
+        // algorithm. Both of those edits are named by path on purpose, because
+        // this paragraph is repeated in three handlers and "not in this file"
+        // would be true in one of them and reassuring in exactly the file that
+        // owns the dangerous line: today they are `providers/sftp.rs` and
+        // `aerorsync/russh_session_transport.rs`, the two that build a
+        // `Preferred`, the second holding the only `key` override, plus
+        // wherever a new `Preferred` is added.
         //
         // WHOEVER ENABLES HOST CERTIFICATES MUST COME BACK TO ALL FOUR
         // HANDLERS FIRST. Filling that list makes this arm live, and accepting

--- a/src-tauri/src/providers/sftp.rs
+++ b/src-tauri/src/providers/sftp.rs
@@ -188,9 +188,20 @@ impl Handler for SshHandler {
         // one. It is refused rather than left to a wildcard so that the answer
         // is a decision instead of an accident.
         //
+        // The default holding is the second half of that claim, and it was
+        // checked rather than assumed: this tree builds a `Preferred` of its
+        // own in exactly two places, `providers/sftp.rs` (compression only) and
+        // `aerorsync/russh_session_transport.rs` (host-key algorithms only),
+        // and both take `host_key_certificates` from the default. The one that
+        // does override `key` lists Ed25519, three ECDSA curves and two RSA
+        // hashes, every one of them a plain-key algorithm, so it does not
+        // reopen the door either. The arm goes live if a third `Preferred`
+        // fills that list, or if a `key` list gains a `*-cert-v01@openssh.com`
+        // algorithm, and neither of those edits is in this file.
+        //
         // WHOEVER ENABLES HOST CERTIFICATES MUST COME BACK TO ALL FOUR
-        // HANDLERS FIRST. Filling
-        // that list makes this arm live, and accepting a certificate is a trust
+        // HANDLERS FIRST. Filling that list makes this arm live, and accepting
+        // a certificate is a trust
         // policy nobody has discussed: it would mean trusting a CA to vouch for
         // hosts, which is a different model from the known-hosts and pinned
         // fingerprint checks below. Refusing keeps today's behaviour exactly,

--- a/src-tauri/src/providers/sftp.rs
+++ b/src-tauri/src/providers/sftp.rs
@@ -18,7 +18,9 @@ use crate::ssh_exec::ssh_exec_collect;
 use async_trait::async_trait;
 use russh::client::AuthResult;
 use russh::client::{self, Config, Handle, Handler};
-use russh::keys::{self, known_hosts, Algorithm, HashAlg, PrivateKeyWithHashAlg, PublicKey};
+use russh::keys::{
+    self, known_hosts, Algorithm, HashAlg, PrivateKeyWithHashAlg, PublicKey, PublicKeyOrCertificate,
+};
 use russh::{compression, Preferred};
 use russh_sftp::client::SftpSession;
 use std::path::{Path, PathBuf};
@@ -177,8 +179,32 @@ impl Handler for SshHandler {
 
     async fn check_server_key(
         &mut self,
-        server_public_key: &PublicKey,
+        server_public_key: &PublicKeyOrCertificate,
     ) -> Result<bool, Self::Error> {
+        // russh 0.63 presents either a bare key or a host CERTIFICATE here.
+        // The certificate arm is unreachable as this client is configured:
+        // `Preferred::host_key_certificates` defaults to an empty list, so no
+        // certificate algorithm is ever offered and a server cannot present
+        // one. It is refused rather than left to a wildcard so that the answer
+        // is a decision instead of an accident.
+        //
+        // WHOEVER ENABLES HOST CERTIFICATES MUST COME BACK TO ALL FOUR
+        // HANDLERS FIRST. Filling
+        // that list makes this arm live, and accepting a certificate is a trust
+        // policy nobody has discussed: it would mean trusting a CA to vouch for
+        // hosts, which is a different model from the known-hosts and pinned
+        // fingerprint checks below. Refusing keeps today's behaviour exactly,
+        // because today the case cannot arise.
+        let server_public_key = match server_public_key {
+            PublicKeyOrCertificate::PublicKey { key, .. } => key,
+            PublicKeyOrCertificate::Certificate(_) => {
+                tracing::warn!(
+                    "SSH: refusing a host certificate; certificate algorithms are not offered \
+                     by this client, so this should be unreachable"
+                );
+                return Ok(false);
+            }
+        };
         // Use russh's built-in known_hosts verification
         match known_hosts::check_known_hosts(&self.host, self.port, server_public_key) {
             Ok(true) => {

--- a/src-tauri/src/providers/sftp.rs
+++ b/src-tauri/src/providers/sftp.rs
@@ -195,9 +195,15 @@ impl Handler for SshHandler {
         // and both take `host_key_certificates` from the default. The one that
         // does override `key` lists Ed25519, three ECDSA curves and two RSA
         // hashes, every one of them a plain-key algorithm, so it does not
-        // reopen the door either. The arm goes live if a third `Preferred`
-        // fills that list, or if a `key` list gains a `*-cert-v01@openssh.com`
-        // algorithm, and neither of those edits is in this file.
+        // reopen the door either. The arm goes live if any `Preferred` fills
+        // that list, or if a `key` list gains a `*-cert-v01@openssh.com`
+        // algorithm. Both of those edits are named by path on purpose, because
+        // this paragraph is repeated in three handlers and "not in this file"
+        // would be true in one of them and reassuring in exactly the file that
+        // owns the dangerous line: today they are `providers/sftp.rs` and
+        // `aerorsync/russh_session_transport.rs`, the two that build a
+        // `Preferred`, the second holding the only `key` override, plus
+        // wherever a new `Preferred` is added.
         //
         // WHOEVER ENABLES HOST CERTIFICATES MUST COME BACK TO ALL FOUR
         // HANDLERS FIRST. Filling that list makes this arm live, and accepting

--- a/src-tauri/src/ssh_shell.rs
+++ b/src-tauri/src/ssh_shell.rs
@@ -38,7 +38,10 @@ impl Handler for ShellSshHandler {
         &mut self,
         server_public_key: &PublicKeyOrCertificate,
     ) -> Result<bool, Self::Error> {
-        // See the sibling handlers: the certificate arm is unreachable while
+        // See the sibling handlers for the full reasoning and the two edits
+        // that would make this arm live: `providers/sftp.rs`,
+        // `host_key_check.rs`, `aerorsync/russh_session_transport.rs`. In
+        // short: the certificate arm is unreachable while
         // `Preferred::host_key_certificates` stays empty, and refusing keeps
         // today's behaviour exactly. Whoever enables host certificates must
         // come back to all FOUR of these first.

--- a/src-tauri/src/ssh_shell.rs
+++ b/src-tauri/src/ssh_shell.rs
@@ -9,7 +9,7 @@
 
 use russh::client::AuthResult;
 use russh::client::{self, Config, Handle, Handler, Msg};
-use russh::keys::{self, known_hosts, PrivateKeyWithHashAlg, PublicKey};
+use russh::keys::{self, known_hosts, PrivateKeyWithHashAlg, PublicKeyOrCertificate};
 use russh::{Channel, ChannelId, ChannelMsg};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -36,8 +36,22 @@ impl Handler for ShellSshHandler {
 
     async fn check_server_key(
         &mut self,
-        server_public_key: &PublicKey,
+        server_public_key: &PublicKeyOrCertificate,
     ) -> Result<bool, Self::Error> {
+        // See the sibling handlers: the certificate arm is unreachable while
+        // `Preferred::host_key_certificates` stays empty, and refusing keeps
+        // today's behaviour exactly. Whoever enables host certificates must
+        // come back to all FOUR of these first.
+        let server_public_key = match server_public_key {
+            PublicKeyOrCertificate::PublicKey { key, .. } => key,
+            PublicKeyOrCertificate::Certificate(_) => {
+                tracing::warn!(
+                    "SSH Shell: refusing a host certificate; certificate algorithms are not \
+                     offered by this client, so this should be unreachable"
+                );
+                return Ok(false);
+            }
+        };
         match known_hosts::check_known_hosts(&self.host, self.port, server_public_key) {
             Ok(true) => Ok(true),
             Ok(false) => {


### PR DESCRIPTION
Three advisories published between 21 and 23 August affect `russh` as a CLIENT, which is what we are. The headline one is **GHSA-47hw-gvq5-r2gm, High, CVSS 7.5**: a hostile or compromised SSH server can trigger channel-scoped `Handler` callbacks for channel IDs the client never opened, producing panics, forged exit statuses and a desynchronised channel state. The other two are a missing zero-point validation for X25519 in the hybrid ML-KEM768 key exchange, patched only in 0.63.0, and a panic with `mac=none` and a block cipher.

## `cargo audit` is green and blind here, and that is documented rather than discovered

`russh` has no RustSec entry, so its advisories live only on GHSA and `cargo audit` cannot see them. Our own `Cargo.toml` already says so from the 0.62.5 bump: "the green does NOT mean this tree is clean of them, that is precisely why the bump had to be driven by hand."

**And the absence of a backport on the 0.62 line is arithmetic, not a reading of a changelog.** 0.62.7 was published on 17 August; 0.63.0 on 21 August and 0.63.1 on 23 August. The last release of the 0.62 line predates the advisories it would have to fix, so `cargo update` cannot reach a fixed version. Dates from crates.io.

## The graph did not move, which was the real question

The 0.62.5 bump required a `[patch.crates-io]` on `n0-mainline`, because it pins `ed25519-dalek = "=3.0.0-rc.0"` while `russh` asks `^3`, and a caret does not match a pre-release. 0.63.1 declares **exactly the same requirements** as 0.62.5, so the fork remains necessary and sufficient and was not touched. The lock moves two lines: `russh` 0.62.5 to 0.63.1 and its checksum. Nothing else.

`ed25519-dalek` 3.0.0 did go stable on 6 July, and it dissolves nothing: an exact pin on a pre-release is not a floor that a later release can satisfy.

## Five sites, not three

The perimeter handed to this work said three `Handler` implementations. It was five things, enumerated by grep across `src/` after the compiler rejected the fourth:

- four implementations, `providers/sftp.rs`, `aerorsync/russh_session_transport.rs`, `host_key_check.rs` and `ssh_shell.rs`, the last of which nobody had listed
- four call sites in the transport's own tests
- and one point outside the trait entirely: `MethodSet::all()` in the CLI, which 0.63 split by side into `client_supported` and `server_supported`

Of the 27 trait methods, 27 remain and exactly one changes signature: `check_server_key`, whose parameter becomes `&PublicKeyOrCertificate`.

## Two things worth knowing beyond this bump

**The default for `check_server_key` REJECTS.** It is `async { Ok(false) }`, so an implementation that stopped overriding it would compile and refuse every server. "It has a default" is normally the sentence that ends the worry; here falling back is total failure, and silently.

**The `MethodSet` split is where a compiler would not have helped.** It caught four of the five because they were removals or type errors. Had `all()` survived with different contents instead of disappearing, a `server::Config` would have advertised a client's method set and nothing would have said so. The two lists were compared by content rather than trusted by name: `None, Password, PublicKey, HostBased, KeyboardInteractive` in both.

The `Certificate` variant is rejected in all four implementations, and the comment says why: it is unreachable while `host_key_certificates` defaults to empty, so rejecting preserves exactly today's behaviour, and whoever enables host certificates must return to all four. A branch that is unreachable without a line saying so is a branch somebody will tidy away.

Gate re-run against the current base after `main` moved underneath the work: clippy `--all-features --tests` at zero errors and zero warnings, clippy on the CLI binary the same, 900 provider tests, 18 in `aerorsync::russh`, 26 in `host_key`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated SSH connectivity to support the latest secure protocol handling.
  * Improved host-key verification by explicitly rejecting unsupported host certificates while preserving known-hosts checks.
  * Maintained compatible server authentication methods for command-line transfers.
  * Addressed client-side security advisories through the updated SSH implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->