### PR TITLE
ci: fail every lane that selects tests and executes none

### DIFF
--- a/.github/workflows/aerorsync-protocol.yml
+++ b/.github/workflows/aerorsync-protocol.yml
@@ -83,9 +83,19 @@ jobs:
       - name: cargo clippy (strict, -D warnings)
         working-directory: src-tauri
         run: cargo clippy --lib --features aerorsync --all-targets -- -D warnings
+      # `aerorsync` is a substring filter over the whole lib, which is the shape
+      # that prints "test result: ok" and exits 0 when it matches nothing: rename
+      # the module and this step passes having compiled the crate and run no
+      # test. 677 is what it executes today (692 selected, 15 of them ignored,
+      # measured on run 33436715702 and reproduced locally); a floor, because the
+      # module is meant to grow.
       - name: Mock + unit test suite
         working-directory: src-tauri
-        run: cargo test --features aerorsync --lib aerorsync
+        run: |
+          set -o pipefail
+          cargo test --features aerorsync --lib aerorsync | tee /tmp/aerorsync-unit.log
+          ../scripts/assert-tests-ran.sh /tmp/aerorsync-unit.log 677 \
+            "aerorsync mock + unit suite"
       - name: Default build regression (feature off)
         working-directory: src-tauri
         run: cargo check --no-default-features --lib
@@ -252,6 +262,7 @@ jobs:
         # All filters go after `--`: cargo itself takes a single
         # positional TESTNAME, libtest ORs multiple filters.
         run: |
+          set -o pipefail
           cargo test --features aerorsync --lib -- \
             aerorsync::native_driver::tests::driver_upload_live_lane_3_real_rsync_byte_identical \
             aerorsync::native_driver::tests::driver_upload_streaming_live_lane_3_real_rsync_byte_identical \
@@ -268,7 +279,9 @@ jobs:
             aerorsync::delta_transport_impl::tests::delta_upload_symlink_xattr_not_inherited_live_lane_3 \
             aerorsync::delta_transport_impl::tests::delta_upload_acl_named_user_live_lane_3 \
             aerorsync::delta_transport_impl::tests::delta_download_acl_named_user_live_lane_3 \
-            --nocapture
+            --nocapture | tee /tmp/aerorsync-lane3.log
+          ../scripts/assert-tests-ran.sh /tmp/aerorsync-lane3.log 15 \
+            "lane 3 live tests"
       # The RSNP_TEST_REAL lane: eight #[ignore] tests that drive the
       # production AerorsyncDeltaTransport upload and download paths against
       # the same stock rsync, with each negotiated checksum forced in turn
@@ -328,25 +341,15 @@ jobs:
         # would turn this lane green having executed NOTHING, and the second one
         # looks like an improvement while doing it. `set -o pipefail` matters for
         # the same reason: without it the exit status would be tee's, not cargo's.
+        # The check itself now lives in scripts/assert-tests-ran.sh, which is
+        # where the shell subtleties it needs are written down once instead of
+        # once per lane.
         run: |
           set -o pipefail
           cargo test --features aerorsync --lib aerorsync::live_tests -- \
             --ignored --nocapture --test-threads=1 | tee /tmp/aerorsync-live.log
-          # `|| true` is load-bearing: GitHub runs a step with no `shell:` as
-          # `bash -e {0}`, and under -e an assignment from a pipeline that
-          # matches nothing ends the script right here, silently. The check
-          # would still fail, but with no message, which is the exact shape
-          # this step exists to remove. `shell: bash` does NOT fix it: that is
-          # `bash -eo pipefail`, so -e is still on.
-          ran=$(grep -oE '^test result: ok\. [0-9]+ passed' /tmp/aerorsync-live.log \
-                | grep -oE '[0-9]+' | head -1 || true)
-          echo "aerorsync live tests executed: ${ran:-none}"
-          if [ -z "${ran}" ] || [ "${ran}" -lt 8 ]; then
-            echo "::error::this lane executed ${ran:-0} live tests, expected at least 8."
-            echo "::error::a green here with fewer tests means the filter stopped matching,"
-            echo "::error::not that the protocol got simpler. Fix the filter, not this check."
-            exit 1
-          fi
+          ../scripts/assert-tests-ran.sh /tmp/aerorsync-live.log 8 \
+            "aerorsync live checksum-matrix tests"
       - name: Tear down harness
         if: always()
         working-directory: src-tauri/src/aerorsync/capture

--- a/.github/workflows/delta-sync-integration.yml
+++ b/.github/workflows/delta-sync-integration.yml
@@ -205,27 +205,48 @@ jobs:
       - name: "Unit tests: delta-sync modules"
         timeout-minutes: 25
         working-directory: src-tauri
+        # Five module filters, so a module renamed on one side and not here
+        # silently narrows what this lane covers, down to nothing in the limit.
+        # 94 is what the five select today (measured on run 33434171154); it is
+        # a floor and not a count, because these modules are meant to grow.
         run: |
+          set -o pipefail
           cargo test --lib --no-fail-fast -- \
             rsync_output:: \
             rsync_over_ssh:: \
             ssh_exec:: \
             delta_transport:: \
-            delta_sync_rsync::
+            delta_sync_rsync:: | tee /tmp/delta-unit.log
+          ../scripts/assert-tests-ran.sh /tmp/delta-unit.log 94 \
+            "delta-sync module unit tests"
 
       # Measured at 3m55s and 4m04s.
       - name: "Integration test: delta sync over SSH"
         timeout-minutes: 15
         working-directory: src-tauri
-        run: cargo test --test integration_delta_sync -- --ignored --nocapture
+        # 12 is the ignored set of this binary today. Selecting with `--ignored`
+        # means removing those attributes empties the lane, so the count is what
+        # separates "the fixture proved the round-trip" from "nothing ran".
+        run: |
+          set -o pipefail
+          cargo test --test integration_delta_sync -- --ignored --nocapture \
+            | tee /tmp/delta-integration.log
+          ../scripts/assert-tests-ran.sh /tmp/delta-integration.log 12 \
+            "delta sync over SSH"
 
       - name: Product-path native delta preserves ACL and xattr
         timeout-minutes: 10
         working-directory: src-tauri
+        # `--exact` on one name: the tightest possible filter and therefore the
+        # one that most easily matches nothing after a rename, with no signal
+        # that it did. Exactly one, because this step promises one named test.
         run: |
+          set -o pipefail
           cargo test --test integration_delta_sync \
             product_path_native_delta_preserves_acl_and_xattr -- \
-            --ignored --nocapture --exact
+            --ignored --nocapture --exact | tee /tmp/delta-acl-xattr.log
+          ../scripts/assert-tests-ran.sh /tmp/delta-acl-xattr.log =1 \
+            "Product-path ACL and xattr"
 
       - name: Dump fixture logs on failure
         if: failure()
@@ -369,20 +390,34 @@ jobs:
         # here too so a change that breaks the string contract without
         # touching the key-auth lane's paths is still caught.
         run: |
+          set -o pipefail
           cargo test --test integration_delta_sync -- \
             hard_rejection_string_contract_is_pinned_offline \
             hard_error_branch_runs_before_classic_fallback_in_bivio \
-            --nocapture
+            --nocapture | tee /tmp/delta-hard-rejection.log
+          ../scripts/assert-tests-ran.sh /tmp/delta-hard-rejection.log 2 \
+            "Offline hard-rejection contract"
 
       # Measured at 3m51s and 4m15s.
+      #
+      # The test named here was `product_path_falls_through_silently_when_
+      # session_not_eligible` until 2026-05-16, when making password-backed
+      # SFTP eligible for the native leg (host key pinned) inverted what it
+      # asserts and it was renamed. This line was not updated, so from that day
+      # the job built the password-only fixture, ran ZERO tests, printed
+      # "test result: ok" and reported success: 0 executed on run 33434171154,
+      # which is what the assertion below now makes impossible.
       - name: "Fallback integration test: password-only fixture"
         timeout-minutes: 15
         working-directory: src-tauri
         run: |
+          set -o pipefail
           cargo test --test integration_delta_sync -- \
             --ignored \
-            product_path_falls_through_silently_when_session_not_eligible \
-            --nocapture
+            product_path_uses_native_delta_for_password_sftp_with_pinned_host_key \
+            --nocapture | tee /tmp/delta-fallback.log
+          ../scripts/assert-tests-ran.sh /tmp/delta-fallback.log =1 \
+            "Password-only fixture contract"
 
       - name: Dump fixture logs on failure
         if: failure()

--- a/.github/workflows/ftp-mlsd.yml
+++ b/.github/workflows/ftp-mlsd.yml
@@ -144,10 +144,21 @@ jobs:
       # 15 minutes is a warm-cache figure. The first run on a branch compiles
       # the Tauri crate from nothing, and a cap that bites once and never again
       # reads as an infrastructure problem rather than as a wrong number.
+      #
+      # The count is asserted for the reason this whole file exists: the two
+      # tests are selected with `--ignored`, so the day somebody removes those
+      # attributes to make them run more often, this lane selects NOTHING,
+      # prints "test result: ok" and stays green while covering nothing. Two,
+      # not "exactly two", because the binary is a module meant to grow.
       - name: Listing tests against an MLSD server
         timeout-minutes: 40
         working-directory: src-tauri
-        run: cargo test --test integration_ftp_mlsd -- --ignored --nocapture
+        run: |
+          set -o pipefail
+          cargo test --test integration_ftp_mlsd -- --ignored --nocapture \
+            | tee /tmp/ftp-mlsd-listing.log
+          ../scripts/assert-tests-ran.sh /tmp/ftp-mlsd-listing.log 2 \
+            "MLSD listing tests"
 
       - name: Dump fixture logs on failure
         if: failure()
@@ -264,8 +275,8 @@ jobs:
       # that prints "test result: ok" and exits 0 when the filter matches
       # nothing. Exactly one, not "at least one": this step promises to run one
       # named test, so a second arriving here is a change to what the job does
-      # and should be said out loud. The sibling aerorsync lane uses `-lt`
-      # instead, and correctly: it collects a whole module, which may grow.
+      # and should be said out loud. The sibling aerorsync lane asks for "at
+      # least", and correctly: it collects a whole module, which may grow.
       - name: The session must not survive a timed-out listing
         timeout-minutes: 40
         working-directory: src-tauri
@@ -273,14 +284,8 @@ jobs:
           set -o pipefail
           cargo test --lib providers::ftp::live_listing_timeout -- \
             --ignored --nocapture | tee /tmp/listing-timeout.log
-          ran=$(grep -oE '^test result: ok\. [0-9]+ passed' /tmp/listing-timeout.log \
-                | grep -oE '[0-9]+' | head -1 || true)
-          echo "live listing-timeout tests executed: ${ran:-none}"
-          if [ "${ran:-0}" -ne 1 ]; then
-            echo "::error::expected exactly 1 test, ran ${ran:-0}: the filter stopped matching,"
-            echo "::error::which is a green that executed nothing. Fix the filter, not this check."
-            exit 1
-          fi
+          ../scripts/assert-tests-ran.sh /tmp/listing-timeout.log =1 \
+            "Listing-timeout guard"
 
       - name: Fixture log on failure
         if: failure()

--- a/.github/workflows/nightly-telemetry.yml
+++ b/.github/workflows/nightly-telemetry.yml
@@ -65,18 +65,38 @@ jobs:
         # transfer_dag_single_file, transfer_dag_sync and the adaptive /
         # metrics / engine_stats / ttfb / executor / work_source telemetry
         # modules under transfer_dag::.
-        run: cargo test --lib transfer_dag -- --nocapture
+        # 358 today (run 33377726369). A substring filter that stops matching
+        # reports "ok" over an empty run, and a nightly nobody watches is exactly
+        # where that goes unnoticed.
+        run: |
+          set -o pipefail
+          cargo test --lib transfer_dag -- --nocapture | tee /tmp/telemetry-dag.log
+          ../scripts/assert-tests-ran.sh /tmp/telemetry-dag.log 358 \
+            "DAG telemetry suites"
 
       - name: Process resource sampler suite
         working-directory: ./src-tauri
-        run: cargo test --lib proc_stats -- --nocapture
+        run: |
+          set -o pipefail
+          cargo test --lib proc_stats -- --nocapture | tee /tmp/telemetry-proc.log
+          ../scripts/assert-tests-ran.sh /tmp/telemetry-proc.log 9 \
+            "Process resource sampler suite"
 
       - name: Local telemetry benchmark cell (emits JSON)
         working-directory: ./src-tauri
         env:
           AEROFTP_TELEMETRY_JSON: ${{ github.workspace }}/telemetry-nightly.json
           AEROFTP_TELEMETRY_BYTES: '16777216'
-        run: cargo test --test telemetry_nightly -- --ignored --nocapture
+        # The artifact upload below has `if-no-files-found: error`, which catches
+        # a cell that ran and wrote nothing. It cannot catch a cell that never
+        # ran: `--ignored` selecting nothing prints "ok" and writes no JSON, and
+        # the two failures would then be told apart only by reading the log.
+        run: |
+          set -o pipefail
+          cargo test --test telemetry_nightly -- --ignored --nocapture \
+            | tee /tmp/telemetry-cell.log
+          ../scripts/assert-tests-ran.sh /tmp/telemetry-cell.log 1 \
+            "Local telemetry benchmark cell"
 
       - name: Upload telemetry metrics artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,9 @@ run-clean.sh
 !/scripts/i18n-untranslated-accepted.json
 # Exception: single pre-release smoke entrypoint (`npm run smoke`, #408 row 1)
 !/scripts/smoke.mjs
+# Exception: asserts a CI lane actually executed the tests it selects, called by
+# ftp-mlsd, delta-sync-integration, aerorsync-protocol and nightly-telemetry
+!/scripts/assert-tests-ran.sh
 
 # Security reports: keep latest snapshot in repo, ignore dated copies
 /docs/security/security-report-20*.html

--- a/scripts/assert-tests-ran.sh
+++ b/scripts/assert-tests-ran.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+#
+# Fail a CI lane that selected no tests, or fewer than it promises to run.
+#
+# `cargo test` with a filter that matches nothing prints "running 0 tests",
+# then "test result: ok." and exits 0. A green lane that executed nothing is
+# indistinguishable, from outside, from a green lane that proved something.
+# The two ways it happens in practice are a rename nobody propagated to the
+# workflow, and somebody removing `#[ignore]` from the tests a lane selects
+# with `--ignored`, which switches the lane off while looking like an
+# improvement. Neither is hypothetical: the password-only fallback lane in
+# delta-sync-integration.yml stood up a Docker fixture and ran zero tests
+# from 2026-05-16, when its test was renamed, until this script landed.
+#
+# Usage:
+#   assert-tests-ran.sh <log> <count> <what>    at least <count> tests ran
+#   assert-tests-ran.sh <log> =<count> <what>   exactly <count> tests ran
+#
+# `=<count>` is for a step that names ONE test: a second test arriving there
+# changes what the step does and should be said out loud. A step that collects
+# a whole module or binary takes the plain form, because such a suite is meant
+# to grow and an exact match would turn the lane red on the day someone adds a
+# legitimate test, which usually gets answered by deleting the check.
+#
+# The counted number is what libtest REPORTS as passed, summed over every test
+# binary in the log, not what the filter looks like it should select. The
+# caller pipes cargo through `tee` and must `set -o pipefail` first, or the
+# step's status is tee's rather than cargo's, which is the same blindness this
+# script exists to remove.
+#
+# No `set -e` here on purpose: every failure path below ends in an explicit
+# exit with a message. `-u` catches a caller that forgot an argument, and
+# `-o pipefail` makes the count pipeline honest.
+set -uo pipefail
+
+if [ "$#" -ne 3 ]; then
+    echo "::error::assert-tests-ran.sh needs <log> <count|=count> <what>, got $# argument(s)"
+    exit 2
+fi
+
+log=$1
+want=$2
+what=$3
+
+case "$want" in
+    "="*)
+        exact=1
+        expected=${want#=}
+        ;;
+    *)
+        exact=0
+        expected=$want
+        ;;
+esac
+
+case "$expected" in
+    '' | *[!0-9]*)
+        echo "::error::assert-tests-ran.sh: '$want' is not a count"
+        exit 2
+        ;;
+esac
+
+if [ ! -s "$log" ]; then
+    # An empty or missing log is not "zero tests": it is a run that died before
+    # libtest printed anything, and it must not be reported as a count.
+    echo "::error::${what}: no test output at ${log}. cargo produced nothing to count,"
+    echo "::error::so the step ran no tests and this is not a pass."
+    exit 1
+fi
+
+# Sum every binary's result line: a step may run more than one. A FAILED line
+# does not match, which is correct, because a failing run has already taken the
+# step down through pipefail before this script is reached.
+ran=$(grep -oE '^test result: ok\. [0-9]+ passed' "$log" \
+      | grep -oE '[0-9]+' \
+      | awk '{ s += $1 } END { print s + 0 }')
+
+if [ "$exact" -eq 1 ]; then
+    if [ "$ran" -ne "$expected" ]; then
+        echo "::error::${what}: executed ${ran} test(s), expected exactly ${expected}."
+        echo "::error::Either the filter stopped matching, which is a green that proved"
+        echo "::error::nothing, or the step now runs more than the one test it names."
+        echo "::error::Fix the filter or say the new number here, do not delete this check."
+        exit 1
+    fi
+else
+    if [ "$ran" -lt "$expected" ]; then
+        echo "::error::${what}: executed ${ran} test(s), expected at least ${expected}."
+        echo "::error::A green here with fewer tests means the selection stopped matching,"
+        echo "::error::not that the work got simpler. Fix the filter, not this check; and"
+        echo "::error::if tests were deliberately removed, lower the number in that commit."
+        exit 1
+    fi
+fi
+
+echo "${what}: ${ran} test(s) executed (expected ${want})."

--- a/src-tauri/src/aerorsync/capture/run_deflate_rsync_capture.sh
+++ b/src-tauri/src/aerorsync/capture/run_deflate_rsync_capture.sh
@@ -292,11 +292,18 @@ EOF
 
 echo "[deflate-harness] checking captured tokens with AeroRsync real_wire"
 (
+  # The header above promises this harness rules out "zero tests", and every
+  # guard it lists is on the capture, not on this run: the oracle is selected
+  # by name over the ignored set, so a rename or a dropped `#[ignore]` leaves
+  # `cargo test` printing "test result: ok" over an empty run and the harness
+  # declaring the byte oracle checked. One named test, so exactly one.
   cd "$SRC_TAURI_DIR"
   AEROFTP_DEFLATE_CAPTURE="$DEST_DIR" \
     cargo test --features aerorsync --lib \
       rsync_3_1_3_deflate_byte_oracle_matches_real_wire_decoder -- \
-      --ignored --nocapture
+      --ignored --nocapture | tee /tmp/aerorsync-deflate-oracle.log
+  ../scripts/assert-tests-ran.sh /tmp/aerorsync-deflate-oracle.log =1 \
+    "rsync 3.1.3 deflate byte oracle"
 )
 
 echo "[deflate-harness] byte oracle written to $DEST_DIR"

--- a/src-tauri/src/aerorsync/capture/run_deflate_rsync_capture.sh
+++ b/src-tauri/src/aerorsync/capture/run_deflate_rsync_capture.sh
@@ -103,7 +103,16 @@ stop_stack() {
   fi
 }
 
+# `mktemp`, not a fixed name under /tmp. This harness runs on developer
+# machines as well as on a CI runner, /tmp is world-writable and shared there,
+# and a predictable path is one another local user can pre-create as a symlink
+# for `tee` to follow into a file this user can write (CWE-377). The template
+# carries the directory explicitly so the line behaves the same under GNU and
+# BSD mktemp.
+ORACLE_LOG="$(mktemp "${TMPDIR:-/tmp}/aerorsync-deflate-oracle.XXXXXX")"
+
 cleanup() {
+  rm -f "$ORACLE_LOG"
   if [[ "$KEEP_STACK" != "1" ]]; then
     stop_stack
   fi
@@ -301,8 +310,8 @@ echo "[deflate-harness] checking captured tokens with AeroRsync real_wire"
   AEROFTP_DEFLATE_CAPTURE="$DEST_DIR" \
     cargo test --features aerorsync --lib \
       rsync_3_1_3_deflate_byte_oracle_matches_real_wire_decoder -- \
-      --ignored --nocapture | tee /tmp/aerorsync-deflate-oracle.log
-  ../scripts/assert-tests-ran.sh /tmp/aerorsync-deflate-oracle.log =1 \
+      --ignored --nocapture | tee "$ORACLE_LOG"
+  ../scripts/assert-tests-ran.sh "$ORACLE_LOG" =1 \
     "rsync 3.1.3 deflate byte oracle"
 )
 

--- a/src-tauri/src/aerorsync/capture/run_real_rsync_capture.sh
+++ b/src-tauri/src/aerorsync/capture/run_real_rsync_capture.sh
@@ -209,9 +209,15 @@ export RSNP_TEST_REAL_HOST_FINGERPRINT="$HOST_FINGERPRINT"
 export RSNP_TEST_REAL_REMOTE_UPLOAD_TARGET="/workspace/real/upload/target.bin"
 
 pushd "$SRC_TAURI_DIR" >/dev/null
+# One named test over the ignored set, so a rename leaves `cargo test` printing
+# "test result: ok" over an empty run and the line below announcing a capture
+# that never happened. Exactly one, because one is what is named here. The
+# `set -euo pipefail` at the top of this file already makes the pipe honest.
 cargo test --features aerorsync \
   aerorsync::live_tests::live_real_rsync_lane_emits_protocol_31_greeting \
-  -- --ignored --nocapture
+  -- --ignored --nocapture | tee /tmp/aerorsync-real-capture.log
+../scripts/assert-tests-ran.sh /tmp/aerorsync-real-capture.log =1 \
+  "real-rsync capture live test"
 popd >/dev/null
 
 echo "[harness] S8a capture + live test complete"

--- a/src-tauri/src/aerorsync/capture/run_real_rsync_capture.sh
+++ b/src-tauri/src/aerorsync/capture/run_real_rsync_capture.sh
@@ -73,7 +73,13 @@ download_final = mutate_payload(basis, 8 * 1024, b"real-live-download")
 (root / "local" / "expected-download.bin").write_bytes(download_final)
 PY
 
+# `mktemp`, not a fixed name under /tmp: same reason as the deflate harness
+# next to it. A predictable path in a shared /tmp is a symlink another local
+# user can pre-create for `tee` to follow (CWE-377).
+LIVE_LOG="$(mktemp "${TMPDIR:-/tmp}/aerorsync-real-capture.XXXXXX")"
+
 cleanup() {
+  rm -f "$LIVE_LOG"
   if [[ "$KEEP_STACK" != "1" ]]; then
     docker compose -f "$CAPTURE_DIR/docker-compose.real-rsync.yml" down --remove-orphans >/dev/null 2>&1 || true
   fi
@@ -215,8 +221,8 @@ pushd "$SRC_TAURI_DIR" >/dev/null
 # `set -euo pipefail` at the top of this file already makes the pipe honest.
 cargo test --features aerorsync \
   aerorsync::live_tests::live_real_rsync_lane_emits_protocol_31_greeting \
-  -- --ignored --nocapture | tee /tmp/aerorsync-real-capture.log
-../scripts/assert-tests-ran.sh /tmp/aerorsync-real-capture.log =1 \
+  -- --ignored --nocapture | tee "$LIVE_LOG"
+../scripts/assert-tests-ran.sh "$LIVE_LOG" =1 \
   "real-rsync capture live test"
 popd >/dev/null
 


### PR DESCRIPTION
## What this is

A pre-release audit finding on the CI lanes, and the fix for the whole class rather than the two instances that were reported.

`cargo test` with a filter that matches nothing prints `running 0 tests`, then `test result: ok`, and exits 0. A lane in that state looks exactly like a lane that proved something. The repo already knew this: #659 added a count to the aerorsync live lane, and `ftp-mlsd.yml` carries the same check on its listing-timeout step. Two instances had the check. Eleven siblings did not.

## One of those lanes was already dead, and this is the evidence

`delta-sync-integration.yml` selected `product_path_falls_through_silently_when_session_not_eligible`. That test was renamed on 2026-05-16 in `bb20f6a6c`, when password-backed SFTP became eligible for the native leg with the host key pinned and the assertion inverted. The workflow line was never updated.

So since that day the job named "SFTP password-only fixture + fallback contract" has built a Docker fixture, waited for SSH, executed **zero tests**, and reported success. From run `33434171154` on `main`, tonight:

```
running 0 tests
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 17 filtered out; finished in 0.00s
```

The step now names `product_path_uses_native_delta_for_password_sftp_with_pinned_host_key`, which is where that contract lives today, and asserts that it ran.

## The fix

One script, `scripts/assert-tests-ran.sh`, called from fourteen places, instead of fourteen copies of a shell snippet whose subtleties decay independently. The subtleties are real and are now written down once:

- `set -o pipefail` at the call site, or the step's status is `tee`'s and not `cargo`'s, which is the same blindness this exists to remove nested inside its own cure.
- no bare assignment from a pipeline under `bash -e`, which is what a step without an explicit `shell:` runs, and which `shell: bash` does not fix, since GitHub expands that to `bash -eo pipefail`.
- an empty or missing log is reported as its own failure rather than counted as zero: a run that died before libtest printed anything is not a run of zero tests.

`=N` means exactly N and is used where a step names one test, because a second test arriving there changes what the step does and should be said out loud. A plain `N` means at least N and is used where a step collects a module or a binary, because such a suite is meant to grow and an exact match would go red the day someone adds a legitimate test, which usually gets answered by deleting the check.

## The numbers are measurements, not guesses

Each floor is what the lane actually executed on a real green run, named in the comment beside it, and each was also reproduced locally:

| Lane | Step | Count | From |
|---|---|---|---|
| delta-sync-integration | delta-sync module unit tests | 94 | run 33434171154 |
| delta-sync-integration | delta sync over SSH (`--ignored`) | 12 | run 33434171154 |
| delta-sync-integration | Product-path ACL and xattr (`--exact`) | =1 | run 33434171154 |
| delta-sync-integration | Offline hard-rejection contract | 2 | run 33434171154 |
| delta-sync-integration | Password-only fixture contract | =1 | was 0, see above |
| aerorsync-protocol | Mock + unit suite | 677 | run 33436715702 (692 selected, 15 ignored) |
| aerorsync-protocol | lane 3 live tests | 15 | run 33436715702 |
| aerorsync-protocol | live checksum matrix | 8 | unchanged, from #659 |
| ftp-mlsd | MLSD listing tests | 2 | run 33425840938 |
| ftp-mlsd | listing-timeout guard | =1 | unchanged, moved to the script |
| nightly-telemetry | DAG telemetry suites | 358 | run 33377726369 |
| nightly-telemetry | process resource sampler | 9 | run 33377726369 |
| nightly-telemetry | telemetry benchmark cell | 1 | run 33377726369 |
| capture harness | deflate byte oracle | =1 | run 33436715702 |
| capture harness | real-rsync capture | =1 | developer harness |

## Shown red before being trusted

A count that has never been seen to fail is the thing being fixed here, so neither check was committed until it failed on purpose.

**MLSD.** With the two `#[ignore]` attributes removed from `integration_ftp_mlsd.rs`, which is the realistic way this breaks, since removing them looks like an improvement:

- today's line: `running 0 tests`, `test result: ok`, step exit **0**, green.
- the same run with the assertion: step exit **1**, `::error::MLSD listing tests: executed 0 test(s), expected at least 2.`

**delta-sync fallback.** Running the line as it stands on `main`, against the real test binary: exit **0** and zero tests; with the assertion, exit **1**.

**The script itself**, under `bash -e`, which is the shell a GitHub step gets, against twelve inputs: at the floor, above it, below it, zero, exactly one, more than one where one was promised, two binaries summed, a `FAILED` result line, an empty log, a missing log, and two malformed argument sets (which exit 2, to keep "you called me wrong" apart from "the gate failed").

## What was NOT verified

- No lane was run end to end here. These jobs need Docker fixtures, a real rsync server and a runner. What was verified locally is the selection and the count for every step, plus the assertion's behaviour on real cargo output.
- The 677 floor was reconciled between CI and local: 692 tests match the `aerorsync` substring, of which 15 are ignored. Two of the 692 are outside the `aerorsync::` module and match by substring, which is why an anchored count gives 690 and the lane reports 692.
- The nightly numbers come from run 33377726369, the most recent successful nightly, not from tonight's tree. If a test landed in `transfer_dag::` since, the floor is conservative, which is the safe direction.

## The instance deliberately left

`tests/gtc/parity_harness.sh` runs a per-cell test name and has the same shape. It is a developer harness rather than a gate, it is not invoked by any workflow, it has its own exit-code handling, and it already parses the log downstream in a way that notices an empty run. It is named here so the class is closed on paper as well as in the tree.

`build.yml` runs `cargo test` with no filter and cannot select nothing, so it needs no assertion.

## Risk

No Rust changed, so the fmt, clippy and test gate is the one `main` already carries.

The floors can only go red by executing FEWER tests than the lane executes today. Adding tests keeps every lane green. If tests are removed deliberately, the lane goes red with a message that says to lower the number in that same commit.

`.gitignore` carries `/scripts/*` with per-file exceptions, so the new script needs its own exception line or it would never have been committed and every guarded lane would fail on a missing file. That line is in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CI checks now detect when filtered test commands run fewer tests than expected—or none at all—preventing misleading successful builds.
  * Test validation now covers Aerorsync, delta-sync, FTP, telemetry, and capture workflows.
  * Test output is retained in logs to improve failure diagnosis.
* **Chores**
  * Added shared validation for minimum and exact test counts across automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Merge record

Merged at zero incomplete check runs, read from the check-runs API on the head commit rather than from this page, where a superseded `cancelled` run reads as red.

CodeRabbit reviewed earlier commits on this branch and raised one Major finding, on a `tee` to a fixed name under `/tmp` in the two capture harnesses, which is fixed in `226981fa` after being REPRODUCED in a test TMPDIR rather than deduced from the rule. The incremental pass over `7204d9dc..226981fa` was then rate limited, so the head as merged carries a human reading only.

The change this pull request makes is to the instruments themselves, so it deserves the plainest possible statement of what was and was not established. Established: each of the fourteen call sites was exercised against real cargo output, the thresholds are what a named green run actually executed rather than estimates, and both gates were watched going RED with the condition made true. Not established: no lane was run end to end here, so what is proven is the selection, the counting and the behaviour of the assertion, not that every lane still passes in CI. That is what the CI run on this pull request is for, and it is green.
