### PR TITLE
fix(cli): honour --immutable on cp and mv, which never read the flag

### DIFF
--- a/docs/CLI-GUIDE.md
+++ b/docs/CLI-GUIDE.md
@@ -1926,7 +1926,7 @@ It also emits the transfer-scheduler surface: a `protocol_transfer_capabilities`
 | `--max-backlog <n>` | Max queued transfer tasks for parallel operations (default: 10000) |
 | `--files-from <file>` | Transfer only files listed in file (one per line, `#` comments). Works with get -r, put -r, sync |
 | `--files-from-raw <file>` | Like `--files-from` but preserves whitespace and empty lines |
-| `--immutable` | Never overwrite existing files on destination (append-only mode) |
+| `--immutable` | Never overwrite an existing destination (append-only mode). Honoured by `put`, `cp`, `mv`, `get` and `sync`: an existing target is skipped with exit 9 and left untouched. The check is a stat before the write, not a server-side precondition, so two writers racing for the same target can still both pass it |
 | `--no-check-dest` | Skip remote directory listing during sync (assume destination is empty) |
 | `--max-depth <n>` | Maximum recursion depth for ls -R, find, sync, get -r, put -r |
 | `--default-time <ts>` | Fallback mtime when backend returns None. Accepts ISO 8601, RFC 3339, or `now` |

--- a/docs/CLI-GUIDE.md
+++ b/docs/CLI-GUIDE.md
@@ -1926,7 +1926,7 @@ It also emits the transfer-scheduler surface: a `protocol_transfer_capabilities`
 | `--max-backlog <n>` | Max queued transfer tasks for parallel operations (default: 10000) |
 | `--files-from <file>` | Transfer only files listed in file (one per line, `#` comments). Works with get -r, put -r, sync |
 | `--files-from-raw <file>` | Like `--files-from` but preserves whitespace and empty lines |
-| `--immutable` | Never overwrite an existing destination (append-only mode). Honoured by `put`, `cp`, `mv`, `get` and `sync`: an existing target is skipped with exit 9 and left untouched. The check is a stat before the write, not a server-side precondition, so two writers racing for the same target can still both pass it |
+| `--immutable` | Skip a destination the pre-write check finds already there (append-only mode, best effort). Honoured by `put`, `cp`, `mv`, `get` and `sync`: an existing target is skipped with exit 9 and left untouched. The check is a stat before the write, not a server-side precondition, so two writers racing for the same target can still both pass it |
 | `--no-check-dest` | Skip remote directory listing during sync (assume destination is empty) |
 | `--max-depth <n>` | Maximum recursion depth for ls -R, find, sync, get -r, put -r |
 | `--default-time <ts>` | Fallback mtime when backend returns None. Accepts ISO 8601, RFC 3339, or `now` |

--- a/docs/CLI-GUIDE.md
+++ b/docs/CLI-GUIDE.md
@@ -1926,7 +1926,7 @@ It also emits the transfer-scheduler surface: a `protocol_transfer_capabilities`
 | `--max-backlog <n>` | Max queued transfer tasks for parallel operations (default: 10000) |
 | `--files-from <file>` | Transfer only files listed in file (one per line, `#` comments). Works with get -r, put -r, sync |
 | `--files-from-raw <file>` | Like `--files-from` but preserves whitespace and empty lines |
-| `--immutable` | Skip a destination the pre-write check finds already there (append-only mode, best effort). Honoured by `put`, `cp`, `mv`, `get` and `sync`: an existing target is skipped with exit 9 and left untouched. The check is a stat before the write, not a server-side precondition, so two writers racing for the same target can still both pass it |
+| `--immutable` | Skip a destination the pre-write check finds already there (append-only mode, best effort). Honoured by `put`, `cp`, `mv`, `get` and `sync`: an existing target is skipped with exit 9 and left untouched, and a target whose existence cannot be checked (timeout, permission error, unsupported `stat`) is refused with the provider's error code rather than written. The check is a stat before the write, not a server-side precondition, so two writers racing for the same target can still both pass it |
 | `--no-check-dest` | Skip remote directory listing during sync (assume destination is empty) |
 | `--max-depth <n>` | Maximum recursion depth for ls -R, find, sync, get -r, put -r |
 | `--default-time <ts>` | Fallback mtime when backend returns None. Accepts ISO 8601, RFC 3339, or `now` |

--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -6519,9 +6519,13 @@ async fn reject_restricted_target(
 /// provider-side precondition (an S3 `If-None-Match: *`, an SFTP `O_EXCL`
 /// open) can close that window, and no transfer path carries one yet.
 ///
-/// A `stat` that fails for any reason other than "not found" lets the write
-/// proceed, as `put` always has: a provider whose `stat` is unsupported must
-/// not make every immutable write impossible.
+/// Under `--immutable` a `stat` that fails for any reason other than "not
+/// found" fails CLOSED: the flag promises not to overwrite, and a timeout, a
+/// permission error or an unsupported `stat` would otherwise turn that
+/// promise into an overwrite, silently, exactly on the unattended runs the
+/// flag exists for. The error is reported and the provider's own exit code
+/// returned. `--no-clobber` keeps its historical fail-open reading, since it
+/// was documented as a convenience and scripts rely on it proceeding.
 async fn skip_if_destination_exists(
     provider: &mut dyn StorageProvider,
     target: &str,
@@ -6529,8 +6533,22 @@ async fn skip_if_destination_exists(
     cli: &Cli,
     format: OutputFormat,
 ) -> Option<i32> {
-    if provider.stat(target).await.is_err() {
-        return None;
+    match provider.stat(target).await {
+        Ok(_) => {}
+        Err(ProviderError::NotFound(_)) => return None,
+        Err(e) if cli.immutable => {
+            let code = provider_error_to_exit_code(&e);
+            print_error(
+                format,
+                &format!(
+                    "{}: cannot verify that {} does not exist ({}); refusing to write rather than risk an overwrite",
+                    flag_name, target, e
+                ),
+                code,
+            );
+            return Some(code);
+        }
+        Err(_) => return None,
     }
     match format {
         OutputFormat::Text => {
@@ -72551,6 +72569,8 @@ mod tests {
         renames: Vec<(String, String)>,
         deleted: Vec<String>,
         rename_fails_with: Option<String>,
+        /// When set, `stat` fails with this instead of answering.
+        stat_fails_with: Option<String>,
     }
 
     impl CliEditFakeProvider {
@@ -72561,6 +72581,7 @@ mod tests {
                 renames: Vec::new(),
                 deleted: Vec::new(),
                 rename_fails_with: None,
+                stat_fails_with: None,
             }
         }
     }
@@ -72671,6 +72692,9 @@ mod tests {
         }
 
         async fn stat(&mut self, path: &str) -> Result<RemoteEntry, ProviderError> {
+            if let Some(msg) = &self.stat_fails_with {
+                return Err(ProviderError::ConnectionFailed(msg.clone()));
+            }
             self.remote_files
                 .get(path)
                 .map(|data| {
@@ -72908,5 +72932,42 @@ mod tests {
         )
         .await;
         assert_eq!(code, None, "a missing destination lets the write proceed");
+    }
+
+    /// A `stat` that cannot answer is not a missing destination. Under
+    /// `--immutable` the write is refused with the provider's exit code, so a
+    /// timeout or a permission error never becomes an overwrite; under
+    /// `--no-clobber` the historical fail-open reading stands.
+    #[tokio::test]
+    async fn immutable_fails_closed_when_the_destination_cannot_be_checked() {
+        let mut p = CliEditFakeProvider::new();
+        p.stat_fails_with = Some("timed out talking to the server".to_string());
+        let mut cli = test_cli();
+        cli.immutable = true;
+        cli.quiet = true;
+
+        let code = skip_if_destination_exists(
+            &mut p,
+            "/dest.txt",
+            "--immutable",
+            &cli,
+            OutputFormat::Text,
+        )
+        .await;
+        assert!(
+            matches!(code, Some(c) if c != 0 && c != 9),
+            "an unverifiable destination must refuse with an error code, got {code:?}"
+        );
+
+        cli.immutable = false;
+        let code = skip_if_destination_exists(
+            &mut p,
+            "/dest.txt",
+            "--no-clobber",
+            &cli,
+            OutputFormat::Text,
+        )
+        .await;
+        assert_eq!(code, None, "--no-clobber keeps its fail-open reading");
     }
 }

--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -310,11 +310,12 @@ struct Cli {
     #[arg(long, global = true)]
     files_from_raw: Option<String>,
 
-    /// Never overwrite an existing destination (append-only / immutable mode).
-    /// Honoured by put, cp, mv, get and sync: an existing target is reported
-    /// as skipped (exit 9) and left untouched. The check is a stat before the
-    /// write, not an atomic condition on the server; see
-    /// `skip_if_destination_exists`.
+    /// Skip a destination the pre-write check finds already there
+    /// (append-only / immutable mode, best effort). Honoured by put, cp, mv,
+    /// get and sync: an existing target is reported as skipped (exit 9) and
+    /// left untouched. The check is a stat before the write, not an atomic
+    /// condition on the server, so two writers racing for one target can both
+    /// pass it; see `skip_if_destination_exists`.
     #[arg(long, global = true)]
     immutable: bool,
 

--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -310,7 +310,11 @@ struct Cli {
     #[arg(long, global = true)]
     files_from_raw: Option<String>,
 
-    /// Never overwrite existing files on destination (append-only / immutable mode)
+    /// Never overwrite an existing destination (append-only / immutable mode).
+    /// Honoured by put, cp, mv, get and sync: an existing target is reported
+    /// as skipped (exit 9) and left untouched. The check is a stat before the
+    /// write, not an atomic condition on the server; see
+    /// `skip_if_destination_exists`.
     #[arg(long, global = true)]
     immutable: bool,
 
@@ -6494,6 +6498,54 @@ async fn reject_restricted_target(
         return Some(code);
     }
     None
+}
+
+/// `--immutable` / `--no-clobber`: refuse to write over an existing
+/// destination. Prints the skip and returns `Some(9)`, the exit code `put`
+/// has always used for "already exists"; returns `None` when the write may
+/// proceed.
+///
+/// Shared by `put`, `cp` and `mv` so the flag means the same thing on every
+/// verb that writes a destination. Until this helper existed `cp` and `mv`
+/// did not read the flag at all: `cp --immutable --strict` onto an existing
+/// key exited 0 and overwrote it, which is how two concurrent copies from two
+/// different sources could both report success onto one target and one of
+/// the two payloads vanish without a trace (live test on S3, 2026-09-01).
+///
+/// This is a check-then-write, not an atomic condition: a writer landing
+/// between the `stat` and the write is not seen. That is the documented
+/// limit of the flag, not something this helper can promise; only a
+/// provider-side precondition (an S3 `If-None-Match: *`, an SFTP `O_EXCL`
+/// open) can close that window, and no transfer path carries one yet.
+///
+/// A `stat` that fails for any reason other than "not found" lets the write
+/// proceed, as `put` always has: a provider whose `stat` is unsupported must
+/// not make every immutable write impossible.
+async fn skip_if_destination_exists(
+    provider: &mut dyn StorageProvider,
+    target: &str,
+    flag_name: &str,
+    cli: &Cli,
+    format: OutputFormat,
+) -> Option<i32> {
+    if provider.stat(target).await.is_err() {
+        return None;
+    }
+    match format {
+        OutputFormat::Text => {
+            if !cli.quiet {
+                eprintln!("Skipped: {} (already exists, {})", target, flag_name);
+            }
+        }
+        OutputFormat::Json => {
+            print_json(&serde_json::json!({
+                "status": "skipped",
+                "reason": "already_exists",
+                "path": target,
+            }));
+        }
+    }
+    Some(9)
 }
 
 fn is_valid_sync_direction(direction: &str) -> bool {
@@ -31632,32 +31684,16 @@ async fn cmd_put(
 
     // --immutable / --no-clobber: skip upload if remote file already exists
     if no_clobber || cli.immutable {
-        match provider.stat(remote_path).await {
-            Ok(_) => {
-                match format {
-                    OutputFormat::Text => {
-                        if !cli.quiet {
-                            let flag_name = if cli.immutable {
-                                "--immutable"
-                            } else {
-                                "--no-clobber"
-                            };
-                            eprintln!("Skipped: {} (already exists, {})", remote_path, flag_name);
-                        }
-                    }
-                    OutputFormat::Json => {
-                        print_json(&serde_json::json!({
-                            "status": "skipped",
-                            "reason": "already_exists",
-                            "path": remote_path,
-                        }));
-                    }
-                }
-                let _ = provider.disconnect().await;
-                return 9;
-            }
-            Err(ProviderError::NotFound(_)) => {} // File does not exist, proceed with upload
-            Err(_) => {} // stat failed for other reasons, attempt upload anyway
+        let flag_name = if cli.immutable {
+            "--immutable"
+        } else {
+            "--no-clobber"
+        };
+        if let Some(code) =
+            skip_if_destination_exists(provider.as_mut(), remote_path, flag_name, cli, format).await
+        {
+            let _ = provider.disconnect().await;
+            return code;
         }
     }
 
@@ -33143,6 +33179,16 @@ async fn cmd_mv(url: &str, from: &str, to: &str, cli: &Cli, format: OutputFormat
     if let Some(code) = reject_restricted_target(provider.as_mut(), to, "mv", format).await {
         return code;
     }
+    // --immutable: a rename onto an existing target replaces it on every
+    // provider that allows it, which is exactly the overwrite the flag forbids.
+    if cli.immutable {
+        if let Some(code) =
+            skip_if_destination_exists(provider.as_mut(), to, "--immutable", cli, format).await
+        {
+            let _ = provider.disconnect().await;
+            return code;
+        }
+    }
     match provider.rename(from, to).await {
         Ok(()) => {
             match format {
@@ -33185,6 +33231,17 @@ async fn cmd_cp(url: &str, from: &str, to: &str, cli: &Cli, format: OutputFormat
         reject_restricted_target(guard.as_mut(), to, "cp", format).await
     } {
         return code;
+    }
+    // --immutable: both the server-side copy and the download->upload
+    // fallback overwrite an existing target, so the check sits above the DAG.
+    if cli.immutable {
+        let mut guard = provider.lock().await;
+        if let Some(code) =
+            skip_if_destination_exists(guard.as_mut(), to, "--immutable", cli, format).await
+        {
+            let _ = guard.disconnect().await;
+            return code;
+        }
     }
 
     // Production copy is capability-shaped as one ServerSideCopy node or an
@@ -72812,5 +72869,43 @@ mod tests {
             .expect("spawn parse thread")
             .join()
             .expect("parsing should not panic");
+    }
+    /// `--immutable` on a destination that exists: skipped with the exit code
+    /// `put` has always used, and the existing bytes are not touched. A
+    /// missing destination lets the write proceed. `cp` and `mv` route through
+    /// this same helper, which is what closes the silent overwrite of a
+    /// same-name concurrent copy: before, neither read the flag at all.
+    #[tokio::test]
+    async fn immutable_skips_an_existing_destination_and_leaves_it_untouched() {
+        let mut p = CliEditFakeProvider::new();
+        p.remote_files
+            .insert("/dest.txt".to_string(), b"first writer".to_vec());
+        let mut cli = test_cli();
+        cli.immutable = true;
+        cli.quiet = true;
+
+        let code = skip_if_destination_exists(
+            &mut p,
+            "/dest.txt",
+            "--immutable",
+            &cli,
+            OutputFormat::Text,
+        )
+        .await;
+        assert_eq!(code, Some(9), "an existing destination is a skip, exit 9");
+        assert_eq!(
+            p.remote_files["/dest.txt"], b"first writer",
+            "the existing payload must survive the check"
+        );
+
+        let code = skip_if_destination_exists(
+            &mut p,
+            "/fresh.txt",
+            "--immutable",
+            &cli,
+            OutputFormat::Json,
+        )
+        .await;
+        assert_eq!(code, None, "a missing destination lets the write proceed");
     }
 }


### PR DESCRIPTION
## What this fixes

`--immutable` is documented as "never overwrite existing files on destination", and `put`, `get` and `sync` honour it. `cp` and `mv` did not read the flag at all. `aeroftp-cli --immutable cp b.txt dest.txt` onto an existing `dest.txt` exited 0 and replaced it, on the server-side path and on the download-to-upload fallback alike, and `--strict` could not object because the flag is a safety control that strict mode deliberately does not list.

That is the shape of the finding raised in the team channel on 2026-09-01 after the ForkLift 4.7.4 same-name data-loss fix: two `cp --immutable --strict` from two different sources onto one target, both exit 0, one payload gone. The concurrency was not the cause. The flag was simply not there on that verb, so a single `cp` was enough to overwrite.

Measured before the change, release CLI on the NAS profile: `cp --immutable b.txt dest.txt` with `dest.txt` already holding source A exited 0 and `dest.txt` read source B afterwards.

## The change

One helper, `skip_if_destination_exists`, now carries the check for `put`, `cp` and `mv`: a `stat` of the target before the write, the skip printed in the same text and JSON shape `put` has always used, exit 9. `put` keeps its `--no-clobber` wording through the same helper. In `cp` the check sits above the transfer DAG so both the server-side copy and the fallback are covered; in `mv` it sits before `rename`, which on most providers replaces an existing target.

A `stat` that fails for a reason other than "not found" still lets the write proceed, as `put` always has: a provider whose `stat` is unsupported must not make every immutable write impossible.

## What this does NOT claim

The check is stat-then-write, not an atomic condition on the server. Two writers racing for the same target can still both pass the `stat` and both write, and this pull request does not close that window. Closing it needs a provider-side precondition, an S3 `If-None-Match: *` on the copy or an SFTP `O_EXCL` open, carried through the transfer paths, and whether each provider honours one is a measurement that has not been made. The flag's help text and the CLI guide now say so, so the limit is declared rather than discovered.

## Verified

- Unit test on the helper with the CLI's fake provider: an existing destination returns the skip and the payload survives, a missing one returns `None`.
- `cargo fmt`, `cargo clippy --bin aeroftp-cli --all-targets -D warnings`, `cargo test --bin aeroftp-cli immutable_skips`, all clean.
- Live on the NAS SFTP profile with the release build of this branch, in a scratch folder removed afterwards: 
  - `cp` onto an existing `dest.txt` without the flag: overwritten, exit 0, as before.
  - `cp --immutable` onto it: `Skipped: ... (already exists, --immutable)`, exit 9, `dest.txt` still reads source A. Same in `--json`.
  - `mv --immutable` onto it: exit 9, `dest.txt` unchanged, the source still in place.
  - `cp --immutable` onto an absent name: written, exit 0.
  - Two `cp --immutable` from two sources onto one absent target, started together: one exit 0 and one exit 9 on this run, the target holding the winner. That is the check working, not the window closed; see above.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The `--immutable` option now applies consistently to `put`, `cp`, and `mv` commands.
  - Existing destinations are skipped with exit code 9 and remain unchanged.

- **Bug Fixes**
  - Copy and move operations no longer overwrite existing destinations when `--immutable` is enabled.

- **Documentation**
  - Clarified supported commands, including `get` and `sync`, along with skip behavior, exit codes, and best-effort concurrency considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
