### PR TITLE
chore(deps): aerovault 0.6.4, the first release under MPL-2.0

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -215,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "aerovault"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "690cffc2e8812e7c31d24017428f3c4164077374ad4fce4cae77f0df660596e3"
+checksum = "acd63b28931512d570a241d55e44bedf651def9c11cc5d80c9172a59a55bb7fb"
 dependencies = [
  "aes-gcm-siv",
  "aes-kw",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -204,7 +204,7 @@ jsonwebtoken = { version = "10.4", default-features = false, features = ["aws_lc
 # AeroVault v2 - Military-Grade Encryption (v1.8.0)
 # T7 convergence: the app consumes the crate's AEROVAULT3 core (aerovault::v3);
 # the vault_v3_* handlers are thin wrappers over it (see src/aerovault_v3.rs).
-aerovault = "0.6.3"                                                    # M7: converged AEROVAULT3 core + standalone/AeroSync EC engine (published on crates.io)
+aerovault = "0.6.4"                                                    # M7: converged AEROVAULT3 core + standalone/AeroSync EC engine (published on crates.io)
 aes-gcm-siv = "0.11"                                                   # AeroVault v3 AEAD content encryption
 # Keep on 0.10.1 until aerovault publishes a release that accepts
 # chacha20poly1305 0.11; aerovault 0.6.3 depends on 0.10.


### PR DESCRIPTION
The crate the application already depends on has been relicensed from GPL-3.0-only to MPL-2.0 and published as 0.6.4. Nothing forces this bump: `aerovault = "0.6.3"` is a caret requirement and already resolves to 0.6.4 on its own. The declaration simply names a version that is no longer the current one, and a manifest that says something different from what is actually built is the kind of small drift that costs an hour to untangle a year later.

There is no code difference between the two versions. 0.6.4 changes the licence, the notices in each source file, and the crate metadata, nothing else, and the on-disk container format is untouched.

The licence change does not affect this application. MPL-2.0 is copyleft at file level and section 3.3 explicitly permits a larger work that combines MPL files with GPL code, provided the MPL files are not marked "Incompatible With Secondary Licenses". They are not, deliberately, so AeroFTP stays GPL-3.0-or-later and combines with the crate exactly as before. If that Exhibit B notice is ever added upstream, this combination stops being permitted and nothing will fail loudly, so it is worth knowing about.

The lockfile moves by two lines, the version and its checksum, and nothing else resolves differently. `cargo check -p aerovault` passes against this application's own dependency graph and feature resolution. The full build is left to CI rather than run twice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the underlying AeroVault engine to a newer published release.
  * Includes updates to the standalone and AeroSync EC engine components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Merge record

Merged at zero incomplete check runs, read from the check-runs API on the head commit rather than from this page, where a superseded `cancelled` run reads as red.

CodeRabbit reviewed through the head commit `0ef26268` and generated no actionable comments, with `src-tauri/Cargo.lock` excluded by path filter.

Licence reading, which no gate performs: MPL-2.0 and GPL-3.0 combine here only because aerovault carries no Exhibit B "Incompatible With Secondary Licenses" notice. Verified absent in 0.6.4. If it ever appears upstream the combination stops being permitted and NO BUILD WILL FAIL, so this is a reading to repeat by hand at every aerovault bump.
