### PR TITLE
fix(jottacloud): purge a trashed folder via its original path (#397)

### DIFF
--- a/docs/COMMAND-INVENTORY.json
+++ b/docs/COMMAND-INVENTORY.json
@@ -160,7 +160,7 @@
       }
     ]
   },
-  "app_version": "4.1.8",
+  "app_version": "4.1.9",
   "cli": {
     "count": 94,
     "subcommands": [
@@ -554,7 +554,7 @@
     "mcp_tools_aliases": 38,
     "mcp_tools_primary": 39,
     "mcp_tools_total": 77,
-    "tauri_commands": 850
+    "tauri_commands": 851
   },
   "mcp": {
     "count": 77,
@@ -947,7 +947,7 @@
     ]
   },
   "parity": {
-    "name_matched_count": 479,
+    "name_matched_count": 480,
     "name_unmatched": [
       "app_ready",
       "set_close_to_tray",
@@ -1834,6 +1834,7 @@
       "jottacloud_list_trash",
       "jottacloud_restore_from_trash",
       "jottacloud_permanent_delete",
+      "jottacloud_empty_trash",
       "mega_move_to_trash",
       "mega_list_trash",
       "mega_restore_from_trash",
@@ -2178,6 +2179,6 @@
       "checkpoint_endpoints",
       "checkpoint_forget_endpoint"
     ],
-    "count": 850
+    "count": 851
   }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20154,6 +20154,7 @@ pub fn run() {
             provider_commands::jottacloud_list_trash,
             provider_commands::jottacloud_restore_from_trash,
             provider_commands::jottacloud_permanent_delete,
+            provider_commands::jottacloud_empty_trash,
             provider_commands::mega_move_to_trash,
             provider_commands::mega_list_trash,
             provider_commands::mega_restore_from_trash,

--- a/src-tauri/src/provider_commands.rs
+++ b/src-tauri/src/provider_commands.rs
@@ -8250,6 +8250,30 @@ pub async fn jottacloud_permanent_delete(
     Ok(())
 }
 
+/// Empty the whole Jottacloud trash (`files/v1/purge_trash`, rclone's
+/// `cleanup`). Returns the counts the server reports, files then folders.
+#[tauri::command]
+pub async fn jottacloud_empty_trash(state: State<'_, ProviderState>) -> Result<(u64, u64), String> {
+    let mut provider_guard = state.provider.lock().await;
+    let provider = provider_guard
+        .as_mut()
+        .ok_or_else(|| "Not connected to any provider".to_string())?;
+
+    if provider.provider_type() != ProviderType::Jottacloud {
+        return Err("This operation is only available for Jottacloud".to_string());
+    }
+
+    let jotta = crate::crypt_overlay_provider::concrete_provider_mut(&mut **provider)
+        .as_any_mut()
+        .downcast_mut::<crate::providers::jottacloud::JottacloudProvider>()
+        .ok_or_else(|| "Failed to access Jottacloud provider".to_string())?;
+
+    jotta
+        .empty_trash()
+        .await
+        .map_err(|e| format!("Empty trash failed: {}", e))
+}
+
 // ── MEGA Trash Operations ────────────────────────────────────────────
 
 /// Move files to MEGA Rubbish Bin (soft delete)

--- a/src-tauri/src/providers/jottacloud.rs
+++ b/src-tauri/src/providers/jottacloud.rs
@@ -2672,6 +2672,42 @@ impl JottacloudProvider {
 
     /// Permanently delete an item from trash.
     /// POST /jfs/{username}/{device}/Trash/{path}?rm=true (file) or `?rmDir=true` (folder)
+    /// Hard-delete form for a trashed FOLDER: `?rmDir=true` on the ORIGINAL
+    /// path, not on the Trash view. Measured on 2026-09-01 against a real
+    /// account: the Trash view answers 404 to `rm`/`rmDir` because folders are
+    /// not addressable there, while this form on the tombstone answers 200 and
+    /// the folder is gone from the trash on re-listing. It is the same request
+    /// rclone's hard delete sends at a live folder, and it purges a tombstone
+    /// as well, which is why `trashed_folder_purge_decision` must run first.
+    fn purge_trashed_dir_url(&self, clean: &str) -> String {
+        format!(
+            "{}?{}=true",
+            self.jfs_url(clean),
+            Self::delete_param(true, true)
+        )
+    }
+
+    /// Whether the object at the ORIGINAL path may be purged with the
+    /// hard-delete form. Only a root `<folder>` carrying the `deleted` stamp
+    /// qualifies: the same POST at a LIVE folder destroys live data, and a
+    /// trash manager must never be able to do that through a stale listing or
+    /// a name that was re-created after being trashed.
+    fn trashed_folder_purge_decision(xml: &str) -> Result<(), &'static str> {
+        match Self::jfs_root_element(xml).as_deref() {
+            Some("folder") if Self::jfs_root_folder_is_tombstone(xml) => Ok(()),
+            Some("folder") => Err(
+                "the original path holds a LIVE folder, not a trash tombstone; hard-deleting it from the trash manager would destroy live data",
+            ),
+            Some("file") => Err("the original path is a file and the file form already failed"),
+            _ => Err("the original path did not answer with a folder"),
+        }
+    }
+
+    /// Permanently delete one trashed entry. Files go through the Trash view
+    /// with `?rm=true` (measured working, v4.1.9). Folders are not addressable
+    /// in the Trash view, so a folder is purged with the hard-delete form on
+    /// its original path, after that path has been read back and confirmed
+    /// to be a tombstone (#397, tracker #701 item 9 corrected).
     pub async fn permanent_delete_from_trash(&mut self, path: &str) -> Result<(), ProviderError> {
         let clean = path.trim_start_matches('/');
         let url = format!(
@@ -2681,21 +2717,49 @@ impl JottacloudProvider {
         );
         jotta_log(&format!("Permanent delete from trash: {}", url));
 
-        let mut resp = self.post_command_with_retry(&url).await?;
+        let resp = self.post_command_with_retry(&url).await?;
+        if resp.status().is_success() {
+            jotta_log(&format!("Permanently deleted from trash: {}", clean));
+            return Ok(());
+        }
+        let file_status = resp.status();
+        let file_body = resp.text().await.unwrap_or_default();
 
-        // A trashed *folder* needs the directory form. Unlike the soft-delete
-        // path there is nothing to lose by retrying with it: both forms are
-        // permanent, so the fallback can only turn a failure into the intended
-        // purge (#397).
-        if !resp.status().is_success() {
-            let dir_url = format!(
-                "{}?{}=true",
-                self.trash_url(clean),
-                Self::delete_param(true, true)
-            );
-            resp = self.post_command_with_retry(&dir_url).await?;
+        // Folder path: read the ORIGINAL path and require a tombstone.
+        let original = self.jfs_url(clean);
+        let get = self.get_with_retry(&original).await?;
+        if get.status() == reqwest::StatusCode::NOT_FOUND {
+            return Err(ProviderError::NotFound(format!(
+                "{} is neither in the trash ({}: {}) nor at its original path",
+                clean,
+                file_status,
+                sanitize_api_error(&file_body)
+            )));
+        }
+        if !get.status().is_success() {
+            let status = get.status();
+            let body = get.text().await.unwrap_or_default();
+            return Err(ProviderError::ServerError(format!(
+                "Permanent delete failed: reading the original path of {} answered {}: {}",
+                clean,
+                status,
+                sanitize_api_error(&body)
+            )));
+        }
+        let xml = get.text().await.unwrap_or_default();
+        if let Err(reason) = Self::trashed_folder_purge_decision(&xml) {
+            return Err(ProviderError::ServerError(format!(
+                "Permanent delete refused for {}: {}",
+                clean, reason
+            )));
         }
 
+        let dir_url = self.purge_trashed_dir_url(clean);
+        jotta_log(&format!(
+            "Purging trashed folder via original path: {}",
+            dir_url
+        ));
+        let resp = self.post_command_with_retry(&dir_url).await?;
         if !resp.status().is_success() {
             let status = resp.status();
             let body = resp.text().await.unwrap_or_default();
@@ -2705,9 +2769,47 @@ impl JottacloudProvider {
                 sanitize_api_error(&body)
             )));
         }
-
-        jotta_log(&format!("Permanently deleted from trash: {}", clean));
+        jotta_log(&format!("Permanently deleted trashed folder: {}", clean));
         Ok(())
+    }
+
+    /// Empty the whole trash: `POST {API_BASE}/files/v1/purge_trash`, the
+    /// request behind rclone's `cleanup`. Measured on 2026-09-01: 200 with
+    /// `{"files":N,"folders":M}` and the trash re-lists empty. Returns the
+    /// counts the server reports, so the caller shows what was confirmed.
+    pub async fn empty_trash(&mut self) -> Result<(u64, u64), ProviderError> {
+        self.refresh_if_needed().await?;
+        let url = format!("{}/files/v1/purge_trash", API_BASE);
+        jotta_log(&format!("Emptying trash: {}", url));
+        let request = self
+            .client
+            .post(&url)
+            .header(AUTHORIZATION, self.auth_header())
+            .header(CONTENT_LENGTH, "0")
+            .build()
+            .map_err(|e| {
+                ProviderError::ConnectionFailed(format!("Build purge_trash request failed: {}", e))
+            })?;
+        let resp = send_with_retry(&self.client, request, &HttpRetryConfig::default())
+            .await
+            .map_err(|e| ProviderError::ConnectionFailed(format!("purge_trash failed: {}", e)))?;
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        if !status.is_success() {
+            return Err(ProviderError::ServerError(format!(
+                "Empty trash failed ({}): {}",
+                status,
+                sanitize_api_error(&body)
+            )));
+        }
+        let counts: serde_json::Value = serde_json::from_str(&body).unwrap_or_default();
+        let files = counts["files"].as_u64().unwrap_or(0);
+        let folders = counts["folders"].as_u64().unwrap_or(0);
+        jotta_log(&format!(
+            "Trash emptied: {} file(s), {} folder(s) purged",
+            files, folders
+        ));
+        Ok((files, folders))
     }
 
     /// Whether this provider supports trash operations.
@@ -3564,6 +3666,33 @@ mod tests {
         }
     }
 
+    /// #397 / tracker #701 item 9: a trashed folder is purged with the
+    /// hard-delete form on its ORIGINAL path, never on the Trash view, and
+    /// only when that path answers with a tombstone. A live folder at the
+    /// same path is refused, because the same POST would destroy it.
+    #[test]
+    fn trashed_folder_purge_goes_to_the_original_path_and_only_for_a_tombstone() {
+        let p = test_provider();
+        let url = p.purge_trashed_dir_url("aeroftp-397-purge");
+        assert!(
+            url.ends_with("/Jotta/Archive/aeroftp-397-purge?rmDir=true"),
+            "{url}"
+        );
+        assert!(!url.contains("/Trash/"), "never the Trash view: {url}");
+
+        let tombstone = r#"<folder name="x" deleted="2026-09-01-T10:41:34Z"><files/></folder>"#;
+        assert_eq!(
+            JottacloudProvider::trashed_folder_purge_decision(tombstone),
+            Ok(())
+        );
+        let live = r#"<folder name="x"><files/></folder>"#;
+        let refused = JottacloudProvider::trashed_folder_purge_decision(live).unwrap_err();
+        assert!(refused.contains("LIVE"), "{refused}");
+        let file = r#"<file name="x" deleted="2026-09-01-T10:41:34Z"/>"#;
+        assert!(JottacloudProvider::trashed_folder_purge_decision(file).is_err());
+        assert!(JottacloudProvider::trashed_folder_purge_decision("garbage").is_err());
+    }
+
     #[test]
     fn folder_tombstone_children_classify_live_and_deleted() {
         // Shape captured from the live API (#397): a trashed folder's listing
@@ -3846,27 +3975,149 @@ mod tests {
         assert_eq!(second.dirs_restored, 0, "{second:?}");
         assert!(second.failed.is_empty(), "{second:?}");
 
-        // Cleanup: trash the tree again, then best-effort purge. As of
-        // v4.1.9 no JFS verb purges a trashed FOLDER (`?rm`/`?rmDir` on the
-        // Trash view 404; `?dl`/`?dlDir` on the original tombstone are 200
-        // no-ops), so a leftover fixture in the bin is logged, not fatal.
+        // Cleanup: trash the tree again, then purge it for real. A trashed
+        // FOLDER is purged with `?rmDir=true` on its ORIGINAL path (the Trash
+        // view still 404s), measured 2026-09-01, so the fixture must leave
+        // the bin and a leftover is a failure, not a log line.
         p.move_to_trash(&root).await.expect("cleanup move to trash");
-        let trash = p.list_trash().await.expect("list trash for cleanup");
-        for entry in trash
-            .iter()
-            .filter(|e| e.name.starts_with("aeroftp-397-e2e-"))
-            .cloned()
-            .collect::<Vec<_>>()
-        {
-            let name = entry.name.trim_start_matches('/').to_string();
-            match p.permanent_delete_from_trash(&name).await {
-                Ok(()) => eprintln!("CLEANUP {name}: purged"),
-                Err(e) => eprintln!(
-                    "CLEANUP {name}: purge unavailable for trashed folders ({e}); \
-                     empty the bin from the Jottacloud web UI"
-                ),
-            }
-        }
+        p.permanent_delete_from_trash(&root)
+            .await
+            .expect("purge of the trashed fixture folder");
+        let trash = p.list_trash().await.expect("list trash after purge");
+        assert!(
+            !trash.iter().any(|e| e.name.trim_start_matches('/') == root),
+            "purged fixture must be gone from the bin: {trash:?}"
+        );
         let _ = tokio::fs::remove_dir_all(&tmp).await;
+    }
+
+    // ─── Live check of the purge guard and of empty_trash (#397, item 9) ──
+    //
+    // Run explicitly (never in CI):
+    //   cargo test --release --lib live_purge_trashed_folder_and_guard -- --ignored --nocapture
+    // Env: JOTTA_TEST_PROFILE (default "Jotta"). Test account only: the last
+    // step empties the WHOLE trash of that account.
+    #[tokio::test]
+    #[ignore = "live Jottacloud test; run explicitly"]
+    async fn live_purge_trashed_folder_and_guard() {
+        use crate::providers::{ProviderConfig, ProviderFactory, ProviderType};
+
+        let profile_query =
+            std::env::var("JOTTA_TEST_PROFILE").unwrap_or_else(|_| "Jotta".to_string());
+        crate::credential_store::CredentialStore::init().expect("vault init failed");
+        let store = crate::credential_store::CredentialStore::from_cache().expect("vault not open");
+        let profiles = crate::user_partitions::mcp_list_active_server_profiles(&store)
+            .expect("profile listing failed");
+        let matched = profiles
+            .iter()
+            .find(|p| p.get("name").and_then(|v| v.as_str()) == Some(profile_query.as_str()))
+            .cloned()
+            .expect("test profile not found");
+        let profile_id = matched
+            .get("id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let raw = crate::user_partitions::resolve_active_credential(
+            &store,
+            &format!("server_{profile_id}"),
+        )
+        .ok()
+        .flatten()
+        .map(|s| s.to_string())
+        .unwrap_or_default();
+        let token = if let Ok(v) = serde_json::from_str::<serde_json::Value>(&raw) {
+            v.get("password")
+                .and_then(|x| x.as_str())
+                .or_else(|| v.get("access_token").and_then(|x| x.as_str()))
+                .unwrap_or("")
+                .to_string()
+        } else {
+            raw.trim_matches('"').to_string()
+        };
+        // The refresh chain to use is selectable: the installed CLI rotates
+        // the legacy singleton (`jottacloud_refresh`), a GUI-bound provider
+        // the per-profile key. Default to the singleton; set
+        // JOTTA_TEST_BIND_PROFILE=1 to bind the profile id instead.
+        let mut extra = std::collections::HashMap::new();
+        if std::env::var("JOTTA_TEST_BIND_PROFILE").is_ok() {
+            extra.insert("profile_id".to_string(), profile_id);
+        }
+        let config = ProviderConfig {
+            name: "jotta-purge".to_string(),
+            provider_type: ProviderType::Jottacloud,
+            host: "jfs.jottacloud.com".to_string(),
+            port: Some(443),
+            username: Some("token".to_string()),
+            password: Some(token),
+            initial_path: None,
+            extra,
+        };
+        let mut boxed = ProviderFactory::create(&config).expect("provider create failed");
+        boxed.connect().await.expect("connect failed");
+        let p = boxed
+            .as_any_mut()
+            .downcast_mut::<JottacloudProvider>()
+            .expect("downcast failed");
+
+        let stamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let trashed = format!("aeroftp-397-purge-{stamp}");
+        let live = format!("aeroftp-397-live-{stamp}");
+        p.mkdir(&trashed).await.expect("mkdir trashed fixture");
+        p.mkdir(&format!("{trashed}/sub")).await.expect("mkdir sub");
+        p.mkdir(&live).await.expect("mkdir live fixture");
+
+        // 1. A trashed folder purges through the original-path form.
+        p.move_to_trash(&trashed).await.expect("move to trash");
+        assert!(p
+            .list_trash()
+            .await
+            .expect("list")
+            .iter()
+            .any(|e| e.name.trim_start_matches('/') == trashed));
+        p.permanent_delete_from_trash(&trashed)
+            .await
+            .expect("PURGE OF A TRASHED FOLDER");
+        assert!(
+            !p.list_trash()
+                .await
+                .expect("list")
+                .iter()
+                .any(|e| e.name.trim_start_matches('/') == trashed),
+            "the purged folder must leave the bin"
+        );
+
+        // 2. The same call at a LIVE folder is refused and the folder survives.
+        let refused = p.permanent_delete_from_trash(&live).await;
+        assert!(
+            matches!(&refused, Err(ProviderError::ServerError(m)) if m.contains("LIVE")),
+            "a live folder must be refused, got {refused:?}"
+        );
+        assert!(
+            p.list("")
+                .await
+                .expect("list root")
+                .iter()
+                .any(|e| e.name == live),
+            "the live folder must survive the refused purge"
+        );
+
+        // 3. empty_trash reports what it removed and the bin re-lists empty.
+        p.move_to_trash(&live)
+            .await
+            .expect("trash the live fixture for cleanup");
+        let (files, folders) = p.empty_trash().await.expect("EMPTY TRASH");
+        eprintln!("empty_trash: {files} file(s), {folders} folder(s)");
+        assert!(
+            folders >= 1,
+            "the trashed fixture must be counted: {folders}"
+        );
+        assert!(
+            p.list_trash().await.expect("list after empty").is_empty(),
+            "bin must be empty"
+        );
     }
 }

--- a/src-tauri/src/providers/jottacloud.rs
+++ b/src-tauri/src/providers/jottacloud.rs
@@ -2708,6 +2708,15 @@ impl JottacloudProvider {
     /// in the Trash view, so a folder is purged with the hard-delete form on
     /// its original path, after that path has been read back and confirmed
     /// to be a tombstone (#397, tracker #701 item 9 corrected).
+    ///
+    /// Declared limit: the tombstone check and the delete are two requests,
+    /// and JFS offers no conditional delete (no revision or ETag precondition
+    /// on `rmDir`), so a session that restores or recreates the same name
+    /// between them would see its live folder purged. The window is one
+    /// round trip, the same window every list-then-purge trash manager has
+    /// on this provider, and it cannot be closed from the client side. The
+    /// check exists so that the ordinary case, a live folder that was never
+    /// the one selected, is refused rather than deleted.
     pub async fn permanent_delete_from_trash(&mut self, path: &str) -> Result<(), ProviderError> {
         let clean = path.trim_start_matches('/');
         let url = format!(
@@ -2773,6 +2782,30 @@ impl JottacloudProvider {
         Ok(())
     }
 
+    /// The counts `purge_trash` reports, or a parse error. A malformed body
+    /// must not read as "0 files, 0 folders": that number is shown to the user
+    /// as what the server confirmed, and a silent zero would say the trash was
+    /// already empty when the answer was in fact unreadable.
+    fn parse_purge_trash_counts(body: &str) -> Result<(u64, u64), ProviderError> {
+        let counts: serde_json::Value = serde_json::from_str(body).map_err(|e| {
+            ProviderError::ParseError(format!(
+                "purge_trash answered 200 with a body that is not JSON ({}): {}",
+                e,
+                sanitize_api_error(body)
+            ))
+        })?;
+        let field = |key: &str| -> Result<u64, ProviderError> {
+            counts.get(key).and_then(|v| v.as_u64()).ok_or_else(|| {
+                ProviderError::ParseError(format!(
+                    "purge_trash answered without a numeric `{}`: {}",
+                    key,
+                    sanitize_api_error(body)
+                ))
+            })
+        };
+        Ok((field("files")?, field("folders")?))
+    }
+
     /// Empty the whole trash: `POST {API_BASE}/files/v1/purge_trash`, the
     /// request behind rclone's `cleanup`. Measured on 2026-09-01: 200 with
     /// `{"files":N,"folders":M}` and the trash re-lists empty. Returns the
@@ -2802,9 +2835,7 @@ impl JottacloudProvider {
                 sanitize_api_error(&body)
             )));
         }
-        let counts: serde_json::Value = serde_json::from_str(&body).unwrap_or_default();
-        let files = counts["files"].as_u64().unwrap_or(0);
-        let folders = counts["folders"].as_u64().unwrap_or(0);
+        let (files, folders) = Self::parse_purge_trash_counts(&body)?;
         jotta_log(&format!(
             "Trash emptied: {} file(s), {} folder(s) purged",
             files, folders
@@ -3693,6 +3724,30 @@ mod tests {
         assert!(JottacloudProvider::trashed_folder_purge_decision("garbage").is_err());
     }
 
+    /// `purge_trash` answers `{"files":N,"folders":M}`; anything else is a
+    /// parse error and never a confirmed zero.
+    #[test]
+    fn purge_trash_counts_are_parsed_strictly() {
+        assert_eq!(
+            JottacloudProvider::parse_purge_trash_counts(r#"{"files":0,"folders":2}"#).unwrap(),
+            (0, 2)
+        );
+        for bad in [
+            "not json",
+            "",
+            r#"{"files":0}"#,
+            r#"{"files":"0","folders":2}"#,
+            r#"{"files":-1,"folders":2}"#,
+            r#"[]"#,
+        ] {
+            let err = JottacloudProvider::parse_purge_trash_counts(bad).unwrap_err();
+            assert!(
+                matches!(err, ProviderError::ParseError(_)),
+                "{bad:?} -> {err:?}"
+            );
+        }
+    }
+
     #[test]
     fn folder_tombstone_children_classify_live_and_deleted() {
         // Shape captured from the live API (#397): a trashed folder's listing
@@ -4114,18 +4169,31 @@ mod tests {
         );
 
         // 3. empty_trash reports what it removed and the bin re-lists empty.
+        // This step purges EVERY entry in the account's trash, not only the
+        // fixtures, so it needs its own opt-in on top of the ignored test:
+        // without JOTTA_TEST_ALLOW_EMPTY_TRASH=1 the fixture is purged one
+        // by one instead and the whole-bin step is reported as skipped.
         p.move_to_trash(&live)
             .await
             .expect("trash the live fixture for cleanup");
-        let (files, folders) = p.empty_trash().await.expect("EMPTY TRASH");
-        eprintln!("empty_trash: {files} file(s), {folders} folder(s)");
-        assert!(
-            folders >= 1,
-            "the trashed fixture must be counted: {folders}"
-        );
-        assert!(
-            p.list_trash().await.expect("list after empty").is_empty(),
-            "bin must be empty"
-        );
+        if std::env::var("JOTTA_TEST_ALLOW_EMPTY_TRASH").as_deref() == Ok("1") {
+            let (files, folders) = p.empty_trash().await.expect("EMPTY TRASH");
+            eprintln!("empty_trash: {files} file(s), {folders} folder(s)");
+            assert!(
+                folders >= 1,
+                "the trashed fixture must be counted: {folders}"
+            );
+            assert!(
+                p.list_trash().await.expect("list after empty").is_empty(),
+                "bin must be empty"
+            );
+        } else {
+            p.permanent_delete_from_trash(&live)
+                .await
+                .expect("purge the second fixture");
+            eprintln!(
+                "empty_trash step SKIPPED: set JOTTA_TEST_ALLOW_EMPTY_TRASH=1 to purge the whole bin"
+            );
+        }
     }
 }

--- a/src-tauri/src/providers/jottacloud.rs
+++ b/src-tauri/src/providers/jottacloud.rs
@@ -3824,7 +3824,11 @@ mod tests {
             .expect("profile listing failed");
         let matched = profiles
             .iter()
-            .find(|p| p.get("name").and_then(|v| v.as_str()) == Some(profile_query.as_str()))
+            .find(|p| {
+                p.get("name")
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|n| n.eq_ignore_ascii_case(&profile_query))
+            })
             .cloned()
             .expect("test profile not found");
         let profile_id = matched
@@ -4010,7 +4014,11 @@ mod tests {
             .expect("profile listing failed");
         let matched = profiles
             .iter()
-            .find(|p| p.get("name").and_then(|v| v.as_str()) == Some(profile_query.as_str()))
+            .find(|p| {
+                p.get("name")
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|n| n.eq_ignore_ascii_case(&profile_query))
+            })
             .cloned()
             .expect("test profile not found");
         let profile_id = matched

--- a/src/components/JottacloudTrashManager.tsx
+++ b/src/components/JottacloudTrashManager.tsx
@@ -136,13 +136,19 @@ export function JottacloudTrashManager({ onClose, onRefreshFiles }: JottacloudTr
     }
   };
 
+  // Escape dismisses the innermost surface: an open confirmation first, the
+  // manager itself only when no confirmation is pending. One key press must
+  // never both cancel a purge prompt and close the whole window.
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
+      if (e.key !== 'Escape') return;
+      if (pendingEmptyConfirm) { setPendingEmptyConfirm(false); return; }
+      if (pendingDeleteConfirm) { setPendingDeleteConfirm(false); return; }
+      onClose();
     };
     window.addEventListener('keydown', handleKey);
     return () => window.removeEventListener('keydown', handleKey);
-  }, [onClose]);
+  }, [onClose, pendingEmptyConfirm, pendingDeleteConfirm]);
 
   // Normalized for the shared trash table (sorting, Type column,
   // Ctrl/Shift and rubber-band selection live there).

--- a/src/components/JottacloudTrashManager.tsx
+++ b/src/components/JottacloudTrashManager.tsx
@@ -34,6 +34,7 @@ export function JottacloudTrashManager({ onClose, onRefreshFiles }: JottacloudTr
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [actionLoading, setActionLoading] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [pendingEmptyConfirm, setPendingEmptyConfirm] = useState(false);
 
   const loadTrash = useCallback(async () => {
     setLoading(true);
@@ -106,6 +107,28 @@ export function JottacloudTrashManager({ onClose, onRefreshFiles }: JottacloudTr
       onRefreshFiles?.();
     } catch (err) {
       humanLog.updateEntry(logId, { status: 'error', message: `[Jottacloud] Failed to permanently delete from trash` });
+      setError(String(err));
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  // Whole-bin purge through `files/v1/purge_trash` (rclone's `cleanup`),
+  // measured 2026-09-01 (#397): the server answers with what it removed,
+  // so the log line carries the confirmed counts, not the selection.
+  const confirmEmptyTrash = async () => {
+    setPendingEmptyConfirm(false);
+    const totalCount = items.length;
+    const logId = humanLog.logRaw('activity.trash_empty_start', 'INFO', { provider: 'Jottacloud', count: totalCount });
+    setActionLoading('empty');
+    setError(null);
+    try {
+      const [files, folders] = await invoke<[number, number]>('jottacloud_empty_trash');
+      humanLog.updateEntry(logId, { status: 'success', message: `[Jottacloud] Emptied trash (${files} file(s), ${folders} folder(s) purged)` });
+      await loadTrash();
+      onRefreshFiles?.();
+    } catch (err) {
+      humanLog.updateEntry(logId, { status: 'error', message: `[Jottacloud] Failed to empty trash` });
       setError(String(err));
     } finally {
       setActionLoading(null);
@@ -199,6 +222,15 @@ export function JottacloudTrashManager({ onClose, onRefreshFiles }: JottacloudTr
               {actionLoading === 'delete' ? <Loader2 size={12} className="animate-spin" /> : <AlertTriangle size={12} />}
               {t('contextMenu.permanentDelete')} {selected.size > 0 && `(${selected.size})`}
             </button>
+            <button
+              onClick={() => setPendingEmptyConfirm(true)}
+              disabled={items.length === 0 || actionLoading !== null}
+              title={t('contextMenu.emptyTrashHint')}
+              className="flex items-center gap-1.5 px-3 py-1 text-xs rounded bg-amber-600 text-white hover:bg-amber-700 disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              {actionLoading === 'empty' ? <Loader2 size={12} className="animate-spin" /> : <AlertTriangle size={12} />}
+              {t('contextMenu.emptyTrash')}
+            </button>
           </div>
         )}
 
@@ -250,6 +282,30 @@ export function JottacloudTrashManager({ onClose, onRefreshFiles }: JottacloudTr
                 className="px-4 py-2 text-white rounded-lg bg-red-500 hover:bg-red-600"
               >
                 {t('contextMenu.permanentDelete')}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {pendingEmptyConfirm && (
+        <div className="fixed inset-0 z-[10000] bg-black/50 flex items-center justify-center" role="dialog" aria-modal="true" onClick={() => setPendingEmptyConfirm(false)}>
+          <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 shadow-2xl max-w-sm animate-scale-in" onClick={e => e.stopPropagation()}>
+            <p className="text-gray-900 dark:text-gray-100 mb-4">
+              {t('contextMenu.emptyTrashConfirm')}
+            </p>
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() => setPendingEmptyConfirm(false)}
+                className="px-4 py-2 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg"
+              >
+                {t('common.cancel')}
+              </button>
+              <button
+                onClick={confirmEmptyTrash}
+                className="px-4 py-2 text-white rounded-lg bg-red-500 hover:bg-red-600"
+              >
+                {t('contextMenu.emptyTrash')}
               </button>
             </div>
           </div>

--- a/src/components/JottacloudTrashManager.tsx
+++ b/src/components/JottacloudTrashManager.tsx
@@ -117,6 +117,7 @@ export function JottacloudTrashManager({ onClose, onRefreshFiles }: JottacloudTr
   // measured 2026-09-01 (#397): the server answers with what it removed,
   // so the log line carries the confirmed counts, not the selection.
   const confirmEmptyTrash = async () => {
+    if (actionLoading !== null) return;
     setPendingEmptyConfirm(false);
     const totalCount = items.length;
     const logId = humanLog.logRaw('activity.trash_empty_start', 'INFO', { provider: 'Jottacloud', count: totalCount });
@@ -265,7 +266,7 @@ export function JottacloudTrashManager({ onClose, onRefreshFiles }: JottacloudTr
 
       {/* Styled confirmation dialog (replaces window.confirm) */}
       {pendingDeleteConfirm && (
-        <div className="fixed inset-0 z-[10000] bg-black/50 flex items-center justify-center" role="dialog" aria-modal="true" onClick={() => setPendingDeleteConfirm(false)}>
+        <div className="fixed inset-0 z-[10000] bg-black/50 flex items-center justify-center" role="dialog" aria-modal="true" onClick={(e) => { e.stopPropagation(); setPendingDeleteConfirm(false); }}>
           <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 shadow-2xl max-w-sm animate-scale-in" onClick={e => e.stopPropagation()}>
             <p className="text-gray-900 dark:text-gray-100 mb-4">
               {t('contextMenu.permanentDeleteConfirm', { count: selected.size })}
@@ -289,7 +290,7 @@ export function JottacloudTrashManager({ onClose, onRefreshFiles }: JottacloudTr
       )}
 
       {pendingEmptyConfirm && (
-        <div className="fixed inset-0 z-[10000] bg-black/50 flex items-center justify-center" role="dialog" aria-modal="true" onClick={() => setPendingEmptyConfirm(false)}>
+        <div className="fixed inset-0 z-[10000] bg-black/50 flex items-center justify-center" role="dialog" aria-modal="true" onClick={(e) => { e.stopPropagation(); setPendingEmptyConfirm(false); }}>
           <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 shadow-2xl max-w-sm animate-scale-in" onClick={e => e.stopPropagation()}>
             <p className="text-gray-900 dark:text-gray-100 mb-4">
               {t('contextMenu.emptyTrashConfirm')}
@@ -303,7 +304,8 @@ export function JottacloudTrashManager({ onClose, onRefreshFiles }: JottacloudTr
               </button>
               <button
                 onClick={confirmEmptyTrash}
-                className="px-4 py-2 text-white rounded-lg bg-red-500 hover:bg-red-600"
+                disabled={actionLoading !== null}
+                className="px-4 py-2 text-white rounded-lg bg-red-500 hover:bg-red-600 disabled:opacity-40 disabled:cursor-not-allowed"
               >
                 {t('contextMenu.emptyTrash')}
               </button>


### PR DESCRIPTION
## What this fixes

Tracker #701 item 9 said permanent purge of a trashed folder is impossible through the Jottacloud API, and the #703 test fixtures could only be cleared from the web UI. That was measured on the Trash view only. rclone's backend, which this implementation follows, sends its hard delete as `?rmDir=true` on the ORIGINAL path, and that form was never tried on a tombstone. Measured on the test account on 2026-09-01 with the owner's clearance:

| request | answer | trash re-listed |
|---|---|---|
| `POST <jfs>/<user>/Jotta/Archive/<folder>?rmDir=true` on a trashed folder's original path | 200 | folder gone (done on two fixtures) |
| `?rm=true` (file form) at a folder | 404 | unchanged |
| `POST api.jottacloud.com/files/v1/purge_trash`, rclone's `cleanup` | 200 `{"files":0,"folders":2}` | empty |

So item 9 was "not addressable through the surface we probed", not "impossible", and this PR makes both operations real.

## The change

- **Permanent delete of a trashed folder** goes through the hard-delete form on the original path, after that path has been read back and confirmed to be a tombstone. The guard is not optional: the same POST at a LIVE folder destroys it, so a live folder at that path is refused with a message that says so, and a path that answers neither in the trash nor at its origin is `NotFound`. Files keep the Trash-view form that already works.
- **Empty trash** for Jottacloud: `empty_trash()` on the provider, a `jottacloud_empty_trash` command, and the amber button plus confirmation in the trash manager, following the Yandex manager. The success line carries the counts the server reports, not the selection.
- The #703 end-to-end test now purges its own fixture and asserts the bin is clean, instead of logging that it cannot.

## Verified

- Unit test: the purge URL targets `/Jotta/Archive/<name>?rmDir=true` and never the Trash view; the decision accepts a tombstoned root folder and refuses a live folder (naming it LIVE), a file, and garbage.
- Live, `live_purge_trashed_folder_and_guard` on the saved Jotta profile: a fresh folder with a subfolder is trashed and purged through the original-path form and leaves the bin; the same call at a live folder is refused with the LIVE message and the folder survives; `empty_trash` on the remaining fixture reports 0 files and 1 folder and the bin re-lists empty. The #703 test cleanup now purges its fixture instead of logging that it cannot.
- `cargo fmt`, `cargo clippy --lib --tests -D warnings`, `cargo test --lib providers::jottacloud`, `tsc --noEmit` (7.0.2), all clean.

## Follow-ups this measurement opened, not in this PR

Tracker #701 item 9 is rewritten from this measurement, and the #397 reply that repeated it is corrected. Two more findings from the same session go to their own PR: the CLI and the GUI keep two different Jottacloud refresh chains on one station (`jottacloud_refresh` versus `jottacloud_refresh_<id>`), and the profile export prefers the per-profile chain even when it is the stale one, which is why an exported profile could arrive dead on the other station tonight.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an “Empty Trash” option to the Jottacloud trash manager.
  - Added a confirmation prompt before permanently deleting all trashed items.
  - Jottacloud trash cleanup now reports deleted file and folder counts.
  - Trash and file listings refresh after emptying the bin.
  - Added loading protection and error feedback during cleanup.

- **Bug Fixes**
  - Improved trashed-folder handling to prevent accidental deletion of active folders.
  - Improved confirmation behavior when dismissing dialogs or pressing Escape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->