### PR TITLE
fix(swift,webdav): the two cycle-introduced defects from the lane A pre-release audit

### DIFF
--- a/src-tauri/src/providers/swift.rs
+++ b/src-tauri/src/providers/swift.rs
@@ -727,33 +727,32 @@ impl SwiftProvider {
     }
 
     /// Swift object keys are flat, so a path is only ever a prefix. This turns
-    /// a UI path into that prefix, and the segment walk is the point: without
-    /// it, `.` survives as a literal segment and the listing asks the server
-    /// for the objects starting with `./`, which are none. The server answers
-    /// 200 with an empty array, so the panel shows an empty container with no
-    /// error at all, which is exactly how this hid.
+    /// a UI path into that prefix, and the root case is the point: without it,
+    /// `.` survives as a literal segment and the listing asks the server for the
+    /// objects starting with `./`, which are none. The server answers 200 with an
+    /// empty array, so the panel shows an empty container with no error at all,
+    /// which is exactly how this hid.
     ///
     /// The GUI reaches it: `provider_list_files` defaults its path to `"."`, so
     /// the first listing after connecting sent `./` and every Swift account
     /// looked empty in the app while the CLI, which passes `/`, worked.
     fn normalize_path(path: &str) -> String {
         // Leading and trailing slashes are framing and go, exactly as the
-        // original trim did. Repeated slashes INSIDE the path do not: a Swift
-        // object name is an opaque key, so `a//b` and `a/b` name two different
-        // objects and collapsing them would point rename, copy and delete at
-        // the wrong one. Only `.` and `..` are resolved, because the GUI opens
-        // a session on `.` and a relative segment has no meaning to the server.
-        let mut segments: Vec<&str> = Vec::new();
-        for segment in path.trim_matches('/').split('/') {
-            match segment {
-                "." => {}
-                ".." => {
-                    segments.pop();
-                }
-                other => segments.push(other),
-            }
+        // original trim did. Nothing else does.
+        let trimmed = path.trim_matches('/');
+        // A whole path of `.` is the GUI saying "the container root", and it is the
+        // only dot this function is allowed to interpret. Anything else stays byte
+        // for byte, INCLUDING `.` and `..` as segments: a Swift object name is an
+        // opaque key, so `foo/../bar` and `bar` are two different objects, exactly
+        // as `a//b` and `a/b` are. Resolving them here pointed `rmdir_recursive`,
+        // `rename` and `server_side_copy` at a prefix the caller never asked for,
+        // so a recursive delete of the literal prefix `foo/../bar/` removed the
+        // unrelated objects under `bar/`. Navigation is where a relative segment
+        // has meaning, and `cd` resolves it there.
+        if trimmed == "." {
+            return String::new();
         }
-        segments.join("/")
+        trimmed.to_string()
     }
 
     // ─── Request with 401 retry ────────────────────────────────
@@ -1078,10 +1077,28 @@ impl StorageProvider for SwiftProvider {
     }
 
     async fn cd(&mut self, path: &str) -> Result<(), ProviderError> {
-        self.current_path = if path.starts_with('/') {
+        let joined = if path.starts_with('/') {
             path.to_string()
         } else {
             format!("{}/{}", self.current_path.trim_end_matches('/'), path)
+        };
+        // `.` and `..` are resolved HERE and nowhere else. This is navigation, where
+        // a relative segment is what the user means; `normalize_path` addresses
+        // objects, where the same characters are part of an opaque key.
+        let mut segments: Vec<&str> = Vec::new();
+        for segment in joined.split('/') {
+            match segment {
+                "" | "." => {}
+                ".." => {
+                    segments.pop();
+                }
+                other => segments.push(other),
+            }
+        }
+        self.current_path = if segments.is_empty() {
+            "/".to_string()
+        } else {
+            format!("/{}", segments.join("/"))
         };
         Ok(())
     }
@@ -1691,13 +1708,13 @@ mod tests {
             "the GUI default and the CLI default must address the same place"
         );
         // A dot inside a path is a segment to drop, not part of a name.
-        assert_eq!(SwiftProvider::normalize_path("foo/./bar"), "foo/bar");
+        assert_eq!(SwiftProvider::normalize_path("foo/./bar"), "foo/./bar");
         // And `..` walks up rather than surviving into a prefix the server
         // would match literally.
-        assert_eq!(SwiftProvider::normalize_path("foo/../bar"), "bar");
-        assert_eq!(SwiftProvider::normalize_path("/foo/bar/../"), "foo");
+        assert_eq!(SwiftProvider::normalize_path("foo/../bar"), "foo/../bar");
+        assert_eq!(SwiftProvider::normalize_path("/foo/bar/../"), "foo/bar/..");
         // A leading `..` cannot escape the container: there is nothing above it.
-        assert_eq!(SwiftProvider::normalize_path("../secrets"), "secrets");
+        assert_eq!(SwiftProvider::normalize_path("../secrets"), "../secrets");
         // A file whose name merely contains a dot is untouched.
         assert_eq!(SwiftProvider::normalize_path("/a.txt"), "a.txt");
         assert_eq!(SwiftProvider::normalize_path("dir/.hidden"), "dir/.hidden");
@@ -1719,6 +1736,59 @@ mod tests {
     /// into `a/b`: listing kept the server's name while rename, copy and delete
     /// went through the normalizer and addressed a different object. Raised by
     /// CodeRabbit on the pull request that introduced it.
+    /// `foo/../bar` and `bar` are two DIFFERENT objects on a Swift account, because
+    /// an object name is an opaque key and the server does no path resolution. The
+    /// normalizer used to resolve the dot segments, so a recursive delete of the
+    /// literal prefix `foo/../bar/` was sent as `bar/` and removed objects the caller
+    /// never named. The property under test is the distinctness, not either value:
+    /// asserting only that `foo/../bar` survives would still pass if `bar` were
+    /// rewritten into it.
+    #[test]
+    fn dot_segments_inside_an_opaque_key_are_not_resolved() {
+        assert_ne!(
+            SwiftProvider::normalize_path("foo/../bar"),
+            SwiftProvider::normalize_path("bar"),
+            "two distinct object keys must not collapse onto one"
+        );
+        assert_eq!(SwiftProvider::normalize_path("foo/../bar"), "foo/../bar");
+        assert_eq!(SwiftProvider::normalize_path("bar"), "bar");
+        // The prefix a recursive delete builds from each of them, which is the value
+        // that actually reached the server.
+        assert_eq!(
+            format!("{}/", SwiftProvider::normalize_path("foo/../bar")),
+            "foo/../bar/"
+        );
+        assert_ne!(
+            format!("{}/", SwiftProvider::normalize_path("foo/../bar")),
+            format!("{}/", SwiftProvider::normalize_path("bar"))
+        );
+        // A single leading `..` is a legal key too, and used to become `secrets`.
+        assert_ne!(
+            SwiftProvider::normalize_path("../secrets"),
+            SwiftProvider::normalize_path("secrets")
+        );
+    }
+
+    /// Navigation is the place where a relative segment means what the user thinks
+    /// it means, so `cd` resolves what `normalize_path` no longer touches. Without
+    /// this, moving the resolution out of the normalizer would have left `cd ..`
+    /// walking into a literal `..` directory that does not exist.
+    #[tokio::test]
+    async fn cd_resolves_relative_segments_that_the_normalizer_leaves_alone() {
+        let mut provider = cleartext_opted_in_provider();
+        provider.cd("/docs/reports").await.unwrap();
+        assert_eq!(provider.pwd().await.unwrap(), "/docs/reports");
+        provider.cd("..").await.unwrap();
+        assert_eq!(provider.pwd().await.unwrap(), "/docs");
+        provider.cd("./drafts").await.unwrap();
+        assert_eq!(provider.pwd().await.unwrap(), "/docs/drafts");
+        provider.cd("../..").await.unwrap();
+        assert_eq!(provider.pwd().await.unwrap(), "/");
+        // Past the root it stops, rather than producing a path with no container.
+        provider.cd("..").await.unwrap();
+        assert_eq!(provider.pwd().await.unwrap(), "/");
+    }
+
     #[test]
     fn normalize_path_keeps_repeated_slashes_inside_the_name() {
         assert_eq!(SwiftProvider::normalize_path("a//b"), "a//b");
@@ -1729,7 +1799,7 @@ mod tests {
         );
         // Framing still goes, and the dot segments still resolve around them.
         assert_eq!(SwiftProvider::normalize_path("//a//b//"), "a//b");
-        assert_eq!(SwiftProvider::normalize_path("a//./b"), "a//b");
+        assert_eq!(SwiftProvider::normalize_path("a//./b"), "a//./b");
     }
 
     #[test]

--- a/src-tauri/src/providers/webdav.rs
+++ b/src-tauri/src/providers/webdav.rs
@@ -909,8 +909,19 @@ impl WebDavProvider {
         // burned attempts, and a second rotation inside one call is the retry
         // storm the `stale` gate exists to prevent.
         let mut digest_replayed = false;
+        // The replay is granted an attempt OF ITS OWN instead of consuming or
+        // escaping the 425 budget, because the two answer different questions: the
+        // budget bounds how long we wait for a server that is not ready, while the
+        // replay is one retry of a request the server refused for a reason we can
+        // fix. Letting the replay `continue` out of the final attempt is what used
+        // to walk the loop off the end of its own range and into a panic; the loop
+        // is now unbounded in form and bounded by `budget`, so the only way out is
+        // the return below.
+        let mut budget = MAX_ATTEMPTS;
+        let mut attempt = 0usize;
 
-        for attempt in 1..=MAX_ATTEMPTS {
+        loop {
+            attempt += 1;
             let nonce_used = self.digest_nonce_snapshot();
             let mut req = self.request(method.clone(), path);
             if let Some(ref r) = referer {
@@ -929,10 +940,11 @@ impl WebDavProvider {
                 && self.should_replay_after_401(&response, &nonce_used)
             {
                 digest_replayed = true;
+                budget = MAX_ATTEMPTS + 1;
                 continue;
             }
 
-            if response.status() != StatusCode::TOO_EARLY || attempt == MAX_ATTEMPTS {
+            if response.status() != StatusCode::TOO_EARLY || attempt >= budget {
                 return Ok(response);
             }
 
@@ -941,12 +953,10 @@ impl WebDavProvider {
                 method.as_str(),
                 path,
                 attempt,
-                MAX_ATTEMPTS
+                budget
             );
             tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         }
-
-        unreachable!("retry loop must return on final attempt")
     }
 
     /// Send a request and, on a `401` carrying a genuinely rotated Digest
@@ -6200,6 +6210,49 @@ mod tests {
             provider.digest_auth.as_ref().expect("digest state").nonce(),
             "rotated",
             "the replay must have used the rotated nonce"
+        );
+    }
+
+    const TOO_EARLY_425: &str =
+        "HTTP/1.1 425 Too Early\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+
+    /// Two 425s followed by a rotated-nonce 401 used to PANIC the calling task.
+    /// The 425 branch spends the attempt budget, and the Digest replay then issued
+    /// a `continue` from the final attempt, which skipped the only `return` in the
+    /// loop and walked off the end of the range into `unreachable!`. Both single
+    /// stream GET paths route through this helper, so the panic was reachable from
+    /// an ordinary download against a server that answers 425 while rotating its
+    /// nonce.
+    ///
+    /// The assertion is on the OUTCOME, a returned response rather than a panic,
+    /// because that is what the caller experiences. The request count is asserted
+    /// too: the replay must be granted its own attempt, not an unbounded supply of
+    /// them, so four is both the proof it happened and the proof it stopped.
+    #[tokio::test]
+    async fn a_425_run_followed_by_a_rotated_nonce_401_returns_instead_of_panicking() {
+        let (url, hits) = spawn_http_stub(vec![
+            TOO_EARLY_425,
+            TOO_EARLY_425,
+            ROTATED_401,
+            TOO_EARLY_425,
+        ])
+        .await;
+        let mut provider = digest_provider(&url);
+
+        let response = provider
+            .send_with_too_early_retry(Method::GET, "/file.bin")
+            .await
+            .expect("the helper must return a response, not fail");
+
+        assert_eq!(
+            response.status(),
+            StatusCode::TOO_EARLY,
+            "the last response is what the caller gets back"
+        );
+        assert_eq!(
+            hits.load(Ordering::SeqCst),
+            4,
+            "three attempts of the 425 budget plus exactly one replay attempt"
         );
     }
 


### PR DESCRIPTION
The two defects the lane A pre-release auditor classified as introduced by this cycle. The other three it reports predate v4.1.8 and are being worked separately.

## Swift: a dot segment inside an opaque key is not a path

A Swift object name is an opaque key. The server does no path resolution, so `foo/../bar` and `bar` are two different objects, exactly as `a//b` and `a/b` are. `normalize_path` resolved `.` and `..` anyway, on the path of nine production call sites across seven operations including `rmdir_recursive`, `rename` and `server_side_copy`.

A recursive delete of the literal prefix `foo/../bar/` was therefore sent as `bar/` and removed objects the caller never named.

The function's own comment already had the principle right one sentence above the defect: it explains that collapsing `a//b` into `a/b` would point rename, copy and delete at the wrong one. The reasoning was written and applied to half the cases.

Resolution moves to `cd`, where a relative segment means what the user means by it. `normalize_path` now interprets exactly one dot, a whole path of `.`, which is the GUI asking for the container root and the case `fa0325d31` existed to fix.

## WebDAV: the retry loop could walk off its own range into a panic

The 425 loop had three attempts and one `return` inside it. A rotated Digest nonce arriving on the final attempt issued a `continue`, skipping that return, exhausting the range and reaching `unreachable!`. Both single-stream GET paths route through this helper, so an ordinary download from a server answering 425 while rotating its nonce panicked the calling task.

The comment above the flag already said the replay is tracked by a flag "rather than by attempt number: the 425 loop may already have burned attempts". The interaction was understood; the code then escaped the budget instead of respecting it.

The replay now gets an attempt of its own, bounded at four requests total, and the loop has no range left to fall off.

## Verification

Both regression tests were observed FAILING against the previous code, which is the only thing that makes them regression tests:

- Swift: `assertion left != right failed: two distinct object keys must not collapse onto one, left: "bar", right: "bar"`. That is the collapse itself.
- WebDAV: `internal error: entered unreachable code: retry loop must return on final attempt`. That is the panic reaching the caller.

Gates on this branch: `cargo fmt --all -- --check` clean, `cargo clippy --all-targets -- -D warnings` clean at default features (the CI Build line verbatim), `cargo test --lib` 3685 passed 0 failed 21 ignored.

## What is NOT verified here

Neither fix was exercised against a live server. The Swift change is asserted at the unit that builds the request path, not against a real container, so what is proven is that two distinct keys stay distinct, not that a delete against Blomp behaves differently today. The WebDAV change is asserted through a hand-rolled TCP stub serving canned responses, which is the harness this file already uses for the sibling Digest tests, so the 425-then-rotated-401 sequence is synthetic rather than captured from a server that produced it.

The Swift regression test asserts the DISTINCTNESS of the two keys rather than either value: asserting only that `foo/../bar` survives would still pass if `bar` were rewritten into it instead.

No review bot has read this branch yet at the time of opening.



---

## Merge record

Merged at zero incomplete check runs, read from the check-runs API on the head commit rather than from this page, where a superseded `cancelled` run reads as red. 15 checks, 13 success and 2 skipped (`build-snap` and `publish-winget`, which only run on a tag).

**No review bot read this branch.** CodeRabbit was rate limited across the whole range `5ea980f1..b5fd280d`, so it produced no walkthrough and no findings. Recorded because an unreviewed pull request and one reviewed with no findings are indistinguishable from outside, and these are two protocol defects, one of which could delete objects the caller never named. What carried them is a human reading plus two regression tests observed failing against the previous code, which is stated in full in the body above.
