### PR TITLE
fix(statusbar): move the language chip to the edge, where a readout belongs

### DIFF
--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -523,29 +523,6 @@ export const StatusBar: React.FC<StatusBarProps> = ({
                     </button>
                 )}
 
-                {/* Language chip. AeroFTP ships 47 interface languages and starts
-                    in English by design (detectBrowserLanguage is deliberately
-                    disabled in I18nContext), so a user whose language IS in the
-                    list has no way of learning that from the running app: the
-                    selector lives four clicks deep, in Settings > Appearance >
-                    Interface. This is the signpost. Code only, no flag: a flag
-                    names a country, and a language is not one.
-
-                    The label needs no translation (it is the language's own
-                    code) and the tooltip is the nativeName already carried by
-                    AVAILABLE_LANGUAGES, so this adds no key to the 47 locale
-                    files. */}
-                {onOpenLanguageSettings && (
-                    <button
-                        onClick={onOpenLanguageSettings}
-                        className="flex items-center px-1.5 py-0.5 rounded transition-colors hover:bg-gray-200 dark:hover:bg-gray-700 uppercase font-medium tracking-wide"
-                        title={languageLabel}
-                        aria-label={languageLabel}
-                    >
-                        {language}
-                    </button>
-                )}
-
                 {/* DevTools Toggle */}
                 {onToggleDevTools && (
                     <button
@@ -560,6 +537,36 @@ export const StatusBar: React.FC<StatusBarProps> = ({
                         <span>{t('statusBar.devTools')}</span>
                     </button>
                 )}
+
+                {/* Language chip, LAST in the cluster and behind its own
+                    divider. It was between the AeroAgent button and DevTools,
+                    which split the Aero family in half and made a readout look
+                    like one more app button. It is neither: it says which
+                    language the app is in, and clicking it goes to the list.
+                    The far right edge is where a status readout belongs, and
+                    the divider says "this is not part of that group".
+
+                    AeroFTP ships 47 interface languages and starts in English
+                    by design (detectBrowserLanguage is deliberately disabled in
+                    I18nContext), so a user whose language IS in the list has no
+                    way of learning that from the running app: the selector
+                    lives four clicks deep, in Settings > Appearance > Interface.
+                    This is the signpost. Code only, no flag: a flag names a
+                    country, and a language is not one. */}
+                {onOpenLanguageSettings && (
+                    <>
+                        <div className="w-px h-4 bg-gray-300 dark:bg-gray-600" />
+                        <button
+                            onClick={onOpenLanguageSettings}
+                            className="flex items-center px-1.5 py-0.5 rounded transition-colors hover:bg-gray-200 dark:hover:bg-gray-700 uppercase font-medium tracking-wide"
+                            title={languageLabel}
+                            aria-label={languageLabel}
+                        >
+                            {language}
+                        </button>
+                    </>
+                )}
+
             </div>
         </div>
     );

--- a/src/components/statusBarLanguageChip.test.ts
+++ b/src/components/statusBarLanguageChip.test.ts
@@ -62,6 +62,24 @@ describe('status bar language chip', () => {
         expect(chipBlock(STATUS_BAR)).not.toContain('flag');
     });
 
+    it('sits at the far right, after every app button', () => {
+        // It used to sit between AeroAgent and DevTools, splitting the Aero
+        // family and reading as one more app button. The property pinned here
+        // is the ORDER, not the styling: a readout belongs at the edge of the
+        // cluster, behind a divider, and any button added later must go before
+        // it rather than after.
+        const chipAt = STATUS_BAR.indexOf('{onOpenLanguageSettings && (');
+        const devToolsAt = STATUS_BAR.indexOf("{/* DevTools Toggle */}");
+        const aeroAgentAt = STATUS_BAR.indexOf("{/* AeroAgent Button");
+        expect(chipAt).toBeGreaterThan(devToolsAt);
+        expect(chipAt).toBeGreaterThan(aeroAgentAt);
+    });
+
+    it('is separated from the buttons by a divider', () => {
+        const chip = chipBlock(STATUS_BAR);
+        expect(chip).toContain('w-px h-4');
+    });
+
     it('is optional, so a caller that has nowhere to send the user gets no chip', () => {
         expect(STATUS_BAR).toContain('onOpenLanguageSettings?: () => void;');
     });


### PR DESCRIPTION
## Why

The language chip shipped in #657 sat between the AeroAgent button and DevTools. That split the Aero family in half and, worse, made a readout read as one more app button. It is not one: it says which language the app is in, and clicking it opens the list.

The placement was caught by the owner in the running app, not by a test, which is the honest way to say where this came from.

## What changes

The chip is now the last element of the right cluster, behind its own divider. The grouping says what the element is before anyone reads the label: the buttons are one group, the readout sits at the edge.

Nothing else changes. No new string, no new key, same behaviour on click.

## What the tests pin

The two new tests pin the ORDER and the divider, not the styling, so a button added later has to go before the chip rather than after it. Both were run against the previous layout and observed failing there. Gates: `tsc --noEmit` clean, 828 unit tests green, `npm run i18n:validate` green (47 locales untouched).

## An alternative that was raised and not taken

Putting the chip in the titlebar instead. It is a reasonable place and it is deliberately not done here: the status bar keeps the chip next to the other elements that describe the current state, and this is the first release in which the control exists at all. Moving it later is cheap, and what people report is better evidence than either of our guesses, so this is written down rather than settled.

Verified in the running app on this build, at the far right with the divider, by the owner.
