### PR TITLE
fix(kdrive): say which scope the token is missing, instead of the raw API error

### DIFF
--- a/src-tauri/src/providers/kdrive.rs
+++ b/src-tauri/src/providers/kdrive.rs
@@ -2123,12 +2123,6 @@ mod tests {
         assert!(text.contains("`user_info`"), "{text}");
     }
 
-    /// The scope names arrive in the response body, so the branch that prints
-    /// them has to clean them exactly as the branch it replaced cleaned the
-    /// body. Verified against the two things `sanitize_api_error` is for: a
-    /// value carrying something secret-shaped, and an array long enough to
-    /// produce an unbounded message.
-    #[test]
     /// A name that is empty or only spaces is not a name. Without the trim and
     /// the filter it survives `filter_map`, `scopes.is_empty()` stays false, and
     /// the message names a scope that is not there instead of falling back to
@@ -2154,6 +2148,12 @@ mod tests {
         );
     }
 
+    /// The scope names arrive in the response body, so the branch that prints
+    /// them has to clean them exactly as the branch it replaced cleaned the
+    /// body. Verified against the two things `sanitize_api_error` is for: a
+    /// value carrying something secret-shaped, and an array long enough to
+    /// produce an unbounded message.
+    #[test]
     fn scope_names_from_the_body_are_cleaned_and_bounded() {
         // 20 characters or more after the prefix: the sanitiser's patterns have a
         // deliberate length floor so ordinary words are not redacted, and a

--- a/src-tauri/src/providers/kdrive.rs
+++ b/src-tauri/src/providers/kdrive.rs
@@ -357,27 +357,48 @@ impl KDriveProvider {
             .and_then(|e| e.get("context"))
             .and_then(|c| c.get("scopes"))
             .and_then(|s| s.as_array())
-            .map(|a| a.iter().filter_map(|s| s.as_str()).collect())
+            .map(|a| {
+                a.iter()
+                    .filter_map(|s| s.as_str())
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .collect()
+            })
             .unwrap_or_default();
         if scopes.is_empty() {
             return Some(
                 "this API token is missing a scope that Infomaniak did not name. \
-                 Fetching the Drive ID needs the account id, so generate a new \
-                 token with `user_info` alongside `drive` at \
+                 Fetching the Drive ID needs `user_info` alongside `drive`, so \
+                 generate a new token with both at \
                  https://manager.infomaniak.com/v3/ng/profile/user/token/list"
                     .to_string(),
             );
         }
+        // These names come out of the response body, so they get the same
+        // treatment the body was already getting: `sanitize_api_error` keeps one
+        // line, caps the length and strips anything that looks like a secret.
+        // The guard was never there because scope names are dangerous, it was
+        // there because a response body is not something to make assumptions
+        // about, and a branch added beside it does not inherit it for free.
+        // The count is capped for the same reason: an array of a hundred long
+        // entries would otherwise produce a message with no bound at all.
+        const MAX_LISTED: usize = 4;
+        let listed: Vec<String> = scopes
+            .iter()
+            .take(MAX_LISTED)
+            .map(|s| format!("`{}`", sanitize_api_error(s)))
+            .collect();
+        let and_more = if scopes.len() > MAX_LISTED {
+            format!(" and {} more", scopes.len() - MAX_LISTED)
+        } else {
+            String::new()
+        };
         Some(format!(
-            "this API token is missing the {} scope. Fetching the Drive ID needs \
-             the account id, which only that scope can supply, so add it to the \
-             existing `drive` scope and generate a new token at \
+            "this API token is missing the {}{} scope, so add it to the token's \
+             existing scopes and generate a new one at \
              https://manager.infomaniak.com/v3/ng/profile/user/token/list",
-            scopes
-                .iter()
-                .map(|s| format!("`{s}`"))
-                .collect::<Vec<_>>()
-                .join(" and ")
+            listed.join(" and "),
+            and_more
         ))
     }
 
@@ -2100,6 +2121,94 @@ mod tests {
         .to_string();
         assert!(text.contains("manager.infomaniak.com"), "{text}");
         assert!(text.contains("`user_info`"), "{text}");
+    }
+
+    /// The scope names arrive in the response body, so the branch that prints
+    /// them has to clean them exactly as the branch it replaced cleaned the
+    /// body. Verified against the two things `sanitize_api_error` is for: a
+    /// value carrying something secret-shaped, and an array long enough to
+    /// produce an unbounded message.
+    #[test]
+    /// A name that is empty or only spaces is not a name. Without the trim and
+    /// the filter it survives `filter_map`, `scopes.is_empty()` stays false, and
+    /// the message names a scope that is not there instead of falling back to
+    /// guidance that would have been useful. Its own test rather than a block
+    /// inside the one below, because that one reuses `text` and an assertion
+    /// added in the middle silently measures the wrong message.
+    #[test]
+    fn a_blank_scope_name_is_no_name_at_all() {
+        let blank = br#"{"error":{"code":"all_scopes","context":{"scopes":["","   "]}}}"#;
+        let text = KDriveProvider::discovery_http_error(
+            reqwest::StatusCode::FORBIDDEN,
+            blank,
+            "Could not read the Infomaniak account profile",
+        )
+        .to_string();
+        assert!(
+            text.contains("did not name"),
+            "blank names are no names, so this is the unnamed case: {text}"
+        );
+        assert!(
+            !text.contains("``"),
+            "and no empty backticks reach the user: {text}"
+        );
+    }
+
+    fn scope_names_from_the_body_are_cleaned_and_bounded() {
+        // 20 characters or more after the prefix: the sanitiser's patterns have a
+        // deliberate length floor so ordinary words are not redacted, and a
+        // hand-picked short value silently exercises nothing. Checked against
+        // `ai.rs`, which requires `{20,}`, rather than assumed.
+        let leaky = br#"{"error":{"code":"all_scopes","context":{"scopes":["sk-AbCdEfGhIjKlMnOpQrStUvWxYz0123"]}}}"#;
+        let text = KDriveProvider::discovery_http_error(
+            reqwest::StatusCode::FORBIDDEN,
+            leaky,
+            "Could not read the Infomaniak account profile",
+        )
+        .to_string();
+        assert!(
+            !text.contains("sk-AbCdEfGhIjKlMnOpQrStUvWxYz0123"),
+            "a secret-shaped scope name is redacted like any other body text: {text}"
+        );
+
+        let many = format!(
+            r#"{{"error":{{"code":"all_scopes","context":{{"scopes":[{}]}}}}}}"#,
+            (0..40)
+                .map(|i| format!("\"scope_number_{i}\""))
+                .collect::<Vec<_>>()
+                .join(",")
+        );
+        let text = KDriveProvider::discovery_http_error(
+            reqwest::StatusCode::FORBIDDEN,
+            many.as_bytes(),
+            "Could not read the Infomaniak account profile",
+        )
+        .to_string();
+        assert!(text.contains("and 36 more"), "the list is bounded: {text}");
+
+        // The property is that the message does not GROW with the array, not
+        // that it fits under some number somebody picked. A fixed threshold
+        // would pass or fail on the length of the surrounding prose, which is
+        // not what is being defended.
+        let few = format!(
+            r#"{{"error":{{"code":"all_scopes","context":{{"scopes":[{}]}}}}}}"#,
+            (0..4)
+                .map(|i| format!("\"scope_number_{i}\""))
+                .collect::<Vec<_>>()
+                .join(",")
+        );
+        let short = KDriveProvider::discovery_http_error(
+            reqwest::StatusCode::FORBIDDEN,
+            few.as_bytes(),
+            "Could not read the Infomaniak account profile",
+        )
+        .to_string();
+        assert!(
+            text.len() < short.len() + 24,
+            "ten times the scopes must not mean a message ten times longer: {} against {}",
+            text.len(),
+            short.len()
+        );
     }
 
     fn test_provider() -> KDriveProvider {

--- a/src-tauri/src/providers/kdrive.rs
+++ b/src-tauri/src/providers/kdrive.rs
@@ -325,13 +325,72 @@ impl KDriveProvider {
             })
     }
 
+    /// Recognise Infomaniak's "your token lacks a scope" refusal and say what
+    /// to do about it, because the answer is in the payload and unreadable there.
+    ///
+    /// Discovery needs an `account_id`, and there is no way to obtain one with a
+    /// `drive`-only token: `/2/profile` requires `user_info`, `/2/accounts`
+    /// requires `accounts`, and `/2/drive` without the parameter is a 422. That
+    /// was measured against the live API rather than read off the documentation,
+    /// so the remedy really is a differently scoped token and not a different
+    /// endpoint. See #650. Measured against the live API with a `drive`-only
+    /// token: `/2/profile` 403 `user_info`, `/2/accounts` and `/1/account` 403
+    /// `accounts`, `/2/drive` without the parameter 422 "The account id field is
+    /// required", `/2/drives` and `/3/drive` 404. `/2/drive/init` is the one
+    /// endpoint that answers 200 on a `drive`-only token, and it returns an
+    /// `ips.uuid`, not an account id, so it is not a way around this.
+    ///
+    /// The scope names come from `error.context.scopes` rather than from the
+    /// prose in `description`: a description is a sentence somebody may reword,
+    /// and a message that parses prose starts lying the day it changes.
+    fn missing_scope_hint(body: &[u8]) -> Option<String> {
+        let parsed: serde_json::Value = serde_json::from_slice(body).ok()?;
+        if parsed.get("error")?.get("code")?.as_str()? != "all_scopes" {
+            return None;
+        }
+        // `context.scopes` is one condition more than `code`, so losing it would
+        // send exactly those replies back to the raw JSON: a defect that returns
+        // for a subset is harder to see than one that returns for all. The
+        // fallback names no scope and still says what to do.
+        let scopes: Vec<&str> = parsed
+            .get("error")
+            .and_then(|e| e.get("context"))
+            .and_then(|c| c.get("scopes"))
+            .and_then(|s| s.as_array())
+            .map(|a| a.iter().filter_map(|s| s.as_str()).collect())
+            .unwrap_or_default();
+        if scopes.is_empty() {
+            return Some(
+                "this API token is missing a scope that Infomaniak did not name. \
+                 Fetching the Drive ID needs the account id, so generate a new \
+                 token with `user_info` alongside `drive` at \
+                 https://manager.infomaniak.com/v3/ng/profile/user/token/list"
+                    .to_string(),
+            );
+        }
+        Some(format!(
+            "this API token is missing the {} scope. Fetching the Drive ID needs \
+             the account id, which only that scope can supply, so add it to the \
+             existing `drive` scope and generate a new token at \
+             https://manager.infomaniak.com/v3/ng/profile/user/token/list",
+            scopes
+                .iter()
+                .map(|s| format!("`{s}`"))
+                .collect::<Vec<_>>()
+                .join(" and ")
+        ))
+    }
+
     fn discovery_http_error(
         status: reqwest::StatusCode,
         body: &[u8],
         context: &str,
     ) -> ProviderError {
         let text = String::from_utf8_lossy(body);
-        let message = format!("{context} ({status}): {}", sanitize_api_error(&text));
+        let message = match Self::missing_scope_hint(body) {
+            Some(hint) => format!("{context} ({status}): {hint}"),
+            None => format!("{context} ({status}): {}", sanitize_api_error(&text)),
+        };
         if matches!(
             status,
             reqwest::StatusCode::UNAUTHORIZED | reqwest::StatusCode::FORBIDDEN
@@ -1973,6 +2032,74 @@ mod tests {
         });
         assert_eq!(KDriveProvider::profile_account_id(&numeric), Some(45665));
         assert_eq!(KDriveProvider::profile_account_id(&string), Some(45665));
+    }
+
+    /// #650. The payload is the one Infomaniak actually returned for a token
+    /// carrying only the `drive` scope, captured live rather than composed
+    /// here, because a message built to match the code proves nothing about
+    /// what the server sends.
+    ///
+    /// The assertion is on the OUTCOME of `discovery_http_error`, not on the
+    /// helper: what was broken is the sentence the user reads, and a test that
+    /// called `missing_scope_hint` directly would stay green if the caller
+    /// stopped consulting it.
+    #[test]
+    fn a_missing_scope_is_reported_as_something_the_user_can_fix() {
+        let body = br#"{"result":"error","error":{"code":"all_scopes","description":"This method require this specific scope: \"user_info\"","context":{"scopes":["user_info"]}}}"#;
+        let err = KDriveProvider::discovery_http_error(
+            reqwest::StatusCode::FORBIDDEN,
+            body,
+            "Could not read the Infomaniak account profile",
+        );
+        let text = err.to_string();
+        assert!(
+            matches!(err, ProviderError::AuthenticationFailed(_)),
+            "a refused scope is still an authentication failure: {err:?}"
+        );
+        assert!(
+            text.contains("`user_info`"),
+            "the scope the token is missing has to be named: {text}"
+        );
+        assert!(
+            text.contains("manager.infomaniak.com"),
+            "and where to add it: {text}"
+        );
+        assert!(
+            !text.contains("all_scopes"),
+            "the raw API error code is not what the user needs to read: {text}"
+        );
+    }
+
+    /// The companion, so the hint cannot swallow every other failure: a body
+    /// that is not a scope refusal still reports what the server said.
+    #[test]
+    fn an_ordinary_discovery_failure_keeps_the_server_text() {
+        let body = br#"{"result":"error","error":{"code":"not_authorized","description":"Nope"}}"#;
+        let text = KDriveProvider::discovery_http_error(
+            reqwest::StatusCode::FORBIDDEN,
+            body,
+            "Could not list accessible kDrive accounts",
+        )
+        .to_string();
+        assert!(text.contains("not_authorized"), "{text}");
+        assert!(!text.contains("manager.infomaniak.com"), "{text}");
+    }
+
+    /// The subset that would otherwise slip back to the raw JSON: the code says
+    /// `all_scopes` and the payload names no scope. Reported because the branch
+    /// added a second condition, and a defect that returns for only some replies
+    /// is harder to see than one that returns for all.
+    #[test]
+    fn a_scope_refusal_that_names_no_scope_still_says_what_to_do() {
+        let body = br#"{"result":"error","error":{"code":"all_scopes","description":"Nope"}}"#;
+        let text = KDriveProvider::discovery_http_error(
+            reqwest::StatusCode::FORBIDDEN,
+            body,
+            "Could not read the Infomaniak account profile",
+        )
+        .to_string();
+        assert!(text.contains("manager.infomaniak.com"), "{text}");
+        assert!(text.contains("`user_info`"), "{text}");
     }
 
     fn test_provider() -> KDriveProvider {


### PR DESCRIPTION
The Drive ID Fetch button failed for a token that carries only the `drive` scope, and printed Infomaniak's raw JSON at the user:

```text
Authentication failed: Could not read the Infomaniak account profile (403 Forbidden):
{"result":"error","error":{"code":"all_scopes","description":"This method require this specific scope:"user_info"","context":{"scopes":["user_info"]}}}
```

The one fact that user needs is inside that blob and unreadable there. It does not say what to do.

## The hypothesis I started with was wrong, and the code comment was right

Discovery calls `/2/profile` to obtain an `account_id`, then `/2/drive?account_id=...`. The obvious fix looked like dropping the profile call: no profile, no `user_info` requirement. A comment at `kdrive.rs` already claimed `account_id` was required, but cited no evidence, and no test covered it.

Measured against the live API with a `drive`-only token rather than read off the documentation:

| request | result |
|---|---|
| `/2/profile` | 403 `all_scopes`, requires `user_info` |
| `/2/drive` without the parameter | **422 "The account id field is required"** |
| `/2/accounts`, `/1/account` | 403 `all_scopes`, requires `accounts` |
| `/2/drives`, `/3/drive`, `/1/drive` | 404 |
| `/2/drive/init` | 200, and it returns an `ips.uuid`, not an account id |

So `account_id` is genuinely required and there is no endpoint that yields one on a `drive`-only token. The two routes are `user_info` or `accounts`, and the remedy really is a differently scoped token rather than a different endpoint. **The comment was right and my hypothesis was wrong**, which is why the measurements are now in the source next to it: the `/2/drive/init` 200 in particular would otherwise send the next reader down a road that does not exist.

## What changed

`discovery_http_error` recognises the `all_scopes` refusal and replaces the payload with a sentence that names the missing scope and where to add it.

**Scope names are read from `error.context.scopes`, not from `description`.** A description is prose somebody may reword; a message that parses prose starts lying the day it changes, which is the failure this repository has just spent a day finding in other forms.

There is a fallback for the case where the code says `all_scopes` and no scope is named. Without it the branch would carry one condition more than the old path, and those replies alone would fall back to the raw JSON: **a defect that returns for a subset is harder to see than one that returns for all.**

## Three tests, and the proof they are pins

The payload in the main test is the one Infomaniak actually returned, captured live rather than composed here, because a message built to match the code proves nothing about what the server sends. All three assert on the outcome of `discovery_http_error` rather than on the helper: what was broken is the sentence the user reads, and a test calling the helper directly would stay green if the caller stopped consulting it.

Verified by reintroducing the defect rather than by reading them. With the caller no longer consulting the hint, two of the three fail, and the failure prints exactly the string from the issue:

```text
the scope the token is missing has to be named: Authentication failed: Could not read
the Infomaniak account profile (403 Forbidden): {"result":"error","error":{"code":"all_scopes"...
```

The third stays green on purpose: it pins that a non-scope failure still reports what the server said, so the new branch cannot swallow every other error.

## Not in this change

The Quick Connect page does not yet say which scopes a kDrive token needs. Adding that would prevent the case rather than explain it, and it is a separate surface with its own review.

Gate: `cargo fmt`, `clippy --all-features --lib --tests` clean, 9 `providers::kdrive` tests passing.

Closes nothing automatically: #650 stays open until the reporter confirms.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drive discovery error messages for missing permissions.
  * Missing permission details are now presented more clearly, with guidance to manage access tokens.
  * Blank or sensitive permission values are excluded from displayed errors.
  * Long permission lists are limited to four items, with a count of additional items.
  * Clear fallback messaging remains available for other discovery failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Merge record

Merged at zero incomplete check runs, read from the check-runs API on the head commit rather than from this page, where a superseded `cancelled` run reads as red.

CodeRabbit reviewed base through `8f3cc939` and raised two inline findings. Both are fixed in `a14461e2`, and that fix commit was NOT re-reviewed: the incremental pass was rate limited. So the findings are closed by a human reading of the fix, not by the bot confirming its own points.

The behaviour itself was measured against the live API with a real token rather than inferred from the documentation: `/2/profile` 403, `/2/drive` 422, `/2/accounts` 403, and `/2/drive/init` 200 returning a uuid rather than an account id.
