### PR TITLE
fix(checkpoint): a record someone else evicted is not a slot we freed

### DIFF
--- a/src-tauri/src/transfer_dag/checkpoint.rs
+++ b/src-tauri/src/transfer_dag/checkpoint.rs
@@ -349,12 +349,7 @@ impl TransferCheckpointStore {
         let Some(mut loaded) = existing else {
             self.persist(&fresh)?;
             if let Err(e) = self.enforce_cap(&fresh.transfer_key) {
-                // Undo the reservation. Ignoring the unlink error is correct
-                // here: the caller is already being told the open failed, and a
-                // residual record is reclaimable by the next cap run, while
-                // replacing the real reason with "could not clean up" would
-                // hide it.
-                let _ = fs::remove_file(&path);
+                self.rollback_reservation(&path, &fresh);
                 return Err(e);
             }
             return Ok(CheckpointOpen {
@@ -594,6 +589,45 @@ impl TransferCheckpointStore {
     }
 
     /// Remove every record bound to one destination endpoint, ignoring the
+    /// Undo our own reservation, and only ours.
+    ///
+    /// The reservation is written under the transfer key, so it is the same
+    /// file for every opener of the same transfer, and a path is not an
+    /// identity. An opener that arrives while ours is on disk does not see a
+    /// placeholder: it sees a resumable record, adopts it (`attempts + 1`, a
+    /// transition, a persist) and returns `resumed: true`. Removing that file
+    /// by path would then destroy a record whose owner has been told it is
+    /// durable, which is this PR's own defect wearing the other mask: the first
+    /// version counted another opener's deletion as ours, and an unconditional
+    /// rollback deletes another opener's record believing it is ours.
+    ///
+    /// So the reservation is removed only when the bytes on disk are still
+    /// exactly the bytes we wrote. `persist` is `to_vec_pretty` plus an atomic
+    /// replace, so a reader sees one whole record and never a torn one, and an
+    /// adopter necessarily changes `attempts`: byte equality is a sound test of
+    /// "nobody has taken this over".
+    ///
+    /// THE WINDOW IT DOES NOT CLOSE, stated rather than left to be discovered:
+    /// an adopter can still land between the read and the unlink. Closing it
+    /// needs an atomic compare-and-delete, which the filesystem does not offer.
+    /// The design that would close it, a reservation marker under a name only
+    /// this opener holds, trades this window for a marker that survives a crash
+    /// and consumes capacity until something ages it out, which is a new way to
+    /// be wrong in exchange for a narrower one. If that trade is ever wanted,
+    /// it is a change of its own and not a line here.
+    ///
+    /// Errors are swallowed on purpose: the caller is already being told why
+    /// the open failed, and replacing that reason with "could not clean up"
+    /// would hide it. A record left behind is reclaimable by the next cap run.
+    fn rollback_reservation(&self, path: &Path, ours: &MultipartCheckpoint) {
+        let Ok(ours_bytes) = serde_json::to_vec_pretty(ours) else {
+            return;
+        };
+        if fs::read(path).is_ok_and(|on_disk| on_disk == ours_bytes) {
+            let _ = fs::remove_file(path);
+        }
+    }
+
     /// Free `needed` slots by deleting candidates in order, counting only the
     /// deletions THIS caller performed.
     ///
@@ -1372,6 +1406,52 @@ mod tests {
         assert!(
             !store.path_for(&key).exists(),
             "a store that said it could not hold the record must not be holding it",
+        );
+    }
+
+    /// The rollback must remove OUR reservation and nothing else.
+    ///
+    /// Two openers of the same transfer share one file, because the name is the
+    /// transfer key. The second one does not see a placeholder: it sees a
+    /// resumable record, adopts it (`attempts + 1`, a transition, a persist)
+    /// and is told `resumed: true`. If the first one's cap enforcement then
+    /// fails and it deletes by path, it destroys a record whose owner believes
+    /// it is durable, and the second opener's checkpoint is silently gone.
+    ///
+    /// Run against an unconditional `remove_file`, the second half of this test
+    /// fails: the adopted record is deleted.
+    #[test]
+    fn the_rollback_removes_our_reservation_and_not_an_adopted_one() {
+        let temp = TempDir::new().unwrap();
+        let store =
+            TransferCheckpointStore::with_limits(temp.path(), DEFAULT_CHECKPOINT_TTL, 8).unwrap();
+        let ours = MultipartCheckpoint::fresh(source(), destination(), layout());
+        let path = store.path_for(&ours.transfer_key);
+
+        // Untouched: ours to remove.
+        store.persist(&ours).unwrap();
+        store.rollback_reservation(&path, &ours);
+        assert!(
+            !path.exists(),
+            "an untouched reservation is ours to withdraw"
+        );
+
+        // Adopted by a concurrent opener of the same transfer: not ours.
+        store.persist(&ours).unwrap();
+        let mut adopted = ours.clone();
+        adopted.attempts = adopted.attempts.saturating_add(1);
+        adopted.transition(CheckpointStatus::Transferring).unwrap();
+        store.persist(&adopted).unwrap();
+
+        store.rollback_reservation(&path, &ours);
+        assert!(
+            path.exists(),
+            "the rollback deleted a record another opener had already adopted",
+        );
+        let still_there = store.load_path(&path).unwrap().unwrap();
+        assert_eq!(
+            still_there.attempts, adopted.attempts,
+            "and it must be the adopter's record, untouched",
         );
     }
 

--- a/src-tauri/src/transfer_dag/checkpoint.rs
+++ b/src-tauri/src/transfer_dag/checkpoint.rs
@@ -327,16 +327,36 @@ impl TransferCheckpointStore {
                 None
             }
         };
-        // The cap runs BEFORE the write, deliberately. `enforce_cap` counts the
-        // kept record as one slot whether or not it is on disk yet, so the
-        // arithmetic is identical, and running it first means a store that
-        // cannot evict refuses to grow instead of reporting failure with the
-        // new record already written: the previous order left the record behind
-        // and pushed the store past the cap in the very call that said it could
-        // not hold it.
+        // A NEW record reserves its slot on disk before the cap is enforced,
+        // and the reason is what another opener can see. `enforce_cap` counts
+        // the kept record as one slot whether or not it is written yet, so the
+        // arithmetic is right for the caller; it is wrong for everyone else.
+        // Between one opener's eviction and its write the store is one record
+        // under its cap, and an opener that scans in that window reads capacity
+        // that is already spoken for, evicts nothing, and writes: the cap is
+        // exceeded by one per opener that arrives in a window. Writing first
+        // puts the claim where the other scans can count it, which is also why
+        // `enforce_cap` already sorts a just-persisted in-flight record LAST
+        // among eviction candidates: the design expected these to be on disk.
+        //
+        // The order this replaces was itself deliberate, and its reason is kept
+        // rather than dropped: a store that cannot evict must refuse to grow,
+        // not report failure with the new record left behind. That is what the
+        // rollback below is for. The window it opens instead is a crash between
+        // the write and the eviction, which leaves one extra record that the
+        // next open reclaims, rather than a record the store said it could not
+        // hold.
         let Some(mut loaded) = existing else {
-            self.enforce_cap(&fresh.transfer_key)?;
             self.persist(&fresh)?;
+            if let Err(e) = self.enforce_cap(&fresh.transfer_key) {
+                // Undo the reservation. Ignoring the unlink error is correct
+                // here: the caller is already being told the open failed, and a
+                // residual record is reclaimable by the next cap run, while
+                // replacing the real reason with "could not clean up" would
+                // hide it.
+                let _ = fs::remove_file(&path);
+                return Err(e);
+            }
             return Ok(CheckpointOpen {
                 checkpoint: fresh,
                 resumed: false,
@@ -1321,6 +1341,91 @@ mod tests {
         assert!(
             err.contains("concurrent eviction"),
             "and why, so the next reader is not left guessing: {err}",
+        );
+    }
+
+    /// The ordering change has one risk and this is it: writing the record
+    /// before enforcing the cap could leave it behind when the store turns out
+    /// to have no room, which is exactly what the previous order existed to
+    /// prevent. The rollback is what keeps that promise, and this fails without
+    /// it.
+    ///
+    /// The eviction is made to fail deterministically rather than by timing: a
+    /// DIRECTORY named like a record is an unremovable candidate (`remove_file`
+    /// gives `IsADirectory`, not `NotFound`), so the cap cannot be met and the
+    /// open must refuse.
+    #[test]
+    fn a_store_that_cannot_evict_does_not_keep_the_record_it_refused() {
+        let temp = TempDir::new().unwrap();
+        let store =
+            TransferCheckpointStore::with_limits(temp.path(), DEFAULT_CHECKPOINT_TTL, 1).unwrap();
+        fs::create_dir(temp.path().join("unremovable.json")).unwrap();
+
+        let key = MultipartCheckpoint::fresh(source(), destination(), layout()).transfer_key;
+        let err = store
+            .open_or_create(source(), destination(), layout())
+            .unwrap_err();
+        assert!(
+            err.contains("reclaimed only"),
+            "the refusal must say why: {err}",
+        );
+        assert!(
+            !store.path_for(&key).exists(),
+            "a store that said it could not hold the record must not be holding it",
+        );
+    }
+
+    /// Three openers, which is the shape a reviewer raised against the counting
+    /// fix alone: with the cap enforced BEFORE the write, one opener deletes its
+    /// victim and has not written yet, and a third opener scanning in that
+    /// window reads capacity that is already spoken for, evicts nothing, and
+    /// writes. Reserving the slot first removes the window rather than guarding
+    /// it: the claim is on disk for every other scan to count.
+    ///
+    /// What this test can and cannot do. It exercises the invariant with real
+    /// concurrency, and it is the reason the fan-out case is not left to an
+    /// argument alone; it cannot FORCE the interleaving, because the store has
+    /// no hook between its scan and its write. The property is carried by the
+    /// ordering, and the deterministic pin for the ordering is the rollback
+    /// test above.
+    #[test]
+    fn three_overlapping_opens_do_not_push_the_store_past_the_cap() {
+        const CAP: usize = 8;
+        let temp = TempDir::new().unwrap();
+        let store =
+            TransferCheckpointStore::with_limits(temp.path(), DEFAULT_CHECKPOINT_TTL, CAP).unwrap();
+        for i in 0..CAP {
+            let r = record_at(
+                &format!("/filled-{i}.bin"),
+                CheckpointStatus::Transferring,
+                1000 + i as u64,
+            );
+            store.persist(&r).unwrap();
+        }
+
+        let barrier = std::sync::Barrier::new(3);
+        std::thread::scope(|scope| {
+            for i in 0..3 {
+                let store = &store;
+                let barrier = &barrier;
+                scope.spawn(move || {
+                    // A distinct source path is what makes a distinct key, so
+                    // the three openers really are three admissions and not one
+                    // record opened three times.
+                    let mut opening = source();
+                    opening.local_path = format!("/opening-{i}.bin");
+                    barrier.wait();
+                    store
+                        .open_or_create(opening, destination(), layout())
+                        .unwrap();
+                });
+            }
+        });
+
+        let present = present_keys(temp.path()).len();
+        assert!(
+            present <= CAP,
+            "{present} records in a store capped at {CAP}",
         );
     }
 

--- a/src-tauri/src/transfer_dag/checkpoint.rs
+++ b/src-tauri/src/transfer_dag/checkpoint.rs
@@ -570,35 +570,67 @@ impl TransferCheckpointStore {
             };
             rank(a.1, a.3).cmp(&rank(b.1, b.3)).then(a.2.cmp(&b.2))
         });
-        // Ignoring every unlink error made the advertised hard cap a claim
-        // rather than a bound: a candidate that cannot be deleted (permissions,
-        // a Windows sharing violation, a read-only filesystem) was reselected
-        // forever while new records kept being accepted. Skip past a stuck one
-        // and try the next, since another candidate may well be removable, and
-        // fail only when the target cannot be met at all.
-        let mut removed = 0usize;
+        Self::reclaim_slots(records.into_iter().map(|(path, _, _, _)| path), evict)
+    }
+
+    /// Remove every record bound to one destination endpoint, ignoring the
+    /// Free `needed` slots by deleting candidates in order, counting only the
+    /// deletions THIS caller performed.
+    ///
+    /// The distinction is the whole function. A candidate that is already gone
+    /// when the unlink runs was taken by a concurrent opener, and that opener
+    /// took the slot for its own record: the file is gone, and no slot was
+    /// freed for us. Counting it as ours is how the cap was exceeded.
+    ///
+    /// Two opens sharing a saturated store both scanned 256, both computed one
+    /// eviction and both selected the same oldest record. One unlinked it, the
+    /// other got `NotFound`, counted it, and wrote: 257 records in a store whose
+    /// cap is 256, with a wider fan-out overshooting by more. Nothing reported
+    /// it, because from inside each call the arithmetic was consistent.
+    ///
+    /// No lock is needed to fix it, and one was considered before being
+    /// rejected. `unlink` IS the mutual exclusion: for a given path exactly one
+    /// caller can succeed and every other gets `NotFound`, on Unix and on
+    /// Windows alike, across processes and not merely across tasks. What was
+    /// missing was not exclusion but bookkeeping: counting somebody else's
+    /// success as our own. A lock file would add stale-lock recovery, a
+    /// filesystem assumption and a new failure mode to buy a guarantee the
+    /// kernel already gives. The GUI and the CLI running at once, which is the
+    /// case that makes this real, are covered by the same argument.
+    ///
+    /// A stuck candidate (permissions, a Windows sharing violation, a read-only
+    /// filesystem) is skipped rather than reselected forever, and the call fails
+    /// only when the target cannot be met at all, which is the pre-existing
+    /// behaviour and the reason this returns an error rather than shrugging.
+    fn reclaim_slots(
+        candidates: impl IntoIterator<Item = PathBuf>,
+        needed: usize,
+    ) -> Result<(), String> {
+        let mut reclaimed = 0usize;
+        let mut vanished = 0usize;
         let mut failures: Vec<String> = Vec::new();
-        for (path, _, _, _) in records {
-            if removed == evict {
+        for path in candidates {
+            if reclaimed == needed {
                 break;
             }
             match fs::remove_file(&path) {
-                Ok(()) => removed += 1,
-                // Another process got there first: that is the desired end state.
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => removed += 1,
+                Ok(()) => reclaimed += 1,
+                // Gone before we got to it: somebody else's eviction, and
+                // somebody else's slot. Move to the next candidate.
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => vanished += 1,
                 Err(e) => failures.push(format!("{}: {e}", path.display())),
             }
         }
-        if removed < evict {
+        if reclaimed < needed {
             return Err(format!(
-                "checkpoint cap removed only {removed} of {evict} records: {}",
+                "checkpoint cap reclaimed only {reclaimed} of {needed} records \
+                 ({vanished} taken by a concurrent eviction): {}",
                 failures.join("; ")
             ));
         }
         Ok(())
     }
 
-    /// Remove every record bound to one destination endpoint, ignoring the
     /// per-file remote path. This is the explicit, honest escape for a
     /// decommissioned server: the TTL scavenger only prunes a record when the
     /// same endpoint is revisited, so without this a server you stop using keeps
@@ -1236,6 +1268,118 @@ mod tests {
         assert!(present.contains(&keys[3]));
         assert!(!present.contains(&keys[1]));
         assert!(!present.contains(&keys[2]));
+    }
+
+    /// The deterministic pin: a candidate that is already gone did not free a
+    /// slot for THIS caller, so it must not be counted as one.
+    ///
+    /// This is the whole defect in one call. The eviction loop treated
+    /// `NotFound` as a success, with a comment saying it was "the desired end
+    /// state": true of the file, false of the slot. The file was taken by a
+    /// concurrent opener that then used the slot for its own record, so the
+    /// caller that merely watched it disappear wrote on top of a full store.
+    ///
+    /// Run against the previous behaviour, `first` survives and nothing is
+    /// reclaimed, because the loop stops as soon as it has counted one.
+    #[test]
+    fn a_vanished_candidate_does_not_count_as_a_slot_we_freed() {
+        let temp = TempDir::new().unwrap();
+        let taken_by_someone_else = temp.path().join("already-evicted.json");
+        let first = temp.path().join("first.json");
+        let second = temp.path().join("second.json");
+        fs::write(&first, b"{}").unwrap();
+        fs::write(&second, b"{}").unwrap();
+
+        TransferCheckpointStore::reclaim_slots(
+            [taken_by_someone_else.clone(), first.clone(), second.clone()],
+            1,
+        )
+        .unwrap();
+
+        assert!(
+            !first.exists(),
+            "the vanished candidate was counted as ours and no slot was actually freed",
+        );
+        assert!(
+            second.exists(),
+            "only the one slot that was needed should be reclaimed",
+        );
+    }
+
+    /// And the failure is reported rather than hidden when the candidates run
+    /// out: a store whose only candidates were taken by other openers cannot
+    /// grow, and saying so is the contract `enforce_cap` already had.
+    #[test]
+    fn reclaiming_nothing_is_an_error_and_names_the_reason() {
+        let temp = TempDir::new().unwrap();
+        let gone = temp.path().join("gone.json");
+        let err = TransferCheckpointStore::reclaim_slots([gone], 1).unwrap_err();
+        assert!(
+            err.contains("reclaimed only 0 of 1"),
+            "the error must say how far it got: {err}",
+        );
+        assert!(
+            err.contains("concurrent eviction"),
+            "and why, so the next reader is not left guessing: {err}",
+        );
+    }
+
+    /// The same thing end to end, with two openers actually overlapping.
+    ///
+    /// Honest about what this is: the interleaving is not forced, so this test
+    /// reproduces the overshoot only when the two scans really do straddle the
+    /// unlink. That is why the pin above exists and is the one that holds the
+    /// behaviour; this one is here because an invariant stated at the level the
+    /// user sees ("the store never exceeds its cap") is worth asserting even
+    /// when the path to breaking it is timing.
+    ///
+    /// It also covers the case the fix is FOR, which is two PROCESSES rather
+    /// than two tasks: threads are what a test can run, and the exclusion the
+    /// fix relies on is the kernel's, not the runtime's. `unlink` gives exactly
+    /// one caller success per path whether the callers share an address space
+    /// or not, so the GUI and the CLI are covered by the same mechanism this
+    /// exercises.
+    #[test]
+    fn two_overlapping_opens_do_not_push_the_store_past_the_cap() {
+        const CAP: usize = 8;
+        let temp = TempDir::new().unwrap();
+        let store =
+            TransferCheckpointStore::with_limits(temp.path(), DEFAULT_CHECKPOINT_TTL, CAP).unwrap();
+        // A FULL store, which is the only state in which the cap runs at all. A
+        // test that starts empty never reaches the branch.
+        for i in 0..CAP {
+            let r = record_at(
+                &format!("/filled-{i}.bin"),
+                CheckpointStatus::Transferring,
+                1000 + i as u64,
+            );
+            store.persist(&r).unwrap();
+        }
+        assert_eq!(present_keys(temp.path()).len(), CAP);
+
+        let barrier = std::sync::Barrier::new(2);
+        std::thread::scope(|scope| {
+            for i in 0..2 {
+                let store = &store;
+                let barrier = &barrier;
+                scope.spawn(move || {
+                    let opening = record_at(
+                        &format!("/opening-{i}.bin"),
+                        CheckpointStatus::Transferring,
+                        9000 + i as u64,
+                    );
+                    barrier.wait();
+                    store.enforce_cap(&opening.transfer_key).unwrap();
+                    store.persist(&opening).unwrap();
+                });
+            }
+        });
+
+        let present = present_keys(temp.path()).len();
+        assert!(
+            present <= CAP,
+            "the cap is a bound, not an average: {present} records in a store capped at {CAP}",
+        );
     }
 
     #[test]

--- a/src-tauri/src/transfer_dag/checkpoint.rs
+++ b/src-tauri/src/transfer_dag/checkpoint.rs
@@ -327,31 +327,16 @@ impl TransferCheckpointStore {
                 None
             }
         };
-        // A NEW record reserves its slot on disk before the cap is enforced,
-        // and the reason is what another opener can see. `enforce_cap` counts
-        // the kept record as one slot whether or not it is written yet, so the
-        // arithmetic is right for the caller; it is wrong for everyone else.
-        // Between one opener's eviction and its write the store is one record
-        // under its cap, and an opener that scans in that window reads capacity
-        // that is already spoken for, evicts nothing, and writes: the cap is
-        // exceeded by one per opener that arrives in a window. Writing first
-        // puts the claim where the other scans can count it, which is also why
-        // `enforce_cap` already sorts a just-persisted in-flight record LAST
-        // among eviction candidates: the design expected these to be on disk.
-        //
-        // The order this replaces was itself deliberate, and its reason is kept
-        // rather than dropped: a store that cannot evict must refuse to grow,
-        // not report failure with the new record left behind. That is what the
-        // rollback below is for. The window it opens instead is a crash between
-        // the write and the eviction, which leaves one extra record that the
-        // next open reclaims, rather than a record the store said it could not
-        // hold.
+        // The cap runs BEFORE the write, deliberately. `enforce_cap` counts the
+        // kept record as one slot whether or not it is on disk yet, so the
+        // arithmetic is identical, and running it first means a store that
+        // cannot evict refuses to grow instead of reporting failure with the
+        // new record already written: the previous order left the record behind
+        // and pushed the store past the cap in the very call that said it could
+        // not hold it.
         let Some(mut loaded) = existing else {
+            self.enforce_cap(&fresh.transfer_key)?;
             self.persist(&fresh)?;
-            if let Err(e) = self.enforce_cap(&fresh.transfer_key) {
-                self.rollback_reservation(&path, &fresh);
-                return Err(e);
-            }
             return Ok(CheckpointOpen {
                 checkpoint: fresh,
                 resumed: false,
@@ -589,45 +574,6 @@ impl TransferCheckpointStore {
     }
 
     /// Remove every record bound to one destination endpoint, ignoring the
-    /// Undo our own reservation, and only ours.
-    ///
-    /// The reservation is written under the transfer key, so it is the same
-    /// file for every opener of the same transfer, and a path is not an
-    /// identity. An opener that arrives while ours is on disk does not see a
-    /// placeholder: it sees a resumable record, adopts it (`attempts + 1`, a
-    /// transition, a persist) and returns `resumed: true`. Removing that file
-    /// by path would then destroy a record whose owner has been told it is
-    /// durable, which is this PR's own defect wearing the other mask: the first
-    /// version counted another opener's deletion as ours, and an unconditional
-    /// rollback deletes another opener's record believing it is ours.
-    ///
-    /// So the reservation is removed only when the bytes on disk are still
-    /// exactly the bytes we wrote. `persist` is `to_vec_pretty` plus an atomic
-    /// replace, so a reader sees one whole record and never a torn one, and an
-    /// adopter necessarily changes `attempts`: byte equality is a sound test of
-    /// "nobody has taken this over".
-    ///
-    /// THE WINDOW IT DOES NOT CLOSE, stated rather than left to be discovered:
-    /// an adopter can still land between the read and the unlink. Closing it
-    /// needs an atomic compare-and-delete, which the filesystem does not offer.
-    /// The design that would close it, a reservation marker under a name only
-    /// this opener holds, trades this window for a marker that survives a crash
-    /// and consumes capacity until something ages it out, which is a new way to
-    /// be wrong in exchange for a narrower one. If that trade is ever wanted,
-    /// it is a change of its own and not a line here.
-    ///
-    /// Errors are swallowed on purpose: the caller is already being told why
-    /// the open failed, and replacing that reason with "could not clean up"
-    /// would hide it. A record left behind is reclaimable by the next cap run.
-    fn rollback_reservation(&self, path: &Path, ours: &MultipartCheckpoint) {
-        let Ok(ours_bytes) = serde_json::to_vec_pretty(ours) else {
-            return;
-        };
-        if fs::read(path).is_ok_and(|on_disk| on_disk == ours_bytes) {
-            let _ = fs::remove_file(path);
-        }
-    }
-
     /// Free `needed` slots by deleting candidates in order, counting only the
     /// deletions THIS caller performed.
     ///
@@ -1378,194 +1324,25 @@ mod tests {
         );
     }
 
-    /// The ordering change has one risk and this is it: writing the record
-    /// before enforcing the cap could leave it behind when the store turns out
-    /// to have no room, which is exactly what the previous order existed to
-    /// prevent. The rollback is what keeps that promise, and this fails without
-    /// it.
+    /// What this PR does NOT close, stated as a test would have to be honest
+    /// about it rather than left for the next reader to find.
     ///
-    /// The eviction is made to fail deterministically rather than by timing: a
-    /// DIRECTORY named like a record is an unremovable candidate (`remove_file`
-    /// gives `IsADirectory`, not `NotFound`), so the cap cannot be met and the
-    /// open must refuse.
-    #[test]
-    fn a_store_that_cannot_evict_does_not_keep_the_record_it_refused() {
-        let temp = TempDir::new().unwrap();
-        let store =
-            TransferCheckpointStore::with_limits(temp.path(), DEFAULT_CHECKPOINT_TTL, 1).unwrap();
-        fs::create_dir(temp.path().join("unremovable.json")).unwrap();
-
-        let key = MultipartCheckpoint::fresh(source(), destination(), layout()).transfer_key;
-        let err = store
-            .open_or_create(source(), destination(), layout())
-            .unwrap_err();
-        assert!(
-            err.contains("reclaimed only"),
-            "the refusal must say why: {err}",
-        );
-        assert!(
-            !store.path_for(&key).exists(),
-            "a store that said it could not hold the record must not be holding it",
-        );
-    }
-
-    /// The rollback must remove OUR reservation and nothing else.
+    /// The counting fix guarantees that each caller frees its OWN slot. It does
+    /// not close the window between one caller's delete and its write: a caller
+    /// scanning inside it reads capacity that is already spoken for, evicts
+    /// nothing and writes, and the store ends one over the cap. That window
+    /// exists on `main` today and is unchanged here.
     ///
-    /// Two openers of the same transfer share one file, because the name is the
-    /// transfer key. The second one does not see a placeholder: it sees a
-    /// resumable record, adopts it (`attempts + 1`, a transition, a persist)
-    /// and is told `resumed: true`. If the first one's cap enforcement then
-    /// fails and it deletes by path, it destroys a record whose owner believes
-    /// it is durable, and the second opener's checkpoint is silently gone.
-    ///
-    /// Run against an unconditional `remove_file`, the second half of this test
-    /// fails: the adopted record is deleted.
-    #[test]
-    fn the_rollback_removes_our_reservation_and_not_an_adopted_one() {
-        let temp = TempDir::new().unwrap();
-        let store =
-            TransferCheckpointStore::with_limits(temp.path(), DEFAULT_CHECKPOINT_TTL, 8).unwrap();
-        let ours = MultipartCheckpoint::fresh(source(), destination(), layout());
-        let path = store.path_for(&ours.transfer_key);
-
-        // Untouched: ours to remove.
-        store.persist(&ours).unwrap();
-        store.rollback_reservation(&path, &ours);
-        assert!(
-            !path.exists(),
-            "an untouched reservation is ours to withdraw"
-        );
-
-        // Adopted by a concurrent opener of the same transfer: not ours.
-        store.persist(&ours).unwrap();
-        let mut adopted = ours.clone();
-        adopted.attempts = adopted.attempts.saturating_add(1);
-        adopted.transition(CheckpointStatus::Transferring).unwrap();
-        store.persist(&adopted).unwrap();
-
-        store.rollback_reservation(&path, &ours);
-        assert!(
-            path.exists(),
-            "the rollback deleted a record another opener had already adopted",
-        );
-        let still_there = store.load_path(&path).unwrap().unwrap();
-        assert_eq!(
-            still_there.attempts, adopted.attempts,
-            "and it must be the adopter's record, untouched",
-        );
-    }
-
-    /// Three openers, which is the shape a reviewer raised against the counting
-    /// fix alone: with the cap enforced BEFORE the write, one opener deletes its
-    /// victim and has not written yet, and a third opener scanning in that
-    /// window reads capacity that is already spoken for, evicts nothing, and
-    /// writes. Reserving the slot first removes the window rather than guarding
-    /// it: the claim is on disk for every other scan to count.
-    ///
-    /// What this test can and cannot do. It exercises the invariant with real
-    /// concurrency, and it is the reason the fan-out case is not left to an
-    /// argument alone; it cannot FORCE the interleaving, because the store has
-    /// no hook between its scan and its write. The property is carried by the
-    /// ordering, and the deterministic pin for the ordering is the rollback
-    /// test above.
-    #[test]
-    fn three_overlapping_opens_do_not_push_the_store_past_the_cap() {
-        const CAP: usize = 8;
-        let temp = TempDir::new().unwrap();
-        let store =
-            TransferCheckpointStore::with_limits(temp.path(), DEFAULT_CHECKPOINT_TTL, CAP).unwrap();
-        for i in 0..CAP {
-            let r = record_at(
-                &format!("/filled-{i}.bin"),
-                CheckpointStatus::Transferring,
-                1000 + i as u64,
-            );
-            store.persist(&r).unwrap();
-        }
-
-        let barrier = std::sync::Barrier::new(3);
-        std::thread::scope(|scope| {
-            for i in 0..3 {
-                let store = &store;
-                let barrier = &barrier;
-                scope.spawn(move || {
-                    // A distinct source path is what makes a distinct key, so
-                    // the three openers really are three admissions and not one
-                    // record opened three times.
-                    let mut opening = source();
-                    opening.local_path = format!("/opening-{i}.bin");
-                    barrier.wait();
-                    store
-                        .open_or_create(opening, destination(), layout())
-                        .unwrap();
-                });
-            }
-        });
-
-        let present = present_keys(temp.path()).len();
-        assert!(
-            present <= CAP,
-            "{present} records in a store capped at {CAP}",
-        );
-    }
-
-    /// The same thing end to end, with two openers actually overlapping.
-    ///
-    /// Honest about what this is: the interleaving is not forced, so this test
-    /// reproduces the overshoot only when the two scans really do straddle the
-    /// unlink. That is why the pin above exists and is the one that holds the
-    /// behaviour; this one is here because an invariant stated at the level the
-    /// user sees ("the store never exceeds its cap") is worth asserting even
-    /// when the path to breaking it is timing.
-    ///
-    /// It also covers the case the fix is FOR, which is two PROCESSES rather
-    /// than two tasks: threads are what a test can run, and the exclusion the
-    /// fix relies on is the kernel's, not the runtime's. `unlink` gives exactly
-    /// one caller success per path whether the callers share an address space
-    /// or not, so the GUI and the CLI are covered by the same mechanism this
-    /// exercises.
-    #[test]
-    fn two_overlapping_opens_do_not_push_the_store_past_the_cap() {
-        const CAP: usize = 8;
-        let temp = TempDir::new().unwrap();
-        let store =
-            TransferCheckpointStore::with_limits(temp.path(), DEFAULT_CHECKPOINT_TTL, CAP).unwrap();
-        // A FULL store, which is the only state in which the cap runs at all. A
-        // test that starts empty never reaches the branch.
-        for i in 0..CAP {
-            let r = record_at(
-                &format!("/filled-{i}.bin"),
-                CheckpointStatus::Transferring,
-                1000 + i as u64,
-            );
-            store.persist(&r).unwrap();
-        }
-        assert_eq!(present_keys(temp.path()).len(), CAP);
-
-        let barrier = std::sync::Barrier::new(2);
-        std::thread::scope(|scope| {
-            for i in 0..2 {
-                let store = &store;
-                let barrier = &barrier;
-                scope.spawn(move || {
-                    let opening = record_at(
-                        &format!("/opening-{i}.bin"),
-                        CheckpointStatus::Transferring,
-                        9000 + i as u64,
-                    );
-                    barrier.wait();
-                    store.enforce_cap(&opening.transfer_key).unwrap();
-                    store.persist(&opening).unwrap();
-                });
-            }
-        });
-
-        let present = present_keys(temp.path()).len();
-        assert!(
-            present <= CAP,
-            "the cap is a bound, not an average: {present} records in a store capped at {CAP}",
-        );
-    }
+    /// A concurrency test was written for it and then removed rather than
+    /// weakened. It could not distinguish the fixed case from the broken one,
+    /// because both overshoot by exactly one and the interleaving cannot be
+    /// forced from outside: an assertion that passes either way is decoration,
+    /// and decoration in a test file is worse than an absence, because it reads
+    /// as coverage. Closing the window needs an exclusive reservation
+    /// (`create_new` on the record path, so exactly one opener creates it and
+    /// the other takes the resume path it already has), which is a change to
+    /// the admission control flow and belongs in its own PR with its own tests.
+    /// See `BATON-checkpoint-exclusive-reservation.md`.
 
     #[test]
     fn cap_evicts_terminal_residue_before_a_newer_resumable() {


### PR DESCRIPTION
## Scope, and why it shrank

This PR was three commits and is now one plus a revert. That is deliberate, and the reason is the most useful thing in it.

**What ships:** a candidate that has already vanished is not a slot this caller freed.

**What does not:** the reservation ordering and its rollback, reverted after they produced two further defects, each found inside the remedy for the one before it.

## The defect that ships fixed

`enforce_cap` counted a `NotFound` from its own unlink as a successful eviction:

```rust
Err(e) if e.kind() == std::io::ErrorKind::NotFound => removed += 1,
// Another process got there first: that is the desired end state.
```

True of the **file**, false of the **slot**. The record that vanished was taken by a concurrent opener, and that opener used the freed slot for its own write. Two opens on a saturated store both scan 256, both plan one eviction, both select the same oldest record; one unlinks it, the other counts the `NotFound` and stops looking, and both persist. **257 records in a store whose cap is 256.**

`unlink` is the mutual exclusion here, on Unix and on Windows, across processes: exactly one caller succeeds per path. What was missing was never exclusion, it was counting somebody else's success as our own.

Pinned by two deterministic tests, both seen red first.

## What is NOT fixed, said plainly

The window between one opener's delete and its write. A caller scanning inside it reads capacity that is already spoken for, evicts nothing and writes, and the store ends one over the cap.

**That window exists on `main` today and is unchanged here.** What ships is strictly better than what is there, with no new failure mode. It is not fixed, and it is not a regression.

## Why the fix for it was reverted

Reserving the slot on disk before enforcing the cap does close that window: the claim becomes visible to every other scan. It also opened two defects in two rounds, each discovered inside the remedy for the previous one.

1. **The rollback deleted by path, and a path is not an identity.** The reservation is written under the transfer key, so it is the same file for every opener of that transfer. A second opener does not find a placeholder: it finds a resumable record, adopts it (`attempts + 1`, a transition, a persist) and is told `resumed: true`. The first opener's rollback then destroyed a record whose owner had been told it was durable.

2. **Byte equality separates MINE from ADOPTED, not MINE from SOMEBODY ELSE'S IDENTICAL.** `MultipartCheckpoint::fresh` is deterministic given source, destination and layout, except `updated_unix_secs`, whose granularity is one **second**. Two openers of the same transfer in the same second write byte-identical records, and the first to fail `enforce_cap` withdraws the second one's reservation.

Three faces of one question answered by omission, **"is this record mine?"**: counting another opener's removal as ours, deleting another opener's record believing it is ours, recognising as ours an identical record that is another's.

## The judgement, since it is a judgement

The direction of each harm decided it.

- The defect that ships fixed grows the store by one record in a situation where it could not evict anyway: **bounded, and reclaimed by the next successful cap run**.
- The defects the remedies introduced **lose, silently, a checkpoint whose owner has been told it is durable**.

Three rounds on the same property in one night is not three edge cases. It is the signal that the admission path wants a design rather than a fourth patch at three in the morning, on a store the GUI and the CLI share.

## The design that closes it, not lost

An **exclusive reservation**: `create_new` on the record path, so exactly one opener creates it and every other gets `AlreadyExists` and falls back to the adoption path `open_or_create` already has, which is the correct behaviour for two openers of the same transfer. It closes the borrowed-capacity window, the rollback that deletes another's record, and the identical-twin case together, using the same primitive the shipped fix relies on: exclusivity the kernel already provides.

It is a change to the admission control flow and belongs in its own PR with its own tests. Written up, with the alternatives already rejected and the reasons, in `BATON-checkpoint-exclusive-reservation.md`.

## The test that was removed rather than weakened

A concurrency test for the overshoot went with the revert. It could not distinguish the fixed case from the broken one: both overshoot by exactly one, and the interleaving cannot be forced from outside, since the store has no hook between its scan and its write. An assertion that passes either way reads as coverage without being any, which in a test file is worse than an absence. The limit it was meant to cover is now stated where the test used to be.

## Verified

- `a_vanished_candidate_does_not_count_as_a_slot_we_freed`: **red** on the shipped behaviour (the missing candidate is counted and the real one survives), green after.
- `reclaiming_nothing_is_an_error_and_names_the_reason`: **red** on the shipped behaviour (it returned `Ok` having reclaimed nothing), green after.
- `transfer_dag::checkpoint::tests`: **22 passed, 0 failed**.
- `cargo clippy --all-targets -- -D warnings` and `cargo fmt --all -- --check`: clean.

## NOT verified

- Two separate processes were not driven. The exclusion the fix relies on is the kernel's, not the runtime's, which is why a single process exercises it, but a GUI and a CLI running together were not measured.
- The borrowed-capacity window is open, by decision, and named above.
- The identical shape in `forget_endpoint` is **not** a defect and is untouched: there `removed` is a report of how many records a sweep got rid of and idempotence is the goal, so a record already gone is a record gone. Same three lines, opposite meaning, named here so nobody aligns them for tidiness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved storage-cap enforcement before saving new records.
  * Prevented storage from growing when existing records cannot be removed to meet the configured limit.
  * Improved handling of records that disappear during cleanup, avoiding incorrect reclaimed-space calculations.
  * Clarified failure behavior when capacity cannot be made available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Merge record

Merged at zero incomplete check runs, read from the check-runs API on the head commit rather than from this page, where a superseded `cancelled` run reads as red.

**Review history read across all three surfaces**, because on this pull request the findings lived as inline comments and a check that read only the issue comments reported "no bot comment" while two Major findings were open. Three Major findings were raised. The first, `NotFound` counted as a slot this caller freed, is fixed and is what ships. The second and third, both introduced by the remedies for the ones before them, are decayed rather than answered: `rollback_reservation` no longer exists on this head, so the code they described is gone. The bot's last comment confirms that function and is therefore stale against the head, which is recorded here so a later reader does not take it as describing shipped code.

**What ships is deliberately less than what was written.** The reservation and its rollback are reverted. The residual defect, a store that can exceed its cap by one when concurrent opens each plan an eviction, already exists on `main` today and is bounded and reabsorbed by the next successful cap; the remedies that were reverted could instead lose, silently, a checkpoint an opener had been told was durable. Not fixed and not a regression are different things and this is the first.

The concurrency test was REMOVED rather than weakened, and that is the deliberate part: it could not distinguish the correct case from the broken one, since both overshoot by one and the interleaving is not forcible from outside. An assertion that passes in every case reads as coverage without being it, which in a test file is worse than an absence, because an absence is visible. The declared limit stands where the test stood.

The design that closes all three faces with one primitive, an exclusive `create_new` reservation falling back to the adoption path `open_or_create` already has, is written up and carried to the next cycle rather than attempted at three in the morning.
