### PR TITLE
chore(governance): certify contribution origin with a DCO, not a CLA

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,7 @@
 - [ ] I have tested my changes
 - [ ] I have updated the documentation (if needed)
 - [ ] My changes generate no new warnings
+- [ ] Every commit is signed off (`git commit -s`), see [CONTRIBUTING](../CONTRIBUTING.md#sign-off-developer-certificate-of-origin)
 
 ## Related Issues
 <!-- Link related issues: Fixes #123 -->

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,54 @@
+name: DCO
+
+# Verifies that every commit in a pull request carries a Developer Certificate
+# of Origin sign-off (see the DCO file at the repository root).
+#
+# Deliberately self-contained: this is a supply-chain sensitive check, so it
+# uses no third-party action beyond the official checkout.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  check-sign-off:
+    name: Check sign-off
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Every commit must be signed off
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          missing=0
+          # Merge commits are exempt: their content is signed off on the branch.
+          for sha in $(git rev-list --no-merges "$BASE".."$HEAD"); do
+            author_name=$(git show -s --format='%an' "$sha")
+            author_mail=$(git show -s --format='%ae' "$sha")
+            expected="Signed-off-by: ${author_name} <${author_mail}>"
+            if git show -s --format='%B' "$sha" | grep -qiF "$expected"; then
+              continue
+            fi
+            echo "::error::commit $sha is missing '$expected'"
+            git show -s --format='  %h %s' "$sha"
+            missing=1
+          done
+          if [ "$missing" -ne 0 ]; then
+            echo ""
+            echo "Add the sign-off by amending or rebasing with -s, for example:"
+            echo "  git commit --amend -s --no-edit"
+            echo "  git rebase --signoff $BASE"
+            echo ""
+            echo "The sign-off must match the commit author exactly. It certifies"
+            echo "the Developer Certificate of Origin, see the DCO file in the repo root."
+            exit 1
+          fi
+          echo "All commits are signed off."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Be respectful, inclusive, and professional. We're here to build great software t
 2. Create a feature branch (`git checkout -b feature/amazing-feature`)
 3. Make your changes
 4. Run tests (`cd src-tauri && cargo test`)
-5. Commit (`git commit -m 'Add amazing feature'`)
+5. Commit **with a sign-off** (`git commit -s -m 'Add amazing feature'`), see [Sign-off](#sign-off-developer-certificate-of-origin)
 6. Push (`git push origin feature/amazing-feature`)
 7. Open a Pull Request
 
@@ -116,6 +116,26 @@ npm run tauri build
 - Use clear, descriptive messages
 - Start with a verb (Add, Fix, Update, Remove)
 - Reference issues when relevant (#123)
+
+## Sign-off (Developer Certificate of Origin)
+
+Every commit must carry a `Signed-off-by` line. Adding one is a single flag:
+
+```bash
+git commit -s -m "fix(webdav): handle 405 on root PROPFIND"
+```
+
+which appends:
+
+```
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+The name and email must match the commit author. If you forget, `git commit --amend -s --no-edit` fixes the last commit and `git rebase --signoff <base>` fixes a whole branch. A CI check enforces this on every pull request.
+
+The sign-off certifies the [Developer Certificate of Origin](DCO) 1.1: in short, that you wrote the contribution yourself, or that you have the right to submit it under the project's licence. It is a statement about the origin of the code, not a transfer of anything: **you keep the copyright in your contribution**.
+
+AeroFTP deliberately uses a DCO rather than a Contributor Licence Agreement. A CLA would ask you to grant rights beyond the project's licence, and that is not something this project needs from you.
 
 ## Test Requirements
 

--- a/DCO
+++ b/DCO
@@ -1,0 +1,34 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.


### PR DESCRIPTION
Adds a Developer Certificate of Origin sign-off requirement, and says in `CONTRIBUTING.md` why this project uses one instead of a contributor licence agreement.

## Why now

While auditing who holds copyright in this repository, the answer turned out to be unusually short: outside my own commits and the dependency bot, there is exactly one contribution from someone else. That means relicensing decisions are still possible today, and a single contribution accepted without any agreement can quietly remove that option for good.

The usual instrument for keeping the option open is a CLA. This project deliberately does not adopt one. A CLA asks contributors to grant rights beyond the project licence so the maintainer alone can monetise them, which is an asymmetry people are right to dislike, and it buys an option a desktop file transfer client has no realistic use for. Nobody buys a commercial exception for this.

A DCO gives the part that is actually needed and none of the part that is not. It certifies that the contributor wrote the code or has the right to submit it under the project licence. It transfers nothing, and **the contributor keeps the copyright in their work**. `CONTRIBUTING.md` now states all three of those points explicitly, including the absence of a CLA, so nobody has to guess what a sign-off commits them to.

## What is in here

| File | |
|---|---|
| `DCO` | The Developer Certificate of Origin 1.1, verbatim from developercertificate.org |
| `.github/workflows/dco.yml` | CI check on every pull request |
| `CONTRIBUTING.md` | A `Sign-off` section, and `git commit -s` in the pull request steps |
| `.github/PULL_REQUEST_TEMPLATE.md` | One checklist item |

## Notes on the check

It is **self-contained**, using no third-party action beyond the official checkout. Verifying the provenance of contributions is exactly the wrong place to introduce a supply chain dependency, so the check is thirty lines of shell rather than a marketplace action.

It requires the sign-off to match the commit author exactly, and it exempts merge commits, whose content is signed off on the branch. On failure it prints the offending commits and the two commands that fix them (`git commit --amend -s --no-edit`, `git rebase --signoff <base>`).

The logic was tested against real commits in this repository before being committed.

## What this means in practice

No commit before this one carries a sign-off, so the requirement applies to pull requests from here on and nothing is retroactive. **It applies to my own pull requests too.** Git has no global "always sign off" setting for commits, so an alias or a `prepare-commit-msg` hook is worth setting up locally.

The commit in this pull request is itself signed off, so it satisfies the check it introduces.


---

## Merge record

Merged at zero incomplete check runs, read from the check-runs API on the head commit rather than from this page, where a superseded `cancelled` run reads as red. That set includes this pull request's own `Check sign-off` job, so the workflow validated its own commit before landing.

CodeRabbit did NOT review this change: it was rate limited on this pull request and never produced a walkthrough. I record it because an unreviewed pull request and one reviewed with no findings look identical from outside, and this one is the former.

What that leaves is a human reading of thirty lines of shell that uses no third-party action beyond the official checkout, which is deliberate: verifying the provenance of contributions is the wrong place to add a supply chain dependency.
