### PR TITLE
fix(onedrive): report the Personal recycle bin as an API limit (#397)

### DIFF
--- a/src-tauri/src/providers/onedrive.rs
+++ b/src-tauri/src/providers/onedrive.rs
@@ -2558,7 +2558,11 @@ mod tests {
             .expect("profile listing failed");
         let matched = profiles
             .iter()
-            .find(|p| p.get("name").and_then(|v| v.as_str()) == Some(profile_query.as_str()))
+            .find(|p| {
+                p.get("name")
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|n| n.eq_ignore_ascii_case(&profile_query))
+            })
             .cloned()
             .expect("test profile not found");
         let profile_id = matched

--- a/src-tauri/src/providers/onedrive.rs
+++ b/src-tauri/src/providers/onedrive.rs
@@ -105,6 +105,43 @@ fn onedrive_retry_marker_tail(
 /// Build a `ProviderError::Other` from a failed OneDrive HTTP response,
 /// appending the Retry-After marker when the response is a throttle
 /// signal. The `context_prefix` is prepended verbatim.
+/// Microsoft Graph exposes no endpoint for the OneDrive Personal recycle bin.
+/// `/me/drive/special/deleted/children` is the shape that works on business
+/// drives, and a personal drive answers it with 400 `invalidRequest: The
+/// special folder identifier isn't valid`: not a bad token, not a bad path,
+/// the bin is simply not addressable through the API for that account kind
+/// (#397). Recognised on the status plus that message, never on the drive
+/// type alone: a personal tenant where the endpoint does work keeps working.
+///
+/// The error is `NotSupported` rather than `Other` so the trash surface
+/// reports a limit rather than a failure, and the message says where the bin
+/// still is: the OneDrive website, which empties it on its own after 30 days.
+fn recycle_bin_not_exposed(
+    status: reqwest::StatusCode,
+    body: &str,
+    drive_type: Option<&str>,
+) -> Option<ProviderError> {
+    if status != reqwest::StatusCode::BAD_REQUEST {
+        return None;
+    }
+    let parsed: serde_json::Value = serde_json::from_str(body).ok()?;
+    let code = parsed["error"]["code"].as_str().unwrap_or_default();
+    let message = parsed["error"]["message"].as_str().unwrap_or_default();
+    if code != "invalidRequest" || !message.contains("special folder identifier") {
+        return None;
+    }
+    let kind = match drive_type {
+        Some("personal") => "This OneDrive Personal account",
+        Some(other) => return Some(ProviderError::NotSupported(format!(
+            "Microsoft Graph does not expose the recycle bin of this OneDrive ({other}) drive, so AeroFTP cannot list, restore or purge it here. Use the Recycle bin on the OneDrive website instead."
+        ))),
+        None => "This OneDrive account",
+    };
+    Some(ProviderError::NotSupported(format!(
+        "{kind} does not expose its recycle bin through Microsoft Graph, so AeroFTP cannot list, restore or purge it here. Use the Recycle bin on onedrive.live.com instead; Microsoft empties it on its own after 30 days."
+    )))
+}
+
 async fn onedrive_error_from_response(
     response: reqwest::Response,
     context_prefix: &str,
@@ -251,6 +288,10 @@ pub struct OneDriveProvider {
     path_cache: HashMap<String, String>,
     /// Authenticated user email
     account_email: Option<String>,
+    /// Graph `driveType` from `/me/drive` at connect: `personal`, `business`
+    /// or `documentLibrary`. Names the account kind in the recycle-bin
+    /// limit below, so the message says which kind of OneDrive this is.
+    drive_type: Option<String>,
     /// Server profile identifier owning these OAuth tokens. Empty when the
     /// caller has not bound a profile (legacy singleton key path). Issue #214.
     profile_id: String,
@@ -290,6 +331,7 @@ impl OneDriveProvider {
             current_item_id: "root".to_string(),
             path_cache: HashMap::new(),
             account_email: None,
+            drive_type: None,
             profile_id: String::new(),
             no_versions: false,
             list_chunk_override: None,
@@ -699,6 +741,23 @@ impl OneDriveProvider {
                 .map_err(|e| ProviderError::ConnectionFailed(e.to_string()))?;
 
             if !response.status().is_success() {
+                let status = response.status();
+                if status == reqwest::StatusCode::BAD_REQUEST {
+                    // The one 400 this endpoint produces on a healthy token is
+                    // Graph saying the recycle bin is not addressable for this
+                    // account (#397). Say that, instead of the raw JSON.
+                    let text = response.text().await.unwrap_or_default();
+                    if let Some(limit) =
+                        recycle_bin_not_exposed(status, &text, self.drive_type.as_deref())
+                    {
+                        return Err(limit);
+                    }
+                    return Err(ProviderError::Other(format!(
+                        "List trash failed: {} {}",
+                        status,
+                        sanitize_api_error(&text)
+                    )));
+                }
                 return Err(onedrive_error_from_response(response, "List trash failed:").await);
             }
 
@@ -968,6 +1027,11 @@ impl StorageProvider for OneDriveProvider {
             if let Some(email) = body["owner"]["user"]["email"].as_str() {
                 self.account_email = Some(email.to_string());
             }
+            self.drive_type = body["driveType"]
+                .as_str()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string);
             // #128-D: persist the Graph drive id + driveType so an rclone export
             // can emit a usable remote. rclone's `onedrive` backend needs
             // `drive_id` + `drive_type` (it fails at use with "unable to get
@@ -2470,6 +2534,91 @@ mod tests {
 
     fn test_provider() -> OneDriveProvider {
         OneDriveProvider::new(OneDriveConfig::new("cid", "csec"))
+    }
+
+    // ─── Live check for #397 on a real account ─────────────────────────
+    //
+    // Run explicitly (never in CI):
+    //   cargo test --release --lib live_personal_recycle_bin -- --ignored --nocapture
+    // Env: ONEDRIVE_TEST_PROFILE (default "OneDrive").
+    //
+    // Connects the saved profile the way the CLI does, reads the drive type
+    // Graph reports, then asks for the recycle bin. On a drive that exposes
+    // it the listing simply succeeds; on one that does not, the answer must
+    // be the declared limit and never the raw 400. Read-only: nothing is
+    // written, trashed or purged.
+    #[tokio::test]
+    #[ignore = "live OneDrive test; run explicitly"]
+    async fn live_personal_recycle_bin_is_reported_as_a_limit() {
+        let profile_query =
+            std::env::var("ONEDRIVE_TEST_PROFILE").unwrap_or_else(|_| "OneDrive".to_string());
+        crate::credential_store::CredentialStore::init().expect("vault init failed");
+        let store = crate::credential_store::CredentialStore::from_cache().expect("vault not open");
+        let profiles = crate::user_partitions::mcp_list_active_server_profiles(&store)
+            .expect("profile listing failed");
+        let matched = profiles
+            .iter()
+            .find(|p| p.get("name").and_then(|v| v.as_str()) == Some(profile_query.as_str()))
+            .cloned()
+            .expect("test profile not found");
+        let profile_id = matched
+            .get("id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let (client_id, client_secret) =
+            crate::bridge_commands::resolve_oauth_client_config(&store, "onedrive");
+        let mut p = OneDriveProvider::new(OneDriveConfig::new(&client_id, &client_secret))
+            .with_profile_id(&profile_id);
+        p.connect().await.expect("connect failed");
+        eprintln!("driveType reported by Graph: {:?}", p.drive_type);
+        match p.list_trash().await {
+            Ok(entries) => eprintln!("recycle bin exposed: {} entries", entries.len()),
+            Err(ProviderError::NotSupported(msg)) => {
+                assert!(msg.contains("recycle bin"), "{msg}");
+                eprintln!("LIMIT (as designed): {msg}");
+            }
+            Err(other) => panic!("a raw failure leaked instead of the limit: {other}"),
+        }
+    }
+
+    /// The exact answer a personal drive gives `/me/drive/special/deleted`
+    /// (#397, reported verbatim): recognised as the API limit it is, and the
+    /// message names the account kind and where the bin still lives. Any
+    /// other 400, and the same body on another status, stay ordinary errors.
+    #[test]
+    fn personal_recycle_bin_400_is_reported_as_a_limit_not_a_failure() {
+        let body = r#"{"error":{"code":"invalidRequest","message":"The special folder identifier isn't valid","innerError":{"date":"2026-07-08T10:00:00","request-id":"r","client-request-id":"c"}}}"#;
+        let bad = reqwest::StatusCode::BAD_REQUEST;
+
+        let limit = recycle_bin_not_exposed(bad, body, Some("personal")).expect("the limit");
+        assert!(matches!(limit, ProviderError::NotSupported(_)), "{limit:?}");
+        let text = limit.to_string();
+        assert!(text.contains("OneDrive Personal"), "{text}");
+        assert!(text.contains("onedrive.live.com"), "{text}");
+        assert!(
+            !text.contains("invalidRequest"),
+            "raw API code must not leak: {text}"
+        );
+
+        // Drive type unknown (connect could not read it): still a limit.
+        let unknown = recycle_bin_not_exposed(bad, body, None).expect("the limit");
+        assert!(unknown.to_string().contains("recycle bin"));
+
+        // A business drive answering the same way is named for what it is.
+        let business = recycle_bin_not_exposed(bad, body, Some("business")).expect("the limit");
+        assert!(business.to_string().contains("business"), "{business}");
+
+        // A different 400 is not this limit.
+        let other = r#"{"error":{"code":"invalidRequest","message":"Invalid filter clause"}}"#;
+        assert!(recycle_bin_not_exposed(bad, other, Some("personal")).is_none());
+        // The same body on a 404 is not this limit either.
+        assert!(
+            recycle_bin_not_exposed(reqwest::StatusCode::NOT_FOUND, body, Some("personal"))
+                .is_none()
+        );
+        // Garbage is never a limit.
+        assert!(recycle_bin_not_exposed(bad, "not json", Some("personal")).is_none());
     }
 
     #[test]

--- a/src-tauri/src/providers/onedrive.rs
+++ b/src-tauri/src/providers/onedrive.rs
@@ -753,7 +753,7 @@ impl OneDriveProvider {
                         return Err(limit);
                     }
                     return Err(ProviderError::Other(format!(
-                        "List trash failed: {} {}",
+                        "List trash failed: {}: {}",
                         status,
                         sanitize_api_error(&text)
                     )));

--- a/src/components/ProvidersDialog.onedrive-trash.test.ts
+++ b/src/components/ProvidersDialog.onedrive-trash.test.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+import { describe, expect, it } from 'vitest';
+
+const sources = import.meta.glob('./ProvidersDialog.tsx', {
+    query: '?raw',
+    import: 'default',
+    eager: true,
+}) as Record<string, string>;
+
+/**
+ * #397: Microsoft Graph does not expose the recycle bin of a OneDrive
+ * Personal drive, and the app reports that as a limit. Help > Providers
+ * keeps the trash tick for OneDrive, because business drives do expose it,
+ * but the tick must carry the caveat and the caveat must reach the tooltip.
+ */
+describe('Help > Providers OneDrive trash', () => {
+    const src = Object.values(sources)[0] ?? '';
+
+    it('keeps trash on the OneDrive row and qualifies it for Personal drives', () => {
+        const start = src.indexOf("{ name: 'OneDrive'");
+        expect(start).toBeGreaterThan(-1);
+        const block = src.slice(start, src.indexOf('advanced:', start));
+        expect(block).toMatch(/'trash'/);
+
+        const details = src.indexOf('const FEATURE_DETAILS');
+        expect(details).toBeGreaterThan(-1);
+        const trash = src.slice(src.indexOf('trash: {', details), src.indexOf('},', src.indexOf('trash: {', details)));
+        expect(trash).toMatch(/onedrive:/);
+        expect(trash).toMatch(/Personal/);
+    });
+
+    it('renders per-feature details on the capability tick, not only on share links', () => {
+        expect(src).toMatch(/FEATURE_DETAILS\[f\]\?\.\[provider\.logoId\]/);
+    });
+});

--- a/src/components/ProvidersDialog.tsx
+++ b/src/components/ProvidersDialog.tsx
@@ -424,12 +424,22 @@ export function ProvidersDialog({ isOpen, onClose }: ProvidersDialogProps) {
                       {OPTIONAL_FEATURES.map(f => (
                         <td key={f} className="text-center py-1.5 px-2">
                           {provider.base.includes(f) ? (
-                            <span
-                              title={(f === 'shareLink' ? SHARE_LINK_DETAILS[provider.logoId] : FEATURE_DETAILS[f]?.[provider.logoId]) || ''}
-                              className={(f === 'shareLink' ? SHARE_LINK_DETAILS[provider.logoId] : FEATURE_DETAILS[f]?.[provider.logoId]) ? 'cursor-help' : ''}
-                            >
-                              <Check size={13} className="inline-block text-emerald-500" />
-                            </span>
+                            (() => {
+                              const detail = (f === 'shareLink' ? SHARE_LINK_DETAILS[provider.logoId] : FEATURE_DETAILS[f]?.[provider.logoId]) || '';
+                              // A caveat that only lives in `title` is unreachable from the
+                              // keyboard and unreliable for screen readers, so a tick that
+                              // carries one is focusable and names it as its label.
+                              return (
+                                <span
+                                  title={detail}
+                                  aria-label={detail ? `${FEATURE_LABELS[f] ?? f}: ${detail}` : undefined}
+                                  tabIndex={detail ? 0 : undefined}
+                                  className={detail ? 'cursor-help inline-block rounded focus:outline-none focus:ring-2 focus:ring-blue-500' : ''}
+                                >
+                                  <Check size={13} className="inline-block text-emerald-500" />
+                                </span>
+                              );
+                            })()
                           ) : (
                             <Minus size={11} className="inline-block text-gray-400 dark:text-gray-600" />
                           )}

--- a/src/components/ProvidersDialog.tsx
+++ b/src/components/ProvidersDialog.tsx
@@ -52,6 +52,18 @@ const FEATURE_LABELS: Record<string, string> = {
   sse: 'Server-Side Encryption', checksum: 'Checksum', tierManagement: 'Tier Management',
 };
 
+// Per-feature, per-provider details for the tooltip on a listed capability.
+// A tick that holds only for some accounts of a provider says so here, so
+// Help never advertises a button the app cannot honour for the reader.
+const FEATURE_DETAILS: Record<string, Record<string, string>> = {
+  trash: {
+    // #397: Microsoft Graph has no endpoint for the OneDrive Personal
+    // recycle bin (`/me/drive/special/deleted` answers 400 invalidRequest
+    // there). The app reports it as a limit; Help must say the same.
+    onedrive: 'Business and SharePoint drives. Microsoft Graph does not expose the recycle bin of a OneDrive Personal drive; use the OneDrive website for it',
+  },
+};
+
 // Share link capability details for tooltip
 const SHARE_LINK_DETAILS: Record<string, string> = {
   googledrive: 'Permissions: view, comment, edit',
@@ -413,8 +425,8 @@ export function ProvidersDialog({ isOpen, onClose }: ProvidersDialogProps) {
                         <td key={f} className="text-center py-1.5 px-2">
                           {provider.base.includes(f) ? (
                             <span
-                              title={f === 'shareLink' ? (SHARE_LINK_DETAILS[provider.logoId] || '') : ''}
-                              className={f === 'shareLink' && SHARE_LINK_DETAILS[provider.logoId] ? 'cursor-help' : ''}
+                              title={(f === 'shareLink' ? SHARE_LINK_DETAILS[provider.logoId] : FEATURE_DETAILS[f]?.[provider.logoId]) || ''}
+                              className={(f === 'shareLink' ? SHARE_LINK_DETAILS[provider.logoId] : FEATURE_DETAILS[f]?.[provider.logoId]) ? 'cursor-help' : ''}
                             >
                               <Check size={13} className="inline-block text-emerald-500" />
                             </span>


### PR DESCRIPTION
## What this fixes

#397, the OneDrive row that has stayed open since v4.1.2. Microsoft Graph has no endpoint for the recycle bin of a OneDrive Personal drive: `/me/drive/special/deleted/children`, the shape that works on business drives, is answered on a personal drive with `400 invalidRequest: The special folder identifier isn't valid`. AeroFTP forwarded that JSON as `List trash failed: 400 Bad Request: {...}`, which reads as a broken request rather than as what it is, an account kind the API does not cover. This is the same class as the pCloud row closed in #642, with one difference: some OneDrive drives do expose the bin, so the control cannot simply be removed.

## The change

- The provider records the `driveType` Graph reports at connect.
- A 400 on the recycle bin listing whose body carries that exact code and message is reported as `NotSupported` with a message that names the account kind, says the bin cannot be listed, restored or purged from here, and points at the OneDrive website, which empties it on its own after 30 days. Recognised on the status plus the message, never on the drive type alone, so a personal tenant where the endpoint works keeps working.
- Any other 400, and the same body on any other status, stay ordinary errors with the raw detail.
- Restore and permanent delete already treated that 400 as "no match"; unchanged.

## Verified

- Unit test with the reported body verbatim: the limit is recognised for a personal drive, for an unknown drive type and for a business drive, each named for what it is, and the raw API code does not leak into the message. A different 400, the same body on a 404, and a non-JSON body are not the limit.
- `cargo fmt`, `cargo clippy --lib --tests -D warnings`, `cargo test --lib providers::onedrive`, all clean.
- Live, read-only, on the saved OneDrive profile with `live_personal_recycle_bin_is_reported_as_a_limit`: Graph reports `driveType: personal` for that profile, the listing answers the reported 400, and the provider returns the limit: "This OneDrive Personal account does not expose its recycle bin through Microsoft Graph, so AeroFTP cannot list, restore or purge it here. Use the Recycle bin on onedrive.live.com instead; Microsoft empties it on its own after 30 days." No raw JSON, nothing written.
- Help > Providers: the OneDrive trash tick now carries the caveat as a tooltip, through a per-feature details map rather than the share-link-only one, pinned by a source test next to the existing pCloud one. `tsc --noEmit` clean, the two dialog tests green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OneDrive Personal drives now clearly report that recycle bin access is unavailable instead of showing a generic error.
  * Improved handling of Microsoft Graph responses when a recycle bin is not exposed across supported drive types.

* **User Experience**
  * Added explanatory details to the Providers dialog for OneDrive trash limitations.
  * Feature capability indicators now provide provider-specific tooltips and keyboard-accessible details when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->