### PR TITLE
chore(deps): postcss-selector-parser 6.1.4, for Dependabot alert 69

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4219,9 +4219,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## What this does

Closes Dependabot alert 69: `postcss-selector-parser` 6.1.2 allows denial of service through uncontrolled AST recursion, fixed in 6.1.3. It is a transitive development dependency, reached only through `tailwindcss` 3.4.19 and its `postcss-nested`, so it never ships in a build; it runs at build time only. Bumped in the lock to 6.1.4, the current release in the 6.x line, with no manifest change since both parents already allow it.

## Verified

Regenerated with `npm@10.8.2`, the version CI's `npm ci` runs on node 20, rather than the local npm 11, which hides lock drift. Then, in a clean worktree: `npm ci` with that same npm, `tsc --noEmit` clean, `vite build` ok.
