### PR TITLE
fix(kdrive): name the token scopes on the Quick Connect page (#650)

### DIFF
--- a/src/components/ConnectionScreen.tsx
+++ b/src/components/ConnectionScreen.tsx
@@ -5229,6 +5229,11 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                                                     {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
                                                 </button>
                                             </div>
+                                            {/* Said here, before the token is pasted: a drive-only
+                                                token connects fine and only Fetch is refused, with a
+                                                403 naming the scope (#650). The hint has to sit where
+                                                the token is created, not in the error. */}
+                                            <p className="mt-1.5 text-xs text-gray-500 dark:text-gray-400">{t('connection.kdriveTokenScopes')}</p>
                                         </div>
                                         <DiscoverableTargetField
                                             label={t('connection.kdriveDriveId')}

--- a/src/i18n/locales/bg.json
+++ b/src/i18n/locales/bg.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "Поставете вашия API Token тук",
             "kdriveDriveIdPlaceholder": "Вашият kDrive ID (числов)",
             "kdriveTokenHelp": "Генерирайте токен на manager.infomaniak.com → Developer → API Tokens",
-            "kdriveTokenScopes": "Токенът трябва да има обхватите drive и user_info: Fetch чете профила на акаунта ви, за да намери Drive ID, а токен само с drive се отхвърля.",
+            "kdriveTokenScopes": "Токенът трябва да има обхватите drive и user_info. Само с drive той се свързва и показва файловете, но „Извличане“ се отхвърля, защото чете профила на акаунта ви, за да намери Drive ID.",
             "kdriveFindDriveId": "Намерете вашия Drive ID",
             "kdriveFindDriveIdHint": "Числовият Drive ID се показва в адресната лента на тази страница",
             "kdriveCreateToken": "Създайте API токен",

--- a/src/i18n/locales/bg.json
+++ b/src/i18n/locales/bg.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "Поставете вашия API Token тук",
             "kdriveDriveIdPlaceholder": "Вашият kDrive ID (числов)",
             "kdriveTokenHelp": "Генерирайте токен на manager.infomaniak.com → Developer → API Tokens",
+            "kdriveTokenScopes": "Токенът трябва да има обхватите drive и user_info: Fetch чете профила на акаунта ви, за да намери Drive ID, а токен само с drive се отхвърля.",
             "kdriveFindDriveId": "Намерете вашия Drive ID",
             "kdriveFindDriveIdHint": "Числовият Drive ID се показва в адресната лента на тази страница",
             "kdriveCreateToken": "Създайте API токен",

--- a/src/i18n/locales/bn.json
+++ b/src/i18n/locales/bn.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "আপনার API Token এখানে পেস্ট করুন",
             "kdriveDriveIdPlaceholder": "আপনার kDrive ID (সংখ্যাসূচক)",
             "kdriveTokenHelp": "manager.infomaniak.com → Developer → API Tokens এ একটি টোকেন তৈরি করুন",
-            "kdriveTokenScopes": "টোকেনে drive এবং user_info স্কোপ থাকতে হবে: Fetch আপনার অ্যাকাউন্ট প্রোফাইল পড়ে Drive ID খুঁজে বের করে, আর শুধু drive স্কোপযুক্ত টোকেন প্রত্যাখ্যাত হয়।",
+            "kdriveTokenScopes": "টোকেনে drive এবং user_info স্কোপ থাকতে হবে। শুধু drive থাকলে এটি সংযোগ করে ও ফাইল তালিকা দেখায়, কিন্তু \"আনুন\" প্রত্যাখ্যাত হয়, কারণ Drive ID খুঁজতে এটি আপনার অ্যাকাউন্টের প্রোফাইল পড়ে।",
             "kdriveFindDriveId": "আপনার Drive ID খুঁজুন",
             "kdriveFindDriveIdHint": "সংখ্যাসূচক Drive ID এই পৃষ্ঠার ঠিকানা বারে দেখা যায়",
             "kdriveCreateToken": "একটি API টোকেন তৈরি করুন",

--- a/src/i18n/locales/bn.json
+++ b/src/i18n/locales/bn.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "আপনার API Token এখানে পেস্ট করুন",
             "kdriveDriveIdPlaceholder": "আপনার kDrive ID (সংখ্যাসূচক)",
             "kdriveTokenHelp": "manager.infomaniak.com → Developer → API Tokens এ একটি টোকেন তৈরি করুন",
+            "kdriveTokenScopes": "টোকেনে drive এবং user_info স্কোপ থাকতে হবে: Fetch আপনার অ্যাকাউন্ট প্রোফাইল পড়ে Drive ID খুঁজে বের করে, আর শুধু drive স্কোপযুক্ত টোকেন প্রত্যাখ্যাত হয়।",
             "kdriveFindDriveId": "আপনার Drive ID খুঁজুন",
             "kdriveFindDriveIdHint": "সংখ্যাসূচক Drive ID এই পৃষ্ঠার ঠিকানা বারে দেখা যায়",
             "kdriveCreateToken": "একটি API টোকেন তৈরি করুন",

--- a/src/i18n/locales/ca.json
+++ b/src/i18n/locales/ca.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "Enganxeu el vostre API Token aquí",
             "kdriveDriveIdPlaceholder": "El vostre kDrive ID (numèric)",
             "kdriveTokenHelp": "Genereu un token a manager.infomaniak.com → Developer → API Tokens",
-            "kdriveTokenScopes": "El token necessita els àmbits drive i user_info: Fetch llegeix el perfil del vostre compte per trobar el Drive ID, i un token només amb drive és rebutjat.",
+            "kdriveTokenScopes": "El token necessita els àmbits drive i user_info. Només amb drive es connecta i llista els fitxers, però \"Obtén\" es rebutja, perquè llegeix el perfil del vostre compte per trobar el Drive ID.",
             "kdriveFindDriveId": "Trobeu el vostre Drive ID",
             "kdriveFindDriveIdHint": "El Drive ID numèric apareix a la barra d'adreces d'aquesta pàgina",
             "kdriveCreateToken": "Creeu un token d'API",

--- a/src/i18n/locales/ca.json
+++ b/src/i18n/locales/ca.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "Enganxeu el vostre API Token aquí",
             "kdriveDriveIdPlaceholder": "El vostre kDrive ID (numèric)",
             "kdriveTokenHelp": "Genereu un token a manager.infomaniak.com → Developer → API Tokens",
+            "kdriveTokenScopes": "El token necessita els àmbits drive i user_info: Fetch llegeix el perfil del vostre compte per trobar el Drive ID, i un token només amb drive és rebutjat.",
             "kdriveFindDriveId": "Trobeu el vostre Drive ID",
             "kdriveFindDriveIdHint": "El Drive ID numèric apareix a la barra d'adreces d'aquesta pàgina",
             "kdriveCreateToken": "Creeu un token d'API",

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "Vložte svůj API Token sem",
             "kdriveDriveIdPlaceholder": "Vaše kDrive ID (číselné)",
             "kdriveTokenHelp": "Vygenerujte token na manager.infomaniak.com → Developer → API Tokens",
+            "kdriveTokenScopes": "Token potřebuje rozsahy drive a user_info: Fetch čte profil vašeho účtu, aby našel Drive ID, a token pouze s drive je odmítnut.",
             "kdriveFindDriveId": "Najděte své Drive ID",
             "kdriveFindDriveIdHint": "Číselné Drive ID se zobrazuje v adresním řádku této stránky",
             "kdriveCreateToken": "Vytvořte token API",

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "Vložte svůj API Token sem",
             "kdriveDriveIdPlaceholder": "Vaše kDrive ID (číselné)",
             "kdriveTokenHelp": "Vygenerujte token na manager.infomaniak.com → Developer → API Tokens",
-            "kdriveTokenScopes": "Token potřebuje rozsahy drive a user_info: Fetch čte profil vašeho účtu, aby našel Drive ID, a token pouze s drive je odmítnut.",
+            "kdriveTokenScopes": "Token potřebuje rozsahy drive a user_info. Pouze s drive se připojí a vypíše soubory, ale „Načíst“ je odmítnuto, protože čte profil vašeho účtu, aby našlo Drive ID.",
             "kdriveFindDriveId": "Najděte své Drive ID",
             "kdriveFindDriveIdHint": "Číselné Drive ID se zobrazuje v adresním řádku této stránky",
             "kdriveCreateToken": "Vytvořte token API",

--- a/src/i18n/locales/cy.json
+++ b/src/i18n/locales/cy.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "Gludiwch eich API Token yma",
             "kdriveDriveIdPlaceholder": "Eich kDrive ID (rhifiadol)",
             "kdriveTokenHelp": "Cynhyrchwch docyn ar manager.infomaniak.com → Developer → API Tokens",
+            "kdriveTokenScopes": "Mae angen y cwmpasau drive a user_info ar y tocyn: mae Fetch yn darllen proffil eich cyfrif i ddod o hyd i'r Drive ID, ac mae tocyn gyda drive yn unig yn cael ei wrthod.",
             "kdriveFindDriveId": "Dewch o hyd i'ch Drive ID",
             "kdriveFindDriveIdHint": "Mae'r Drive ID rhifiadol yn ymddangos ym mar cyfeiriad y dudalen hon",
             "kdriveCreateToken": "Creu tocyn API",

--- a/src/i18n/locales/cy.json
+++ b/src/i18n/locales/cy.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "Gludiwch eich API Token yma",
             "kdriveDriveIdPlaceholder": "Eich kDrive ID (rhifiadol)",
             "kdriveTokenHelp": "Cynhyrchwch docyn ar manager.infomaniak.com → Developer → API Tokens",
-            "kdriveTokenScopes": "Mae angen y cwmpasau drive a user_info ar y tocyn: mae Fetch yn darllen proffil eich cyfrif i ddod o hyd i'r Drive ID, ac mae tocyn gyda drive yn unig yn cael ei wrthod.",
+            "kdriveTokenScopes": "Mae angen y cwmpasau drive a user_info ar y tocyn. Gyda drive yn unig mae'n cysylltu ac yn rhestru ffeiliau, ond mae \"Nôl\" yn cael ei wrthod, am ei fod yn darllen proffil eich cyfrif i ddod o hyd i'r Drive ID.",
             "kdriveFindDriveId": "Dewch o hyd i'ch Drive ID",
             "kdriveFindDriveIdHint": "Mae'r Drive ID rhifiadol yn ymddangos ym mar cyfeiriad y dudalen hon",
             "kdriveCreateToken": "Creu tocyn API",

--- a/src/i18n/locales/da.json
+++ b/src/i18n/locales/da.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "Indsæt dit API Token her",
             "kdriveDriveIdPlaceholder": "Dit kDrive ID (numerisk)",
             "kdriveTokenHelp": "Generér et token på manager.infomaniak.com → Developer → API Tokens",
-            "kdriveTokenScopes": "Tokenet skal have scopes drive og user_info: Fetch læser din kontoprofil for at finde Drive ID, og et token med drive alene afvises.",
+            "kdriveTokenScopes": "Tokenet skal have scopes drive og user_info. Med drive alene forbinder det og viser filer, men \"Hent\" afvises, fordi den læser din kontoprofil for at finde Drive ID.",
             "kdriveFindDriveId": "Find dit Drive ID",
             "kdriveFindDriveIdHint": "Det numeriske Drive ID vises i adresselinjen på denne side",
             "kdriveCreateToken": "Opret et API-token",

--- a/src/i18n/locales/da.json
+++ b/src/i18n/locales/da.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "Indsæt dit API Token her",
             "kdriveDriveIdPlaceholder": "Dit kDrive ID (numerisk)",
             "kdriveTokenHelp": "Generér et token på manager.infomaniak.com → Developer → API Tokens",
+            "kdriveTokenScopes": "Tokenet skal have scopes drive og user_info: Fetch læser din kontoprofil for at finde Drive ID, og et token med drive alene afvises.",
             "kdriveFindDriveId": "Find dit Drive ID",
             "kdriveFindDriveIdHint": "Det numeriske Drive ID vises i adresselinjen på denne side",
             "kdriveCreateToken": "Opret et API-token",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "Fügen Sie Ihren API Token hier ein",
             "kdriveDriveIdPlaceholder": "Ihre kDrive ID (numerisch)",
             "kdriveTokenHelp": "Generieren Sie einen Token unter manager.infomaniak.com → Developer → API Tokens",
-            "kdriveTokenScopes": "Das Token braucht die Scopes drive und user_info: Fetch liest Ihr Kontoprofil, um die Drive ID zu finden, und ein Token nur mit drive wird abgelehnt.",
+            "kdriveTokenScopes": "Das Token braucht die Scopes drive und user_info. Mit drive allein verbindet es sich und listet Dateien, aber „Abrufen“ wird abgelehnt, weil es Ihr Kontoprofil liest, um die Drive ID zu finden.",
             "kdriveFindDriveId": "Ihre Drive ID finden",
             "kdriveFindDriveIdHint": "Die numerische Drive ID erscheint in der Adressleiste dieser Seite",
             "kdriveCreateToken": "Einen API-Token erstellen",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "Fügen Sie Ihren API Token hier ein",
             "kdriveDriveIdPlaceholder": "Ihre kDrive ID (numerisch)",
             "kdriveTokenHelp": "Generieren Sie einen Token unter manager.infomaniak.com → Developer → API Tokens",
+            "kdriveTokenScopes": "Das Token braucht die Scopes drive und user_info: Fetch liest Ihr Kontoprofil, um die Drive ID zu finden, und ein Token nur mit drive wird abgelehnt.",
             "kdriveFindDriveId": "Ihre Drive ID finden",
             "kdriveFindDriveIdHint": "Die numerische Drive ID erscheint in der Adressleiste dieser Seite",
             "kdriveCreateToken": "Einen API-Token erstellen",

--- a/src/i18n/locales/el.json
+++ b/src/i18n/locales/el.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "Επικολλήστε το API Token σας εδώ",
             "kdriveDriveIdPlaceholder": "Το kDrive ID σας (αριθμητικό)",
             "kdriveTokenHelp": "Δημιουργήστε ένα token στο manager.infomaniak.com → Developer → API Tokens",
-            "kdriveTokenScopes": "Το token χρειάζεται τα scopes drive και user_info: το Fetch διαβάζει το προφίλ του λογαριασμού σας για να βρει το Drive ID, και ένα token μόνο με drive απορρίπτεται.",
+            "kdriveTokenScopes": "Το token χρειάζεται τα scopes drive και user_info. Μόνο με drive συνδέεται και εμφανίζει αρχεία, αλλά το «Ανάκτηση» απορρίπτεται, επειδή διαβάζει το προφίλ του λογαριασμού σας για να βρει το Drive ID.",
             "kdriveFindDriveId": "Βρείτε το Drive ID σας",
             "kdriveFindDriveIdHint": "Το αριθμητικό Drive ID εμφανίζεται στη γραμμή διευθύνσεων αυτής της σελίδας",
             "kdriveCreateToken": "Δημιουργήστε ένα token API",

--- a/src/i18n/locales/el.json
+++ b/src/i18n/locales/el.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "Επικολλήστε το API Token σας εδώ",
             "kdriveDriveIdPlaceholder": "Το kDrive ID σας (αριθμητικό)",
             "kdriveTokenHelp": "Δημιουργήστε ένα token στο manager.infomaniak.com → Developer → API Tokens",
+            "kdriveTokenScopes": "Το token χρειάζεται τα scopes drive και user_info: το Fetch διαβάζει το προφίλ του λογαριασμού σας για να βρει το Drive ID, και ένα token μόνο με drive απορρίπτεται.",
             "kdriveFindDriveId": "Βρείτε το Drive ID σας",
             "kdriveFindDriveIdHint": "Το αριθμητικό Drive ID εμφανίζεται στη γραμμή διευθύνσεων αυτής της σελίδας",
             "kdriveCreateToken": "Δημιουργήστε ένα token API",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1243,6 +1243,7 @@
             "kdriveTokenPlaceholder": "Paste your API token here",
             "kdriveDriveIdPlaceholder": "Your kDrive ID (numeric)",
             "kdriveTokenHelp": "Generate a token in Infomaniak Manager → User Profile → Developer → API Tokens",
+            "kdriveTokenScopes": "The token needs the drive and user_info scopes: Fetch reads your account profile to find the Drive ID, and a token with drive alone is refused.",
             "kdriveFindDriveId": "Find your Drive ID",
             "kdriveFindDriveIdHint": "The numeric Drive ID appears in the address bar of this page",
             "kdriveCreateToken": "Create an API token",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1243,7 +1243,7 @@
             "kdriveTokenPlaceholder": "Paste your API token here",
             "kdriveDriveIdPlaceholder": "Your kDrive ID (numeric)",
             "kdriveTokenHelp": "Generate a token in Infomaniak Manager → User Profile → Developer → API Tokens",
-            "kdriveTokenScopes": "The token needs the drive and user_info scopes: Fetch reads your account profile to find the Drive ID, and a token with drive alone is refused.",
+            "kdriveTokenScopes": "The token needs the drive and user_info scopes. With drive alone it connects and lists files, but \"Fetch\" is refused, because it reads your account profile to find the Drive ID.",
             "kdriveFindDriveId": "Find your Drive ID",
             "kdriveFindDriveIdHint": "The numeric Drive ID appears in the address bar of this page",
             "kdriveCreateToken": "Create an API token",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "Pegue su API Token aquí",
             "kdriveDriveIdPlaceholder": "Su kDrive ID (numérico)",
             "kdriveTokenHelp": "Genere un token en manager.infomaniak.com → Developer → API Tokens",
+            "kdriveTokenScopes": "El token necesita los ámbitos drive y user_info: Fetch lee el perfil de tu cuenta para encontrar el Drive ID, y un token solo con drive es rechazado.",
             "kdriveFindDriveId": "Encuentre su Drive ID",
             "kdriveFindDriveIdHint": "El Drive ID numérico aparece en la barra de direcciones de esta página",
             "kdriveCreateToken": "Cree un token de API",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "Pegue su API Token aquí",
             "kdriveDriveIdPlaceholder": "Su kDrive ID (numérico)",
             "kdriveTokenHelp": "Genere un token en manager.infomaniak.com → Developer → API Tokens",
-            "kdriveTokenScopes": "El token necesita los ámbitos drive y user_info: Fetch lee el perfil de tu cuenta para encontrar el Drive ID, y un token solo con drive es rechazado.",
+            "kdriveTokenScopes": "El token necesita los ámbitos drive y user_info. Solo con drive se conecta y lista archivos, pero \"Obtener\" se rechaza, porque lee el perfil de tu cuenta para encontrar el Drive ID.",
             "kdriveFindDriveId": "Encuentre su Drive ID",
             "kdriveFindDriveIdHint": "El Drive ID numérico aparece en la barra de direcciones de esta página",
             "kdriveCreateToken": "Cree un token de API",

--- a/src/i18n/locales/et.json
+++ b/src/i18n/locales/et.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "Kleepige oma API Token siia",
             "kdriveDriveIdPlaceholder": "Teie kDrive ID (numbriline)",
             "kdriveTokenHelp": "Looge token aadressil manager.infomaniak.com → Developer → API Tokens",
-            "kdriveTokenScopes": "Token vajab õigusi drive ja user_info: Fetch loeb teie konto profiili, et leida Drive ID, ning ainult drive õigusega token lükatakse tagasi.",
+            "kdriveTokenScopes": "Token vajab õigusi drive ja user_info. Ainult drive õigusega see ühendub ja kuvab faile, kuid \"Too\" lükatakse tagasi, sest see loeb teie konto profiili, et leida Drive ID.",
             "kdriveFindDriveId": "Leidke oma Drive ID",
             "kdriveFindDriveIdHint": "Numbriline Drive ID kuvatakse selle lehe aadressiribal",
             "kdriveCreateToken": "Looge API token",

--- a/src/i18n/locales/et.json
+++ b/src/i18n/locales/et.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "Kleepige oma API Token siia",
             "kdriveDriveIdPlaceholder": "Teie kDrive ID (numbriline)",
             "kdriveTokenHelp": "Looge token aadressil manager.infomaniak.com → Developer → API Tokens",
+            "kdriveTokenScopes": "Token vajab õigusi drive ja user_info: Fetch loeb teie konto profiili, et leida Drive ID, ning ainult drive õigusega token lükatakse tagasi.",
             "kdriveFindDriveId": "Leidke oma Drive ID",
             "kdriveFindDriveIdHint": "Numbriline Drive ID kuvatakse selle lehe aadressiribal",
             "kdriveCreateToken": "Looge API token",

--- a/src/i18n/locales/eu.json
+++ b/src/i18n/locales/eu.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "Itsatsi zure API Token hemen",
             "kdriveDriveIdPlaceholder": "Zure kDrive ID (zenbakizkoa)",
             "kdriveTokenHelp": "Sortu token bat manager.infomaniak.com → Developer → API Tokens gunean",
-            "kdriveTokenScopes": "Tokenak drive eta user_info esparruak behar ditu: Fetch-ek zure kontuaren profila irakurtzen du Drive ID aurkitzeko, eta drive bakarrik duen token bat baztertu egiten da.",
+            "kdriveTokenScopes": "Tokenak drive eta user_info esparruak behar ditu. drive bakarrik izanda konektatu eta fitxategiak zerrendatzen ditu, baina \"Eskuratu\" baztertu egiten da, zure kontuaren profila irakurtzen duelako Drive ID aurkitzeko.",
             "kdriveFindDriveId": "Aurkitu zure Drive ID",
             "kdriveFindDriveIdHint": "Drive ID zenbakizkoa orri honen helbide-barran agertzen da",
             "kdriveCreateToken": "Sortu API token bat",

--- a/src/i18n/locales/eu.json
+++ b/src/i18n/locales/eu.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "Itsatsi zure API Token hemen",
             "kdriveDriveIdPlaceholder": "Zure kDrive ID (zenbakizkoa)",
             "kdriveTokenHelp": "Sortu token bat manager.infomaniak.com → Developer → API Tokens gunean",
+            "kdriveTokenScopes": "Tokenak drive eta user_info esparruak behar ditu: Fetch-ek zure kontuaren profila irakurtzen du Drive ID aurkitzeko, eta drive bakarrik duen token bat baztertu egiten da.",
             "kdriveFindDriveId": "Aurkitu zure Drive ID",
             "kdriveFindDriveIdHint": "Drive ID zenbakizkoa orri honen helbide-barran agertzen da",
             "kdriveCreateToken": "Sortu API token bat",

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "Liitä API Token tähän",
             "kdriveDriveIdPlaceholder": "kDrive ID (numeerinen)",
             "kdriveTokenHelp": "Luo token osoitteessa manager.infomaniak.com → Developer → API Tokens",
+            "kdriveTokenScopes": "Tunnus tarvitsee oikeudet drive ja user_info: Fetch lukee tilisi profiilin löytääkseen Drive ID:n, ja pelkällä drive-oikeudella varustettu tunnus hylätään.",
             "kdriveFindDriveId": "Etsi Drive ID",
             "kdriveFindDriveIdHint": "Numeerinen Drive ID näkyy tämän sivun osoiterivillä",
             "kdriveCreateToken": "Luo API-token",

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "Liitä API Token tähän",
             "kdriveDriveIdPlaceholder": "kDrive ID (numeerinen)",
             "kdriveTokenHelp": "Luo token osoitteessa manager.infomaniak.com → Developer → API Tokens",
-            "kdriveTokenScopes": "Tunnus tarvitsee oikeudet drive ja user_info: Fetch lukee tilisi profiilin löytääkseen Drive ID:n, ja pelkällä drive-oikeudella varustettu tunnus hylätään.",
+            "kdriveTokenScopes": "Tunnus tarvitsee oikeudet drive ja user_info. Pelkällä drive-oikeudella se yhdistää ja listaa tiedostot, mutta \"Hae\" hylätään, koska se lukee tilisi profiilin löytääkseen Drive ID:n.",
             "kdriveFindDriveId": "Etsi Drive ID",
             "kdriveFindDriveIdHint": "Numeerinen Drive ID näkyy tämän sivun osoiterivillä",
             "kdriveCreateToken": "Luo API-token",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "Collez votre API Token ici",
             "kdriveDriveIdPlaceholder": "Votre kDrive ID (numérique)",
             "kdriveTokenHelp": "Générez un token sur manager.infomaniak.com → Developer → API Tokens",
+            "kdriveTokenScopes": "Le jeton doit avoir les portées drive et user_info : Fetch lit le profil de votre compte pour trouver le Drive ID, et un jeton avec drive seul est refusé.",
             "kdriveFindDriveId": "Trouvez votre Drive ID",
             "kdriveFindDriveIdHint": "Le Drive ID numérique apparaît dans la barre d'adresse de cette page",
             "kdriveCreateToken": "Créez un token d'API",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "Collez votre API Token ici",
             "kdriveDriveIdPlaceholder": "Votre kDrive ID (numérique)",
             "kdriveTokenHelp": "Générez un token sur manager.infomaniak.com → Developer → API Tokens",
-            "kdriveTokenScopes": "Le jeton doit avoir les portées drive et user_info : Fetch lit le profil de votre compte pour trouver le Drive ID, et un jeton avec drive seul est refusé.",
+            "kdriveTokenScopes": "Le jeton doit avoir les portées drive et user_info. Avec drive seul il se connecte et liste les fichiers, mais « Récupérer » est refusé, car il lit le profil de votre compte pour trouver le Drive ID.",
             "kdriveFindDriveId": "Trouvez votre Drive ID",
             "kdriveFindDriveIdHint": "Le Drive ID numérique apparaît dans la barre d'adresse de cette page",
             "kdriveCreateToken": "Créez un token d'API",

--- a/src/i18n/locales/gl.json
+++ b/src/i18n/locales/gl.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "Pegue o seu API Token aquí",
             "kdriveDriveIdPlaceholder": "O seu kDrive ID (numérico)",
             "kdriveTokenHelp": "Xere un token en manager.infomaniak.com → Developer → API Tokens",
+            "kdriveTokenScopes": "O token necesita os ámbitos drive e user_info: Fetch le o perfil da túa conta para atopar o Drive ID, e un token só con drive é rexeitado.",
             "kdriveFindDriveId": "Atope o seu Drive ID",
             "kdriveFindDriveIdHint": "O Drive ID numérico aparece na barra de enderezos desta páxina",
             "kdriveCreateToken": "Cree un token de API",

--- a/src/i18n/locales/gl.json
+++ b/src/i18n/locales/gl.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "Pegue o seu API Token aquí",
             "kdriveDriveIdPlaceholder": "O seu kDrive ID (numérico)",
             "kdriveTokenHelp": "Xere un token en manager.infomaniak.com → Developer → API Tokens",
-            "kdriveTokenScopes": "O token necesita os ámbitos drive e user_info: Fetch le o perfil da túa conta para atopar o Drive ID, e un token só con drive é rexeitado.",
+            "kdriveTokenScopes": "O token necesita os ámbitos drive e user_info. Só con drive conéctase e lista os ficheiros, pero \"Obter\" é rexeitado, porque le o perfil da túa conta para atopar o Drive ID.",
             "kdriveFindDriveId": "Atope o seu Drive ID",
             "kdriveFindDriveIdHint": "O Drive ID numérico aparece na barra de enderezos desta páxina",
             "kdriveCreateToken": "Cree un token de API",

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "अपना API Token यहाँ पेस्ट करें",
             "kdriveDriveIdPlaceholder": "आपका kDrive ID (संख्यात्मक)",
             "kdriveTokenHelp": "manager.infomaniak.com → Developer → API Tokens पर टोकन बनाएँ",
+            "kdriveTokenScopes": "टोकन में drive और user_info स्कोप होने चाहिए: Fetch आपकी खाता प्रोफ़ाइल पढ़कर Drive ID खोजता है, और केवल drive वाला टोकन अस्वीकार कर दिया जाता है।",
             "kdriveFindDriveId": "अपना Drive ID खोजें",
             "kdriveFindDriveIdHint": "संख्यात्मक Drive ID इस पृष्ठ के पता बार में दिखाई देता है",
             "kdriveCreateToken": "एक API टोकन बनाएँ",

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "अपना API Token यहाँ पेस्ट करें",
             "kdriveDriveIdPlaceholder": "आपका kDrive ID (संख्यात्मक)",
             "kdriveTokenHelp": "manager.infomaniak.com → Developer → API Tokens पर टोकन बनाएँ",
-            "kdriveTokenScopes": "टोकन में drive और user_info स्कोप होने चाहिए: Fetch आपकी खाता प्रोफ़ाइल पढ़कर Drive ID खोजता है, और केवल drive वाला टोकन अस्वीकार कर दिया जाता है।",
+            "kdriveTokenScopes": "टोकन में drive और user_info स्कोप होने चाहिए। केवल drive के साथ यह कनेक्ट होकर फ़ाइलें सूचीबद्ध करता है, लेकिन \"प्राप्त करें\" अस्वीकार हो जाता है, क्योंकि यह Drive ID खोजने के लिए आपके खाते की प्रोफ़ाइल पढ़ता है।",
             "kdriveFindDriveId": "अपना Drive ID खोजें",
             "kdriveFindDriveIdHint": "संख्यात्मक Drive ID इस पृष्ठ के पता बार में दिखाई देता है",
             "kdriveCreateToken": "एक API टोकन बनाएँ",

--- a/src/i18n/locales/hr.json
+++ b/src/i18n/locales/hr.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "Zalijepite svoj API Token ovdje",
             "kdriveDriveIdPlaceholder": "Vaš kDrive ID (numerički)",
             "kdriveTokenHelp": "Generirajte token na manager.infomaniak.com → Developer → API Tokens",
+            "kdriveTokenScopes": "Token treba opsege drive i user_info: Fetch čita profil vašeg računa da bi pronašao Drive ID, a token samo s drive se odbija.",
             "kdriveFindDriveId": "Pronađite svoj Drive ID",
             "kdriveFindDriveIdHint": "Numerički Drive ID prikazuje se u adresnoj traci ove stranice",
             "kdriveCreateToken": "Stvorite API token",

--- a/src/i18n/locales/hr.json
+++ b/src/i18n/locales/hr.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "Zalijepite svoj API Token ovdje",
             "kdriveDriveIdPlaceholder": "Vaš kDrive ID (numerički)",
             "kdriveTokenHelp": "Generirajte token na manager.infomaniak.com → Developer → API Tokens",
-            "kdriveTokenScopes": "Token treba opsege drive i user_info: Fetch čita profil vašeg računa da bi pronašao Drive ID, a token samo s drive se odbija.",
+            "kdriveTokenScopes": "Token treba opsege drive i user_info. Samo s drive povezuje se i prikazuje datoteke, ali „Dohvati“ se odbija, jer čita profil vašeg računa da bi pronašao Drive ID.",
             "kdriveFindDriveId": "Pronađite svoj Drive ID",
             "kdriveFindDriveIdHint": "Numerički Drive ID prikazuje se u adresnoj traci ove stranice",
             "kdriveCreateToken": "Stvorite API token",

--- a/src/i18n/locales/hu.json
+++ b/src/i18n/locales/hu.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "Illessze be az API tokent ide",
             "kdriveDriveIdPlaceholder": "Az Ön kDrive azonosítója (szám)",
             "kdriveTokenHelp": "Token létrehozása: manager.infomaniak.com → Developer → API Tokens",
-            "kdriveTokenScopes": "A tokenhez a drive és a user_info hatókör kell: a Fetch a fiókprofilodat olvassa a Drive ID megtalálásához, és a csak drive hatókörű tokent elutasítja.",
+            "kdriveTokenScopes": "A tokenhez a drive és a user_info hatókör kell. Csak a drive hatókörrel csatlakozik és listázza a fájlokat, de a „Lekérés” elutasításra kerül, mert a Drive ID megtalálásához a fiókprofilodat olvassa.",
             "kdriveFindDriveId": "Keresse meg a Drive ID-t",
             "kdriveFindDriveIdHint": "A numerikus Drive ID az oldal címsorában jelenik meg",
             "kdriveCreateToken": "API token létrehozása",

--- a/src/i18n/locales/hu.json
+++ b/src/i18n/locales/hu.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "Illessze be az API tokent ide",
             "kdriveDriveIdPlaceholder": "Az Ön kDrive azonosítója (szám)",
             "kdriveTokenHelp": "Token létrehozása: manager.infomaniak.com → Developer → API Tokens",
+            "kdriveTokenScopes": "A tokenhez a drive és a user_info hatókör kell: a Fetch a fiókprofilodat olvassa a Drive ID megtalálásához, és a csak drive hatókörű tokent elutasítja.",
             "kdriveFindDriveId": "Keresse meg a Drive ID-t",
             "kdriveFindDriveIdHint": "A numerikus Drive ID az oldal címsorában jelenik meg",
             "kdriveCreateToken": "API token létrehozása",

--- a/src/i18n/locales/hy.json
+++ b/src/i18n/locales/hy.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "Տեղադրեք Ձեր API տոկենը այստեղ",
             "kdriveDriveIdPlaceholder": "Ձեր kDrive իդենտիֆիկատորը (թիվ)",
             "kdriveTokenHelp": "Ստեղծեք տոկեն՝ manager.infomaniak.com → Developer → API Tokens",
+            "kdriveTokenScopes": "Թոքենին անհրաժեշտ են drive և user_info շրջանակները. Fetch-ը կարդում է ձեր հաշվի պրոֆիլը Drive ID-ն գտնելու համար, և միայն drive ունեցող թոքենը մերժվում է:",
             "kdriveFindDriveId": "Գտեք ձեր Drive ID-ն",
             "kdriveFindDriveIdHint": "Թվային Drive ID-ն երևում է այս էջի հասցեի տողում",
             "kdriveCreateToken": "Ստեղծել API տոկեն",

--- a/src/i18n/locales/hy.json
+++ b/src/i18n/locales/hy.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "Տեղադրեք Ձեր API տոկենը այստեղ",
             "kdriveDriveIdPlaceholder": "Ձեր kDrive իդենտիֆիկատորը (թիվ)",
             "kdriveTokenHelp": "Ստեղծեք տոկեն՝ manager.infomaniak.com → Developer → API Tokens",
-            "kdriveTokenScopes": "Թոքենին անհրաժեշտ են drive և user_info շրջանակները. Fetch-ը կարդում է ձեր հաշվի պրոֆիլը Drive ID-ն գտնելու համար, և միայն drive ունեցող թոքենը մերժվում է:",
+            "kdriveTokenScopes": "Թոքենին անհրաժեշտ են drive և user_info շրջանակները։ Միայն drive-ով այն միանում և ցուցադրում է ֆայլերը, բայց «Ստանալ»-ը մերժվում է, քանի որ Drive ID-ն գտնելու համար կարդում է ձեր հաշվի պրոֆիլը։",
             "kdriveFindDriveId": "Գտեք ձեր Drive ID-ն",
             "kdriveFindDriveIdHint": "Թվային Drive ID-ն երևում է այս էջի հասցեի տողում",
             "kdriveCreateToken": "Ստեղծել API տոկեն",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "Tempelkan token API Anda di sini",
             "kdriveDriveIdPlaceholder": "ID kDrive Anda (numerik)",
             "kdriveTokenHelp": "Buat token di manager.infomaniak.com → Developer → API Tokens",
+            "kdriveTokenScopes": "Token memerlukan cakupan drive dan user_info: Fetch membaca profil akun Anda untuk menemukan Drive ID, dan token dengan drive saja akan ditolak.",
             "kdriveFindDriveId": "Temukan Drive ID Anda",
             "kdriveFindDriveIdHint": "Drive ID numerik muncul di bilah alamat halaman ini",
             "kdriveCreateToken": "Buat token API",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "Tempelkan token API Anda di sini",
             "kdriveDriveIdPlaceholder": "ID kDrive Anda (numerik)",
             "kdriveTokenHelp": "Buat token di manager.infomaniak.com → Developer → API Tokens",
-            "kdriveTokenScopes": "Token memerlukan cakupan drive dan user_info: Fetch membaca profil akun Anda untuk menemukan Drive ID, dan token dengan drive saja akan ditolak.",
+            "kdriveTokenScopes": "Token memerlukan cakupan drive dan user_info. Dengan drive saja token dapat terhubung dan menampilkan berkas, tetapi \"Ambil\" ditolak, karena membaca profil akun Anda untuk menemukan Drive ID.",
             "kdriveFindDriveId": "Temukan Drive ID Anda",
             "kdriveFindDriveIdHint": "Drive ID numerik muncul di bilah alamat halaman ini",
             "kdriveCreateToken": "Buat token API",

--- a/src/i18n/locales/is.json
+++ b/src/i18n/locales/is.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "Límdu API lykilorðið þitt hér",
             "kdriveDriveIdPlaceholder": "kDrive auðkennið þitt (tala)",
             "kdriveTokenHelp": "Búðu til lykil á manager.infomaniak.com → Developer → API Tokens",
+            "kdriveTokenScopes": "Lykillinn þarf umfangið drive og user_info: Fetch les reikningssnið þitt til að finna Drive ID, og lykli með drive einu er hafnað.",
             "kdriveFindDriveId": "Finndu Drive ID-ið þitt",
             "kdriveFindDriveIdHint": "Tölulega Drive ID-ið birtist í veffangastiku þessarar síðu",
             "kdriveCreateToken": "Búa til API-lykil",

--- a/src/i18n/locales/is.json
+++ b/src/i18n/locales/is.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "Límdu API lykilorðið þitt hér",
             "kdriveDriveIdPlaceholder": "kDrive auðkennið þitt (tala)",
             "kdriveTokenHelp": "Búðu til lykil á manager.infomaniak.com → Developer → API Tokens",
-            "kdriveTokenScopes": "Lykillinn þarf umfangið drive og user_info: Fetch les reikningssnið þitt til að finna Drive ID, og lykli með drive einu er hafnað.",
+            "kdriveTokenScopes": "Lykillinn þarf bæði umfangið drive og umfangið user_info. Með aðeins drive tengist hann og sýnir skrár, en „Sækja“ er hafnað, því hún les reikningssnið þitt til að finna Drive ID.",
             "kdriveFindDriveId": "Finndu Drive ID-ið þitt",
             "kdriveFindDriveIdHint": "Tölulega Drive ID-ið birtist í veffangastiku þessarar síðu",
             "kdriveCreateToken": "Búa til API-lykil",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -354,7 +354,7 @@
             "kdriveTokenPlaceholder": "Incolla qui il tuo token API",
             "kdriveDriveIdPlaceholder": "Il tuo ID kDrive (numerico)",
             "kdriveTokenHelp": "Genera un token in Infomaniak Manager → Profilo Utente → Developer → API Tokens",
-            "kdriveTokenScopes": "Il token deve avere gli ambiti drive e user_info: Fetch legge il profilo del tuo account per trovare il Drive ID, e un token con il solo drive viene rifiutato.",
+            "kdriveTokenScopes": "Il token deve avere gli ambiti drive e user_info. Con il solo drive si connette ed elenca i file, ma \"Recupera\" viene rifiutato, perché legge il profilo del tuo account per trovare il Drive ID.",
             "kdriveFindDriveId": "Trova il tuo Drive ID",
             "kdriveFindDriveIdHint": "Il Drive ID numerico appare nella barra degli indirizzi di questa pagina",
             "kdriveCreateToken": "Crea un token API",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -354,6 +354,7 @@
             "kdriveTokenPlaceholder": "Incolla qui il tuo token API",
             "kdriveDriveIdPlaceholder": "Il tuo ID kDrive (numerico)",
             "kdriveTokenHelp": "Genera un token in Infomaniak Manager → Profilo Utente → Developer → API Tokens",
+            "kdriveTokenScopes": "Il token deve avere gli ambiti drive e user_info: Fetch legge il profilo del tuo account per trovare il Drive ID, e un token con il solo drive viene rifiutato.",
             "kdriveFindDriveId": "Trova il tuo Drive ID",
             "kdriveFindDriveIdHint": "Il Drive ID numerico appare nella barra degli indirizzi di questa pagina",
             "kdriveCreateToken": "Crea un token API",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "APIトークンをここに貼り付けてください",
             "kdriveDriveIdPlaceholder": "kDrive ID（数値）",
             "kdriveTokenHelp": "manager.infomaniak.com → Developer → API Tokens でトークンを生成してください",
-            "kdriveTokenScopes": "トークンには drive と user_info のスコープが必要です。Fetch はアカウントプロファイルを読み取って Drive ID を見つけるため、drive のみのトークンは拒否されます。",
+            "kdriveTokenScopes": "トークンには drive と user_info のスコープが必要です。drive のみでも接続と一覧表示はできますが、「取得」は拒否されます。Drive ID を見つけるためにアカウントプロファイルを読み取るからです。",
             "kdriveFindDriveId": "Drive ID を確認する",
             "kdriveFindDriveIdHint": "数値の Drive ID はこのページのアドレスバーに表示されます",
             "kdriveCreateToken": "API トークンを作成する",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "APIトークンをここに貼り付けてください",
             "kdriveDriveIdPlaceholder": "kDrive ID（数値）",
             "kdriveTokenHelp": "manager.infomaniak.com → Developer → API Tokens でトークンを生成してください",
+            "kdriveTokenScopes": "トークンには drive と user_info のスコープが必要です。Fetch はアカウントプロファイルを読み取って Drive ID を見つけるため、drive のみのトークンは拒否されます。",
             "kdriveFindDriveId": "Drive ID を確認する",
             "kdriveFindDriveIdHint": "数値の Drive ID はこのページのアドレスバーに表示されます",
             "kdriveCreateToken": "API トークンを作成する",

--- a/src/i18n/locales/ka.json
+++ b/src/i18n/locales/ka.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "ჩასვით თქვენი API ტოკენი აქ",
             "kdriveDriveIdPlaceholder": "თქვენი kDrive იდენტიფიკატორი (რიცხვითი)",
             "kdriveTokenHelp": "შექმენით ტოკენი manager.infomaniak.com → Developer → API Tokens",
+            "kdriveTokenScopes": "ტოკენს სჭირდება drive და user_info სკოუპები: Fetch კითხულობს თქვენი ანგარიშის პროფილს Drive ID-ის საპოვნელად, და მხოლოდ drive-ის მქონე ტოკენი უარყოფილია.",
             "kdriveFindDriveId": "იპოვეთ თქვენი Drive ID",
             "kdriveFindDriveIdHint": "რიცხვითი Drive ID ჩანს ამ გვერდის მისამართის ველში",
             "kdriveCreateToken": "შექმენით API ტოკენი",

--- a/src/i18n/locales/ka.json
+++ b/src/i18n/locales/ka.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "ჩასვით თქვენი API ტოკენი აქ",
             "kdriveDriveIdPlaceholder": "თქვენი kDrive იდენტიფიკატორი (რიცხვითი)",
             "kdriveTokenHelp": "შექმენით ტოკენი manager.infomaniak.com → Developer → API Tokens",
-            "kdriveTokenScopes": "ტოკენს სჭირდება drive და user_info სკოუპები: Fetch კითხულობს თქვენი ანგარიშის პროფილს Drive ID-ის საპოვნელად, და მხოლოდ drive-ის მქონე ტოკენი უარყოფილია.",
+            "kdriveTokenScopes": "ტოკენს სჭირდება drive და user_info სკოუპები. მხოლოდ drive-ით ის უკავშირდება და აჩვენებს ფაილებს, მაგრამ „მიღება“ უარყოფილია, რადგან Drive ID-ის საპოვნელად ის კითხულობს თქვენი ანგარიშის პროფილს.",
             "kdriveFindDriveId": "იპოვეთ თქვენი Drive ID",
             "kdriveFindDriveIdHint": "რიცხვითი Drive ID ჩანს ამ გვერდის მისამართის ველში",
             "kdriveCreateToken": "შექმენით API ტოკენი",

--- a/src/i18n/locales/km.json
+++ b/src/i18n/locales/km.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "បិទភ្ជាប់ API token របស់អ្នកនៅទីនេះ",
             "kdriveDriveIdPlaceholder": "លេខសម្គាល់ kDrive របស់អ្នក (ជាលេខ)",
             "kdriveTokenHelp": "បង្កើត token នៅ manager.infomaniak.com → Developer → API Tokens",
+            "kdriveTokenScopes": "ថូខិនត្រូវការវិសាលភាព drive និង user_info៖ Fetch អានប្រវត្តិរូបគណនីរបស់អ្នកដើម្បីរក Drive ID ហើយថូខិនដែលមានតែ drive ត្រូវបានបដិសេធ។",
             "kdriveFindDriveId": "ស្វែងរក Drive ID របស់អ្នក",
             "kdriveFindDriveIdHint": "Drive ID ជាលេខបង្ហាញនៅក្នុងរបារអាសយដ្ឋាននៃទំព័រនេះ",
             "kdriveCreateToken": "បង្កើត token API",

--- a/src/i18n/locales/km.json
+++ b/src/i18n/locales/km.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "បិទភ្ជាប់ API token របស់អ្នកនៅទីនេះ",
             "kdriveDriveIdPlaceholder": "លេខសម្គាល់ kDrive របស់អ្នក (ជាលេខ)",
             "kdriveTokenHelp": "បង្កើត token នៅ manager.infomaniak.com → Developer → API Tokens",
-            "kdriveTokenScopes": "ថូខិនត្រូវការវិសាលភាព drive និង user_info៖ Fetch អានប្រវត្តិរូបគណនីរបស់អ្នកដើម្បីរក Drive ID ហើយថូខិនដែលមានតែ drive ត្រូវបានបដិសេធ។",
+            "kdriveTokenScopes": "ថូខិនត្រូវការវិសាលភាព drive និង user_info។ ដោយមានតែ drive វាភ្ជាប់ និងបង្ហាញឯកសារបាន ប៉ុន្តែ \"ទាញយក\" ត្រូវបានបដិសេធ ព្រោះវាអានប្រវត្តិរូបគណនីរបស់អ្នកដើម្បីរក Drive ID។",
             "kdriveFindDriveId": "ស្វែងរក Drive ID របស់អ្នក",
             "kdriveFindDriveIdHint": "Drive ID ជាលេខបង្ហាញនៅក្នុងរបារអាសយដ្ឋាននៃទំព័រនេះ",
             "kdriveCreateToken": "បង្កើត token API",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "여기에 API 토큰을 붙여넣으세요",
             "kdriveDriveIdPlaceholder": "kDrive ID (숫자)",
             "kdriveTokenHelp": "manager.infomaniak.com → Developer → API Tokens에서 토큰을 생성하세요",
+            "kdriveTokenScopes": "토큰에는 drive와 user_info 범위가 필요합니다. Fetch는 계정 프로필을 읽어 Drive ID를 찾으므로 drive만 있는 토큰은 거부됩니다.",
             "kdriveFindDriveId": "Drive ID 찾기",
             "kdriveFindDriveIdHint": "숫자로 된 Drive ID는 이 페이지의 주소 표시줄에 나타납니다",
             "kdriveCreateToken": "API 토큰 생성",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "여기에 API 토큰을 붙여넣으세요",
             "kdriveDriveIdPlaceholder": "kDrive ID (숫자)",
             "kdriveTokenHelp": "manager.infomaniak.com → Developer → API Tokens에서 토큰을 생성하세요",
-            "kdriveTokenScopes": "토큰에는 drive와 user_info 범위가 필요합니다. Fetch는 계정 프로필을 읽어 Drive ID를 찾으므로 drive만 있는 토큰은 거부됩니다.",
+            "kdriveTokenScopes": "토큰에는 drive와 user_info 범위가 필요합니다. drive만 있어도 연결과 파일 목록 조회는 되지만, \"가져오기\"는 Drive ID를 찾기 위해 계정 프로필을 읽으므로 거부됩니다.",
             "kdriveFindDriveId": "Drive ID 찾기",
             "kdriveFindDriveIdHint": "숫자로 된 Drive ID는 이 페이지의 주소 표시줄에 나타납니다",
             "kdriveCreateToken": "API 토큰 생성",

--- a/src/i18n/locales/lt.json
+++ b/src/i18n/locales/lt.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "Įklijuokite savo API raktą čia",
             "kdriveDriveIdPlaceholder": "Jūsų kDrive ID (skaitinis)",
             "kdriveTokenHelp": "Sukurkite raktą adresu manager.infomaniak.com → Developer → API Tokens",
-            "kdriveTokenScopes": "Žetonui reikia drive ir user_info aprėpčių: Fetch skaito jūsų paskyros profilį, kad rastų Drive ID, o žetonas tik su drive atmetamas.",
+            "kdriveTokenScopes": "Žetonui reikia drive ir user_info aprėpčių. Vien su drive jis prisijungia ir rodo failus, bet „Gauti“ atmetamas, nes Drive ID surasti jis skaito jūsų paskyros profilį.",
             "kdriveFindDriveId": "Raskite savo Drive ID",
             "kdriveFindDriveIdHint": "Skaitinis Drive ID rodomas šio puslapio adreso juostoje",
             "kdriveCreateToken": "Sukurti API raktą",

--- a/src/i18n/locales/lt.json
+++ b/src/i18n/locales/lt.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "Įklijuokite savo API raktą čia",
             "kdriveDriveIdPlaceholder": "Jūsų kDrive ID (skaitinis)",
             "kdriveTokenHelp": "Sukurkite raktą adresu manager.infomaniak.com → Developer → API Tokens",
+            "kdriveTokenScopes": "Žetonui reikia drive ir user_info aprėpčių: Fetch skaito jūsų paskyros profilį, kad rastų Drive ID, o žetonas tik su drive atmetamas.",
             "kdriveFindDriveId": "Raskite savo Drive ID",
             "kdriveFindDriveIdHint": "Skaitinis Drive ID rodomas šio puslapio adreso juostoje",
             "kdriveCreateToken": "Sukurti API raktą",

--- a/src/i18n/locales/lv.json
+++ b/src/i18n/locales/lv.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "Ielīmējiet savu API marķieri šeit",
             "kdriveDriveIdPlaceholder": "Jūsu kDrive ID (ciparu)",
             "kdriveTokenHelp": "Ģenerējiet marķieri vietnē manager.infomaniak.com → Developer → API Tokens",
+            "kdriveTokenScopes": "Tokenam nepieciešami drive un user_info tvērumi: Fetch nolasa jūsu konta profilu, lai atrastu Drive ID, un tokens tikai ar drive tiek noraidīts.",
             "kdriveFindDriveId": "Atrodiet savu Drive ID",
             "kdriveFindDriveIdHint": "Skaitliskais Drive ID ir redzams šīs lapas adreses joslā",
             "kdriveCreateToken": "Izveidot API marķieri",

--- a/src/i18n/locales/lv.json
+++ b/src/i18n/locales/lv.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "Ielīmējiet savu API marķieri šeit",
             "kdriveDriveIdPlaceholder": "Jūsu kDrive ID (ciparu)",
             "kdriveTokenHelp": "Ģenerējiet marķieri vietnē manager.infomaniak.com → Developer → API Tokens",
-            "kdriveTokenScopes": "Tokenam nepieciešami drive un user_info tvērumi: Fetch nolasa jūsu konta profilu, lai atrastu Drive ID, un tokens tikai ar drive tiek noraidīts.",
+            "kdriveTokenScopes": "Tokenam nepieciešami drive un user_info tvērumi. Tikai ar drive tas pieslēdzas un parāda failus, bet \"Iegūt\" tiek noraidīts, jo Drive ID atrašanai tas nolasa jūsu konta profilu.",
             "kdriveFindDriveId": "Atrodiet savu Drive ID",
             "kdriveFindDriveIdHint": "Skaitliskais Drive ID ir redzams šīs lapas adreses joslā",
             "kdriveCreateToken": "Izveidot API marķieri",

--- a/src/i18n/locales/mk.json
+++ b/src/i18n/locales/mk.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "Залепете го вашиот API токен овде",
             "kdriveDriveIdPlaceholder": "Вашиот kDrive ID (нумерички)",
             "kdriveTokenHelp": "Генерирајте токен на manager.infomaniak.com → Developer → API Tokens",
+            "kdriveTokenScopes": "Токенот треба да ги има опсезите drive и user_info: Fetch го чита профилот на вашата сметка за да го најде Drive ID, а токен само со drive се одбива.",
             "kdriveFindDriveId": "Најдете го вашиот Drive ID",
             "kdriveFindDriveIdHint": "Нумеричкиот Drive ID се појавува во адресната лента на оваа страница",
             "kdriveCreateToken": "Создадете API токен",

--- a/src/i18n/locales/mk.json
+++ b/src/i18n/locales/mk.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "Залепете го вашиот API токен овде",
             "kdriveDriveIdPlaceholder": "Вашиот kDrive ID (нумерички)",
             "kdriveTokenHelp": "Генерирајте токен на manager.infomaniak.com → Developer → API Tokens",
-            "kdriveTokenScopes": "Токенот треба да ги има опсезите drive и user_info: Fetch го чита профилот на вашата сметка за да го најде Drive ID, а токен само со drive се одбива.",
+            "kdriveTokenScopes": "Токенот треба да ги има опсезите drive и user_info. Само со drive се поврзува и ги прикажува датотеките, но „Преземи“ се одбива, бидејќи го чита профилот на вашата сметка за да го најде Drive ID.",
             "kdriveFindDriveId": "Најдете го вашиот Drive ID",
             "kdriveFindDriveIdHint": "Нумеричкиот Drive ID се појавува во адресната лента на оваа страница",
             "kdriveCreateToken": "Создадете API токен",

--- a/src/i18n/locales/ms.json
+++ b/src/i18n/locales/ms.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "Tampalkan token API anda di sini",
             "kdriveDriveIdPlaceholder": "ID kDrive anda (numerik)",
             "kdriveTokenHelp": "Jana token di manager.infomaniak.com → Developer → API Tokens",
-            "kdriveTokenScopes": "Token memerlukan skop drive dan user_info: Fetch membaca profil akaun anda untuk mencari Drive ID, dan token dengan drive sahaja ditolak.",
+            "kdriveTokenScopes": "Token memerlukan skop drive dan user_info. Dengan drive sahaja ia boleh menyambung dan menyenaraikan fail, tetapi \"Dapatkan\" ditolak, kerana ia membaca profil akaun anda untuk mencari Drive ID.",
             "kdriveFindDriveId": "Cari Drive ID anda",
             "kdriveFindDriveIdHint": "Drive ID berangka muncul dalam bar alamat halaman ini",
             "kdriveCreateToken": "Cipta token API",

--- a/src/i18n/locales/ms.json
+++ b/src/i18n/locales/ms.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "Tampalkan token API anda di sini",
             "kdriveDriveIdPlaceholder": "ID kDrive anda (numerik)",
             "kdriveTokenHelp": "Jana token di manager.infomaniak.com → Developer → API Tokens",
+            "kdriveTokenScopes": "Token memerlukan skop drive dan user_info: Fetch membaca profil akaun anda untuk mencari Drive ID, dan token dengan drive sahaja ditolak.",
             "kdriveFindDriveId": "Cari Drive ID anda",
             "kdriveFindDriveIdHint": "Drive ID berangka muncul dalam bar alamat halaman ini",
             "kdriveCreateToken": "Cipta token API",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "Plak hier uw API-token",
             "kdriveDriveIdPlaceholder": "Uw kDrive ID (numeriek)",
             "kdriveTokenHelp": "Genereer een token op manager.infomaniak.com → Developer → API Tokens",
-            "kdriveTokenScopes": "Het token heeft de scopes drive en user_info nodig: Fetch leest je accountprofiel om de Drive ID te vinden, en een token met alleen drive wordt geweigerd.",
+            "kdriveTokenScopes": "Het token heeft de scopes drive en user_info nodig. Met alleen drive maakt het verbinding en toont het bestanden, maar \"Ophalen\" wordt geweigerd, omdat het je accountprofiel leest om de Drive ID te vinden.",
             "kdriveFindDriveId": "Vind uw Drive ID",
             "kdriveFindDriveIdHint": "Het numerieke Drive ID verschijnt in de adresbalk van deze pagina",
             "kdriveCreateToken": "Maak een API-token aan",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "Plak hier uw API-token",
             "kdriveDriveIdPlaceholder": "Uw kDrive ID (numeriek)",
             "kdriveTokenHelp": "Genereer een token op manager.infomaniak.com → Developer → API Tokens",
+            "kdriveTokenScopes": "Het token heeft de scopes drive en user_info nodig: Fetch leest je accountprofiel om de Drive ID te vinden, en een token met alleen drive wordt geweigerd.",
             "kdriveFindDriveId": "Vind uw Drive ID",
             "kdriveFindDriveIdHint": "Het numerieke Drive ID verschijnt in de adresbalk van deze pagina",
             "kdriveCreateToken": "Maak een API-token aan",

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "Lim inn API-tokenet ditt her",
             "kdriveDriveIdPlaceholder": "Din kDrive-ID (numerisk)",
             "kdriveTokenHelp": "Generer et token på manager.infomaniak.com → Developer → API Tokens",
+            "kdriveTokenScopes": "Tokenet trenger omfangene drive og user_info: Fetch leser kontoprofilen din for å finne Drive ID, og et token med bare drive avvises.",
             "kdriveFindDriveId": "Finn din Drive ID",
             "kdriveFindDriveIdHint": "Den numeriske Drive ID-en vises i adresselinjen på denne siden",
             "kdriveCreateToken": "Opprett et API-token",

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "Lim inn API-tokenet ditt her",
             "kdriveDriveIdPlaceholder": "Din kDrive-ID (numerisk)",
             "kdriveTokenHelp": "Generer et token på manager.infomaniak.com → Developer → API Tokens",
-            "kdriveTokenScopes": "Tokenet trenger omfangene drive og user_info: Fetch leser kontoprofilen din for å finne Drive ID, og et token med bare drive avvises.",
+            "kdriveTokenScopes": "Tokenet trenger omfangene drive og user_info. Med bare drive kobler det til og viser filer, men \"Hent\" avvises, fordi den leser kontoprofilen din for å finne Drive ID.",
             "kdriveFindDriveId": "Finn din Drive ID",
             "kdriveFindDriveIdHint": "Den numeriske Drive ID-en vises i adresselinjen på denne siden",
             "kdriveCreateToken": "Opprett et API-token",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "Wklej tutaj swój API Token",
             "kdriveDriveIdPlaceholder": "Twój identyfikator kDrive (numeryczny)",
             "kdriveTokenHelp": "Wygeneruj token na manager.infomaniak.com → Developer → API Tokens",
+            "kdriveTokenScopes": "Token musi mieć zakresy drive i user_info: Fetch odczytuje profil Twojego konta, aby znaleźć Drive ID, a token z samym drive jest odrzucany.",
             "kdriveFindDriveId": "Znajdź swój Drive ID",
             "kdriveFindDriveIdHint": "Numeryczny Drive ID pojawia się w pasku adresu tej strony",
             "kdriveCreateToken": "Utwórz token API",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "Wklej tutaj swój API Token",
             "kdriveDriveIdPlaceholder": "Twój identyfikator kDrive (numeryczny)",
             "kdriveTokenHelp": "Wygeneruj token na manager.infomaniak.com → Developer → API Tokens",
-            "kdriveTokenScopes": "Token musi mieć zakresy drive i user_info: Fetch odczytuje profil Twojego konta, aby znaleźć Drive ID, a token z samym drive jest odrzucany.",
+            "kdriveTokenScopes": "Token musi mieć zakresy drive i user_info. Z samym drive łączy się i wyświetla pliki, ale „Pobierz” jest odrzucane, ponieważ odczytuje profil Twojego konta, aby znaleźć Drive ID.",
             "kdriveFindDriveId": "Znajdź swój Drive ID",
             "kdriveFindDriveIdHint": "Numeryczny Drive ID pojawia się w pasku adresu tej strony",
             "kdriveCreateToken": "Utwórz token API",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "Cole o seu API Token aqui",
             "kdriveDriveIdPlaceholder": "O seu ID do kDrive (numérico)",
             "kdriveTokenHelp": "Gere um token em manager.infomaniak.com → Developer → API Tokens",
+            "kdriveTokenScopes": "O token precisa dos escopos drive e user_info: o Fetch lê o perfil da sua conta para encontrar o Drive ID, e um token só com drive é recusado.",
             "kdriveFindDriveId": "Encontre o seu Drive ID",
             "kdriveFindDriveIdHint": "O Drive ID numérico aparece na barra de endereço desta página",
             "kdriveCreateToken": "Criar um token de API",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "Cole o seu API Token aqui",
             "kdriveDriveIdPlaceholder": "O seu ID do kDrive (numérico)",
             "kdriveTokenHelp": "Gere um token em manager.infomaniak.com → Developer → API Tokens",
-            "kdriveTokenScopes": "O token precisa dos escopos drive e user_info: o Fetch lê o perfil da sua conta para encontrar o Drive ID, e um token só com drive é recusado.",
+            "kdriveTokenScopes": "O token precisa dos escopos drive e user_info. Só com drive ele se conecta e lista arquivos, mas \"Obter\" é recusado, porque lê o perfil da sua conta para encontrar o Drive ID.",
             "kdriveFindDriveId": "Encontre o seu Drive ID",
             "kdriveFindDriveIdHint": "O Drive ID numérico aparece na barra de endereço desta página",
             "kdriveCreateToken": "Criar um token de API",

--- a/src/i18n/locales/ro.json
+++ b/src/i18n/locales/ro.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "Lipiți API Token-ul aici",
             "kdriveDriveIdPlaceholder": "ID-ul kDrive (numeric)",
             "kdriveTokenHelp": "Generează un token pe manager.infomaniak.com → Developer → API Tokens",
+            "kdriveTokenScopes": "Tokenul are nevoie de domeniile drive și user_info: Fetch citește profilul contului tău pentru a găsi Drive ID, iar un token doar cu drive este respins.",
             "kdriveFindDriveId": "Găsește-ți Drive ID-ul",
             "kdriveFindDriveIdHint": "Drive ID-ul numeric apare în bara de adrese a acestei pagini",
             "kdriveCreateToken": "Creează un token API",

--- a/src/i18n/locales/ro.json
+++ b/src/i18n/locales/ro.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "Lipiți API Token-ul aici",
             "kdriveDriveIdPlaceholder": "ID-ul kDrive (numeric)",
             "kdriveTokenHelp": "Generează un token pe manager.infomaniak.com → Developer → API Tokens",
-            "kdriveTokenScopes": "Tokenul are nevoie de domeniile drive și user_info: Fetch citește profilul contului tău pentru a găsi Drive ID, iar un token doar cu drive este respins.",
+            "kdriveTokenScopes": "Tokenul are nevoie de permisiunile drive și user_info. Doar cu drive se conectează și listează fișierele, dar „Preia” este respins, pentru că citește profilul contului tău pentru a găsi Drive ID.",
             "kdriveFindDriveId": "Găsește-ți Drive ID-ul",
             "kdriveFindDriveIdHint": "Drive ID-ul numeric apare în bara de adrese a acestei pagini",
             "kdriveCreateToken": "Creează un token API",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "Вставьте ваш API Token сюда",
             "kdriveDriveIdPlaceholder": "Ваш идентификатор kDrive (числовой)",
             "kdriveTokenHelp": "Сгенерируйте токен на manager.infomaniak.com → Developer → API Tokens",
+            "kdriveTokenScopes": "Токену нужны области drive и user_info: Fetch читает профиль вашей учётной записи, чтобы найти Drive ID, а токен только с drive отклоняется.",
             "kdriveFindDriveId": "Найдите свой Drive ID",
             "kdriveFindDriveIdHint": "Числовой Drive ID отображается в адресной строке этой страницы",
             "kdriveCreateToken": "Создать токен API",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "Вставьте ваш API Token сюда",
             "kdriveDriveIdPlaceholder": "Ваш идентификатор kDrive (числовой)",
             "kdriveTokenHelp": "Сгенерируйте токен на manager.infomaniak.com → Developer → API Tokens",
-            "kdriveTokenScopes": "Токену нужны области drive и user_info: Fetch читает профиль вашей учётной записи, чтобы найти Drive ID, а токен только с drive отклоняется.",
+            "kdriveTokenScopes": "Токену нужны области drive и user_info. Только с drive он подключается и показывает файлы, но «Получить» отклоняется, потому что читает профиль вашей учётной записи, чтобы найти Drive ID.",
             "kdriveFindDriveId": "Найдите свой Drive ID",
             "kdriveFindDriveIdHint": "Числовой Drive ID отображается в адресной строке этой страницы",
             "kdriveCreateToken": "Создать токен API",

--- a/src/i18n/locales/sk.json
+++ b/src/i18n/locales/sk.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "Vložte sem svoj API Token",
             "kdriveDriveIdPlaceholder": "Vaše ID kDrive (číselné)",
             "kdriveTokenHelp": "Vygenerujte token na manager.infomaniak.com → Developer → API Tokens",
-            "kdriveTokenScopes": "Token potrebuje rozsahy drive a user_info: Fetch číta profil vášho účtu, aby našiel Drive ID, a token iba s drive je odmietnutý.",
+            "kdriveTokenScopes": "Token potrebuje rozsahy drive a user_info. Iba s drive sa pripojí a zobrazí súbory, ale „Načítať“ je odmietnuté, pretože číta profil vášho účtu, aby našlo Drive ID.",
             "kdriveFindDriveId": "Nájdite svoj Drive ID",
             "kdriveFindDriveIdHint": "Číselný Drive ID sa zobrazuje v paneli s adresou tejto stránky",
             "kdriveCreateToken": "Vytvoriť token API",

--- a/src/i18n/locales/sk.json
+++ b/src/i18n/locales/sk.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "Vložte sem svoj API Token",
             "kdriveDriveIdPlaceholder": "Vaše ID kDrive (číselné)",
             "kdriveTokenHelp": "Vygenerujte token na manager.infomaniak.com → Developer → API Tokens",
+            "kdriveTokenScopes": "Token potrebuje rozsahy drive a user_info: Fetch číta profil vášho účtu, aby našiel Drive ID, a token iba s drive je odmietnutý.",
             "kdriveFindDriveId": "Nájdite svoj Drive ID",
             "kdriveFindDriveIdHint": "Číselný Drive ID sa zobrazuje v paneli s adresou tejto stránky",
             "kdriveCreateToken": "Vytvoriť token API",

--- a/src/i18n/locales/sl.json
+++ b/src/i18n/locales/sl.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "Prilepite svoj API Token sem",
             "kdriveDriveIdPlaceholder": "Vaš ID kDrive (številčni)",
             "kdriveTokenHelp": "Ustvarite žeton na manager.infomaniak.com → Developer → API Tokens",
-            "kdriveTokenScopes": "Žeton potrebuje obsega drive in user_info: Fetch prebere profil vašega računa, da najde Drive ID, žeton samo z drive pa je zavrnjen.",
+            "kdriveTokenScopes": "Žeton potrebuje obsega drive in user_info. Samo z drive se poveže in prikaže datoteke, „Pridobi“ pa je zavrnjen, ker bere profil vašega računa, da najde Drive ID.",
             "kdriveFindDriveId": "Poiščite svoj Drive ID",
             "kdriveFindDriveIdHint": "Številčni Drive ID se prikaže v naslovni vrstici te strani",
             "kdriveCreateToken": "Ustvari žeton API",

--- a/src/i18n/locales/sl.json
+++ b/src/i18n/locales/sl.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "Prilepite svoj API Token sem",
             "kdriveDriveIdPlaceholder": "Vaš ID kDrive (številčni)",
             "kdriveTokenHelp": "Ustvarite žeton na manager.infomaniak.com → Developer → API Tokens",
+            "kdriveTokenScopes": "Žeton potrebuje obsega drive in user_info: Fetch prebere profil vašega računa, da najde Drive ID, žeton samo z drive pa je zavrnjen.",
             "kdriveFindDriveId": "Poiščite svoj Drive ID",
             "kdriveFindDriveIdHint": "Številčni Drive ID se prikaže v naslovni vrstici te strani",
             "kdriveCreateToken": "Ustvari žeton API",

--- a/src/i18n/locales/sr.json
+++ b/src/i18n/locales/sr.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "Налепите ваш API Token овде",
             "kdriveDriveIdPlaceholder": "Ваш kDrive ID (нумерички)",
             "kdriveTokenHelp": "Генеришите токен на manager.infomaniak.com → Developer → API Tokens",
+            "kdriveTokenScopes": "Токен мора да има опсеге drive и user_info: Fetch чита профил вашег налога да би пронашао Drive ID, а токен само са drive се одбија.",
             "kdriveFindDriveId": "Пронађите свој Drive ID",
             "kdriveFindDriveIdHint": "Нумерички Drive ID појављује се у адресној траци ове странице",
             "kdriveCreateToken": "Направи API токен",

--- a/src/i18n/locales/sr.json
+++ b/src/i18n/locales/sr.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "Налепите ваш API Token овде",
             "kdriveDriveIdPlaceholder": "Ваш kDrive ID (нумерички)",
             "kdriveTokenHelp": "Генеришите токен на manager.infomaniak.com → Developer → API Tokens",
-            "kdriveTokenScopes": "Токен мора да има опсеге drive и user_info: Fetch чита профил вашег налога да би пронашао Drive ID, а токен само са drive се одбија.",
+            "kdriveTokenScopes": "Токен мора да има опсеге drive и user_info. Само са drive повезује се и приказује датотеке, али „Преузми“ се одбија, јер чита профил вашег налога да би пронашао Drive ID.",
             "kdriveFindDriveId": "Пронађите свој Drive ID",
             "kdriveFindDriveIdHint": "Нумерички Drive ID појављује се у адресној траци ове странице",
             "kdriveCreateToken": "Направи API токен",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "Klistra in din API Token här",
             "kdriveDriveIdPlaceholder": "Ditt kDrive-ID (numeriskt)",
             "kdriveTokenHelp": "Generera en token på manager.infomaniak.com → Developer → API Tokens",
+            "kdriveTokenScopes": "Token behöver omfattningarna drive och user_info: Fetch läser din kontoprofil för att hitta Drive ID, och ett token med enbart drive avvisas.",
             "kdriveFindDriveId": "Hitta ditt Drive ID",
             "kdriveFindDriveIdHint": "Det numeriska Drive ID visas i adressfältet på den här sidan",
             "kdriveCreateToken": "Skapa en API-token",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "Klistra in din API Token här",
             "kdriveDriveIdPlaceholder": "Ditt kDrive-ID (numeriskt)",
             "kdriveTokenHelp": "Generera en token på manager.infomaniak.com → Developer → API Tokens",
-            "kdriveTokenScopes": "Token behöver omfattningarna drive och user_info: Fetch läser din kontoprofil för att hitta Drive ID, och ett token med enbart drive avvisas.",
+            "kdriveTokenScopes": "Token behöver omfattningarna drive och user_info. Med enbart drive ansluter den och listar filer, men \"Hämta\" avvisas, eftersom den läser din kontoprofil för att hitta Drive ID.",
             "kdriveFindDriveId": "Hitta ditt Drive ID",
             "kdriveFindDriveIdHint": "Det numeriska Drive ID visas i adressfältet på den här sidan",
             "kdriveCreateToken": "Skapa en API-token",

--- a/src/i18n/locales/sw.json
+++ b/src/i18n/locales/sw.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "Bandika API Token yako hapa",
             "kdriveDriveIdPlaceholder": "Kitambulisho chako cha kDrive (nambari)",
             "kdriveTokenHelp": "Tengeneza tokeni kwenye manager.infomaniak.com → Developer → API Tokens",
+            "kdriveTokenScopes": "Tokeni inahitaji upeo wa drive na user_info: Fetch husoma wasifu wa akaunti yako ili kupata Drive ID, na tokeni yenye drive pekee inakataliwa.",
             "kdriveFindDriveId": "Tafuta Drive ID yako",
             "kdriveFindDriveIdHint": "Drive ID ya nambari huonekana kwenye upau wa anwani wa ukurasa huu",
             "kdriveCreateToken": "Tengeneza tokeni ya API",

--- a/src/i18n/locales/sw.json
+++ b/src/i18n/locales/sw.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "Bandika API Token yako hapa",
             "kdriveDriveIdPlaceholder": "Kitambulisho chako cha kDrive (nambari)",
             "kdriveTokenHelp": "Tengeneza tokeni kwenye manager.infomaniak.com → Developer → API Tokens",
-            "kdriveTokenScopes": "Tokeni inahitaji upeo wa drive na user_info: Fetch husoma wasifu wa akaunti yako ili kupata Drive ID, na tokeni yenye drive pekee inakataliwa.",
+            "kdriveTokenScopes": "Tokeni inahitaji upeo wa drive na user_info. Kwa drive pekee inaunganisha na kuorodhesha faili, lakini \"Leta\" inakataliwa, kwa sababu inasoma wasifu wa akaunti yako ili kupata Drive ID.",
             "kdriveFindDriveId": "Tafuta Drive ID yako",
             "kdriveFindDriveIdHint": "Drive ID ya nambari huonekana kwenye upau wa anwani wa ukurasa huu",
             "kdriveCreateToken": "Tengeneza tokeni ya API",

--- a/src/i18n/locales/th.json
+++ b/src/i18n/locales/th.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "วาง API Token ของคุณที่นี่",
             "kdriveDriveIdPlaceholder": "ID kDrive ของคุณ (ตัวเลข)",
             "kdriveTokenHelp": "สร้างโทเคนที่ manager.infomaniak.com → Developer → API Tokens",
+            "kdriveTokenScopes": "โทเค็นต้องมีขอบเขต drive และ user_info: Fetch จะอ่านโปรไฟล์บัญชีของคุณเพื่อค้นหา Drive ID และโทเค็นที่มีเฉพาะ drive จะถูกปฏิเสธ",
             "kdriveFindDriveId": "ค้นหา Drive ID ของคุณ",
             "kdriveFindDriveIdHint": "Drive ID ที่เป็นตัวเลขจะปรากฏในแถบที่อยู่ของหน้านี้",
             "kdriveCreateToken": "สร้างโทเคน API",

--- a/src/i18n/locales/th.json
+++ b/src/i18n/locales/th.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "วาง API Token ของคุณที่นี่",
             "kdriveDriveIdPlaceholder": "ID kDrive ของคุณ (ตัวเลข)",
             "kdriveTokenHelp": "สร้างโทเคนที่ manager.infomaniak.com → Developer → API Tokens",
-            "kdriveTokenScopes": "โทเค็นต้องมีขอบเขต drive และ user_info: Fetch จะอ่านโปรไฟล์บัญชีของคุณเพื่อค้นหา Drive ID และโทเค็นที่มีเฉพาะ drive จะถูกปฏิเสธ",
+            "kdriveTokenScopes": "โทเค็นต้องมีขอบเขต drive และ user_info หากมีเฉพาะ drive จะเชื่อมต่อและแสดงรายการไฟล์ได้ แต่ \"ดึงข้อมูล\" จะถูกปฏิเสธ เพราะต้องอ่านโปรไฟล์บัญชีของคุณเพื่อค้นหา Drive ID",
             "kdriveFindDriveId": "ค้นหา Drive ID ของคุณ",
             "kdriveFindDriveIdHint": "Drive ID ที่เป็นตัวเลขจะปรากฏในแถบที่อยู่ของหน้านี้",
             "kdriveCreateToken": "สร้างโทเคน API",

--- a/src/i18n/locales/tl.json
+++ b/src/i18n/locales/tl.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "Idikit ang iyong API Token dito",
             "kdriveDriveIdPlaceholder": "Ang iyong kDrive ID (numero)",
             "kdriveTokenHelp": "Bumuo ng token sa manager.infomaniak.com → Developer → API Tokens",
-            "kdriveTokenScopes": "Kailangan ng token ang mga saklaw na drive at user_info: binabasa ng Fetch ang profile ng iyong account para hanapin ang Drive ID, at tinatanggihan ang token na drive lamang.",
+            "kdriveTokenScopes": "Kailangan ng token ang mga saklaw na drive at user_info. Sa drive lamang ay nakakakonekta ito at nakakapaglista ng mga file, ngunit tinatanggihan ang \"Kunin\", dahil binabasa nito ang profile ng iyong account para hanapin ang Drive ID.",
             "kdriveFindDriveId": "Hanapin ang iyong Drive ID",
             "kdriveFindDriveIdHint": "Lumalabas ang numerikong Drive ID sa address bar ng pahinang ito",
             "kdriveCreateToken": "Gumawa ng token ng API",

--- a/src/i18n/locales/tl.json
+++ b/src/i18n/locales/tl.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "Idikit ang iyong API Token dito",
             "kdriveDriveIdPlaceholder": "Ang iyong kDrive ID (numero)",
             "kdriveTokenHelp": "Bumuo ng token sa manager.infomaniak.com → Developer → API Tokens",
+            "kdriveTokenScopes": "Kailangan ng token ang mga saklaw na drive at user_info: binabasa ng Fetch ang profile ng iyong account para hanapin ang Drive ID, at tinatanggihan ang token na drive lamang.",
             "kdriveFindDriveId": "Hanapin ang iyong Drive ID",
             "kdriveFindDriveIdHint": "Lumalabas ang numerikong Drive ID sa address bar ng pahinang ito",
             "kdriveCreateToken": "Gumawa ng token ng API",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "API Token'inizi buraya yapıştırın",
             "kdriveDriveIdPlaceholder": "kDrive ID'niz (sayısal)",
             "kdriveTokenHelp": "manager.infomaniak.com → Developer → API Tokens adresinden bir token oluşturun",
-            "kdriveTokenScopes": "Belirtecin drive ve user_info kapsamlarına ihtiyacı var: Fetch, Drive ID'yi bulmak için hesap profilinizi okur ve yalnızca drive kapsamlı bir belirteç reddedilir.",
+            "kdriveTokenScopes": "Belirtecin drive ve user_info kapsamlarına ihtiyacı var. Yalnızca drive ile bağlanır ve dosyaları listeler, ancak \"Getir\" reddedilir, çünkü Drive ID'yi bulmak için hesap profilinizi okur.",
             "kdriveFindDriveId": "Drive ID'nizi bulun",
             "kdriveFindDriveIdHint": "Sayısal Drive ID bu sayfanın adres çubuğunda görünür",
             "kdriveCreateToken": "Bir API token'ı oluşturun",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "API Token'inizi buraya yapıştırın",
             "kdriveDriveIdPlaceholder": "kDrive ID'niz (sayısal)",
             "kdriveTokenHelp": "manager.infomaniak.com → Developer → API Tokens adresinden bir token oluşturun",
+            "kdriveTokenScopes": "Belirtecin drive ve user_info kapsamlarına ihtiyacı var: Fetch, Drive ID'yi bulmak için hesap profilinizi okur ve yalnızca drive kapsamlı bir belirteç reddedilir.",
             "kdriveFindDriveId": "Drive ID'nizi bulun",
             "kdriveFindDriveIdHint": "Sayısal Drive ID bu sayfanın adres çubuğunda görünür",
             "kdriveCreateToken": "Bir API token'ı oluşturun",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "Вставте ваш API Token тут",
             "kdriveDriveIdPlaceholder": "Ваш ідентифікатор kDrive (числовий)",
             "kdriveTokenHelp": "Створіть токен на manager.infomaniak.com → Developer → API Tokens",
+            "kdriveTokenScopes": "Токену потрібні області drive та user_info: Fetch читає профіль вашого облікового запису, щоб знайти Drive ID, а токен лише з drive відхиляється.",
             "kdriveFindDriveId": "Знайдіть свій Drive ID",
             "kdriveFindDriveIdHint": "Числовий Drive ID відображається в адресному рядку цієї сторінки",
             "kdriveCreateToken": "Створити токен API",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "Вставте ваш API Token тут",
             "kdriveDriveIdPlaceholder": "Ваш ідентифікатор kDrive (числовий)",
             "kdriveTokenHelp": "Створіть токен на manager.infomaniak.com → Developer → API Tokens",
-            "kdriveTokenScopes": "Токену потрібні області drive та user_info: Fetch читає профіль вашого облікового запису, щоб знайти Drive ID, а токен лише з drive відхиляється.",
+            "kdriveTokenScopes": "Токену потрібні області drive та user_info. Лише з drive він підключається і показує файли, але «Отримати» відхиляється, бо читає профіль вашого облікового запису, щоб знайти Drive ID.",
             "kdriveFindDriveId": "Знайдіть свій Drive ID",
             "kdriveFindDriveIdHint": "Числовий Drive ID відображається в адресному рядку цієї сторінки",
             "kdriveCreateToken": "Створити токен API",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "Dán API Token của bạn vào đây",
             "kdriveDriveIdPlaceholder": "ID kDrive của bạn (số)",
             "kdriveTokenHelp": "Tạo token tại manager.infomaniak.com → Developer → API Tokens",
-            "kdriveTokenScopes": "Token cần các phạm vi drive và user_info: Fetch đọc hồ sơ tài khoản của bạn để tìm Drive ID, và token chỉ có drive sẽ bị từ chối.",
+            "kdriveTokenScopes": "Token cần các phạm vi drive và user_info. Chỉ với drive, token vẫn kết nối và liệt kê tệp, nhưng \"Lấy\" bị từ chối, vì nó đọc hồ sơ tài khoản của bạn để tìm Drive ID.",
             "kdriveFindDriveId": "Tìm Drive ID của bạn",
             "kdriveFindDriveIdHint": "Drive ID dạng số xuất hiện trên thanh địa chỉ của trang này",
             "kdriveCreateToken": "Tạo token API",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "Dán API Token của bạn vào đây",
             "kdriveDriveIdPlaceholder": "ID kDrive của bạn (số)",
             "kdriveTokenHelp": "Tạo token tại manager.infomaniak.com → Developer → API Tokens",
+            "kdriveTokenScopes": "Token cần các phạm vi drive và user_info: Fetch đọc hồ sơ tài khoản của bạn để tìm Drive ID, và token chỉ có drive sẽ bị từ chối.",
             "kdriveFindDriveId": "Tìm Drive ID của bạn",
             "kdriveFindDriveIdHint": "Drive ID dạng số xuất hiện trên thanh địa chỉ của trang này",
             "kdriveCreateToken": "Tạo token API",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -224,7 +224,7 @@
             "kdriveTokenPlaceholder": "在此粘贴您的 API Token",
             "kdriveDriveIdPlaceholder": "您的 kDrive ID（数字）",
             "kdriveTokenHelp": "在 manager.infomaniak.com → Developer → API Tokens 生成令牌",
-            "kdriveTokenScopes": "令牌需要 drive 和 user_info 两个范围：Fetch 会读取您的账户资料来查找 Drive ID，仅有 drive 范围的令牌会被拒绝。",
+            "kdriveTokenScopes": "令牌需要 drive 和 user_info 两个范围。仅有 drive 时可以连接并列出文件，但“获取”会被拒绝，因为它需要读取您的账户资料来查找 Drive ID。",
             "kdriveFindDriveId": "查找您的 Drive ID",
             "kdriveFindDriveIdHint": "数字 Drive ID 会显示在此页面的地址栏中",
             "kdriveCreateToken": "创建 API 令牌",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -224,6 +224,7 @@
             "kdriveTokenPlaceholder": "在此粘贴您的 API Token",
             "kdriveDriveIdPlaceholder": "您的 kDrive ID（数字）",
             "kdriveTokenHelp": "在 manager.infomaniak.com → Developer → API Tokens 生成令牌",
+            "kdriveTokenScopes": "令牌需要 drive 和 user_info 两个范围：Fetch 会读取您的账户资料来查找 Drive ID，仅有 drive 范围的令牌会被拒绝。",
             "kdriveFindDriveId": "查找您的 Drive ID",
             "kdriveFindDriveIdHint": "数字 Drive ID 会显示在此页面的地址栏中",
             "kdriveCreateToken": "创建 API 令牌",


### PR DESCRIPTION
## What this fixes

#650. A kDrive API token created with the `drive` scope alone connects and lists, and only the Fetch button is refused, with a 403 that names `user_info`. v4.1.9 turned that reply into a readable message (#686), which is the right thing at the point of failure and the wrong place to learn it: the user has already created the token. The only help text for the token field, `connection.kdriveTokenHelp`, turned out never to be rendered.

## The change

A one-line hint under the token field on the Quick Connect page, next to the "Create an API token" link: the token needs the `drive` and `user_info` scopes, Fetch reads the account profile to find the Drive ID, and a token with `drive` alone is refused. New key `connection.kdriveTokenScopes`, translated in all 47 locales, with `drive`, `user_info`, `Fetch` and `Drive ID` kept literal since they are what the Infomaniak Manager and the button show.

## Verified

- `npm run i18n:validate`: all translations complete and structurally valid, 0 needing translation.
- `tsc --noEmit` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an inline hint to the kDrive connection form explaining the required `drive` and `user_info` token scopes.
  - Clarified that drive-only tokens are rejected when fetching connection details.

- **Localization**
  - Added the new guidance across all supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->