### PR TITLE
ci: drop the runner's Microsoft apt repos before installing packages

### DIFF
--- a/.github/workflows/aerorsync-protocol.yml
+++ b/.github/workflows/aerorsync-protocol.yml
@@ -73,6 +73,9 @@ jobs:
           workspaces: src-tauri
       - name: Install Linux system deps
         run: |
+          # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
+          # enough to redden a run, and nothing here installs from them.
+          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev \
@@ -129,6 +132,9 @@ jobs:
           df -h /
       - name: Install Linux system deps
         run: |
+          # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
+          # enough to redden a run, and nothing here installs from them.
+          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev \
@@ -185,6 +191,9 @@ jobs:
           echo "After:"; df -h /
       - name: Install Linux system deps
         run: |
+          # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
+          # enough to redden a run, and nothing here installs from them.
+          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,6 +118,9 @@ jobs:
       - name: Install Linux dependencies
         if: matrix.target == 'linux'
         run: |
+          # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
+          # enough to redden a run, and nothing here installs from them.
+          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
           sudo apt-get update
           # `dbus` is here for the `Rust tests` step below, not for the build.
           # `portal_chooser`'s three cases stand up a throwaway session bus with
@@ -783,6 +786,9 @@ jobs:
         env:
           SNAP_FILE: ${{ steps.snap-check.outputs.snap }}
         run: |
+          # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
+          # enough to redden a run, and nothing here installs from them.
+          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends squashfs-tools binutils file
           ./scripts/snap-abi-check.sh "$SNAP_FILE"
@@ -841,6 +847,9 @@ jobs:
           SNAP_GUI_SCREENSHOT: ${{ runner.temp }}/snap-gui-screenshot.png
         run: |
           set -euo pipefail
+          # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
+          # enough to redden a run, and nothing here installs from them.
+          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends xvfb x11-apps imagemagick
           sudo snap install --dangerous "$SNAP_FILE"

--- a/.github/workflows/cli-smoke.yml
+++ b/.github/workflows/cli-smoke.yml
@@ -101,6 +101,9 @@ jobs:
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
         run: |
+          # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
+          # enough to redden a run, and nothing here installs from them.
+          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             libwebkit2gtk-4.1-dev \
@@ -267,6 +270,9 @@ jobs:
 
       - name: Install Linux dependencies
         run: |
+          # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
+          # enough to redden a run, and nothing here installs from them.
+          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             libwebkit2gtk-4.1-dev \
@@ -328,6 +334,9 @@ jobs:
 
       - name: Install Linux dependencies
         run: |
+          # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
+          # enough to redden a run, and nothing here installs from them.
+          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             libwebkit2gtk-4.1-dev \

--- a/.github/workflows/delta-sync-integration.yml
+++ b/.github/workflows/delta-sync-integration.yml
@@ -146,6 +146,9 @@ jobs:
             # next apt-get would refuse to run until it is told to finish.
             sudo dpkg --configure -a || true
             mkdir -p "$HOME/apt-archives/partial"
+            # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
+            # enough to redden a run, and nothing here installs from them.
+            sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
             sudo apt-get update
             # rsync + ssh client for the host side of the integration test.
             # Webkit/GTK stack is needed because compiling the aeroftp
@@ -342,6 +345,9 @@ jobs:
             set -euo pipefail
             sudo dpkg --configure -a || true
             mkdir -p "$HOME/apt-archives/partial"
+            # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
+            # enough to redden a run, and nothing here installs from them.
+            sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
             sudo apt-get update
             sudo apt-get install -y --no-install-recommends \
               -o Dir::Cache::archives="$HOME/apt-archives/" \

--- a/.github/workflows/ftp-mlsd.yml
+++ b/.github/workflows/ftp-mlsd.yml
@@ -91,6 +91,9 @@ jobs:
             # next apt-get would refuse to run until it is told to finish.
             sudo dpkg --configure -a || true
             mkdir -p "$HOME/apt-archives/partial"
+            # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
+            # enough to redden a run, and nothing here installs from them.
+            sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
             sudo apt-get update
             sudo apt-get install -y --no-install-recommends \
               -o Dir::Cache::archives="$HOME/apt-archives/" \
@@ -232,6 +235,9 @@ jobs:
             set -euo pipefail
             sudo dpkg --configure -a || true
             mkdir -p "$HOME/apt-archives/partial"
+            # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
+            # enough to redden a run, and nothing here installs from them.
+            sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
             sudo apt-get update
             sudo apt-get install -y --no-install-recommends \
               -o Dir::Cache::archives="$HOME/apt-archives/" \

--- a/.github/workflows/nightly-telemetry.yml
+++ b/.github/workflows/nightly-telemetry.yml
@@ -48,6 +48,9 @@ jobs:
       # system dev packages. Same set as cli-smoke.yml.
       - name: Install Linux dependencies
         run: |
+          # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
+          # enough to redden a run, and nothing here installs from them.
+          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             libwebkit2gtk-4.1-dev \

--- a/.github/workflows/portal-chooser.yml
+++ b/.github/workflows/portal-chooser.yml
@@ -71,6 +71,9 @@ jobs:
 
       - name: Install D-Bus
         run: |
+          # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
+          # enough to redden a run, and nothing here installs from them.
+          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends dbus
 
@@ -128,6 +131,9 @@ jobs:
       # windows, never to click.
       - name: Install the desktop and accessibility stack
         run: |
+          # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
+          # enough to redden a run, and nothing here installs from them.
+          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev \

--- a/.github/workflows/snap-refresh.yml
+++ b/.github/workflows/snap-refresh.yml
@@ -129,7 +129,11 @@ jobs:
           node-version: '20'
 
       - name: Install audit tooling
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends squashfs-tools
+        # Runner-image extras: Microsoft's apt repos 403 on their InRelease
+        # often enough to redden a run, and nothing here installs from them.
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
+          sudo apt-get update && sudo apt-get install -y --no-install-recommends squashfs-tools
 
       - name: Audit published revision against the Ubuntu archive
         id: audit
@@ -170,6 +174,9 @@ jobs:
 
       - name: Install Linux build dependencies
         run: |
+          # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
+          # enough to redden a run, and nothing here installs from them.
+          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
           sudo apt-get update
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev \
@@ -303,6 +310,9 @@ jobs:
         env:
           SNAP_FILE: ${{ steps.snap-check.outputs.snap }}
         run: |
+          # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
+          # enough to redden a run, and nothing here installs from them.
+          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends squashfs-tools binutils file
           ./ci-tools/scripts/snap-abi-check.sh "$SNAP_FILE" snap/snapcraft.yaml
@@ -349,6 +359,9 @@ jobs:
           SNAP_GUI_SCREENSHOT: ${{ runner.temp }}/snap-gui-screenshot.png
         run: |
           set -euo pipefail
+          # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
+          # enough to redden a run, and nothing here installs from them.
+          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends xvfb x11-apps imagemagick
           sudo snap install --dangerous "$SNAP_FILE"


### PR DESCRIPTION
## Description

`packages.microsoft.com` answers 403 Forbidden on the `InRelease` files of the two repositories the runner image preinstalls, `repos/azure-cli` and `ubuntu/24.04/prod`, often enough to redden a run at random. `apt-get update` exits 100 when any configured source fails to verify, so the step dies before a line of this repository's code has run. It happened on `main` right after #717 merged: the Delta Sync Integration lane failed at "Install system dependencies" in the password-only job, three attempts in a row, while the sibling job in the same run had passed the same step minutes earlier, and a re-run of the failed job went green with nothing changed.

Nothing here installs from those repositories. The only mentions of Microsoft packages in the workflows are the `rm -rf /usr/share/dotnet` lines that free disk space. So the twenty places that run `sudo apt-get update` now drop those two source lists first, and only those: the Ubuntu archives and the Chrome repository the image also ships are left alone.

The removal cannot fail a step on its own. `rm -f` returns success when a glob matches nothing, so a future runner image that stops shipping those files changes nothing here, and there is no pipeline for a `set -o pipefail` to trip on. Every one of the twenty sites sits inside a Linux-only step, guarded either by `runner.os == 'Linux'` or by a matrix target, and runs under bash.

This pull request verifies itself: its own CI runs with the change in place, so a green run is the evidence that the twenty edits are well formed. The YAML of all thirteen workflows was also parsed locally.

Retrying was already in place where it matters and did not help, because the outage outlived the three attempts. The trap is now entry 15 of the recurring CI-red checklist, with the instruction to add the same line to any new workflow step that installs a package.

## Type of Change
- [x] CI reliability, no product code
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] My code follows the project's code style
- [x] I have tested my changes
- [x] I have updated the documentation (if needed)
- [x] My changes generate no new warnings
- [x] Every commit is signed off (`git commit -s`), see [CONTRIBUTING](../CONTRIBUTING.md#sign-off-developer-certificate-of-origin)

## Related Issues

None. Follows the red seen on `main` at `50bcd412e` after #717.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the reliability of Linux-based automated checks and builds by preventing unavailable Microsoft and Azure CLI package repositories from interrupting dependency installation.
  - Reduced workflow failures caused by repository access errors during package updates across integration, smoke-test, telemetry, desktop, and snap validation jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->