### PR TITLE
fix(ftp): only path replies become a path error, not every 5xx

### DIFF
--- a/src-tauri/src/providers/ftp.rs
+++ b/src-tauri/src/providers/ftp.rs
@@ -854,8 +854,21 @@ impl FtpProvider {
             }
         }
         if let FtpError::UnexpectedResponse(ref response) = err {
-            let code = response.status as u32;
-            if (500..600).contains(&code) {
+            // Only the replies that are ABOUT the path. The condition used to be
+            // any 5xx, which reads every permanent refusal as a bad path: "502
+            // Command not implemented" and "530 Not logged in" both came back to
+            // the user as an invalid path, and a login problem presented as a
+            // naming problem sends them to look in the wrong place.
+            //
+            // 550 and 553 are the two the server uses to talk about the name
+            // itself. `classify_missing_path` above has already taken the subset
+            // of those whose text names a missing path; what is left here is the
+            // same family for another reason, such as a name the server refuses.
+            // Everything else keeps the typing it had.
+            if matches!(
+                response.status,
+                Status::FileUnavailable | Status::BadFilename
+            ) {
                 let text = response.to_string();
                 return ProviderError::InvalidPath(Self::doing(operation, path, &text));
             }
@@ -3162,6 +3175,51 @@ async fn ftp_download_one_range(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A permanent refusal that is not about the path must not be reported as
+    /// one. The condition used to be any 5xx, so "530 Not logged in" reached the
+    /// user as an invalid path and sent them to check a name when the problem
+    /// was the session.
+    ///
+    /// 530 rather than the 502 that a review example named, and the difference
+    /// was measured rather than assumed: 502 arrives from a command the server
+    /// does not implement, and every caller of `checksum` discards its error, so
+    /// a test built on that case would never defend anything. 530 arrives on the
+    /// reading and writing paths, whose errors do reach the user.
+    #[test]
+    fn a_non_path_5xx_is_not_reported_as_a_bad_path() {
+        for (code, body) in [
+            (530u32, "Not logged in"),
+            (502, "Command not implemented"),
+            (552, "Exceeded storage allocation"),
+        ] {
+            let err = FtpProvider::classify_data_failure(
+                "reading",
+                "/srv/data/report.csv",
+                cwd_reply(code, body),
+            );
+            assert!(
+                !matches!(err, ProviderError::InvalidPath(_)),
+                "{code} {body} is not a statement about the path: {err:?}"
+            );
+        }
+
+        // The two that ARE about the name keep their classification.
+        for (code, body) in [
+            (550u32, "Permission denied"),
+            (553, "File name not allowed"),
+        ] {
+            let err = FtpProvider::classify_data_failure(
+                "reading",
+                "/srv/data/report.csv",
+                cwd_reply(code, body),
+            );
+            assert!(
+                matches!(err, ProviderError::InvalidPath(_)),
+                "{code} {body} is about the name: {err:?}"
+            );
+        }
+    }
 
     fn cwd_reply(code: u32, body: &str) -> FtpError {
         FtpError::UnexpectedResponse(suppaftp::types::Response::new(

--- a/src-tauri/src/providers/ftp.rs
+++ b/src-tauri/src/providers/ftp.rs
@@ -3198,9 +3198,15 @@ mod tests {
                 "/srv/data/report.csv",
                 cwd_reply(code, body),
             );
+            // Asserted as "must still be this" rather than "must not be that".
+            // A negative assertion is weak in proportion to how many variants
+            // exist and gets weaker each time someone adds one, silently and
+            // without touching the test; it is also blind to the case a reviewer
+            // would most want flagged, a change that reclassifies the failure
+            // into a third thing nobody considered.
             assert!(
-                !matches!(err, ProviderError::InvalidPath(_)),
-                "{code} {body} is not a statement about the path: {err:?}"
+                matches!(err, ProviderError::TransferFailed(_)),
+                "{code} {body} must remain TransferFailed: {err:?}"
             );
         }
 


### PR DESCRIPTION
The other half of #671. That PR was split so the security fix could land while `main` was red on RUSTSEC-2026-0271; this is the part that was taken out, rebased onto current `main`.

## The defect, which is still live

`classify_data_failure` turned **any** remaining 5xx into `InvalidPath`. So a permanent refusal that has nothing to do with the name is reported as a bad path:

```text
Invalid path: [530] Not logged in (while reading /srv/data/report.csv)
```

A session that lost its login is presented as a naming problem, which sends the reader to check a path that was never wrong. It reaches the user: the reading and writing paths surface their errors, unlike `checksum`, whose callers discard them.

Only `550` and `553` are replies a server uses to talk about the name itself, so only those become `InvalidPath` now. Everything else keeps the typing it had.

## Why it was taken out of #671 rather than merged with it

Splitting was right and the reason is worth recording, because it is not obvious from the diff. Narrowing the noun also changes **retryability** for ten codes, and the mechanism is a square bracket: `Response` renders as `[552] Exceeded storage allocation`, while every status needle in `sync::classify_sync_error` is written with a trailing space, `"552 "`, `"530 "`. `"552]"` is not `"552 "`, so those needles have never matched an FTP message. The only thing holding those codes non-retryable was the `invalid path` label, which is the wrong noun this change removes.

**The wrong noun was carrying the right answer.** Removing it alone would make a full storage quota and a lost login retryable, silently, and they would be retried to the limit.

So this PR is deliberately not the whole fix. The retryability half belongs with making `classify_sync_error` read the type, now that the variant carries the meaning, rather than widening the needles to include the bracket: that would be curing the disease with the disease.

## A side effect of the split, declared

While this was out, a 5xx during `HASH` took the untouched blanket and became `InvalidPath`, so it went from retryable to non-retryable. For a permanent 5xx the direction happens to be right, and that is not the point: it would have fallen the same way had the direction been wrong. This PR puts the decision back where it is made on purpose.

## Verified

The test uses `530` rather than the `502` a review example named, and says so in the test. Every caller of `checksum` discards its error, so a case built on the command-not-implemented path would never have defended anything, while `530` arrives where errors are surfaced. The review supplied the region; the measurement supplied the case.

Checked by restoring the blanket and watching the test fail on `530 Not logged in is not a statement about the path`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhB1WQp9kb1CXaCHSjsX5h


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FTP error reporting by distinguishing unavailable files and invalid filenames from other permanent server errors.
  * FTP authentication, unsupported-command, and storage-limit failures are now reported as transfer failures instead of misleading path errors.
  * Added coverage to verify accurate classification of FTP server responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Merge record

Merged at zero incomplete check runs, read from the check-runs API on the head commit rather than from this page, where a superseded `cancelled` run reads as red.

CodeRabbit reviewed base through `501fb28d` and raised one inline comment, which is addressed. The head commit `2cf3729d`, which is the test that asserts what the failure must remain rather than what it must not be, was NOT re-reviewed: the incremental pass was rate limited.
