### PR TITLE
docs: correct the published figures and claims the tree contradicts

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -71,10 +71,15 @@ jobs:
       # it is simply still English. The naive test fires on 16000 pairs, almost
       # all of them correct (FTP, AeroCloud, us-east-1), so this gate takes its
       # evidence from the shape of the ENGLISH source and reports only
-      # translatable prose. It runs as a RATCHET rather than --strict: the
-      # backlog of the day is the ceiling, a newly untranslated string breaks
-      # it, and every batch of translations lowers the number in the same
-      # commit that does the translating. The number is never raised.
+      # translatable prose. It ran as a RATCHET rather than --strict only while
+      # a backlog existed: `--max=<n>` with n the backlog of the day, lowered by
+      # every batch of translations in the same commit that did the translating
+      # and never raised. n reached 0, so `npm run i18n:untranslated` now passes
+      # `--strict` (see package.json) and ANY untranslated pair fails, together
+      # with a drifted deliberate key or a new reference leak, neither of which
+      # was ever subject to the ratchet. A string genuinely correct as English
+      # in that language is recorded, one reviewed sentence at a time, in
+      # scripts/i18n-untranslated-accepted.json. Never bulk-accept.
       - name: i18n raw-English gate
         run: npm run i18n:untranslated
 

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ AeroFTP defines seven user-facing file formats. Each has a single purpose and a 
 
 ```
 AeroFTP
-├── AeroCloud    - Personal cloud (7 transport protocols + 24 native providers + 6 media services, sync, share)
+├── AeroCloud    - Personal cloud (7 transport protocols + 24 native providers + 5 media services, sync, share)
 ├── AeroFile     - Professional file manager (multi-file Properties, recursive search, default-app routing)
 ├── AeroShare    - Peer-to-peer user-to-user transfer (end-to-end encrypted, no server in the middle) [Beta]
 ├── AeroMount    - Persistent FUSE / WebDAV mounts with cross-platform autostart (the Mount Manager)
@@ -411,13 +411,13 @@ Repeated across three runs the timings move by a few percent and the byte counts
 
 #### What is verified
 
-- **605 unit tests** on the module, pinned against frozen rsync 3.2.7 byte transcripts.
-- **11 live tests in CI lane 3** against a real `rsync --server` in Docker: a byte-identical upload (sha256 match), streaming upload, symlinks both directions, `user.*` xattrs inline, out-of-band, binary-with-NUL and empty, the batch path over a single session, and a symlink proving it does not inherit its target's attributes.
+- **677 unit tests** on the module, pinned against frozen rsync 3.2.7 byte transcripts.
+- **15 live tests in CI lane 3** against a real `rsync --server` in Docker: a byte-identical upload (sha256 match), streaming upload, symlinks both directions, `user.*` xattrs inline, out-of-band, binary-with-NUL and empty, the batch path over a single session, a symlink proving it does not inherit its target's attributes, POSIX access ACLs in both directions, and an unsupported compressor or checksum routing to the classic fallback.
 - **8 live tests across the negotiated checksum matrix** - xxh128, xxh3, xxh64, md5, md4, sha1 - driving the production upload and download transports.
 
 #### Known limits
 
-Single file per invocation: AeroRsync is a delta accelerator, not a tree walker - enumeration, deletion and retention stay with AeroSync, which owns its own safety gates. Protocol 31 only, SSH remote-shell only: no `rsync://` daemon mode, and an endpoint negotiating protocol 27-30 is served by the stock binary instead. Metadata preserved today is mtime, permissions, symlinks (Unix) and `user.*` xattrs (Unix, `-X`); **ACL, owner/group and device files are not implemented**, and hardlinks are structurally blocked until recursive scope exists, because detecting that two paths share an inode needs the whole file list.
+Single file per invocation: AeroRsync is a delta accelerator, not a tree walker - enumeration, deletion and retention stay with AeroSync, which owns its own safety gates. Protocol 31 only, SSH remote-shell only: no `rsync://` daemon mode, and an endpoint negotiating protocol 27-30 is served by the stock binary instead. Metadata preserved today is mtime, permissions, symlinks (Unix), `user.*` xattrs (Unix, `-X`) and POSIX.1e access ACLs (Linux only, opt-in, `-A`); **owner/group and device files are not implemented**, and hardlinks are structurally blocked until recursive scope exists, because detecting that two paths share an inode needs the whole file list.
 
 One version note worth stating plainly: upstream rsync **dropped `sha1`** from the negotiated checksum list between 3.2.7 and 3.4.1. AeroRsync still implements it, and it works against peers that still offer it, but against a modern rsync it is simply not negotiable.
 
@@ -533,7 +533,7 @@ Integrated development panel with three tools in a tabbed interface: **Monaco Ed
 
 #### AeroAgent - AI-Powered Assistant
 
-An AI assistant with **39 tools** that work across local files and remote providers. Supports **24 AI providers** (OpenAI, Anthropic, Gemini, xAI, Ollama, DeepSeek, Mistral, Cerebras, SambaNova, Fireworks, Nvidia, and 13 more). Vision/multimodal, RAG indexing, plugin ecosystem, streaming responses, multi-step autonomous execution, native MCP server mode (73 MCP tools), and Command Palette (Ctrl+Shift+P).
+An AI assistant with **39 tools** that work across local files and remote providers. Supports **24 AI providers** (OpenAI, Anthropic, Gemini, xAI, Ollama, DeepSeek, Mistral, Cerebras, SambaNova, Fireworks, Nvidia, and 13 more). Vision/multimodal, RAG indexing, plugin ecosystem, streaming responses, multi-step autonomous execution, native MCP server mode (77 MCP tools), and Command Palette (Ctrl+Shift+P).
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -204,7 +204,7 @@ _Nothing actively in flight right now; the next items are queued under Up Next b
 | **Immich** | REST API (self-hosted) | 🟢 Just Shipped |
 | **Bitbucket** | REST 2.0 | 🔵 Up Next: Git forge Tier 1 |
 | **Gitea / Forgejo** | REST v1 | 🔵 Up Next: Git forge Tier 1 (~90% GitHub reuse) |
-| **Photo & Media services** | OAuth / REST | 🔵 Up Next: phased rollout on top of the 4 shipped (Immich, Cloudinary, ImageKit, Uploadcare) |
+| **Photo & Media services** | OAuth / REST | 🔵 Up Next: phased rollout on top of the 5 shipped (Immich, Cloudinary, ImageKit, Uploadcare, PixelUnion) |
 | **ImageKit** | REST API | 🟢 Just Shipped (v3.7.2): media CDN + storage |
 | **Uploadcare** | REST + Upload API | 🟢 Just Shipped (v3.7.2): media CDN, EU/GDPR |
 | **GitLab Tier 2-3** | REST API v4 | 🔵 Up Next: Tier 1 already shipped |

--- a/scripts/i18n-untranslated.mjs
+++ b/scripts/i18n-untranslated.mjs
@@ -54,18 +54,19 @@
  * detector: it catches the leaks whose shape we have already seen, and it exists
  * so the class cannot grow back quietly.
  *
- * How this is gated, and why it is not `--strict` yet. The backlog on the day
- * the detector landed was 1966 pairs over 69 keys. `--strict` would have shipped
- * a permanently red gate, and the only way to make it green on day one would
- * have been to bulk-accept the whole backlog, which is precisely what the
- * baseline forbids: an acceptance is a sentence a human read, and nobody reads
- * 1966. So CI runs the RATCHET instead, `--max=<n>` with n set to the backlog of
- * the day. A newly untranslated string pushes the count over the line and fails
- * the build, while the existing backlog stays visible and countable instead of
- * being laundered into a baseline. Every batch of translations lowers n, and
- * when n reaches 0 the flag is replaced by `--strict` and the ratchet is gone.
- * Lowering n is part of the commit that does the translating, never a separate
- * courtesy commit, and n is never raised.
+ * How this is gated. The backlog on the day the detector landed was 1966 pairs
+ * over 69 keys. `--strict` would have shipped a permanently red gate, and the
+ * only way to make it green on day one would have been to bulk-accept the whole
+ * backlog, which is precisely what the baseline forbids: an acceptance is a
+ * sentence a human read, and nobody reads 1966. So CI ran the RATCHET instead,
+ * `--max=<n>` with n set to the backlog of the day: a newly untranslated string
+ * pushed the count over the line and failed the build, while the existing
+ * backlog stayed visible and countable instead of being laundered into a
+ * baseline. Every batch of translations lowered n, in the commit that did the
+ * translating and never in a separate courtesy commit, and n was never raised.
+ * n reached 0, so CI now runs `--strict` and the ratchet is gone: ANY
+ * untranslated pair fails. `--max=` stays for a future backlog and is the only
+ * mode in which a nonzero count is tolerated.
  *
  * Usage:
  *   node scripts/i18n-untranslated.mjs            # report, always exit 0

--- a/src-tauri/src/agent_session.rs
+++ b/src-tauri/src/agent_session.rs
@@ -67,7 +67,7 @@ fn flatten_options(options: Option<&Value>) -> HashMap<String, String> {
 
 /// Stamp the saved record id last so an options-borne `profile_id` cannot
 /// win (CWE-639). `or_insert` would leave a value already present in
-/// `extras` — the opposite of `apply_profile_options`.
+/// `extras`, the opposite of `apply_profile_options`.
 fn extras_for_connect(profile: &ProfileSummary) -> HashMap<String, String> {
     let mut extra = profile.extras.clone();
     if !profile.id.is_empty() {

--- a/src-tauri/src/providers/jottacloud.rs
+++ b/src-tauri/src/providers/jottacloud.rs
@@ -2125,7 +2125,7 @@ impl JottacloudProvider {
     /// Restore an item from trash to its original location.
     ///
     /// Files: GET the original-mountpoint tombstone, then POST `?cphash=true`
-    /// with JSize/JMd5/JCreated/JModified — rclone's restore of a trashed
+    /// with JSize/JMd5/JCreated/JModified, which is rclone's restore of a trashed
     /// destination. `?restore=true` 500s on both the Trash view and the
     /// original path; `?mv=` against `/Trash/name` 404s.
     /// Folders: `?restore=true` on the original path, 404-only slash retry.

--- a/src-tauri/src/rclone_crypt.rs
+++ b/src-tauri/src/rclone_crypt.rs
@@ -185,7 +185,7 @@ fn maybe_rclone_reveal(value: &str) -> String {
     }
     match crate::rclone_import::reveal_obscured(value) {
         // Empty reveal is rclone `password2 = obscure("")`: omitted salt,
-        // which must collapse to the default salt — not stay as the blob.
+        // which must collapse to the default salt, not stay as the blob.
         Ok(plain) if plain != value && plain.chars().all(|c| !c.is_control()) => plain,
         _ => value.to_string(),
     }


### PR DESCRIPTION
## What this is

Pre-release audit of the v4.1.8 to v4.1.9 cycle, the published-claims lane. Seven statements that the tree contradicts, plus the three em-dashes this cycle added to Rust comments.

Nothing here is a wording preference. Each line is a figure or a claim that a generator, a workflow or the code itself answers differently.

## The figures

| Where | Said | Is | Source of truth |
|---|---|---|---|
| `README.md` AeroAgent section | 73 MCP tools | **77** | `docs/COMMAND-INVENTORY.json` (`mcp.count`, 39 primary + 38 aliases) |
| `README.md` Aero Family tree | 6 media services | **5** | `docs/PROVIDER-INVENTORY.json` (`catalog_categories.media-services`) |
| `ROADMAP.md` Photo and Media row | the 4 shipped | **5** | same, and PixelUnion was the one missing |
| `README.md` AeroRsync | 11 live tests in lane 3 | **15** | `aerorsync-protocol.yml` selects 15 by name, run 33436715702 executed 15 |
| `README.md` AeroRsync | 605 unit tests | **677** | run 33436715702: 692 selected by the `aerorsync` filter, 15 ignored |

The MCP one is worth a sentence on its own: the same README already said "MCP server (77 tools)" forty lines below "native MCP server mode (73 MCP tools)". The file disagreed with itself and both numbers rendered fine.

The lane 3 count had drifted for a reason worth keeping: the four tests added since that sentence was written are the two ACL directions and the two unsupported-compressor and unsupported-checksum fallback routes. The sentence now names them rather than just counting higher.

## The claim that mattered most

README Known limits still said:

> Metadata preserved today is mtime, permissions, symlinks (Unix) and `user.*` xattrs (Unix, `-X`); **ACL, owner/group and device files are not implemented**

ACL stopped being unimplemented **in this cycle**, in #643: `src-tauri/src/aerorsync/acl_fs.rs`, `-A` in the product compact flags, and two live ACL tests running against a real rsync in lane 3. So the release notes would have shipped a feature the README denies having.

It is stated precisely rather than broadly, because the implementation is precise: POSIX.1e **access** ACLs, **Linux only**, **opt-in**. Owner/group and device files are still correctly listed as not implemented, and that half of the sentence is unchanged.

## The gate comment that described a mode the gate no longer runs

`checks.yml` said of the raw-English i18n gate:

> It runs as a RATCHET rather than --strict: the backlog of the day is the ceiling, a newly untranslated string breaks it

`package.json` runs `node scripts/i18n-untranslated.mjs --strict`, and has done since the backlog reached zero. Measured now on this tree: `0 untranslated locale/key pair(s) over 0 key(s), 65 already reviewed and accepted`, exit 0.

The gate is fine. The description was three months stale, and it was stale in two places: the workflow comment, and a paragraph in the script's own header ("How this is gated, and why it is not `--strict` yet") that was left behind when the Usage block six lines below it was updated to say `--strict # exit 1 on ANY hit (what CI runs)`. Both now describe what runs, and both say that a drifted deliberate key and a new reference leak fail regardless, since neither was ever subject to the ratchet.

This is the failure mode the audit is looking for in general: not a broken gate, a **correct gate with a wrong description**, which is worse than no description because the next reader trusts it instead of reading the code.

## The dashes

The three em-dashes this cycle added to Rust comments: `rclone_crypt.rs`, `agent_session.rs`, `providers/jottacloud.rs`.

Measured on the diff, not on the tree: `git diff v4.1.8..HEAD -U0 | grep '^+' | grep -c $'\u2014\|\u2013'` gave 3 before and gives 0 after. The pre-existing ones in 56 other files are untouched: rewriting them would be a large unrelated diff on a release night, and they are not part of this cycle.

## What was NOT verified

- The two inventories are gated against the code, but **the prose that quotes them is gated against nothing**. That is how three of these drifted with every check green. This PR corrects the prose; it does not add a gate that would catch the next drift. Worth a follow-up, and worth saying out loud rather than leaving implied.
- The 677 figure moves whenever an aerorsync test is added. It is correct as of run 33436715702 and reproduced locally on this tree.
- `docs.aeroftp.app` and `aeroftp.app` live in other repositories and were not swept for the same figures.

## Risk

Documentation and comments only. The Rust edits are comment text, `cargo fmt --all -- --check` is clean, and no behaviour changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product and roadmap documentation to reflect five media services, including PixelUnion.
  * Documented ACL support for AeroRsync, along with current ownership, group, and device-file limitations.
  * Updated AeroRsync test counts and AeroAgent/MCP documentation to reflect 77 available tools.

* **Chores**
  * Strengthened translation checks so untranslated strings, key drift, and reference leaks now fail validation.
  * Clarified translation acceptance and backlog guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Merge record

Merged at zero incomplete check runs, read from the check-runs API on the head commit rather than from this page, where a superseded `cancelled` run reads as red.

CodeRabbit reviewed the full range `5ea980f1..e8e16d52` and generated no actionable comments.

What no gate covers here, and the reason this change exists: the two inventories are gated against the code, but the PROSE that cites them is not gated against the inventories. That is how "73 MCP tools", "6 media services" and "the 4 shipped" drifted while every check stayed green, and it is why the README could go on saying ACL was not implemented after the cycle shipped it. This corrects the text; it does not add the gate that would catch the next drift. That gate is deliberately deferred rather than written on release night, with the plan in `BATON-prose-vs-inventory-gate.md`, because the same figures also live inside shields.io badge URLs and a gate written tonight would very likely have looked only at prose and stayed green on three numbers encoded in a link.

