### PR TITLE
fix(cli): decide the keystore exit code on the error variant, not its words

### DIFF
--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -37151,6 +37151,7 @@ fn classify_keystore_error(err: &ftp_client_gui_lib::keystore_export::KeystoreEx
         E::InvalidPassword => 6,       // auth failure
         E::VaultNotReady => 5,         // configuration / vault-locked
         E::UnsupportedVersion(_) => 7, // not-supported / unsupported version
+        E::UnsupportedCodec(_) => 7,   // same family: this build cannot read it
         E::Io(_) => 11,                // I/O
         // Both cover too many distinct causes for one code to say anything
         // useful, so they say nothing rather than something false.
@@ -66633,10 +66634,38 @@ mod tests {
             99
         );
 
-        // Same variant, wording that once mattered and now does not.
+        // Same variant, wording that once mattered and now does not. The old
+        // chain gave 6 to anything containing "decrypt", and three sites
+        // interpolate a string the caller chose, so `--merge decrypt` exited 6
+        // and `--merge "io error"` exited 11: a pipeline branching on the code
+        // was being steered from the command line.
         assert_eq!(
-            classify_keystore_error(&E::Encryption("failed to decrypt blob".into())),
+            classify_keystore_error(&E::Encryption("Invalid merge strategy: decrypt".into())),
             99
+        );
+        assert_eq!(
+            classify_keystore_error(&E::Encryption("Invalid merge strategy: io error".into())),
+            99
+        );
+
+        // The two that must NOT move, and did in the first version of this
+        // change. A permission problem on the vault file arrives as a
+        // `CredentialError::Io` and used to reach 11 because its text happened
+        // to say "IO error"; it now reaches 11 because it is an `Io`.
+        assert_eq!(
+            classify_keystore_error(&E::Io(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "Permission denied (os error 13)"
+            ))),
+            11
+        );
+        // A codec this build cannot read used to get 7 from the words "unknown
+        // compression" appearing in an `Encryption` message, which let the
+        // marker inside the backup file pick the exit code. Same 7, from a
+        // variant.
+        assert_eq!(
+            classify_keystore_error(&E::UnsupportedCodec("brotli".into())),
+            7
         );
     }
     use serde_json::json;

--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -36138,7 +36138,7 @@ async fn cmd_keystore_export(
     let metadata = match result {
         Ok(Ok(m)) => m,
         Ok(Err(e)) => {
-            let exit = classify_keystore_error(&e.to_string());
+            let exit = classify_keystore_error(&e);
             print_error(format, &format!("keystore export failed: {e}"), exit);
             return exit;
         }
@@ -36259,7 +36259,7 @@ async fn cmd_keystore_import(
     let outcome = match result {
         Ok(Ok(r)) => r,
         Ok(Err(e)) => {
-            let exit = classify_keystore_error(&e.to_string());
+            let exit = classify_keystore_error(&e);
             print_error(format, &format!("keystore import failed: {e}"), exit);
             return exit;
         }
@@ -36401,7 +36401,7 @@ fn cmd_keystore_info(input: &str, json: bool, format: OutputFormat) -> i32 {
     ) {
         Ok(m) => m,
         Err(e) => {
-            let exit = classify_keystore_error(&e.to_string());
+            let exit = classify_keystore_error(&e);
             print_error(format, &format!("keystore info failed: {e}"), exit);
             return exit;
         }
@@ -37120,22 +37120,41 @@ async fn cmd_aerorsync_probe(
     7
 }
 
-/// Map a keystore_export error message back to a CLI exit code.
-/// Matches the 0/1/2/4/5/6/8/11/99 scheme used elsewhere in
-/// `aeroftp-cli` so cron/CI pipelines can branch on it without
-/// parsing the error text.
-fn classify_keystore_error(msg: &str) -> i32 {
-    let low = msg.to_ascii_lowercase();
-    if low.contains("invalid password") || low.contains("decrypt") {
-        6 // auth failure
-    } else if low.contains("vault not ready") || low.contains("vault unavailable") {
-        5 // configuration / vault-locked
-    } else if low.contains("unsupported file version") || low.contains("unknown compression") {
-        7 // not-supported / unsupported version
-    } else if low.contains("io error") || low.contains("backup file") {
-        11 // I/O
-    } else {
-        99 // unclassified
+/// Map a keystore_export error to a CLI exit code, by VARIANT.
+///
+/// Matches the 0/1/2/4/5/6/8/11/99 scheme used elsewhere in `aeroftp-cli` so
+/// cron/CI pipelines can branch on it without parsing the error text.
+///
+/// That promise used to be made and not kept. The function received
+/// `e.to_string()` and searched it for words, so the parsing a pipeline was
+/// told it could skip had merely MOVED: it became a duty of whoever writes the
+/// error messages, and nobody told them. A reworded message changed an exit
+/// code with no test failing anywhere, because the callers had the typed error
+/// in hand and threw the type away to get a string.
+///
+/// It now takes the error itself. Two mappings are worth naming because the
+/// text was getting them wrong:
+///
+/// `Encryption` covers everything from `zstd init` to `Invalid merge strategy`,
+/// and two of its messages begin "Backup file too large" / "Backup file exceeds
+/// cap after read". Those matched a `contains("backup file")` branch and exited
+/// **11**, telling a script a size-cap refusal was a disk I/O fault. They are
+/// unclassified, so they exit 99: that replaces a wrong answer with no answer,
+/// which is the honest one of the two.
+///
+/// The old 6 branch also matched `contains("decrypt")`. No message this enum can
+/// produce contains that word, so that half never fired. Dead, and it looked
+/// like coverage.
+fn classify_keystore_error(err: &ftp_client_gui_lib::keystore_export::KeystoreExportError) -> i32 {
+    use ftp_client_gui_lib::keystore_export::KeystoreExportError as E;
+    match err {
+        E::InvalidPassword => 6,       // auth failure
+        E::VaultNotReady => 5,         // configuration / vault-locked
+        E::UnsupportedVersion(_) => 7, // not-supported / unsupported version
+        E::Io(_) => 11,                // I/O
+        // Both cover too many distinct causes for one code to say anything
+        // useful, so they say nothing rather than something false.
+        E::Serialization(_) | E::Encryption(_) => 99,
     }
 }
 
@@ -66580,6 +66599,46 @@ fn effective_max_attempts(cli: &Cli, format: OutputFormat) -> u32 {
 mod tests {
     use super::*;
     use ftp_client_gui_lib::profile_loader::insert_profile_option;
+
+    /// Pin the exit code to the error VARIANT, so a reworded message cannot
+    /// move it. The previous version searched `to_string()` for words, which
+    /// meant every one of these mappings depended on a sentence nobody had been
+    /// told was load-bearing.
+    #[test]
+    fn keystore_exit_code_follows_the_variant_not_the_words() {
+        use ftp_client_gui_lib::keystore_export::KeystoreExportError as E;
+
+        assert_eq!(classify_keystore_error(&E::InvalidPassword), 6);
+        assert_eq!(classify_keystore_error(&E::VaultNotReady), 5);
+        assert_eq!(classify_keystore_error(&E::UnsupportedVersion(3)), 7);
+        assert_eq!(
+            classify_keystore_error(&E::Io(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "no such file"
+            ))),
+            11
+        );
+
+        // The two that the text was getting wrong. Both begin "Backup file",
+        // which matched an I/O branch and exited 11 for a size-cap refusal.
+        // They are refusals, not disk faults, and they are not classified.
+        assert_eq!(
+            classify_keystore_error(&E::Encryption(
+                "Backup file too large: 1 bytes (cap is 0)".into()
+            )),
+            99
+        );
+        assert_eq!(
+            classify_keystore_error(&E::Encryption("zstd init: broken".into())),
+            99
+        );
+
+        // Same variant, wording that once mattered and now does not.
+        assert_eq!(
+            classify_keystore_error(&E::Encryption("failed to decrypt blob".into())),
+            99
+        );
+    }
     use serde_json::json;
 
     #[test]

--- a/src-tauri/src/keystore_export.rs
+++ b/src-tauri/src/keystore_export.rs
@@ -319,6 +319,32 @@ pub enum KeystoreExportError {
     VaultNotReady,
 }
 
+/// Classify an import rollback failure, keeping both halves of it.
+///
+/// The sentence and the class both matter. `from_store_error` alone would keep
+/// the class and lose the account name and the rollback count, which are the
+/// useful part of the message; `Encryption` alone would keep the sentence and
+/// lose the class, and an IO failure writing the vault would stop being an 11.
+///
+/// It is a named function rather than an inline match so the call site and the
+/// test are the SAME code. The first test written for this rebuilt the error by
+/// hand and asserted on its own construction, so putting the defect back left it
+/// green: the check stood one step away from the thing checked, and the step was
+/// invisible because the test code looked identical to the code in the file.
+fn rollback_failure(
+    account: &str,
+    e: crate::credential_store::CredentialError,
+    rolled_back: usize,
+) -> KeystoreExportError {
+    let text = format!("Import failed at '{account}': {e}. {rolled_back} entries rolled back.");
+    match e {
+        crate::credential_store::CredentialError::Io(io) => {
+            KeystoreExportError::Io(std::io::Error::new(io.kind(), text))
+        }
+        _ => KeystoreExportError::Encryption(text),
+    }
+}
+
 /// Carry a credential-store failure across without flattening what it already
 /// knows.
 ///
@@ -1305,18 +1331,7 @@ pub fn import_keystore(
                 // vault would stop being an 11. The rollback writes the vault
                 // through `store` twice, so `Io` is reachable here for the same
                 // reasons it is at the three sites `from_store_error` covers.
-                let text = format!(
-                    "Import failed at '{}': {}. {} entries rolled back.",
-                    account,
-                    e,
-                    committed.len()
-                );
-                return Err(match e {
-                    crate::credential_store::CredentialError::Io(io) => {
-                        KeystoreExportError::Io(std::io::Error::new(io.kind(), text))
-                    }
-                    _ => KeystoreExportError::Encryption(text),
-                });
+                return Err(rollback_failure(account, e, committed.len()));
             }
         }
     }
@@ -1648,16 +1663,19 @@ mod tests {
     /// what goes into it is chosen by hand.
     #[test]
     fn the_rollback_message_keeps_its_class_and_its_words() {
-        let io = std::io::Error::new(
-            std::io::ErrorKind::PermissionDenied,
-            "Permission denied (os error 13)",
-        );
-        let text = format!("Import failed at 'acct': {io}. 3 entries rolled back.");
-        let err = KeystoreExportError::Io(std::io::Error::new(io.kind(), text));
+        use crate::credential_store::CredentialError;
 
+        let err = rollback_failure(
+            "acct",
+            CredentialError::Io(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "Permission denied (os error 13)",
+            )),
+            3,
+        );
         assert!(
             matches!(err, KeystoreExportError::Io(_)),
-            "an IO failure during rollback is still an IO failure"
+            "an IO failure during rollback is still an IO failure: {err:?}"
         );
         let rendered = err.to_string();
         assert!(
@@ -1668,6 +1686,15 @@ mod tests {
             rendered.contains("3 entries rolled back"),
             "the rollback count survives: {rendered}"
         );
+
+        // The other half. Without it, classifying EVERY inner failure as `Io`
+        // would leave the assertions above green.
+        let other = rollback_failure("acct", CredentialError::VaultNotInitialized, 3);
+        assert!(
+            matches!(other, KeystoreExportError::Encryption(_)),
+            "a non-IO store failure stays unclassified: {other:?}"
+        );
+        assert!(other.to_string().contains("3 entries rolled back"));
     }
 
     /// zstd round-trip on the shape of payload we actually produce:

--- a/src-tauri/src/keystore_export.rs
+++ b/src-tauri/src/keystore_export.rs
@@ -1297,12 +1297,26 @@ pub fn import_keystore(
                         tracing::warn!("Rollback failed for '{}': {}", rollback_account, re);
                     }
                 }
-                return Err(KeystoreExportError::Encryption(format!(
+                // The sentence and the class both matter here, so neither is
+                // given up. `from_store_error` alone would keep the class and
+                // lose the account name and the rollback count, which are the
+                // useful half of the message; `Encryption` alone would keep the
+                // sentence and lose the class, and an IO failure writing the
+                // vault would stop being an 11. The rollback writes the vault
+                // through `store` twice, so `Io` is reachable here for the same
+                // reasons it is at the three sites `from_store_error` covers.
+                let text = format!(
                     "Import failed at '{}': {}. {} entries rolled back.",
                     account,
                     e,
                     committed.len()
-                )));
+                );
+                return Err(match e {
+                    crate::credential_store::CredentialError::Io(io) => {
+                        KeystoreExportError::Io(std::io::Error::new(io.kind(), text))
+                    }
+                    _ => KeystoreExportError::Encryption(text),
+                });
             }
         }
     }
@@ -1620,6 +1634,40 @@ mod tests {
             from_store_error(CredentialError::VaultNotInitialized),
             KeystoreExportError::Encryption(_)
         ));
+    }
+
+    /// The import rollback builds a composite sentence and must keep both halves
+    /// of it: the account name and the rollback count, which are the useful part
+    /// of the message, and the class, without which an IO failure writing the
+    /// vault stops being an 11.
+    ///
+    /// This case was missed once. The site was simulated with an invented inner
+    /// value ("disk full") instead of with the variants the store can actually
+    /// return, so the `Io` that renders as "IO error: ..." inside the composite
+    /// text never appeared in the check. Enumerating the site is not enough if
+    /// what goes into it is chosen by hand.
+    #[test]
+    fn the_rollback_message_keeps_its_class_and_its_words() {
+        let io = std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "Permission denied (os error 13)",
+        );
+        let text = format!("Import failed at 'acct': {io}. 3 entries rolled back.");
+        let err = KeystoreExportError::Io(std::io::Error::new(io.kind(), text));
+
+        assert!(
+            matches!(err, KeystoreExportError::Io(_)),
+            "an IO failure during rollback is still an IO failure"
+        );
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("acct"),
+            "the account name survives: {rendered}"
+        );
+        assert!(
+            rendered.contains("3 entries rolled back"),
+            "the rollback count survives: {rendered}"
+        );
     }
 
     /// zstd round-trip on the shape of payload we actually produce:

--- a/src-tauri/src/keystore_export.rs
+++ b/src-tauri/src/keystore_export.rs
@@ -308,8 +308,30 @@ pub enum KeystoreExportError {
     Encryption(String),
     #[error("Unsupported file version: {0}")]
     UnsupportedVersion(u32),
+    /// A compression codec this build cannot read. Its own variant because the
+    /// exit code for it used to come from the words "unknown compression"
+    /// appearing in an `Encryption` message, which meant the marker inside the
+    /// backup file decided the code: a file naming its codec "decrypt" exited 6,
+    /// an authentication failure.
+    #[error("Unsupported compression codec: {0}")]
+    UnsupportedCodec(String),
     #[error("Vault not ready")]
     VaultNotReady,
+}
+
+/// Carry a credential-store failure across without flattening what it already
+/// knows.
+///
+/// These call sites used to do `Encryption(e.to_string())`, which threw away a
+/// typed error to make a string. A permission problem on the vault file arrived
+/// as an `Encryption` whose text happened to contain "IO error", and the CLI's
+/// exit code came from that coincidence: the right answer, held up by the wrong
+/// mechanism. Keeping `Io` as `Io` makes the same answer follow from the type.
+fn from_store_error(e: crate::credential_store::CredentialError) -> KeystoreExportError {
+    match e {
+        crate::credential_store::CredentialError::Io(io) => KeystoreExportError::Io(io),
+        other => KeystoreExportError::Encryption(other.to_string()),
+    }
 }
 
 // ============ File Format ============
@@ -885,9 +907,7 @@ pub fn export_keystore(
         .ok_or(KeystoreExportError::VaultNotReady)?;
 
     // List all accounts and read their values
-    let accounts = store
-        .list_accounts()
-        .map_err(|e| KeystoreExportError::Encryption(e.to_string()))?;
+    let accounts = store.list_accounts().map_err(from_store_error)?;
 
     let mut entries: HashMap<String, String> = HashMap::new();
     let mut read_errors: u32 = 0;
@@ -1183,7 +1203,7 @@ pub fn import_keystore(
         None | Some("none") | Some("") => raw_payload.to_vec(),
         Some("zstd") => decompress_with_cap(&raw_payload)?,
         Some(other) => {
-            return Err(KeystoreExportError::Encryption(format!(
+            return Err(KeystoreExportError::UnsupportedCodec(format!(
                 "Unknown compression codec: {other}"
             )))
         }
@@ -1204,7 +1224,7 @@ pub fn import_keystore(
     let existing = if merge_strategy == "skip_existing" {
         store
             .list_accounts()
-            .map_err(|e| KeystoreExportError::Encryption(e.to_string()))?
+            .map_err(from_store_error)?
             .into_iter()
             .collect::<HashSet<_>>()
     } else {
@@ -1237,7 +1257,7 @@ pub fn import_keystore(
         let original = match store.get(account) {
             Ok(existing_value) => Some(existing_value),
             Err(crate::credential_store::CredentialError::NotFound(_)) => None,
-            Err(e) => return Err(KeystoreExportError::Encryption(e.to_string())),
+            Err(e) => return Err(from_store_error(e)),
         };
         originals.insert(account.clone(), original);
         staged.push((account.clone(), value.clone()));
@@ -1573,6 +1593,34 @@ pub fn read_keystore_metadata(file_path: &Path) -> Result<KeystoreMetadata, Keys
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The producer half of the exit-code contract.
+    ///
+    /// The classifier test pins variant to code; this pins failure to variant,
+    /// and without it the two halves could drift apart silently. A permission
+    /// problem on the vault file must arrive as `Io`, because that is what makes
+    /// its exit code 11 follow from the type instead of from the words "IO
+    /// error" happening to appear in a flattened string.
+    #[test]
+    fn a_store_io_failure_keeps_its_type() {
+        use crate::credential_store::CredentialError;
+
+        let denied = CredentialError::Io(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "Permission denied (os error 13)",
+        ));
+        assert!(
+            matches!(from_store_error(denied), KeystoreExportError::Io(_)),
+            "an IO failure from the store must not be flattened into Encryption"
+        );
+
+        // Everything else the store can say has no keystore equivalent, so it
+        // keeps arriving as Encryption and, deliberately, as an unclassified 99.
+        assert!(matches!(
+            from_store_error(CredentialError::VaultNotInitialized),
+            KeystoreExportError::Encryption(_)
+        ));
+    }
 
     /// zstd round-trip on the shape of payload we actually produce:
     /// a `Vec<u8>` of serialised JSON containing structured text and


### PR DESCRIPTION
`classify_keystore_error` decided a CLI exit code by searching `e.to_string()` for phrases, while its own doc comment promised the scheme exists "so cron/CI pipelines can branch on it without parsing the error text". The parsing had not been removed, it had been **moved**: what a pipeline no longer had to do became a duty of whoever writes the error messages, and nobody told them.

## The reason, which only the simulation made visible

Three sites interpolate a string the caller chose. So the exit code was a parameter:

| command | message | exit |
|---|---|---|
| `--merge sideways` | `Invalid merge strategy: sideways` | 99 |
| `--merge decrypt` | `Invalid merge strategy: decrypt` | **6**, an authentication failure |
| `--merge "io error"` | `Invalid merge strategy: io error` | **11**, a disk fault |
| `--merge "vault not ready"` | `Invalid merge strategy: vault not ready` | **5**, vault locked |

Same failure, same cause, four codes chosen by what the user typed. `--format` behaves the same way, and the compression-codec marker read out of a backup file could steer it too, so a crafted file picked the exit code of the tool reading it.

## What the first version of this PR got wrong

It declared two changed codes and changed six. The count of construction sites it rested on was wrong: nineteen, not eight. That number came from a `grep | head -8`, eight printed lines read as eight sites, with the truncation added by the same hand that then trusted the result.

Running the old chain over **all nineteen** messages, instead of over the ones expected to matter, shows the four that were regressions:

| site | message | before | first version | now |
|---|---|---|---|---|
| `:190` | `Backup file too large: …` | 11 | 99 | 99 |
| `:203` | `Backup file exceeds cap after read: …` | 11 | 99 | 99 |
| `:890` `:1207` `:1240` | `IO error: Permission denied` (from the store) | 11 | **99** | 11 |
| `:1186` | `Unknown compression codec: …` | 7 | **99** | 7 |

The four in bold replaced a correct answer with none, which is the opposite of the argument this PR makes.

## The remedy is one floor up

Not a different mapping: `Encryption(String)` was swallowing failures that already had a type. The three store sites now map `CredentialError::Io` to `KeystoreExportError::Io`, so 11 follows from the variant rather than from the words "IO error" surviving a flattening. The codec gets a variant of its own carrying 7.

Re-run over the same nineteen, **two** codes move, and they are the two this change is about: a size-cap refusal is not a disk I/O fault, and 99 replaces a wrong answer with no answer.

## Verified

Both halves of the contract are pinned, and each was checked by breaking it: variant to code in the CLI (`UnsupportedCodec` forced to 99 makes the test fail `left: 99, right: 7`), and failure to variant in the producer (flattening `Io` back into `Encryption` makes it fail on "an IO failure from the store must not be flattened").

Local gate: `cargo fmt` clean, `cargo clippy --all-targets -- -D warnings` zero errors, `cargo test` 4202 passed and 0 failed across 23 test binaries.

Whether anything branches on these codes was checked separately and nothing in this repository does: no branch on 5, 6, 7, 11 or 99 in `scripts/` or `.github/`, none of the 31 `aeroftp-cli` invocations touches the keystore, no cron. With a control, since 23 numeric exit-code comparisons do exist, so the pattern would have been found. Limit: this covers our repositories and this user's crontab, not automation elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhB1WQp9kb1CXaCHSjsX5h


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Keystore CLI error handling for export, import, and info commands.
  * Commands now return consistent exit codes based on the underlying error type.
  * Serialization and encryption failures return exit code 99, while recognized keystore errors retain their specific codes.
  * Fixed cases where errors with similar messages were previously assigned incorrect exit codes.
  * Improved handling and reporting of unsupported compression formats and storage errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Merge record

Merged at zero incomplete check runs, read from the check-runs API on the head commit rather than from this page, where a superseded `cancelled` run reads as red.

CodeRabbit reviewed `d3ce8f1a` through `5762711f` with no actionable comments. The two later commits, `8915f15f` and the head `71df9161`, were NOT re-reviewed: the incremental pass was rate limited. So the part that names the rollback classification so a test can call it directly carries a human reading only.
