### PR TITLE
fix(rclone-crypt): an empty reveal is not an empty password

### DIFF
--- a/src-tauri/src/rclone_crypt.rs
+++ b/src-tauri/src/rclone_crypt.rs
@@ -175,17 +175,61 @@ pub fn derive_keys(password: &str, salt: &str) -> Result<([u8; 32], [u8; 32]), S
     Ok((name_key, data_key))
 }
 
+/// Which secret is being revealed. The two are NOT interchangeable and the
+/// difference decides one ambiguous case, so the caller has to say.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum RcloneSecret {
+    /// `password` in rclone terms. rclone has no concept of an empty crypt
+    /// password: `rclone obscure ""` is accepted for a salt and meaningless
+    /// here, so an empty reveal is PROOF the input was a literal password.
+    Password,
+    /// `password2`, the salt. Here `obscure("")` is documented and means
+    /// "no salt", which selects rclone's built-in default salt, so an empty
+    /// reveal is a legitimate value and not a failure.
+    Salt,
+}
+
 /// If `value` is an rclone-obscured secret (`rclone obscure` / `rclone.conf`
 /// password / password2), return the revealed plaintext. Otherwise return
 /// `value` unchanged. Closed: a string that is not valid rclone-obscure is
 /// never modified (#600: Ehud pasted rclone.conf password1/password2).
-fn maybe_rclone_reveal(value: &str) -> String {
+///
+/// # The empty reveal, and why the answer depends on the field
+///
+/// rclone-obscure is AES-CTR with a 16-byte IV prepended, base64url without
+/// padding. A 22-character string decodes to exactly 16 bytes: all IV and no
+/// ciphertext, so it reveals as the empty string.
+///
+/// Measured rather than assumed, because the first statement of this was wider
+/// than the truth: it is NOT every 22-character string over `[A-Za-z0-9_-]`.
+/// Strict base64 requires the discarded low bits of the final symbol to be
+/// zero, so the last character must be one of `A`, `Q`, `g`, `w`. That is 4 of
+/// 64, one in sixteen of such passwords, which is rare enough to never appear
+/// in testing and common enough to reach a user: password managers generate
+/// inside that alphabet.
+///
+/// Treating that empty result as the secret would derive the key from nothing
+/// and encrypt with it, silently, which is the worst available outcome: the
+/// data is written, no error is raised, and rclone cannot open it.
+///
+/// The ambiguity is only resolvable per field, and it resolves completely:
+/// for a PASSWORD an empty result cannot be what the user meant, because
+/// rclone has no empty crypt password, so the input must have been a literal
+/// that happened to look like base64. For a SALT it is exactly what
+/// `password2 = obscure("")` means. Same bytes, opposite reading, and the
+/// field is the only thing that tells them apart.
+fn maybe_rclone_reveal(value: &str, secret: RcloneSecret) -> String {
     if value.is_empty() {
         return String::new();
     }
     match crate::rclone_import::reveal_obscured(value) {
-        // Empty reveal is rclone `password2 = obscure("")`: omitted salt,
-        // which must collapse to the default salt, not stay as the blob.
+        Ok(plain) if plain.is_empty() => match secret {
+            // Never plausible: keep the literal the user typed.
+            RcloneSecret::Password => value.to_string(),
+            // rclone `password2 = obscure("")`: omitted salt, which must
+            // collapse to the default salt, not stay as the blob.
+            RcloneSecret::Salt => plain,
+        },
         Ok(plain) if plain != value && plain.chars().all(|c| !c.is_control()) => plain,
         _ => value.to_string(),
     }
@@ -198,8 +242,8 @@ pub fn derive_keys_with_tweak(
     password: &str,
     salt: &str,
 ) -> Result<RcloneCryptKeyMaterial, String> {
-    let password = maybe_rclone_reveal(password);
-    let salt = maybe_rclone_reveal(salt);
+    let password = maybe_rclone_reveal(password, RcloneSecret::Password);
+    let salt = maybe_rclone_reveal(salt, RcloneSecret::Salt);
     // scrypt 0.11 limits Params::len to <=64 for password-hash metadata, but
     // the raw scrypt() function accepts rclone's 80-byte output buffer.
     let params = ScryptParams::new(SCRYPT_LOG_N, SCRYPT_R, SCRYPT_P, SCRYPT_PARAMS_LEN)
@@ -1527,6 +1571,56 @@ mod tests {
         assert_eq!(from_obscured.0, from_plain.0);
         assert_eq!(from_obscured.1, from_plain.1);
         assert_eq!(from_obscured.2, from_plain.2);
+    }
+
+    /// A 22-character password drawn from `[A-Za-z0-9_-]` decodes to exactly
+    /// 16 bytes under base64url, which is the IV and nothing else, so
+    /// rclone-reveal returns the EMPTY STRING for it. Before this was decided
+    /// per field, such a password was silently replaced by nothing and the
+    /// content was encrypted under a key derived from an empty password: no
+    /// error, no sign, and unopenable by rclone. Password managers generate
+    /// inside that alphabet, so the input is ordinary rather than exotic.
+    ///
+    /// The assertion is that the 22-character password behaves like a
+    /// password and NOT like the empty one, which is stronger than asserting
+    /// its literal survival: it would still fail if the value were replaced by
+    /// any other constant.
+    #[test]
+    fn a_22_char_password_is_not_swallowed_by_the_reveal() {
+        let colliding = "Aa0-_Bb1cDd2eEf3gHh4iA";
+        assert_eq!(colliding.len(), 22, "the collision needs exactly 22 chars");
+        assert_eq!(
+            crate::rclone_import::reveal_obscured(colliding).as_deref(),
+            Ok(""),
+            "precondition: this input really does reveal as empty"
+        );
+
+        let from_literal = derive_keys_with_tweak(colliding, "").unwrap();
+        let from_empty = derive_keys_with_tweak("", "").unwrap();
+        assert_ne!(
+            from_literal.0, from_empty.0,
+            "a 22-char password must not derive the same key as no password at all"
+        );
+
+        // And it must be the key of THAT password, not of some other value.
+        let control = derive_keys_with_tweak("Aa0-_Bb1cDd2eEf3gHh4iQ", "").unwrap();
+        assert_ne!(from_literal.0, control.0);
+    }
+
+    /// The other half of the same ambiguity, kept adjacent on purpose: for the
+    /// SALT an empty reveal is `password2 = obscure("")`, which is rclone
+    /// saying "no salt" and must still collapse to the built-in default. The
+    /// two tests fail in opposite directions if the field is ever ignored
+    /// again, which is what makes them a pair rather than a duplicate.
+    #[test]
+    fn a_22_char_salt_still_reads_as_the_default_salt() {
+        let colliding = "Aa0-_Bb1cDd2eEf3gHh4iA";
+        let with_colliding_salt = derive_keys_with_tweak("pw-600", colliding).unwrap();
+        let with_omitted_salt = derive_keys_with_tweak("pw-600", "").unwrap();
+        assert_eq!(
+            with_colliding_salt.0, with_omitted_salt.0,
+            "an empty reveal on the salt is rclone's omitted salt"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes the residual hazard declared on #600, the one that was left as a documented limit rather than fixed.

## The defect

rclone-obscure is AES-CTR with a 16-byte IV prepended, base64url without padding. A 22-character value therefore decodes to exactly 16 bytes: all IV and no ciphertext, so it reveals as the empty string. The reveal was applied identically to the password and to the salt, so a real password of that shape was silently replaced by nothing and the content encrypted under a key derived from an empty password. No error, no sign, and unopenable by rclone.

## The remedy, and why it is an asymmetry and not a heuristic

The ambiguity is only resolvable per field, and there it resolves completely:

- for a **password**, an empty result cannot be what the user meant, because rclone has no empty crypt password, so the input must have been a literal that happened to look like base64. The literal is kept.
- for the **salt**, an empty result is exactly what `password2 = obscure("")` means: an omitted salt, which selects rclone's built-in default. It still collapses to the default.

Same bytes, opposite reading, and the field is the only thing that separates them, which is why the caller now says which secret it is holding.

## Verification

The two tests are a **pair rather than a duplicate**: with the field ignored again, `a_22_char_password_is_not_swallowed_by_the_reveal` FAILS and `a_22_char_salt_still_reads_as_the_default_salt` PASSES. Observed by putting the field-blind behaviour back, not reasoned about.

The password test asserts that the value behaves like a password and NOT like the empty one, rather than asserting its literal survival: that is stronger, because it would still fail if the value were replaced by any other constant.

Gates: `cargo fmt --all -- --check` clean, `cargo clippy --all-targets -- -D warnings` clean, `cargo clippy --bin aeroftp-cli --all-features --tests -- -D warnings` clean, `cargo test --lib` 3693 passed 0 failed, `tsc --noEmit` clean.

## A correction this work produced, which is the part worth reading

The declared scope of the collision was **wider than the truth**, and the regression test is what caught it, by failing on its own precondition.

`4099cc2f` and the reply on the issue both said that ANY 22-character password over `[A-Za-z0-9_-]` reveals as empty. Strict base64 rejects a final symbol whose discarded low bits are non-zero, so the last character must be one of `A`, `Q`, `g`, `w`: four of sixty-four, one in sixteen of such passwords. Rare enough never to appear in testing, common enough to reach someone, since password managers generate inside that alphabet.

The correction is in the source comment and has been posted to the reporter.

## What is NOT verified here

No live rclone round-trip was run for the colliding password specifically: the assertions are on the derived key material, not on a file written by AeroFTP and opened by rclone 1.74.3. That direction was checked for the ordinary cases in `4099cc2f`. The limit leans safe: a wrong answer here would show as a key mismatch in the test, not as a silent pass.

No review bot has read this branch at the time of opening.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of encrypted passwords and salts when obscured values appear empty.
  * Preserved intentionally empty passwords instead of incorrectly replacing them.
  * Applied the expected default behavior for empty secondary salt values.
  * Improved compatibility with ambiguous 22-character password and salt values.
  * Added coverage for these edge cases to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Merge record

Merged at zero incomplete check runs, read from the check-runs API on the head commit rather than from this page, where a superseded `cancelled` run reads as red.

CodeRabbit reviewed the full range `54eec668..22c096c1` and generated no actionable comments. Coverage verified across all three surfaces, issue comments, submitted reviews and inline comments on this head, rather than only the first: reading only issue comments reported "no bot comment" on a sibling pull request that had two Major findings open inline.

The correction in the body is the part worth keeping. The declared scope of this collision was WIDER than the truth, and the regression test written to confirm it is what caught it, by failing on its own precondition. It is one in sixteen of such passwords, not all of them, and the reporter has been told.
