### PR TITLE
feat(bridge): show the tools you actually have, first

### DIFF
--- a/src/components/BridgeSourcePanel.tsx
+++ b/src/components/BridgeSourcePanel.tsx
@@ -13,6 +13,7 @@ import { ServerProfile } from '../types';
 import { useTranslation } from '../i18n';
 import { Checkbox } from './ui/Checkbox';
 import { BridgeSourceDescriptor, BridgeSourceMeta } from './bridge/bridgeSources';
+import { detectBridgeConfigBounded } from '../hooks/useDetectedBridgeConfigs';
 import { commitImportedServers } from './bridge/bridgeImportCommit';
 
 interface ImportedServer {
@@ -94,9 +95,11 @@ export const BridgeSourcePanel: React.FC<Props> = ({
     // file was already identified for this source (presetFilePath wins).
     useEffect(() => {
         if (direction === 'import' && detectedPath === null && !presetFilePath) {
-            invoke<string | null>('detect_bridge_config', { source: source.id })
-                .then(p => setDetectedPath(p || ''))
-                .catch(() => setDetectedPath(''));
+            // Bounded, and served from the picker's sweep when that already
+            // knows the answer. An unbounded probe left this panel on an
+            // eternal "Detecting..." spinner whenever the backend call did not
+            // come back, with the browse button unreachable behind it.
+            void detectBridgeConfigBounded(source.id).then(setDetectedPath);
         }
     }, [direction, source.id, detectedPath, presetFilePath]);
 

--- a/src/components/ExportImportDialog.tsx
+++ b/src/components/ExportImportDialog.tsx
@@ -17,6 +17,7 @@ import { Checkbox } from './ui/Checkbox';
 import { BridgeSourcePanel } from './BridgeSourcePanel';
 import { BridgeSourceDescriptor, GENERIC_BRIDGE_SOURCES } from './bridge/bridgeSources';
 import { useDraggableModal } from '../hooks/useDraggableModal';
+import { useDetectedBridgeConfigs, shortenConfigPath, orderBridgeSourcesByDetection } from '../hooks/useDetectedBridgeConfigs';
 
 interface ExportImportDialogProps {
     servers: ServerProfile[];
@@ -81,6 +82,10 @@ export const ExportImportDialog: React.FC<ExportImportDialogProps> = ({ servers,
     // A profile file dropped onto the dialog and identified by
     // bridge_identify; handed to BridgeSourcePanel to skip browse.
     const [bridgePresetPath, setBridgePresetPath] = useState<string | null>(null);
+    // Which bridge tools are actually installed on this machine. Probed once,
+    // and only while the import picker is on screen: the export picker offers
+    // every tool regardless, since exporting does not need a config to exist.
+    const { detected: detectedBridgeConfigs } = useDetectedBridgeConfigs(mode === 'bridge-import');
     const [password, setPassword] = useState('');
     const [confirmPassword, setConfirmPassword] = useState('');
     const [includeCredentials, setIncludeCredentials] = useState(true);
@@ -461,6 +466,14 @@ export const ExportImportDialog: React.FC<ExportImportDialogProps> = ({ servers,
                             const filtered = q
                                 ? GENERIC_BRIDGE_SOURCES.filter(s => s.label.toLowerCase().includes(q))
                                 : GENERIC_BRIDGE_SOURCES;
+                            // Tools whose config was found on this machine float to the top,
+                            // so the one you are migrating from is the first thing you see.
+                            // Array.sort is stable, so the curated order survives inside
+                            // each group. Import only: an export target does not need a
+                            // config file to already exist.
+                            const ordered = isImport
+                                ? orderBridgeSourcesByDetection(filtered, detectedBridgeConfigs)
+                                : filtered;
                             return (
                                 <div className="space-y-3">
                                     <div className="text-sm text-gray-600 dark:text-gray-300">
@@ -475,26 +488,38 @@ export const ExportImportDialog: React.FC<ExportImportDialogProps> = ({ servers,
                                         className="w-full pl-3 pr-3 py-2 text-sm rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 focus:outline-none focus:border-blue-400 dark:focus:border-blue-500"
                                     />
                                     <div className="space-y-2 max-h-[336px] overflow-y-auto pr-1">
-                                        {filtered.length === 0 ? (
+                                        {ordered.length === 0 ? (
                                             <div className="py-6 text-center text-sm text-gray-400 dark:text-gray-500">{t('settings.bridgeNoApps')}</div>
-                                        ) : filtered.map(s => (
+                                        ) : ordered.map(s => {
+                                            const foundPath = isImport ? detectedBridgeConfigs[s.id] : undefined;
+                                            return (
                                             <button
                                                 key={s.id}
                                                 onClick={() => pick(s)}
                                                 disabled={!isImport && servers.length === 0}
-                                                className="w-full p-3 border border-gray-200 dark:border-gray-700 rounded-lg hover:border-blue-400 dark:hover:border-blue-500 flex items-center gap-3 transition-colors disabled:opacity-50"
+                                                title={foundPath}
+                                                className={`w-full p-3 border rounded-lg hover:border-blue-400 dark:hover:border-blue-500 flex items-center gap-3 transition-colors disabled:opacity-50 ${foundPath ? 'border-green-300 dark:border-green-800' : 'border-gray-200 dark:border-gray-700'}`}
                                             >
                                                 <div className={`w-9 h-9 rounded-lg ${s.accentBg} flex items-center justify-center flex-shrink-0`}>
                                                     <Icon size={18} className={s.accent} />
                                                 </div>
                                                 <div className="text-left min-w-0">
-                                                    <div className="font-medium">{s.label}</div>
-                                                    <div className="text-xs text-gray-500 dark:text-gray-400 truncate">
-                                                        {(isImport ? t('settings.bridgeGenericImportDesc') : t('settings.bridgeGenericExportDesc')).replace('{app}', s.label)}
+                                                    <div className="font-medium flex items-center gap-1.5">
+                                                        {s.label}
+                                                        {foundPath && <CheckCircle2 size={13} className="text-green-600 dark:text-green-400 flex-shrink-0" />}
+                                                    </div>
+                                                    {/* The path IS the message: it says the config exists and
+                                                        where it is, in every language, with no string to
+                                                        translate. Falls back to the generic blurb otherwise. */}
+                                                    <div className={`text-xs truncate ${foundPath ? 'text-green-700 dark:text-green-400' : 'text-gray-500 dark:text-gray-400'}`}>
+                                                        {foundPath
+                                                            ? shortenConfigPath(foundPath)
+                                                            : (isImport ? t('settings.bridgeGenericImportDesc') : t('settings.bridgeGenericExportDesc')).replace('{app}', s.label)}
                                                     </div>
                                                 </div>
                                             </button>
-                                        ))}
+                                            );
+                                        })}
                                     </div>
                                     <div className="flex gap-2">
                                         <button onClick={() => { setBridgeFilter(''); resetMode(); }} className="px-4 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">{t('common.back')}</button>

--- a/src/hooks/useDetectedBridgeConfigs.test.ts
+++ b/src/hooks/useDetectedBridgeConfigs.test.ts
@@ -1,12 +1,24 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
 
-// Pins the two pure decisions behind the bridge picker's autodetect: which
-// tools come first, and how their config path is shown. The probe loop itself
-// is a Tauri round trip and is not covered here.
+// Pins the bridge picker's autodetect: which tools come first, how their
+// config path is shown, and the sweep's contract with its consumers.
+//
+// That last group exists because of a live failure the first version's gates
+// could not see. The sweep used to live inside the effect behind a per-mount
+// ref; under StrictMode the first pass was discarded by its own cleanup and
+// the second returned early on the surviving ref, so the picker never showed
+// a single detection in the running app while tsc, vitest and a by-hand call
+// to the backend all said the code was fine. The probe itself is a Tauri round
+// trip and still is not covered here: only a live run proves that end.
 
-import { describe, it, expect } from 'vitest';
-import { orderBridgeSourcesByDetection, shortenConfigPath } from './useDetectedBridgeConfigs';
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+    loadDetectedBridgeConfigs,
+    orderBridgeSourcesByDetection,
+    resetDetectedBridgeConfigsCache,
+    shortenConfigPath,
+} from './useDetectedBridgeConfigs';
 import { GENERIC_BRIDGE_SOURCES } from '../components/bridge/bridgeSources';
 
 const ids = (list: { id: string }[]) => list.map(s => s.id);
@@ -52,5 +64,63 @@ describe('shortenConfigPath', () => {
     it('returns short paths untouched rather than prefixing an ellipsis to nothing', () => {
         expect(shortenConfigPath('/etc/s3cfg')).toBe('/etc/s3cfg');
         expect(shortenConfigPath('.lftprc')).toBe('.lftprc');
+    });
+});
+
+describe('loadDetectedBridgeConfigs', () => {
+    beforeEach(resetDetectedBridgeConfigsCache);
+
+    const found: Record<string, string> = {
+        rclone: '/home/me/.config/rclone/rclone.conf',
+        ssh: '/home/me/.ssh/config',
+    };
+    const probeInstalled = async (id: string) => found[id] ?? null;
+
+    it('reports the tools that have a config here and omits the rest', async () => {
+        expect(await loadDetectedBridgeConfigs(probeInstalled)).toEqual(found);
+    });
+
+    it('serves a consumer that arrives while the sweep is still running', async () => {
+        // The live failure this pins: the dialog mounts, the sweep starts, the
+        // mount is thrown away and redone (StrictMode does exactly this), and
+        // the second consumer must still receive the answer. The first version
+        // guarded the sweep with a per-mount ref, so the second consumer got
+        // nothing at all and the picker stayed blank in the running app while
+        // every gate here was green.
+        let release: (() => void) | undefined;
+        const gate = new Promise<void>(resolve => { release = resolve; });
+        let calls = 0;
+        const slowProbe = async (id: string) => {
+            calls += 1;
+            await gate;
+            return found[id] ?? null;
+        };
+
+        const first = loadDetectedBridgeConfigs(slowProbe);
+        const second = loadDetectedBridgeConfigs(slowProbe);
+        release?.();
+
+        expect(await second).toEqual(found);
+        expect(await first).toEqual(await second);
+        // One sweep, not two: the late consumer joined it.
+        expect(calls).toBe(GENERIC_BRIDGE_SOURCES.length);
+    });
+
+    it('probes once per app run, then answers from the cache', async () => {
+        let calls = 0;
+        const counting = async (id: string) => { calls += 1; return found[id] ?? null; };
+        await loadDetectedBridgeConfigs(counting);
+        await loadDetectedBridgeConfigs(counting);
+        expect(calls).toBe(GENERIC_BRIDGE_SOURCES.length);
+    });
+
+    it('keeps going when one probe throws', async () => {
+        // rclone shells out to `rclone config file`; a machine without rclone
+        // must cost that one row, not the whole list.
+        const flaky = async (id: string) => {
+            if (id === 'rclone') throw new Error('rclone not installed');
+            return found[id] ?? null;
+        };
+        expect(await loadDetectedBridgeConfigs(flaky)).toEqual({ ssh: found.ssh });
     });
 });

--- a/src/hooks/useDetectedBridgeConfigs.test.ts
+++ b/src/hooks/useDetectedBridgeConfigs.test.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+// Pins the two pure decisions behind the bridge picker's autodetect: which
+// tools come first, and how their config path is shown. The probe loop itself
+// is a Tauri round trip and is not covered here.
+
+import { describe, it, expect } from 'vitest';
+import { orderBridgeSourcesByDetection, shortenConfigPath } from './useDetectedBridgeConfigs';
+import { GENERIC_BRIDGE_SOURCES } from '../components/bridge/bridgeSources';
+
+const ids = (list: { id: string }[]) => list.map(s => s.id);
+
+describe('orderBridgeSourcesByDetection', () => {
+    it('floats detected tools to the top', () => {
+        // cyberduck sits at index 10 of the curated list, dreamweaver at 11:
+        // exactly the "hiding at position 11 of 15" case this exists to fix.
+        const ordered = orderBridgeSourcesByDetection(GENERIC_BRIDGE_SOURCES, {
+            cyberduck: '/home/me/Library/Application Support/Cyberduck/bookmark.duck',
+            dreamweaver: '/home/me/sites/site.ste',
+        });
+        expect(ids(ordered).slice(0, 2)).toEqual(['cyberduck', 'dreamweaver']);
+    });
+
+    it('keeps the curated order inside each group', () => {
+        const ordered = orderBridgeSourcesByDetection(GENERIC_BRIDGE_SOURCES, {
+            filezilla: '/home/me/.config/filezilla/sitemanager.xml',
+            lftp: '/home/me/.lftprc',
+        });
+        // Detected pair in curated order (filezilla is 3rd, lftp 10th), and the
+        // untouched remainder still starts with rclone, winscp, aws.
+        expect(ids(ordered).slice(0, 2)).toEqual(['filezilla', 'lftp']);
+        expect(ids(ordered).slice(2, 5)).toEqual(['rclone', 'winscp', 'aws']);
+    });
+
+    it('leaves the list alone when nothing was detected, and does not mutate the input', () => {
+        const before = ids(GENERIC_BRIDGE_SOURCES);
+        expect(ids(orderBridgeSourcesByDetection(GENERIC_BRIDGE_SOURCES, {}))).toEqual(before);
+        expect(ids(GENERIC_BRIDGE_SOURCES)).toEqual(before);
+    });
+});
+
+describe('shortenConfigPath', () => {
+    it('keeps the two segments that identify the tool', () => {
+        expect(shortenConfigPath('/home/me/.config/filezilla/sitemanager.xml')).toBe('…/filezilla/sitemanager.xml');
+    });
+
+    it('handles Windows paths', () => {
+        expect(shortenConfigPath('C:\\Users\\me\\AppData\\Roaming\\FileZilla\\sitemanager.xml')).toBe('…/FileZilla/sitemanager.xml');
+    });
+
+    it('returns short paths untouched rather than prefixing an ellipsis to nothing', () => {
+        expect(shortenConfigPath('/etc/s3cfg')).toBe('/etc/s3cfg');
+        expect(shortenConfigPath('.lftprc')).toBe('.lftprc');
+    });
+});

--- a/src/hooks/useDetectedBridgeConfigs.test.ts
+++ b/src/hooks/useDetectedBridgeConfigs.test.ts
@@ -14,7 +14,9 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
+    detectedBridgeConfigsSoFar,
     loadDetectedBridgeConfigs,
+    subscribeDetectedBridgeConfigs,
     orderBridgeSourcesByDetection,
     resetDetectedBridgeConfigsCache,
     shortenConfigPath,
@@ -122,5 +124,64 @@ describe('loadDetectedBridgeConfigs', () => {
             return found[id] ?? null;
         };
         expect(await loadDetectedBridgeConfigs(flaky)).toEqual({ ssh: found.ssh });
+    });
+});
+
+describe('results arrive in pieces', () => {
+    beforeEach(resetDetectedBridgeConfigsCache);
+
+    /** Probe that answers `fast` immediately and never answers for `hangs`. */
+    const hangingProbe = (found: Record<string, string>, hangs: string) =>
+        async (id: string): Promise<string | null> => {
+            if (id === hangs) return new Promise<string | null>(() => { /* never settles */ });
+            return found[id] ?? null;
+        };
+
+    it('publishes a detection before the sweep is over', async () => {
+        // The assertion is the TIMING, not the content: a version that
+        // collected everything and published once at the end would satisfy
+        // "ssh was seen" just as well, while leaving the picker blank for as
+        // long as the slowest probe takes. So the sweep is held open on a
+        // probe that has not answered yet, and the update has to arrive anyway.
+        const seen: Record<string, string>[] = [];
+        subscribeDetectedBridgeConfigs(found => seen.push(found));
+
+        let release: (() => void) | undefined;
+        const held = new Promise<void>(resolve => { release = resolve; });
+        const sweep = loadDetectedBridgeConfigs(async id => {
+            if (id === 'ssh') return '/home/me/.ssh/config';
+            if (id === 'restic') { await held; return null; }
+            return null;
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+        // restic has not answered, so the sweep cannot have finished.
+        expect(seen).toEqual([{ ssh: '/home/me/.ssh/config' }]);
+
+        release?.();
+        await sweep;
+    });
+
+    it('a probe that never answers does not bury the ones that did', async () => {
+        // rclone shells out to a binary; if that binary hangs, the promise from
+        // loadDetectedBridgeConfigs never resolves. The other fourteen tools
+        // must still reach the picker, so the answer cannot be final-only.
+        const updates: Record<string, string>[] = [];
+        subscribeDetectedBridgeConfigs(found => updates.push(found));
+        void loadDetectedBridgeConfigs(hangingProbe({ ssh: '/home/me/.ssh/config' }, 'rclone'));
+
+        // Let the workers drain everything that can answer.
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(updates[updates.length - 1]).toEqual({ ssh: '/home/me/.ssh/config' });
+        expect(detectedBridgeConfigsSoFar()).toEqual({ ssh: '/home/me/.ssh/config' });
+    });
+
+    it('stops talking to a listener that unsubscribed', async () => {
+        const seen: Record<string, string>[] = [];
+        const unsubscribe = subscribeDetectedBridgeConfigs(found => seen.push(found));
+        unsubscribe();
+        await loadDetectedBridgeConfigs(async id => (id === 'ssh' ? '/home/me/.ssh/config' : null));
+        expect(seen).toEqual([]);
     });
 });

--- a/src/hooks/useDetectedBridgeConfigs.test.ts
+++ b/src/hooks/useDetectedBridgeConfigs.test.ts
@@ -12,8 +12,9 @@
 // to the backend all said the code was fine. The probe itself is a Tauri round
 // trip and still is not covered here: only a live run proves that end.
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
+    detectBridgeConfigBounded,
     detectedBridgeConfigsSoFar,
     loadDetectedBridgeConfigs,
     subscribeDetectedBridgeConfigs,
@@ -183,5 +184,34 @@ describe('results arrive in pieces', () => {
         unsubscribe();
         await loadDetectedBridgeConfigs(async id => (id === 'ssh' ? '/home/me/.ssh/config' : null));
         expect(seen).toEqual([]);
+    });
+});
+
+describe('detectBridgeConfigBounded', () => {
+    beforeEach(resetDetectedBridgeConfigsCache);
+    afterEach(() => { vi.useRealTimers(); });
+
+    it('answers from the sweep when it already knows, without probing again', async () => {
+        await loadDetectedBridgeConfigs(async id => (id === 'ssh' ? '/home/me/.ssh/config' : null));
+        let probed = false;
+        const path = await detectBridgeConfigBounded('ssh', async () => { probed = true; return null; });
+        expect(path).toBe('/home/me/.ssh/config');
+        expect(probed).toBe(false);
+    });
+
+    it('gives up instead of spinning forever when the probe never answers', async () => {
+        // The panel shows "Detecting..." until this resolves, and its browse
+        // button lives behind that spinner: a probe that hangs used to strand
+        // the user there with nothing to click.
+        vi.useFakeTimers();
+        const pending = detectBridgeConfigBounded('rclone', () => new Promise(() => { /* never */ }), 6000);
+        await vi.advanceTimersByTimeAsync(6000);
+        expect(await pending).toBe('');
+    });
+
+    it('reports a real answer as itself, and a failure as no config', async () => {
+        expect(await detectBridgeConfigBounded('ssh', async () => '/home/me/.ssh/config')).toBe('/home/me/.ssh/config');
+        expect(await detectBridgeConfigBounded('lftp', async () => null)).toBe('');
+        expect(await detectBridgeConfigBounded('putty', async () => { throw new Error('nope'); })).toBe('');
     });
 });

--- a/src/hooks/useDetectedBridgeConfigs.ts
+++ b/src/hooks/useDetectedBridgeConfigs.ts
@@ -44,9 +44,33 @@ const tauriProbe: BridgeConfigProbe = source =>
 let cache: DetectedBridgeConfigs | null = null;
 let inFlight: Promise<DetectedBridgeConfigs> | null = null;
 
+// What the running sweep has found so far, and who wants to hear about it.
+// Results are published as they land rather than only at the end, for two
+// reasons. A probe that never answers (rclone shelling out to a binary that
+// hangs) would otherwise hold the entire answer hostage: with a final-only
+// result the other fourteen tools stay invisible forever. And the dialog this
+// feeds is currently on a machine where the page has a few healthy seconds to
+// be read, so an answer that arrives in pieces is worth more than a complete
+// one that arrives last.
+let partial: DetectedBridgeConfigs = {};
+type Listener = (found: DetectedBridgeConfigs) => void;
+const listeners = new Set<Listener>();
+
+function publish(): void {
+    const snapshot = { ...partial };
+    listeners.forEach(listener => listener(snapshot));
+}
+
+/** Hear about detections as they land. Returns the unsubscribe function. */
+export function subscribeDetectedBridgeConfigs(listener: Listener): () => void {
+    listeners.add(listener);
+    return () => {
+        listeners.delete(listener);
+    };
+}
+
 async function probeAll(probe: BridgeConfigProbe): Promise<DetectedBridgeConfigs> {
     const queue = GENERIC_BRIDGE_SOURCES.map(s => s.id);
-    const found: DetectedBridgeConfigs = {};
 
     const worker = async (): Promise<void> => {
         for (;;) {
@@ -54,7 +78,10 @@ async function probeAll(probe: BridgeConfigProbe): Promise<DetectedBridgeConfigs
             if (id === undefined) return;
             try {
                 const path = await probe(id);
-                if (path) found[id] = path;
+                if (path) {
+                    partial[id] = path;
+                    publish();
+                }
             } catch {
                 // A source we cannot probe is simply not reported as found.
                 // The tool stays in the list and stays pickable by hand.
@@ -63,12 +90,14 @@ async function probeAll(probe: BridgeConfigProbe): Promise<DetectedBridgeConfigs
     };
 
     await Promise.all(Array.from({ length: Math.min(PROBE_CONCURRENCY, queue.length) }, worker));
-    return found;
+    return { ...partial };
 }
 
 /**
  * The detected configs, probing at most once per app run. Concurrent callers
- * share the sweep in progress instead of starting a second one.
+ * share the sweep in progress instead of starting a second one. The promise
+ * resolves when every probe has answered; a consumer that cannot wait for the
+ * slowest one subscribes instead.
  */
 export function loadDetectedBridgeConfigs(
     probe: BridgeConfigProbe = tauriProbe,
@@ -84,10 +113,17 @@ export function loadDetectedBridgeConfigs(
     return inFlight;
 }
 
-/** Test seam: forget both the cached answer and any sweep in progress. */
+/** What the sweep has found so far, empty before it starts. */
+export function detectedBridgeConfigsSoFar(): DetectedBridgeConfigs {
+    return cache ?? { ...partial };
+}
+
+/** Test seam: forget the cached answer, any sweep in progress, and listeners. */
 export function resetDetectedBridgeConfigsCache(): void {
     cache = null;
     inFlight = null;
+    partial = {};
+    listeners.clear();
 }
 
 export interface DetectedBridgeConfigsState {
@@ -101,13 +137,19 @@ export interface DetectedBridgeConfigsState {
  * turns true, so a caller that never opens the picker pays nothing.
  */
 export function useDetectedBridgeConfigs(enabled: boolean): DetectedBridgeConfigsState {
-    const [detected, setDetected] = useState<DetectedBridgeConfigs>(() => cache ?? {});
+    const [detected, setDetected] = useState<DetectedBridgeConfigs>(detectedBridgeConfigsSoFar);
     const [probing, setProbing] = useState(false);
 
     useEffect(() => {
         if (!enabled) return;
         let cancelled = false;
         setProbing(true);
+        // Subscribe first, then start (or join) the sweep: a result that lands
+        // between the two calls would otherwise be missed.
+        const unsubscribe = subscribeDetectedBridgeConfigs(found => {
+            if (!cancelled) setDetected(found);
+        });
+        setDetected(detectedBridgeConfigsSoFar());
         void loadDetectedBridgeConfigs().then(result => {
             if (cancelled) return;
             setDetected(result);
@@ -115,6 +157,7 @@ export function useDetectedBridgeConfigs(enabled: boolean): DetectedBridgeConfig
         });
         return () => {
             cancelled = true;
+            unsubscribe();
         };
     }, [enabled]);
 

--- a/src/hooks/useDetectedBridgeConfigs.ts
+++ b/src/hooks/useDetectedBridgeConfigs.ts
@@ -11,12 +11,22 @@
 // while the picker is on screen is what lets the tools you actually use rise
 // to the top of the list instead of hiding at position 11 of 15.
 //
-// Probes run with bounded concurrency because they are not all pure path
-// math: the rclone probe shells out to `rclone config file`. Results stream
-// in as they land, so the list renders immediately and decorates itself
-// rather than waiting for the slowest probe.
+// The sweep is owned by this module rather than by the component, and that is
+// the whole design. The first version kept it inside the effect, guarded by a
+// ref so it would run once per mount, and it never produced a single result in
+// the running app: StrictMode mounts, cleans up, and remounts, so the first
+// pass was discarded by its own cleanup while the second returned early on a
+// ref that had survived the remount. Every gate was green, the wiring read
+// correctly, and the backend answered when called by hand from the same page.
+// A cache plus a shared in-flight promise has no such state to get wrong: a
+// late consumer joins the sweep already running, and the answer outlives any
+// single mount, which is right because a config file does not appear halfway
+// through a session.
+//
+// Probes run with bounded concurrency because they are not all pure path math:
+// the rclone probe shells out to `rclone config file`.
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { GENERIC_BRIDGE_SOURCES, type BridgeSourceDescriptor } from '../components/bridge/bridgeSources';
 
@@ -25,54 +35,84 @@ const PROBE_CONCURRENCY = 4;
 /** Bridge source id -> absolute path of the config found on this machine. */
 export type DetectedBridgeConfigs = Record<string, string>;
 
+/** Asks the backend about one source; null when that tool has no config here. */
+export type BridgeConfigProbe = (source: string) => Promise<string | null>;
+
+const tauriProbe: BridgeConfigProbe = source =>
+    invoke<string | null>('detect_bridge_config', { source });
+
+let cache: DetectedBridgeConfigs | null = null;
+let inFlight: Promise<DetectedBridgeConfigs> | null = null;
+
+async function probeAll(probe: BridgeConfigProbe): Promise<DetectedBridgeConfigs> {
+    const queue = GENERIC_BRIDGE_SOURCES.map(s => s.id);
+    const found: DetectedBridgeConfigs = {};
+
+    const worker = async (): Promise<void> => {
+        for (;;) {
+            const id = queue.shift();
+            if (id === undefined) return;
+            try {
+                const path = await probe(id);
+                if (path) found[id] = path;
+            } catch {
+                // A source we cannot probe is simply not reported as found.
+                // The tool stays in the list and stays pickable by hand.
+            }
+        }
+    };
+
+    await Promise.all(Array.from({ length: Math.min(PROBE_CONCURRENCY, queue.length) }, worker));
+    return found;
+}
+
+/**
+ * The detected configs, probing at most once per app run. Concurrent callers
+ * share the sweep in progress instead of starting a second one.
+ */
+export function loadDetectedBridgeConfigs(
+    probe: BridgeConfigProbe = tauriProbe,
+): Promise<DetectedBridgeConfigs> {
+    if (cache) return Promise.resolve(cache);
+    if (!inFlight) {
+        inFlight = probeAll(probe).then(result => {
+            cache = result;
+            inFlight = null;
+            return result;
+        });
+    }
+    return inFlight;
+}
+
+/** Test seam: forget both the cached answer and any sweep in progress. */
+export function resetDetectedBridgeConfigsCache(): void {
+    cache = null;
+    inFlight = null;
+}
+
 export interface DetectedBridgeConfigsState {
     detected: DetectedBridgeConfigs;
-    /** True while at least one probe is still outstanding. */
+    /** True while the sweep this consumer is waiting on has not landed yet. */
     probing: boolean;
 }
 
 /**
- * Probe every bridge source once, the first time `enabled` turns true.
- * Disabled callers pay nothing: no probe is issued until the picker is shown.
+ * The detected configs for a component. Nothing is probed until `enabled`
+ * turns true, so a caller that never opens the picker pays nothing.
  */
 export function useDetectedBridgeConfigs(enabled: boolean): DetectedBridgeConfigsState {
-    const [detected, setDetected] = useState<DetectedBridgeConfigs>({});
+    const [detected, setDetected] = useState<DetectedBridgeConfigs>(() => cache ?? {});
     const [probing, setProbing] = useState(false);
-    // One sweep per mount. Without this, toggling back and forth between the
-    // import and export pickers would re-probe (and re-spawn rclone) on every
-    // switch, for an answer that cannot have changed meanwhile.
-    const started = useRef(false);
 
     useEffect(() => {
-        if (!enabled || started.current) return;
-        started.current = true;
-
+        if (!enabled) return;
         let cancelled = false;
-        const queue = GENERIC_BRIDGE_SOURCES.map(s => s.id);
         setProbing(true);
-
-        const worker = async (): Promise<void> => {
-            for (;;) {
-                const id = queue.shift();
-                if (id === undefined || cancelled) return;
-                try {
-                    const path = await invoke<string | null>('detect_bridge_config', { source: id });
-                    if (!cancelled && path) {
-                        setDetected(prev => ({ ...prev, [id]: path }));
-                    }
-                } catch {
-                    // A source we cannot probe is simply not reported as found.
-                    // The tool stays in the list and stays pickable by hand.
-                }
-            }
-        };
-
-        void Promise.all(
-            Array.from({ length: Math.min(PROBE_CONCURRENCY, queue.length) }, worker),
-        ).finally(() => {
-            if (!cancelled) setProbing(false);
+        void loadDetectedBridgeConfigs().then(result => {
+            if (cancelled) return;
+            setDetected(result);
+            setProbing(false);
         });
-
         return () => {
             cancelled = true;
         };
@@ -84,7 +124,7 @@ export function useDetectedBridgeConfigs(enabled: boolean): DetectedBridgeConfig
 /**
  * Last two segments of a config path, prefixed with an ellipsis when anything
  * was dropped: `/home/me/.config/filezilla/sitemanager.xml` becomes
- * `.../filezilla/sitemanager.xml`.
+ * `…/filezilla/sitemanager.xml`.
  *
  * The row shows the path rather than a "found on this computer" label, so the
  * information carries no translated string. Plain CSS truncation would defeat

--- a/src/hooks/useDetectedBridgeConfigs.ts
+++ b/src/hooks/useDetectedBridgeConfigs.ts
@@ -113,6 +113,44 @@ export function loadDetectedBridgeConfigs(
     return inFlight;
 }
 
+/**
+ * How long a single-source probe may take before the UI stops waiting on it.
+ * Not a cancellation: the backend call runs on, we simply stop letting it hold
+ * a spinner. Six seconds is far above a normal answer (a path lookup, or one
+ * `rclone config file` spawn) and far below a user's patience.
+ */
+export const BRIDGE_PROBE_TIMEOUT_MS = 6000;
+
+/**
+ * The config path for ONE source, for a caller that has a spinner on screen:
+ * the sweep's answer when it already has one, otherwise a probe that gives up
+ * rather than spinning forever. Resolves to '' for "no config here", which is
+ * also what a timeout looks like, because both mean the same thing to the user:
+ * pick the file by hand.
+ *
+ * A hanging probe used to leave BridgeSourcePanel on an eternal "Detecting..."
+ * with no way to reach the browse button.
+ */
+export function detectBridgeConfigBounded(
+    source: string,
+    probe: BridgeConfigProbe = tauriProbe,
+    timeoutMs: number = BRIDGE_PROBE_TIMEOUT_MS,
+): Promise<string> {
+    const known = (cache ?? partial)[source];
+    if (known) return Promise.resolve(known);
+    return new Promise<string>(resolve => {
+        let settled = false;
+        const finish = (value: string) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timer);
+            resolve(value);
+        };
+        const timer = setTimeout(() => finish(''), timeoutMs);
+        probe(source).then(path => finish(path || '')).catch(() => finish(''));
+    });
+}
+
 /** What the sweep has found so far, empty before it starts. */
 export function detectedBridgeConfigsSoFar(): DetectedBridgeConfigs {
     return cache ?? { ...partial };

--- a/src/hooks/useDetectedBridgeConfigs.ts
+++ b/src/hooks/useDetectedBridgeConfigs.ts
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+// Which of the 15 bridge tools have a config file on THIS machine.
+//
+// `detect_bridge_config` (src-tauri/src/bridge_commands.rs) resolves a tool's
+// conventional config path per platform and returns Some only when that file
+// exists, so a returned path means "installed and configured here". The
+// Export/Import dialog used to ask this one tool at a time, and only after
+// the user had already picked one (BridgeSourcePanel); asking for all of them
+// while the picker is on screen is what lets the tools you actually use rise
+// to the top of the list instead of hiding at position 11 of 15.
+//
+// Probes run with bounded concurrency because they are not all pure path
+// math: the rclone probe shells out to `rclone config file`. Results stream
+// in as they land, so the list renders immediately and decorates itself
+// rather than waiting for the slowest probe.
+
+import { useEffect, useRef, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { GENERIC_BRIDGE_SOURCES, type BridgeSourceDescriptor } from '../components/bridge/bridgeSources';
+
+const PROBE_CONCURRENCY = 4;
+
+/** Bridge source id -> absolute path of the config found on this machine. */
+export type DetectedBridgeConfigs = Record<string, string>;
+
+export interface DetectedBridgeConfigsState {
+    detected: DetectedBridgeConfigs;
+    /** True while at least one probe is still outstanding. */
+    probing: boolean;
+}
+
+/**
+ * Probe every bridge source once, the first time `enabled` turns true.
+ * Disabled callers pay nothing: no probe is issued until the picker is shown.
+ */
+export function useDetectedBridgeConfigs(enabled: boolean): DetectedBridgeConfigsState {
+    const [detected, setDetected] = useState<DetectedBridgeConfigs>({});
+    const [probing, setProbing] = useState(false);
+    // One sweep per mount. Without this, toggling back and forth between the
+    // import and export pickers would re-probe (and re-spawn rclone) on every
+    // switch, for an answer that cannot have changed meanwhile.
+    const started = useRef(false);
+
+    useEffect(() => {
+        if (!enabled || started.current) return;
+        started.current = true;
+
+        let cancelled = false;
+        const queue = GENERIC_BRIDGE_SOURCES.map(s => s.id);
+        setProbing(true);
+
+        const worker = async (): Promise<void> => {
+            for (;;) {
+                const id = queue.shift();
+                if (id === undefined || cancelled) return;
+                try {
+                    const path = await invoke<string | null>('detect_bridge_config', { source: id });
+                    if (!cancelled && path) {
+                        setDetected(prev => ({ ...prev, [id]: path }));
+                    }
+                } catch {
+                    // A source we cannot probe is simply not reported as found.
+                    // The tool stays in the list and stays pickable by hand.
+                }
+            }
+        };
+
+        void Promise.all(
+            Array.from({ length: Math.min(PROBE_CONCURRENCY, queue.length) }, worker),
+        ).finally(() => {
+            if (!cancelled) setProbing(false);
+        });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [enabled]);
+
+    return { detected, probing };
+}
+
+/**
+ * Last two segments of a config path, prefixed with an ellipsis when anything
+ * was dropped: `/home/me/.config/filezilla/sitemanager.xml` becomes
+ * `.../filezilla/sitemanager.xml`.
+ *
+ * The row shows the path rather than a "found on this computer" label, so the
+ * information carries no translated string. Plain CSS truncation would defeat
+ * that: it cuts the tail, and the tail is the only part that differs between
+ * one tool's config and another's. The full path stays in the row's tooltip.
+ */
+export function shortenConfigPath(path: string): string {
+    const parts = path.split(/[\\/]+/).filter(Boolean);
+    if (parts.length <= 2) return path;
+    return `…/${parts.slice(-2).join('/')}`;
+}
+
+/**
+ * Tools whose config was found on this machine first, everything else after,
+ * curated order preserved inside each group (Array.sort is stable).
+ *
+ * Kept out of the JSX so it can be tested without rendering the dialog.
+ */
+export function orderBridgeSourcesByDetection<T extends BridgeSourceDescriptor>(
+    sources: readonly T[],
+    detected: DetectedBridgeConfigs,
+): T[] {
+    return [...sources].sort((a, b) => (detected[b.id] ? 1 : 0) - (detected[a.id] ? 1 : 0));
+}


### PR DESCRIPTION
## Summary

- probe all 15 bridge import sources when the app picker is visible
- move sources with a detected local config to the top while preserving curated order inside both groups
- show the shortened detected path in the row and retain the full path in its tooltip
- keep the sweep alive across React StrictMode remounts, publish results progressively, and bound the per-source waiting spinner

## Verification

Independent reviewer verification on this branch tip:

- `useDetectedBridgeConfigs.test.ts`: 16/16 passed
- full frontend suite: 832 passed across 95 files
- `tsc --noEmit`: passed
- frontend and backend source sets: 15/15, no differences in either direction
- Tauri invoke registration: confirmed
- new files: no TODO, FIXME, XXX, or `@ts-ignore`

Live Linux verification on 2026-08-31:

- built and launched the branch tip as the real Tauri/WebKitGTK app under Wayland
- called `detect_bridge_config` for every one of the 15 source ids in the running backend; all 15 returned without error in 3.084 s total
- detected on this machine: AWS (`~/.aws/credentials`), OpenSSH (`~/.ssh/config`), MinIO Client (`~/.mc/config.json`), rclone (`~/.config/rclone/rclone.conf`), and FileZilla (`~/.config/filezilla/sitemanager.xml`)
- returned `null` on this machine: Cyberduck, s3cmd, lftp, PuTTY, MobaXterm, Dreamweaver, Kopia, Duplicacy, restic, and WinSCP
- opened Export / Import -> Import from another app through the WebKit inspector: all 15 cards rendered, the five detected sources moved to the first five positions with green detected styling and shortened paths, the other ten followed, and no spinner remained
- navigated Back and opened the picker a second time: the same 15-card order and five detections remained, covering the remount path that broke the first implementation
- returned the app to My Servers and closed it cleanly

## Notes

- no i18n keys are added: a detection row displays the config path itself, while the existing generic subtitle remains for sources not found
- no native file chooser or import was exercised; this PR changes source detection, ordering, and picker presentation, not parsing or import execution

Refs #628


## One report about the step AFTER this picker, now closed

Driving an earlier tip of this branch in a DEV build on another machine, clicking a row in the picker opened no tool panel at all: the picker closed and nothing appeared, sampled 22 times over 18 seconds, with "Detecting configuration..." never observed. That has never been reproduced on bare main, and it was not seen in the run recorded above, which exercised the picker itself but not the row click.

What is established: this branch does not touch the mount path. `routeBridgeSource`, the state it sets, and the render condition `mode === 'bridge-src' && bridgeSrc` are byte-identical to main, and the only change inside `BridgeSourcePanel` runs in an effect, which is after mount. `ExportImportDialog.tsx`, `BridgeSourcePanel.tsx` and `src/components/bridge/*` are also byte-identical between `v4.1.8` and main, so an earlier guess that the defect was born after the tag does not hold and was withdrawn.

What is not established: whether that observation was the branch, the dev build, or the driving. The reading that separates the three cases is the dialog TITLE, which is computed from the same state as the body: `<Tool> Import from another app` means the panel mounted; the generic `Export / Import` with an empty body means `mode` is `bridge-src` while `bridgeSrc` is null, so the shell is there and no branch matched; no dialog in the DOM at all means something called `onClose`.

So this pull request improves discovery and is verified on that ground, and the step it leads to carries an open report that is nobody's confirmed defect yet. It is written here so a reviewer weighs both, instead of reading a green run as an answer to a question it did not ask.


**Closed on 2026-08-31, with the reading described above.** A row was clicked in the picker on the RELEASED v4.1.8 and the dialog title came back as `rclone Import from another app`, tool-specific rather than the generic `Export / Import`, with the found configuration and its path in the body. That is the first of the three cases: the panel mounts.

So the 22 samples do not reproduce on the shipped version. `ExportImportDialog.tsx` and `BridgeSourcePanel.tsx` are byte-identical between `v4.1.8` and main, and this branch does not touch the mount path, so what is left is the dev build or the driving of it. Neither is this change, and the report is no longer an open question against it.

Worth keeping for whoever meets this again: asking "does it open?" would have returned a yes without separating a mounted panel from an empty shell, which look alike. The title is computed from the same state as the body, so one click answered it. The reading was designed before it was taken.
