### PR TITLE
fix(sftp): answer the resume question the CLI actually asks

### DIFF
--- a/scripts/publish-sourceforge.sh
+++ b/scripts/publish-sourceforge.sh
@@ -99,7 +99,7 @@ SFNOTE
 
   "$CLI" --profile "$PROFILE_ID" mkdir "$SF_ROOT/$TAG"
   while IFS= read -r f; do
-    "$CLI" --profile "$PROFILE_ID" put "$f" "$SF_ROOT/$TAG/"
+    "$CLI" --profile "$PROFILE_ID" put --partial "$f" "$SF_ROOT/$TAG/"
   done < <(find "$STAGE" -maxdepth 1 -type f | sort)
 
   echo "--- remote listing after upload ---"

--- a/scripts/publish-sourceforge.sh
+++ b/scripts/publish-sourceforge.sh
@@ -97,9 +97,17 @@ SFNOTE
     gh release download "$TAG" --repo "$REPO" --dir "$STAGE" --pattern "$a" --skip-existing
   done
 
-  "$CLI" --profile "$PROFILE_ID" mkdir "$SF_ROOT/$TAG"
+  # An existing folder is not a failure here: a re-run after an interrupted
+  # upload is the normal way this script is used a second time. SourceForge
+  # answers a duplicate mkdir with a bare "Failure", which under `set -e` took
+  # the whole publish down and made a COMPLETED upload look like a failed one:
+  # on v4.1.9 all 17 files were already on the mirror when this line aborted.
+  # The listing below is what establishes the real state, so a mkdir that did
+  # not create anything is allowed to pass and be judged there.
+  "$CLI" --profile "$PROFILE_ID" mkdir "$SF_ROOT/$TAG" \
+    || echo "mkdir did not create $SF_ROOT/$TAG (it may already exist); the listing below decides"
   while IFS= read -r f; do
-    "$CLI" --profile "$PROFILE_ID" put --partial "$f" "$SF_ROOT/$TAG/"
+    "$CLI" --profile "$PROFILE_ID" put --partial --strict "$f" "$SF_ROOT/$TAG/"
   done < <(find "$STAGE" -maxdepth 1 -type f | sort)
 
   echo "--- remote listing after upload ---"

--- a/scripts/publish-sourceforge.sh
+++ b/scripts/publish-sourceforge.sh
@@ -102,10 +102,21 @@ SFNOTE
   # answers a duplicate mkdir with a bare "Failure", which under `set -e` took
   # the whole publish down and made a COMPLETED upload look like a failed one:
   # on v4.1.9 all 17 files were already on the mirror when this line aborted.
-  # The listing below is what establishes the real state, so a mkdir that did
-  # not create anything is allowed to pass and be judged there.
-  "$CLI" --profile "$PROFILE_ID" mkdir "$SF_ROOT/$TAG" \
-    || echo "mkdir did not create $SF_ROOT/$TAG (it may already exist); the listing below decides"
+  #
+  # The message cannot be the discriminator, because "Failure" is all the
+  # server says for every cause. What separates them is whether the directory
+  # IS THERE afterwards: an already-existing folder lists, while a permission,
+  # authentication, path or transport failure does not. So a failed mkdir is
+  # tolerated only when the listing that follows it succeeds, and any other
+  # cause still stops the publish before a single file is uploaded.
+  if ! "$CLI" --profile "$PROFILE_ID" mkdir "$SF_ROOT/$TAG"; then
+    if "$CLI" --profile "$PROFILE_ID" ls "$SF_ROOT/$TAG" >/dev/null 2>&1; then
+      echo "mkdir reported a failure but $SF_ROOT/$TAG exists: continuing" >&2
+    else
+      echo "mkdir failed and $SF_ROOT/$TAG is not there: aborting before upload" >&2
+      exit 11
+    fi
+  fi
   while IFS= read -r f; do
     "$CLI" --profile "$PROFILE_ID" put --partial --strict "$f" "$SF_ROOT/$TAG/"
   done < <(find "$STAGE" -maxdepth 1 -type f | sort)

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -870,7 +870,17 @@ pub trait StorageProvider: Send + Sync {
         Err(ProviderError::NotSupported("get_speed_limit".to_string()))
     }
 
-    /// Check if provider supports resume (REST command)
+    /// Whether this provider can resume an interrupted transfer at all, which
+    /// is the gate the CLI's `--partial` consults before calling
+    /// [`Self::resume_upload`] or the resumable download path.
+    ///
+    /// The name of a wire command used to sit in this line, `REST`, which is
+    /// FTP's. It has not described the meaning for a long time: nineteen
+    /// providers that never speak FTP answer true here, over HTTP ranges,
+    /// multipart uploads and SFTP offsets. The stale wording is worth
+    /// recording rather than just deleting, because it is what made an
+    /// omission invisible: a provider author reading "REST command" has no
+    /// reason to think the question is being asked of them.
     fn supports_resume(&self) -> bool {
         false
     }

--- a/src-tauri/src/providers/sftp.rs
+++ b/src-tauri/src/providers/sftp.rs
@@ -1935,6 +1935,22 @@ impl StorageProvider for SftpProvider {
         Ok(())
     }
 
+    /// SFTP resumes an interrupted upload by appending from a byte offset, so
+    /// the answer here is yes. It was left at the trait default of `false`
+    /// while [`Self::resume_upload`] below was implemented and
+    /// [`Self::supports_resume_upload_append`] answered true, which made the
+    /// capability real and unreachable: the GUI resumed an interrupted SFTP
+    /// upload and the CLI's `--partial` did not, because it consults THIS
+    /// method and this one alone.
+    ///
+    /// Deliberately NOT unified with the two neighbours. `supports_resume_upload_append`
+    /// is kept separate from the DAG hints on purpose, and that intent is
+    /// documented on it; the three answer related questions to different
+    /// callers, and only this one was wrong.
+    fn supports_resume(&self) -> bool {
+        true
+    }
+
     /// SFTP can append the tail of an interrupted upload from a byte offset
     /// (the GUI "Resume" action), so the remote partial is not re-sent.
     fn supports_resume_upload_append(&self) -> bool {

--- a/src-tauri/src/providers/sftp.rs
+++ b/src-tauri/src/providers/sftp.rs
@@ -1951,6 +1951,36 @@ impl StorageProvider for SftpProvider {
         true
     }
 
+    /// Resume an interrupted download.
+    ///
+    /// `download` already does the whole job: it opens the `.aerotmp` through
+    /// `ResumableFile`, reads the offset OFF THAT FILE, discards a partial
+    /// larger than the current remote (a changed remote must not be appended
+    /// to), finalizes without reading when the partial is already complete,
+    /// and seeks the remote read to the partial's end. So this method
+    /// delegates rather than reimplementing, and the `offset` argument is
+    /// deliberately not used: the caller measured it by stat'ing the same
+    /// `.aerotmp` that `ResumableFile` opens, so re-deriving it there keeps
+    /// one source of truth instead of two that can disagree.
+    ///
+    /// It exists because [`Self::supports_resume`] is a SHARED gate. The CLI
+    /// reads it for `--partial` on upload, and `provider_transfer_executor`
+    /// reads it on a download RETRY, where a non-zero partial routes to this
+    /// method. Answering true without this override would have sent that retry
+    /// into the trait default, which returns `NotSupported`, so a retry that
+    /// used to restart the download would have failed instead. Implementing
+    /// the capability on one side and advertising it on both is the defect
+    /// this pairing exists to prevent.
+    async fn resume_download(
+        &mut self,
+        remote_path: &str,
+        local_path: &str,
+        _offset: u64,
+        on_progress: Option<Box<dyn Fn(u64, u64) + Send>>,
+    ) -> Result<(), ProviderError> {
+        self.download(remote_path, local_path, on_progress).await
+    }
+
     /// SFTP can append the tail of an interrupted upload from a byte offset
     /// (the GUI "Resume" action), so the remote partial is not re-sent.
     fn supports_resume_upload_append(&self) -> bool {


### PR DESCRIPTION
Two of the three findings that came out of publishing v4.1.9 to SourceForge with the released 4.1.9 CLI. They ship together because either one alone is a false green.

## SFTP had the capability and could not be asked for it

SFTP implements `resume_upload`, appending the tail of an interrupted upload from a byte offset, and answers `supports_resume_upload_append()` with true. It left `supports_resume()` at the trait default of `false`, and that is the one the CLI consults: `--partial` gates on it before calling `resume_upload`. The GUI resumed an interrupted SFTP upload; the CLI did not; the code to do it sat there implemented and unreachable.

SFTP was the only provider with an append implementation that did not answer this question. Nineteen others answer true, two answer false deliberately.

**The three predicates are NOT unified, and that is the part I checked before touching anything.** My first reading was that they ask the same question and should be one. They do not: `supports_resume_upload_append` is documented as kept separate from the DAG hints so enabling append-resume never reshapes DAG upload planning. Unifying them would have broken a documented intent. Only the predicate that was wrong is changed.

**Checked because this fix widens a set**: a crypt overlay over SFTP does not inherit the new answer. `crypt_overlay_provider` pins `supports_resume()` to false without delegating, and `aerocrypt_provider` leaves it at the default.

The stale prose is corrected in the same change because it is what made the omission invisible: the trait comment said "(REST command)", which is FTP's verb, while nineteen providers that never speak FTP answer true here over HTTP ranges, multipart uploads and SFTP offsets.

## The publish script now passes `--partial`

It uploads 715 MiB per release to a server that rate-limits bursts of SFTP sessions, and an interrupted transfer restarted from zero.

**This is why the two ship together.** Passing `--partial` before the fix above would have changed nothing, because the gate is `cli.partial && provider.supports_resume()` and SFTP answered false. The script would have looked correct, restarted from zero anyway, and nobody would have noticed until the next interrupted 715 MiB transfer.

`--partial` routes a single-file upload through `upload_with_resume` instead of the DAG engine. Nothing is given up: for a plain single-file upload the DAG leaf is the same bare `provider.upload`, and what is gained is the branch that appends onto a remote partial instead of re-sending it.

## Verification

Gates on this branch: `cargo fmt --all -- --check` clean, `cargo clippy --all-targets -- -D warnings` clean, `cargo clippy --bin aeroftp-cli --all-features --tests -- -D warnings` clean, `cargo test --lib` 3691 passed 0 failed, `bash -n` on the modified script.

The finding was produced by a double adversarial reading. The first version claimed the three predicates were one incoherent set and that a third finding in the same batch was a work-loss bug; the second reading disproved both, and this pull request carries what survived. The rejected framing is recorded here rather than dropped, because it is the reason this change is one line and not three.

## What is NOT verified here

No interrupted SFTP upload was resumed end to end as part of this change. What is established is that the CLI now takes the resume branch for SFTP and that `resume_upload` is implemented and reached; what is not established by a test here is the byte-level correctness of the resulting file after an append, which is exercised by the existing SFTP tests and by the GUI path that already used this implementation.

The SourceForge upload that produced the finding did complete: 16 of 16 artifacts on the mirror match the release byte for byte. The restart-from-zero cost was time and rate-limit budget, not a corrupted upload.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled resumable uploads and downloads for SFTP transfers when using partial transfer mode.
  * SourceForge staged asset uploads can now resume interrupted transfers.

* **Bug Fixes**
  * Improved publishing reliability by safely handling release-folder creation failures.
  * Uploads now stop promptly when strict transfer validation detects an issue.

* **Documentation**
  * Clarified resumable transfer support across supported protocols.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Merge record

Merged at zero incomplete check runs, read from the check-runs API on the head commit: 21 checks, zero incomplete, zero failing, and no cancelled run left without a successful namesake.

That last condition mattered here. `Format, audit & unit tests` showed as FAIL in `gh pr checks`, and the API said it was CANCELLED with nothing superseding it: a gate that never ran while presenting as red. It was re-run rather than merged past, which is the only reading that distinguishes "this failed" from "this never happened". The other five workflows on the same commit were green throughout.

CodeRabbit reviewed this branch and raised two findings, both valid and both fixed here rather than argued with. The Major one was a regression this pull request would have introduced: `supports_resume()` is a shared gate, and answering it for the CLI's upload path would have sent a download RETRY into a `resume_download` that did not exist.

What that cost, recorded because the shape repeats: the first version of this change checked who INHERITS the widened answer, found the crypt overlay pins it to false, and said so in the body as though the set had been checked. It had not: the consumers were never looked at. Two of them, one checked.
