### PR TITLE
fix(ftp): end the data wait on a refusal the control reader already holds

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10142,8 +10142,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "suppaftp"
 version = "10.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "821001051ea3d12a60fb790b8c7cb9a6f5f8698dcfdca4cd533a025fefb0b5b8"
+source = "git+https://github.com/axpdev-lab/suppaftp?rev=2d39fadca96b4be37998c3097cb97c36b39231e1#2d39fadca96b4be37998c3097cb97c36b39231e1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -467,6 +467,15 @@ n0-mainline = { git = "https://github.com/axpdev-lab/n0-mainline", rev = "25ee35
 # Filing it is an action on somebody else's repository under somebody's name,
 # so it belongs to the account owner rather than to whoever edits this file.
 #
+# COST OF STAYING FORKED, stated because it is easy to forget once it builds:
+# `cargo audit` matches advisories by crate name and version against the
+# crates.io index, and a git source is not that. So for as long as this entry
+# exists, suppaftp is outside the advisory scanning the released version would
+# get, and a RUSTSEC advisory landing on it may not turn the audit lane red.
+# The pin is v10.0.2 plus one method, so the exposure is that of v10.0.2, but
+# nothing here will TELL us if that changes. That is a reason to file upstream
+# rather than to keep the fork comfortable.
+#
 # When it is sent, REPLACE the two lines above with its URL. That is the
 # whole point of writing the state here: "we will upstream it" is a sentence
 # nobody can check six months later, while "not opened as of a date" and a

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -455,12 +455,17 @@ n0-mainline = { git = "https://github.com/axpdev-lab/n0-mainline", rev = "25ee35
 # stream. Pinned by `rev` on purpose, for the same reason as n0-mainline
 # above.
 #
-# UPSTREAM PR: NOT OPENED as of 2026-09-01. Prepared and waiting on @axpnet
-# to send it: the branch `buffered-reply-bytes` is pushed on
-# axpdev-lab/suppaftp, the diff is the one method, and the text plus the
-# one-line command are in `BATON-suppaftp-upstream-pr.md` outside this repo.
-# Filing it is an action on somebody else's repository, so it belongs to the
-# account owner rather than to whoever touches this file next.
+# UPSTREAM: NOTHING FILED as of 2026-09-01, and the branch being ready is not
+# the same as the contribution being ready. suppaftp asks for an issue first
+# (CONTRIBUTING.md), and its PR checklist wants tests and a local
+# `just check_code`, neither of which exists for this method yet. It also has
+# a binding AI_POLICY.md: disclosure is mandatory and must go through their PR
+# template, and the contributor has to be a person who understands the change
+# and answers review in their own words. The branch `buffered-reply-bytes` is
+# pushed on axpdev-lab/suppaftp and the issue text, the disclosure wording and
+# the remaining work are in `BATON-suppaftp-upstream-pr.md` outside this repo.
+# Filing it is an action on somebody else's repository under somebody's name,
+# so it belongs to the account owner rather than to whoever edits this file.
 #
 # When it is sent, REPLACE the two lines above with its URL. That is the
 # whole point of writing the state here: "we will upstream it" is a sentence

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -441,3 +441,32 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 # time -- exit 1 means still needed, exit 0 means this section can go.
 [patch.crates-io]
 n0-mainline = { git = "https://github.com/axpdev-lab/n0-mainline", rev = "25ee35e827f642635a1028606f0bbd4e9c530ae0" }
+# suppaftp: the v10.0.2 release commit plus ONE method,
+# `buffered_reply_bytes()`, on the tokio stream, so the data-channel watch in
+# `providers/ftp.rs` can see a reply that the control reader has already
+# pulled off the socket. A server that sends `150` and the final reply in one
+# segment leaves the socket empty and the refusal inside the BufReader, and a
+# peek on the bare socket is blind to it: the transfer then waits out the
+# full data idle timeout for an answer that arrived with the first one. The
+# fork can be audited at a glance: `git diff v10.0.2` shows only that method.
+#
+# EXIT CONDITION: delete this entry as soon as an upstream release exposes
+# the reader's buffered bytes (or an equivalent readiness) on the tokio
+# stream. Pinned by `rev` on purpose, for the same reason as n0-mainline
+# above.
+#
+# UPSTREAM PR: NOT OPENED as of 2026-09-01. Prepared and waiting on @axpnet
+# to send it: the branch `buffered-reply-bytes` is pushed on
+# axpdev-lab/suppaftp, the diff is the one method, and the text plus the
+# one-line command are in `BATON-suppaftp-upstream-pr.md` outside this repo.
+# Filing it is an action on somebody else's repository, so it belongs to the
+# account owner rather than to whoever touches this file next.
+#
+# When it is sent, REPLACE the two lines above with its URL. That is the
+# whole point of writing the state here: "we will upstream it" is a sentence
+# nobody can check six months later, while "not opened as of a date" and a
+# link are both things a reader can verify in a second. A fork does not
+# become permanent because the exit condition is missing; it becomes
+# permanent because the exit condition is written in a form nobody can
+# verify.
+suppaftp = { git = "https://github.com/axpdev-lab/suppaftp", rev = "2d39fadca96b4be37998c3097cb97c36b39231e1" }

--- a/src-tauri/src/providers/ftp.rs
+++ b/src-tauri/src/providers/ftp.rs
@@ -2345,13 +2345,17 @@ where
                 watch,
                 ..
             } = self;
-            let control = provider
+            let stream = provider
                 .stream
                 .as_ref()
-                .ok_or(ProviderError::NotConnected)?
-                .get_ref();
+                .ok_or(ProviderError::NotConnected)?;
+            let control = stream.get_ref();
+            // Replies the control reader has already pulled off the socket
+            // and not yet consumed. A peek on the bare socket is blind to
+            // them, and they are exactly where a fast refusal hides.
+            let buffered = stream.buffered_reply_bytes();
             let data = data.as_mut().ok_or(ProviderError::NotConnected)?;
-            FtpProvider::read_watching_control(data, control, buf, watch).await
+            FtpProvider::read_watching_control(data, control, buffered, buf, watch).await
         };
         match step {
             Ok(DataStep::Read(n)) => Ok(n),
@@ -2561,6 +2565,12 @@ impl FtpProvider {
                 // "aligned" in exactly the case it was added to catch, and a
                 // fixture sending the two in separate writes would make that
                 // green. Segmentation is not ours to control.
+                // What the reader holds is no longer invisible:
+                // `buffered_reply_bytes` exists now and the data-channel watch
+                // uses it. Whether a second reply is queued could be answered
+                // here with it; the decision that answer feeds, keep or drop
+                // the session, is still tracked separately and is not part of
+                // the change that added the accessor.
                 // THE COST IS NOT BOUNDED, and an earlier version of this
                 // comment said it was. Measured, not reasoned: a server
                 // answering `RETR` with `550` and `421` in ONE write leaves
@@ -2713,9 +2723,21 @@ impl FtpProvider {
     /// 2yz is the ordinary completion reply, which arrives on this channel too
     /// and must be left alone for `finalize_retr_stream` to consume, or the
     /// tail of a perfectly good transfer would be thrown away.
+    ///
+    /// TWO PLACES are watched, because a reply can wait in either. `control`
+    /// is the bare socket under the control reader, and its peek sees what
+    /// has arrived but not yet been read. `buffered` is the reader's own
+    /// unconsumed bytes: a server that sends `150` and the final reply in ONE
+    /// segment has both pulled into the reader by the read that collected the
+    /// `150`, and the socket then shows nothing at all. Looking only at the
+    /// socket reported "no reply" in exactly that case, measured as a thirty
+    /// minute wait for an answer already inside the process. The buffered
+    /// bytes are plaintext even under FTPS, so the status class stays
+    /// decidable there when the wire bytes would not be.
     async fn read_watching_control<S>(
         data: &mut S,
         control: &tokio::net::TcpStream,
+        buffered: &[u8],
         buf: &mut [u8],
         watch: &mut ControlWatch,
     ) -> Result<DataStep, ProviderError>
@@ -2740,9 +2762,9 @@ impl FtpProvider {
             // and wait for ever. A remedy for an unbounded wait must not open
             // one where it claims to close them.
             //
-            // The check is another peek, so it consumes nothing and works on an
-            // encrypted channel too: bytes waiting mean the server spoke, even
-            // when what it said cannot be read from this side.
+            // The check looks at both places a reply can wait: another peek,
+            // so it consumes nothing and works on an encrypted channel too,
+            // and the reader's buffer, which the peek cannot see.
             let mut probe = [0u8; 1];
             let mut got = tokio::io::ReadBuf::new(&mut probe);
             // Polled exactly once and always Ready: "is there something now",
@@ -2754,10 +2776,24 @@ impl FtpProvider {
                 })
             })
             .await;
-            return if queued > 0 {
+            return if queued > 0 || !buffered.is_empty() {
                 Ok(DataStep::ControlRefused)
             } else {
                 step
+            };
+        }
+        // A reply the reader is already holding needs no waiting on anything:
+        // classify it from its first byte, exactly as the socket peek does.
+        if let Some(first) = buffered.first() {
+            return match first {
+                b'4' | b'5' => Ok(DataStep::ControlRefused),
+                // A completion reply, or anything else: leave the bytes for
+                // the finalizer and let the shortened deadline take over, the
+                // same treatment the socket arm gives a non-refusal.
+                _ => {
+                    *watch = ControlWatch::Spoke;
+                    Self::read_with_deadline(data, buf, DATA_IDLE_AFTER_CONTROL_SPOKE).await
+                }
             };
         }
         tokio::select! {
@@ -4148,7 +4184,8 @@ mod data_channel_watch_tests {
         let mut watch = ControlWatch::Spoke;
 
         let step =
-            FtpProvider::read_watching_control(&mut data, &control, &mut buf, &mut watch).await;
+            FtpProvider::read_watching_control(&mut data, &control, &[], &mut buf, &mut watch)
+                .await;
 
         match step {
             Err(ProviderError::TransferFailed(msg)) => {
@@ -4186,7 +4223,8 @@ mod data_channel_watch_tests {
         let mut watch = ControlWatch::Spoke;
 
         let step =
-            FtpProvider::read_watching_control(&mut data, &control, &mut buf, &mut watch).await;
+            FtpProvider::read_watching_control(&mut data, &control, &[], &mut buf, &mut watch)
+                .await;
 
         assert!(
             matches!(step, Ok(DataStep::ControlRefused)),
@@ -4280,6 +4318,7 @@ mod data_channel_watch_tests {
             FtpProvider::read_watching_control(
                 &mut data_client,
                 &control_client,
+                &[],
                 &mut buf,
                 &mut watch,
             ),
@@ -4295,6 +4334,91 @@ mod data_channel_watch_tests {
         assert!(
             matches!(watch, ControlWatch::Quiet),
             "a refusal must not move the watch on: the caller still has to read the reply"
+        );
+    }
+
+    /// The refusal the BufReader already swallowed ends the wait, instead of
+    /// the wait outliving the transfer.
+    ///
+    /// The one case a peek on the bare socket cannot see. The server answers
+    /// `RETR` with `150` and the final `550` in ONE segment; suppaftp's
+    /// BufReader, reading the `150`, pulls the whole segment and the refusal
+    /// is now in the reader's buffer, not in the socket. `readable()` never
+    /// fires again and the watch would wait out DATA_IDLE_TIMEOUT, thirty
+    /// minutes, for a reply that arrived together with the first one.
+    ///
+    /// The BufReader is modelled by hand: one read with a buffer large enough
+    /// for both replies is exactly what the reader did when it collected the
+    /// `150`. The assertion on the captured bytes is part of the test, not a
+    /// nicety: if the `550` were still sitting on the socket the peek would
+    /// see it, and the test would pass without ever having exercised the
+    /// defect.
+    ///
+    /// The data socket stays open and silent on purpose: on loopback a server
+    /// that closes it at once would end the wait by another road, which is
+    /// the shortcut measured at the head of `read_watching_control`, and the
+    /// stall would never show.
+    #[tokio::test]
+    async fn a_refusal_absorbed_by_the_reader_ends_the_wait() {
+        use tokio::io::AsyncReadExt;
+
+        let (mut data_client, _data_server_kept_open) = silent_pair().await;
+        let (mut control_client, mut control_server) = silent_pair().await;
+
+        // One write, one segment: the precondition of the whole finding. A
+        // server flushing between the two replies would leave the refusal on
+        // the socket, and that is the case the peek already covers.
+        control_server
+            .write_all(b"150 Opening data connection.\r\n550 Failed to open file.\r\n")
+            .await
+            .unwrap();
+        control_server.flush().await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        // suppaftp's BufReader, answering the command, pulls the segment: it
+        // asked for the `150` and the `550` came along into its buffer. What
+        // the watch is handed is what the reader still holds after consuming
+        // the preliminary reply: everything past the first line.
+        let mut reader_buffer = [0u8; 4096];
+        let swallowed = control_client.read(&mut reader_buffer).await.unwrap();
+        let first_line_end = reader_buffer[..swallowed]
+            .windows(2)
+            .position(|w| w == b"\r\n")
+            .map(|p| p + 2)
+            .expect("the preliminary reply is a full line");
+        let buffered = &reader_buffer[first_line_end..swallowed];
+        assert!(
+            buffered.starts_with(b"550"),
+            "the reader did not absorb the refusal: the test would be proving nothing"
+        );
+        assert_eq!(
+            control_client.try_read(&mut [0u8; 1]).unwrap_err().kind(),
+            std::io::ErrorKind::WouldBlock,
+            "the socket must be empty now: the refusal lives only inside the reader"
+        );
+
+        let mut buf = [0u8; 64];
+        let mut watch = ControlWatch::Quiet;
+        let step = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            FtpProvider::read_watching_control(
+                &mut data_client,
+                &control_client,
+                buffered,
+                &mut buf,
+                &mut watch,
+            ),
+        )
+        .await
+        .expect(
+            "the wait did not end: a refusal already inside the reader is invisible to a peek \
+             on the bare socket, and the transfer hangs until DATA_IDLE_TIMEOUT",
+        )
+        .expect("watching the control channel must not fail");
+
+        assert!(
+            matches!(step, DataStep::ControlRefused),
+            "a refusal the reader already holds has to stop the wait"
         );
     }
 
@@ -4325,6 +4449,7 @@ mod data_channel_watch_tests {
             FtpProvider::read_watching_control(
                 &mut data_client,
                 &control_client,
+                &[],
                 &mut buf,
                 &mut watch,
             ),


### PR DESCRIPTION
## What this is

Pre-release audit finding A-04 (lane A, marked PLAUSIBLE, no fixture run by
the auditor): the data-channel watch in `read_watching_control` peeks the
bare TCP socket UNDERNEATH suppaftp's `BufReader`. When a server sends the
preliminary `150` and the final `4xx/5xx` reply in ONE segment, the read that
collects the `150` pulls the whole segment into the reader's buffer. The
socket then shows nothing, `poll_peek` returns 0, and the transfer waits out
the full `DATA_IDLE_TIMEOUT` (1800 s) for an answer that is already inside
the process.

## Reproduction first

The first step was not the fix, it was making the defect happen. New test
`a_refusal_absorbed_by_the_reader_ends_the_wait`:

- the server writes `150 ...\r\n550 ...\r\n` in a single write (one segment,
  no flush between, which is precisely the condition of the finding; two
  separate writes would have proved nothing);
- the BufReader is modelled by hand: one read with a large buffer, which is
  what the reader did when it collected the `150`;
- two assertions guard the validity of the setup itself: the refusal bytes
  ARE inside the modelled reader buffer, and the socket is empty
  (`WouldBlock`);
- the data socket is held open and silent, so the loopback shortcut measured
  at the head of `read_watching_control` (the data socket closing at once
  and ending the wait by another road) cannot hide the stall.

On the pinned base this test FAILED with a 5 s timeout: the wait never
ended, exactly as predicted. Red seen before the fix.

## The fix

The observation point was wrong, not the case: looking at the socket under
the `BufReader` cannot establish that no reply is already queued. suppaftp
10.0.2 does not expose the reader's buffered bytes (the field is private;
only `get_ref()` is public), so:

- `axpdev-lab/suppaftp`, branch `buffered-reply-bytes` off tag `v10.0.2`,
  adds exactly one method, `buffered_reply_bytes()` (`self.reader.buffer()`),
  consuming nothing. `git diff v10.0.2` on the fork shows only that method.
  Pinned by `rev` in `[patch.crates-io]`, same shape as the existing
  n0-mainline patch, with a written exit condition (drop the patch once an
  upstream release exposes the buffered bytes; upstream PR to be filed from
  the same branch).
- `read_watching_control` now also takes the buffered bytes. In `Quiet`
  state a buffered reply is classified from its first byte, same rule as the
  socket peek (`4`/`5` ends the wait, anything else shortens the deadline
  and leaves the bytes for the finalizer). In `Spoke` state an expired
  deadline counts as a refusal when the socket OR the buffer holds bytes.
- Side effect worth having: the reader's buffer holds plaintext even under
  FTPS, so the 4xx/5xx classification now works where the wire bytes would
  be TLS records.

The refusal itself is still consumed by `read_queued_refusal`, which reads
through the `BufReader` and therefore sees the buffered reply. The reply is
never eaten by the watch.

## Verified

- The new test fails on the pinned base (5 s timeout, reason: the wait did
  not end) and passes with the fix.
- The four pre-existing watch tests still pass, including
  `a_completion_reply_is_left_alone_and_the_data_keeps_flowing` with its
  "peek did not eat the reply" assertion.
- `cargo fmt --all -- --check`, clippy and the full pre-push gate: see
  below, updated before merge if anything moved.

## NOT verified, and which way each limit leans

- Real-server end-to-end: the repro is an in-memory socket pair, not the
  Docker fixture. On loopback the real flow closes the data socket at once
  and the wait ends by another road in about two seconds, so a Docker
  fixture could not have shown the stall anyway (measured constraint, noted
  in the code at the head of `read_watching_control`). The limit leans
  toward the defect being rarer in practice on loopback, unchanged on real
  networks.
- The sibling case named in `after_timed_out_open` (`550` then `421` in one
  segment, session kept with the `421` queued) is NOT fixed here: it is
  tracked separately in the code, and the keep/drop session decision it
  feeds is its own change. The new accessor makes it solvable; the comment
  there now says so.
- The suppaftp fork patch is tokio-only, which is the only flavour this
  crate builds.

---

## Added during the recovery

**The gate was run WITH the patch active**, which is the thing the unit test cannot cover: a forked dependency can break builds the test never touches.

- `cargo test --lib -- providers::ftp::`: **29 passed, 0 failed, 1 ignored**.
- `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo fmt --all -- --check`: clean.
- `Cargo.lock` already carries the git source and the pinned rev, so the patch resolves in CI and not only on one disk. Verified before it was asked for.
- The fork's rev is reachable from the remote (`axpdev-lab/suppaftp`, branch `buffered-reply-bytes`, fork of `veeso/suppaftp`), so `[patch.crates-io]` resolves for anybody, not just here.

**The exit condition was rewritten, because it was inert.** It said "an upstream PR is to be filed from the same branch": a future tense with no subject and no link, which six months from now reads like something that was done. It now states the three things a later reader can check: **who** has to send it (`@axpnet`), the **status in plain words** (`NOT OPENED as of 2026-09-01`), and **where the URL goes** when it exists.

A fork does not become permanent because the exit condition is missing. It becomes permanent because the exit condition is written in a form nobody can verify.

**The upstream PR is prepared and deliberately NOT sent.** Filing a PR on a third-party repository under the account owner's name is an outward-facing action that belongs to the owner, not to whoever is holding the keyboard. Branch, diff and text are ready and the send is one command; it is waiting on a decision, and the Cargo.toml says so out loud.

## Was the fork avoidable

Checked against the crate source rather than assumed. In `suppaftp` 10.0.2, `ImplAsyncFtpStream` keeps `reader: BufReader<DataStream<T>>` **private**, and the only accessor is `get_ref()`, which returns the `TcpStream` **underneath** the buffer. From outside the crate those bytes are not observable at all.

The two alternatives, and why they lose:

- **Consume instead of observe**, reading the control channel when the data channel stalls. Blocked by a constraint already written in this file at the head of `read_watching_control`: `read_response_in` is not cancellation-safe, and a `timeout` around it drops it mid-line and misaligns the control channel. That replaces a control channel we ignore with one we corrupt.
- **Own the control channel ourselves**, parsing replies without suppaftp's reader. It closes everything and it is a rewrite of the FTP reply layer on the evening of a tag, against seventeen lines that can be audited with `git diff v10.0.2`.

So the fork is the honest minimum here, and it has a house precedent in the n0-mainline patch directly above it.


---

## Merge record

Merged at zero incomplete check runs, read from the check-runs API on the head commit rather than from this page, where a superseded `cancelled` run reads as red.

**No review bot read this branch**: CodeRabbit was rate limited across the whole range `5ea980f1..0345f759`, verified across all three surfaces (issue comments, submitted reviews, inline comments on this head) rather than only the first, which is how two Major findings on a sibling pull request were nearly missed tonight.

**The work is Kimi K3's**, including the part that matters most: a test that fails on the pinned base FOR THE PREDICTED REASON, with the `150` and the `550` leaving in one write, the refusal asserted to be inside the reader's buffer and the socket asserted to be empty, and the data channel held open and silent. The chosen vehicle is a direct test on the watch with an in-memory socket pair, not a Docker fixture: the file itself records that on loopback the data socket closes at once and the wait ends by itself, so a fixture there could have shown nothing for a reason unrelated to the defect and the silence would have read as "does not reproduce".

**This ships a forked dependency**, and that is a decision rather than a detail. suppaftp keeps its reader private and `get_ref()` returns the socket UNDER the buffer, so the bytes already absorbed are not observable from outside the crate, verified in the registry source rather than taken on trust. The fork adds one method and nothing else, auditable with `git diff v10.0.2`. The two alternatives were rejected for reasons already written in this file: consuming instead of observing puts a non-cancellation-safe read inside a `select!`, which replaces a control channel we ignore with one we corrupt, and owning the response layer ourselves is a rewrite on the eve of a tag.

The exit condition in `Cargo.toml` names WHO must file the upstream pull request, states that it is not open as of 2026-09-01, and says where the URL goes when it exists. It is prepared and deliberately not sent: opening a pull request against a third-party repository in the owner's name is the owner's call.
