### PR TITLE
fix(sync): export the compare fields the verify policy implies (#514)

### DIFF
--- a/src/utils/syncTemplateApply.test.ts
+++ b/src/utils/syncTemplateApply.test.ts
@@ -105,6 +105,12 @@ describe('AeroSync template import application', () => {
         });
         expect(overlaid.profile.compression_mode).toBe('auto');
         expect(overlaid.profile.verify_policy).toBe('full');
+        // The comparison triple follows the verify policy, not the preset:
+        // the preset says true / true / false, full checksum says compare
+        // by checksum too (#514).
+        expect(overlaid.profile.compare_checksum).toBe(true);
+        expect(overlaid.profile.compare_timestamp).toBe(true);
+        expect(overlaid.profile.compare_size).toBe(true);
         expect(overlaid.profile.canary).toEqual({ percent: 15, selection: 'newest' });
         const imported = settingsFromTemplate(overlaid);
         expect(imported.ok).toBe(true);
@@ -115,6 +121,41 @@ describe('AeroSync template import application', () => {
         expect(patch['plan.canaryMode']).toBe(true);
         expect(patch['plan.canaryPercent']).toBe(15);
         expect(patch['plan.canarySelection']).toBe('newest');
+    });
+
+    it('exports the compare_* triple the verify policy implies, and leaves it alone for none (#514)', () => {
+        const base: SyncTemplate = {
+            schema_version: 1,
+            name: 'T',
+            description: '',
+            created_by: 'test',
+            path_patterns: [{ local: '/a', remote: '/b' }],
+            profile: {
+                direction: 'local_to_remote',
+                compare_timestamp: true,
+                compare_size: true,
+                compare_checksum: false,
+                delete_orphans: true,
+                parallel_streams: 4,
+                compression_mode: 'off',
+            },
+            exclude_patterns: [],
+            schedule: null,
+        };
+        const triple = (t: SyncTemplate) => [t.profile.compare_size, t.profile.compare_timestamp, t.profile.compare_checksum];
+        expect(triple(overlayLivePlanOnTemplate(base, { verifyPolicy: 'full_checksum' }))).toEqual([true, true, true]);
+        expect(triple(overlayLivePlanOnTemplate(base, { verifyPolicy: 'size_and_mtime' }))).toEqual([true, true, false]);
+        expect(triple(overlayLivePlanOnTemplate(base, { verifyPolicy: 'size_only' }))).toEqual([true, false, false]);
+        // `none` says nothing about comparison: the preset's own fields stand.
+        const untouched = overlayLivePlanOnTemplate(
+            { ...base, profile: { ...base.profile, compare_timestamp: false } },
+            { verifyPolicy: 'none' },
+        );
+        expect(triple(untouched)).toEqual([true, false, false]);
+        expect(untouched.profile.verify_policy).toBe('none');
+        // And the round trip: what was exported with size_only comes back as size_only.
+        const imported = settingsFromTemplate(overlayLivePlanOnTemplate(base, { verifyPolicy: 'size_only' }));
+        expect(imported.ok && imported.settings.verifyPolicy).toBe('size_only');
     });
 
     it('maps a legacy wrapper import without inventing absent runtime knobs', () => {

--- a/src/utils/syncTemplateApply.ts
+++ b/src/utils/syncTemplateApply.ts
@@ -90,6 +90,30 @@ function toTemplateVerify(value: VerifyPolicy | AeroSyncVerifyPolicy | undefined
 }
 
 /**
+ * The `compare_*` triple a verify policy implies. The backend serialises the
+ * named preset, so an exported template carried the preset's comparison
+ * fields (true / true / false for every stock preset) whatever the Plan tab
+ * said, and a reader of the file, human or the CLI's `sync`, saw "size and
+ * mtime" on a template exported with full checksum (#514). The verify
+ * policy is the only comparison knob the Plan tab exposes, so it is the
+ * source of truth for all four fields; `none` verifies nothing after the
+ * transfer and says nothing about how to compare, so the preset's own
+ * fields stand.
+ */
+function compareFieldsForVerify(verify: VerifyPolicy): Partial<SyncTemplate['profile']> {
+    switch (verify) {
+        case 'full':
+            return { compare_size: true, compare_timestamp: true, compare_checksum: true };
+        case 'size_and_mtime':
+            return { compare_size: true, compare_timestamp: true, compare_checksum: false };
+        case 'size_only':
+            return { compare_size: true, compare_timestamp: false, compare_checksum: false };
+        case 'none':
+            return {};
+    }
+}
+
+/**
  * Stamp the live Plan-tab values onto an exported .aerosync document.
  * The backend serialises the named preset (Mirror → compression off, no
  * canary, no verify_policy). Without this overlay those knobs round-trip
@@ -102,7 +126,7 @@ export function overlayLivePlanOnTemplate(template: SyncTemplate, live: LivePlan
         profile: {
             ...template.profile,
             ...(live.compressionMode ? { compression_mode: live.compressionMode } : {}),
-            ...(verify ? { verify_policy: verify } : {}),
+            ...(verify ? { verify_policy: verify, ...compareFieldsForVerify(verify) } : {}),
             ...(live.canary
                 ? { canary: { percent: live.canary.percent, selection: live.canary.selection } }
                 : { canary: undefined }),


### PR DESCRIPTION
## What this fixes

#514, the part of the 2026-08-29 retest that v4.1.9 did not cover. The backend serialises the named preset, so every exported AeroSync template carried the preset's comparison triple, `compare_size` / `compare_timestamp` / `compare_checksum` = true / true / false, whatever the Plan tab said. The v4.1.9 overlay added `verify_policy`, compression and canary to the payload, so import stopped resetting them, but the file itself still said "size and mtime" on a template exported with full checksum. A human reading it, or the CLI's `sync` consuming it, saw the opposite of what was chosen.

## The change

The verify policy is the only comparison knob the Plan tab exposes, so it now drives all four fields on export: `full` sets `compare_checksum`, `size_and_mtime` and `size_only` clear the checksum and then the timestamp in turn, and `none`, which verifies nothing after the transfer and says nothing about comparison, leaves the preset's fields alone. Import already prefers `verify_policy`, so the round trip is unchanged and now agrees with the bytes on disk.

## Verified

- Two tests, both red on the previous code and green on this one: the existing Mirror export test now asserts the triple, and a new one walks every policy plus the round trip.
- `tsc --noEmit` clean, `vitest` on the file 9 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Exported sync templates now preserve the comparison settings selected in the Plan tab.
  - Verification policies correctly map to checksum, timestamp, and file-size comparison options.
  - Templates using “none” retain their existing comparison settings.
  - Reopened templates accurately reflect the comparison behavior configured before export, ensuring settings remain consistent after export and reopening.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->