### PR TITLE
refactor(aerorsync): the module imports nothing from the application

### DIFF
--- a/src-tauri/src/aerorsync/README.md
+++ b/src-tauri/src/aerorsync/README.md
@@ -157,7 +157,7 @@ Elenco allineato a `mod.rs` (una riga per file, dal doc di testa del file).
 
 - `acl_fs.rs`: I/O delle ACL POSIX.1e locali (B2)
 - `delta_engine.rs`: motore delta rolling checksum + block matching, entrato nel modulo con la tranche A1
-- `delta_transport_impl.rs`: `AerorsyncDeltaTransport` (impl `DeltaTransport`) + `AerorsyncBatch` session reuse
+- `delta_transport_impl.rs`: `AerorsyncDeltaTransport`, i suoi entry point crate-owned e `AerorsyncBatch` per il riuso di sessione; l'`impl DeltaTransport` vive nell'adapter (vedi Boundary)
 - `engine_adapter.rs`: ponte fra il layer di protocollo nativo e il motore delta
 - `engine_protocol_types.rs`: tipi di forma protocollare rimasti dopo Y-RSC.8
 - `events.rs`: eventi mux out-of-band, `EventSink`, `AerorsyncEvent::notice()` e `WarningCollector`

--- a/src-tauri/src/aerorsync/README.md
+++ b/src-tauri/src/aerorsync/README.md
@@ -131,6 +131,26 @@ cargo test --features aerorsync \
 3. ~~**Session reuse**: ogni file apre una nuova sessione SSH~~ Done (P3-T01 W3, `AerorsyncBatch` in `delta_transport_impl.rs`): una sessione SSH racchiude N file, usata da sync-tree core, DAG serial lane e CLI sync. Validata live (Z.1.1, smoke KPI).
 4. **Scope funzionale**: single-file delta accelerator, non sostituto completo di rsync. Le categorie qui sotto non vanno accorpate in un unico backlog (vedi `docs/PROTOCOL-RSYNC-COMPARE.md`, tassonomia operativa). **(a) Fuori scope per design del prodotto integrato**, perche' l'autorita' vive a un altro layer, richiede privilegi incompatibili con il desktop product o e' un altro transport: recursive tree sync, `--delete*`, `--backup`, `--link-dest` (cancellazione e retention sono di AeroSync/AeroCloud, con i gate v4.1.6 AUDIT-03), `--inplace` / `--append` / `--partial-dir` (la strategia di scrittura e' di `StreamingAtomicWriter`), filtri wire `--exclude` / `--include` / `--files-from`, daemon mode `rsync://`, owner/group (`-o`/`-g`) e device/special files (`-D`). **(b) Gate della futura sessione multi-entry e della valutazione standalone**, non promesse del path integrato single-file: hardlink (`-H`, richiede una mappa device/inode tree-scope) e directory default ACL. **Supportati**: symlink end-to-end su Unix; **`user.*` xattr (`-X`) su Unix** con opt-in produzione e ENOTSUP soft di default; **POSIX access ACL (`-A`) su Linux** con read/apply sullo stesso fd, named user + mask live in entrambe le direzioni e opt-in produzione Linux-only. Un errore di lettura ACL sorgente e' hard; ENOTSUP in apply resta soft di default; symlink e non-Linux non entrano nel path ACL. E' supportato anche un analogo `--sparse` opt-in sul local delta path. **`--mkpath` NON e' implementato**.
 
+## Boundary
+
+Il modulo non importa nulla dall'applicazione: nessuna riga
+`crate::<modulo applicativo>` esiste qui, e il test che lo misura e'
+`tests::aerorsync_module_imports_nothing_from_the_app`, che scandisce la
+cartella piatta e rifiuta anche le forme che una scansione cieca non
+vedrebbe (import raggruppati, `super::super::`, attributo `path`, macro
+di inclusione, sottocartelle).
+
+Tutto cio' che l'applicazione deve vedere passa da
+`src-tauri/src/aerorsync_adapter/`: li' vivono gli `impl` di
+`DeltaTransport` e `DeltaBatch` per il transport remoto e per quello
+locale, la costruzione di un transport da un profilo (`config.rs`) e le
+mappe verso `RsyncError`, `RsyncStats` e `RsyncCapability` (`errors.rs`).
+L'adapter dichiara a sua volta il proprio perimetro con
+`aerorsync_adapter::tests::aerorsync_adapter_declares_its_imports`: da un
+lato gli import applicativi, dall'altro i sottomoduli del modulo che
+tocca, che sono la superficie pubblica minima che il crate dovra'
+esporre quando verra' estratto.
+
 ## File del modulo
 
 Elenco allineato a `mod.rs` (una riga per file, dal doc di testa del file).

--- a/src-tauri/src/aerorsync/delta_transport_impl.rs
+++ b/src-tauri/src/aerorsync/delta_transport_impl.rs
@@ -1,20 +1,22 @@
-//! A4: `AerorsyncDeltaTransport`: production-facing `DeltaTransport`
-//! implementation backed by the Strada C native rsync driver.
+//! `AerorsyncDeltaTransport`: the transport the native rsync driver
+//! drives, with a crate-owned surface.
 //!
-//! The module is the bridge between the prototype driver
-//! (`AerorsyncDriver` + the `WarningCollector` event sink) and the production
-//! delta-transport trait consumed by the sync loop, whose
-//! implementation lives in the application adapter. It owns:
+//! Everything here speaks the module's own types. The entry points take
+//! paths and an optional progress sink and return a `TransferReport` or a
+//! `TransferError`; nothing in this file names an application type, and
+//! the test that measures it is
+//! `tests::aerorsync_module_imports_nothing_from_the_app`. What the
+//! application does with the outcome, including which of its own error
+//! variants a failure becomes, lives in the adapter. It owns:
 //!
 //! - Construction of the SSH transport, driver and engine adapter for
 //!   each individual transfer (no cross-transfer session caching: the
 //!   trait methods are `&self`, so we avoid locking altogether).
-//! - Reporting a failure as a crate-owned `types::TransferError`, which
-//!   carries the typed `AerorsyncError` and the commit flag observed at
-//!   the failure site. Turning that into an application error, through
-//!   the `fallback_policy::classify_fallback` matrix, belongs to the
-//!   application adapter since the A3 tranche: the module does not name
-//!   the application error type, and cannot import the adapter either.
+//! - Reporting a failure as a `types::TransferError`, which carries the
+//!   typed `AerorsyncError` and the commit flag observed at the failure
+//!   site. Turning that into an application error, through the
+//!   `fallback_policy::classify_fallback` matrix, belongs to the
+//!   application adapter: the module cannot import it, by construction.
 //! - Atomic disk write of the download result via the temp-file + rename
 //!   helper with kill-9 invariant pin (`write_atomic_chunked`, owned by
 //!   `streaming_writer` since the A1 crate tranche; `WriteAtomicError`
@@ -23,7 +25,7 @@
 //! # Q5 PreCommit / PostCommit semantics (recap)
 //!
 //! The driver flips `committed = true` when it writes the first outbound
-//! delta byte. The A4 adapter additionally tracks a `local_committed`
+//! delta byte. The download path additionally tracks a `local_committed`
 //! boolean through `write_atomic_chunked`: once the temp file is open,
 //! subsequent failures must NOT silently fall back to classic (the disk
 //! has been touched). `WriteAtomicError::PostOpen` surfaces as a
@@ -2148,12 +2150,6 @@ pub(crate) fn map_write_atomic_error(err: WriteAtomicError) -> TransferError {
 mod tests {
     use super::*;
     use crate::aerorsync::streaming_writer::{write_atomic_chunked, write_atomic_chunked_sparse};
-    // `DeltaTransport` is what the lane 3 tests need in scope to drive the
-    // production path; the implementation itself lives in the application
-    // adapter and is resolved crate-wide. Kept on one line so the module's
-    // import budget still counts a single application import here.
-    #[cfg_attr(not(ci_lane3), allow(unused_imports))]
-    use crate::delta_transport::{DeltaBatch, DeltaTransport};
     use std::io::Write;
     use std::time::Duration;
     use tempfile::TempDir;
@@ -3378,7 +3374,7 @@ mod tests {
             MockTransportConfig::healthy_upload()
                 .with_raw_inbound(symlink_download_session_inbound("down.lnk", target)),
         );
-        let stats = do_download(
+        let report = do_download(
             transport,
             CancelHandle::inert(),
             "/remote/down.lnk",
@@ -3391,7 +3387,7 @@ mod tests {
         )
         .await
         .expect("symlink download must create the link");
-        assert_eq!(stats.total_size, target.len() as u64);
+        assert_eq!(report.total_size, target.len() as u64);
 
         let meta = std::fs::symlink_metadata(&local).unwrap();
         assert!(meta.file_type().is_symlink(), "local must be a symlink");
@@ -3546,7 +3542,7 @@ mod tests {
         let remote_path = format!("/workspace/lane3-symlink-up-{nanos}.lnk");
 
         let transport = SshRemoteShellTransport::new(lane3_ssh_config(key_path.clone()));
-        let stats = do_upload(
+        let report = do_upload(
             transport,
             CancelHandle::inert(),
             &link,
@@ -3559,7 +3555,7 @@ mod tests {
         )
         .await
         .expect("live symlink upload against stock rsync");
-        assert_eq!(stats.total_size, relative_target.len() as u64);
+        assert_eq!(report.total_size, relative_target.len() as u64);
 
         let observed = lane3_ssh_testuser(&key_path, &format!("readlink '{remote_path}'"));
         eprintln!("[lane3-symlink] server readlink: {observed}");
@@ -3607,7 +3603,7 @@ mod tests {
         let dir = fresh_tempdir();
         let local = dir.path().join("lane3-dl.lnk");
         let transport = SshRemoteShellTransport::new(lane3_ssh_config(key_path.clone()));
-        let stats = do_download(
+        let report = do_download(
             transport,
             CancelHandle::inert(),
             &remote_link,
@@ -3620,7 +3616,7 @@ mod tests {
         )
         .await
         .expect("live symlink download against stock rsync");
-        assert_eq!(stats.total_size, relative_target.len() as u64);
+        assert_eq!(report.total_size, relative_target.len() as u64);
 
         let meta = std::fs::symlink_metadata(&local).expect("local link created");
         assert!(meta.file_type().is_symlink(), "local must be a symlink");
@@ -4013,12 +4009,12 @@ PY"#
 
         let transport =
             AerorsyncDeltaTransport::new(lane3_ssh_config(key_path.clone()), 0).with_xattrs(true);
-        let stats = transport
-            .upload(&local, &remote_path)
+        let report = transport
+            .upload_inner(&local, &remote_path, None)
             .await
             .unwrap_or_else(|e| panic!("[{label}] live xattr upload failed: {e:?}"));
         assert_eq!(
-            stats.total_size,
+            report.total_size,
             payload.len() as u64,
             "[{label}] transferred size"
         );
@@ -4165,11 +4161,11 @@ PY"#
         let local = dir.path().join("lane3-xattr-dl.bin");
         let transport =
             AerorsyncDeltaTransport::new(lane3_ssh_config(key_path.clone()), 0).with_xattrs(true);
-        let stats = transport
-            .download(&remote_path, &local)
+        let report = transport
+            .download_inner(&remote_path, &local, None)
             .await
             .expect("live xattr download against stock rsync");
-        assert_eq!(stats.total_size, payload.len() as u64);
+        assert_eq!(report.total_size, payload.len() as u64);
 
         let got_bytes = std::fs::read(&local).expect("read downloaded file");
         assert_eq!(got_bytes.as_slice(), payload, "download content must match");
@@ -4337,11 +4333,11 @@ PY"#
         let remote_path = format!("/workspace/lane3-acl-up-{nanos}.bin");
         let transport =
             AerorsyncDeltaTransport::new(lane3_ssh_config(key_path.clone()), 0).with_acls(true);
-        let stats = transport
-            .upload(&local, &remote_path)
+        let report = transport
+            .upload_inner(&local, &remote_path, None)
             .await
             .expect("live ACL upload against stock rsync");
-        assert_eq!(stats.total_size, payload.len() as u64);
+        assert_eq!(report.total_size, payload.len() as u64);
         assert_eq!(
             lane3_remote_sha256(&key_path, &remote_path),
             lane3_local_sha256(&local),
@@ -4396,11 +4392,11 @@ PY"#
         let local = dir.path().join("lane3-acl-download.bin");
         let transport =
             AerorsyncDeltaTransport::new(lane3_ssh_config(key_path.clone()), 0).with_acls(true);
-        let stats = transport
-            .download(&remote_path, &local)
+        let report = transport
+            .download_inner(&remote_path, &local, None)
             .await
             .expect("live ACL download against stock rsync");
-        assert_eq!(stats.total_size, payload.len() as u64);
+        assert_eq!(report.total_size, payload.len() as u64);
         assert_eq!(
             std::fs::read(&local).expect("read downloaded ACL payload"),
             payload
@@ -4470,39 +4466,36 @@ PY"#
 
         let transport =
             AerorsyncDeltaTransport::new(lane3_ssh_config(key_path.clone()), 0).with_xattrs(true);
-        let mut batch = transport
-            .begin_batch()
-            .await
-            .expect("begin_batch must not error on a reachable harness");
-        // begin_batch degrades to NoopBatch when the russh connect fails, and
-        // NoopBatch::upload would then fail with a message about session reuse
-        // that says nothing about xattrs. Name the real cause here instead.
-        assert!(
-            !batch.is_noop(),
-            "batch degraded to NoopBatch: russh could not connect to the lane 3 harness, \
-             so the batch xattr path was never exercised"
-        );
+        // `open_batch` reports a failed handshake instead of degrading: the
+        // degradation to the application's no-op batch is the adapter's
+        // decision, so here a connect failure names itself.
+        let batch = transport.open_batch().await.unwrap_or_else(|e| {
+            panic!(
+                "russh could not connect to the lane 3 harness, so the batch xattr \
+                 path was never exercised: {e}"
+            )
+        });
 
-        let stats_a = batch
-            .upload(&local_a, &remote_a)
+        let report_a = batch
+            .upload_file(&local_a, &remote_a)
             .await
             .expect("batch upload of file a");
         assert_eq!(
-            stats_a.total_size,
+            report_a.total_size,
             std::fs::metadata(&local_a).unwrap().len(),
             "[batch-a] transferred size"
         );
-        let stats_b = batch
-            .upload(&local_b, &remote_b)
+        let report_b = batch
+            .upload_file(&local_b, &remote_b)
             .await
             .expect("batch upload of file b");
         assert_eq!(
-            stats_b.total_size,
+            report_b.total_size,
             std::fs::metadata(&local_b).unwrap().len(),
             "[batch-b] transferred size"
         );
 
-        let batch_stats = batch.finalize().await.expect("batch finalize");
+        let batch_stats = Box::new(batch).batch_totals().await;
         assert_eq!(
             batch_stats.files_transferred, 2,
             "both files must be counted by the batch"
@@ -4636,11 +4629,11 @@ PY"#
             1_000_000, // prohibitive threshold: a symlink must bypass TooSmall
         )
         .with_xattrs(true);
-        let stats = transport
-            .upload(&link, &remote_link)
+        let report = transport
+            .upload_inner(&link, &remote_link, None)
             .await
             .expect("live symlink upload with -X negotiated must not fail (pre-R2 risk: EPERM)");
-        assert_eq!(stats.total_size, relative_target.len() as u64);
+        assert_eq!(report.total_size, relative_target.len() as u64);
 
         let ftype = lane3_ssh_testuser(
             &key_path,
@@ -5087,14 +5080,14 @@ PY"#
     async fn aerorsync_batch_reuses_ssh_session() {
         let cfg = crate::aerorsync::russh_session_transport::test_dummy_config();
         let transport = RusshSessionTransport::test_with_empty_handle(cfg, 1);
-        let mut batch = AerorsyncBatch::new(transport, 1, false, false, false);
+        let batch = AerorsyncBatch::new(transport, 1, false, false, false);
         let dir = fresh_tempdir();
         let local = write_test_file(&dir, "batch_reuse.bin", b"1234567890");
 
         // All operations fail because the test transport has no live handle,
         // but they still exercise the per-file open_raw_stream attempt path.
         for _ in 0..3 {
-            let _ = batch.upload(&local, "/remote/reuse.bin").await;
+            let _ = batch.upload_file(&local, "/remote/reuse.bin").await;
         }
 
         assert_eq!(batch.transport.handshake_count(), 1);
@@ -5104,15 +5097,15 @@ PY"#
     async fn aerorsync_batch_per_file_open_raw_stream_count_equals_file_count() {
         let cfg = crate::aerorsync::russh_session_transport::test_dummy_config();
         let transport = RusshSessionTransport::test_with_empty_handle(cfg, 1);
-        let mut batch = AerorsyncBatch::new(transport, 1, false, false, false);
+        let batch = AerorsyncBatch::new(transport, 1, false, false, false);
         let dir = fresh_tempdir();
         let a = write_test_file(&dir, "a.bin", b"AAAA");
         let b = write_test_file(&dir, "b.bin", b"BBBB");
 
-        let _ = batch.upload(&a, "/remote/a.bin").await;
-        let _ = batch.upload(&b, "/remote/b.bin").await;
+        let _ = batch.upload_file(&a, "/remote/a.bin").await;
+        let _ = batch.upload_file(&b, "/remote/b.bin").await;
         let _ = batch
-            .download("/remote/c.bin", &dir.path().join("c.bin"))
+            .download_file("/remote/c.bin", &dir.path().join("c.bin"))
             .await;
 
         assert_eq!(batch.transport.raw_open_count(), 3);
@@ -5124,12 +5117,9 @@ PY"#
         let transport = RusshSessionTransport::test_with_empty_handle(cfg, 1);
         let batch = AerorsyncBatch::new(transport, 1, false, false, false);
 
-        let stats = Box::new(batch)
-            .finalize()
-            .await
-            .expect("finalize should succeed");
+        let totals = Box::new(batch).batch_totals().await;
 
-        assert_eq!(stats.session_count, 1);
+        assert_eq!(totals.session_count, 1);
     }
 
     #[tokio::test]
@@ -5142,12 +5132,9 @@ PY"#
         let batch = AerorsyncBatch::new(transport, 1, false, false, false);
         batch.transport.test_set_handshake_count(2);
 
-        let stats = Box::new(batch)
-            .finalize()
-            .await
-            .expect("finalize should succeed");
+        let totals = Box::new(batch).batch_totals().await;
 
-        assert_eq!(stats.session_count, 2);
+        assert_eq!(totals.session_count, 2);
     }
 
     /// Regression: WD MyCloud early-close and transient delta failures.

--- a/src-tauri/src/aerorsync/delta_transport_impl.rs
+++ b/src-tauri/src/aerorsync/delta_transport_impl.rs
@@ -73,15 +73,12 @@ use crate::aerorsync::native_driver::{
 use crate::aerorsync::real_wire::{is_symlink_mode, FileListEntry};
 use crate::aerorsync::remote_command::{EffectiveMetadataFlags, RemoteCommandSpec};
 use crate::aerorsync::russh_session_transport::RusshSessionTransport;
-use crate::aerorsync::ssh_transport::{
-    SshHostKeyPolicy, SshRemoteShellTransport, SshTransportConfig,
-};
+use crate::aerorsync::ssh_transport::{SshRemoteShellTransport, SshTransportConfig};
 use crate::aerorsync::streaming_writer::{StreamingAtomicWriter, WriteAtomicError, TEMP_SUFFIX};
 use crate::aerorsync::transport::{
-    CancelHandle, RawRemoteShellTransport, RemoteExecRequest, RemoteShellTransport, TransportProbe,
+    CancelHandle, RawRemoteShellTransport, RemoteShellTransport, TransportProbe,
 };
 use crate::aerorsync::types::{AerorsyncError, TransferError, TransferReport};
-use crate::rsync_over_ssh::{RsyncConfig, RsyncError};
 
 /// Display name surfaced by `DeltaTransport::name()`.
 pub(crate) const AERORSYNC_TRANSPORT_NAME: &str = "aerorsync-proto-31";
@@ -198,74 +195,18 @@ impl AerorsyncDeltaTransport {
             self.fail_on_metadata_loss,
         )
     }
-
-    /// Convenience constructor that maps the production `RsyncConfig`
-    /// (used by `providers::sftp::delta_transport`) onto the prototype's
-    /// `SshTransportConfig`. `host_key_policy` is provided by the caller
-    /// so the factory (Zona B1) can honour whatever pinning the SFTP
-    /// session established during connect.
-    pub fn from_rsync_config(
-        cfg: &RsyncConfig,
-        host_key_policy: SshHostKeyPolicy,
-    ) -> Result<Self, RsyncError> {
-        // Z.4.5 R1 dispatch step (2026-05-14): the previous boundary
-        // refusal `Err(PasswordAuthUnsupported)` was a placeholder while
-        // the russh transport gained password auth. Now that
-        // `RusshSessionTransport::connect` branches on
-        // `SshTransportConfig::usable_password()`, the gate moves to
-        // `RsyncConfig::validate_auth_material()` which enforces:
-        //   - SshKey  → ssh_key_path required (else MissingKey)
-        //   - Password → ssh_password required and non-empty (else MissingPassword)
-        //   - Neither → HardRejection (integration bug, never silently retry)
-        // Callers that want password-based delta sync can now construct
-        // an `RsyncConfig { auth_method: Password, ssh_password: Some(_), .. }`
-        // and the russh leg picks it up. Subprocess `rsync_over_ssh::build_ssh_e_arg`
-        // still refuses Password upfront so the binary path never accidentally
-        // shells out without auth material.
-        cfg.validate_auth_material()?;
-
-        // Password-only profiles legitimately have no key path. The
-        // russh leg ignores `private_key_path` when `usable_password()`
-        // is Some, so an empty placeholder is safe; it is never opened
-        // or dereferenced. We MUST NOT default to `~/.ssh/id_rsa` or
-        // any other concrete path: that would silently load credentials
-        // the user did not opt into.
-        let key_path = cfg.ssh_key_path.clone().unwrap_or_default();
-        let ssh_config = SshTransportConfig {
-            host: cfg.ssh_host.clone(),
-            port: cfg.ssh_port.unwrap_or(22),
-            username: cfg.ssh_user.clone(),
-            private_key_path: key_path,
-            connect_timeout_ms: 10_000,
-            io_timeout_ms: 30_000,
-            worker_idle_poll_ms: 250,
-            max_frame_size: 1 << 20,
-            host_key_policy,
-            auth_password: cfg.ssh_password.clone(),
-            // An Agent profile carries no key/password; the russh leg
-            // resolves SSH_AUTH_SOCK at connect time. `prefers_russh_leg`
-            // then routes probe + single-shot through russh (libssh2 is
-            // pubkey-file-only).
-            auth_agent: matches!(cfg.auth_method, crate::rsync_over_ssh::AuthMethod::Agent),
-            // B.1/B.4: probe stock `rsync --version` on the remote. The
-            // parser in `parse_probe_protocol` extracts the numeric
-            // protocol version from the multi-line banner. A missing
-            // `rsync` binary surfaces as exit != 0 and is mapped to
-            // `RsyncError::RemoteNotAvailable` (soft classic fallback);
-            // only `HostKeyRejected` escalates to `HardRejection`.
-            probe_request: RemoteExecRequest {
-                program: "rsync".into(),
-                args: vec!["--version".into()],
-                environment: Vec::new(),
-            },
-        };
-        Ok(Self::new(ssh_config, cfg.min_file_size))
-    }
 }
 
 // --- upload flow ---------------------------------------------------------
 
 impl AerorsyncDeltaTransport {
+    /// Read-only view of the SSH configuration this transport was built
+    /// with. The application adapter reads it to check what a profile
+    /// turned into; nothing outside can mutate it.
+    pub fn ssh_config(&self) -> &SshTransportConfig {
+        &self.ssh_config
+    }
+
     /// Endpoint of the configured SSH leg, for the adapter's log lines.
     pub(crate) fn endpoint(&self) -> (&str, u16) {
         (&self.ssh_config.host, self.ssh_config.port)
@@ -3519,6 +3460,7 @@ mod tests {
 
     #[cfg(all(ci_lane3, unix))]
     fn lane3_ssh_config(key_path: PathBuf) -> crate::aerorsync::ssh_transport::SshTransportConfig {
+        use crate::aerorsync::ssh_transport::SshHostKeyPolicy;
         use crate::aerorsync::transport::RemoteExecRequest;
         crate::aerorsync::ssh_transport::SshTransportConfig {
             host: "127.0.0.1".into(),
@@ -5206,201 +5148,6 @@ PY"#
             .expect("finalize should succeed");
 
         assert_eq!(stats.session_count, 2);
-    }
-
-    // -- from_rsync_config: Z.4.5 R1 wire-up --------------------------------
-
-    /// Z.4.5 R1: when the production [`RsyncConfig`] carries an SSH
-    /// password (a password-auth rsync-over-SSH profile), the
-    /// constructor MUST
-    /// propagate it onto [`SshTransportConfig::auth_password`] so the
-    /// russh leg can pick it up. The propagation is independent of the
-    /// `auth_method` discriminant: a profile may legitimately carry
-    /// both a key and a password (e.g. for paranoid two-factor setups
-    /// in the future); the actual selection happens inside
-    /// `RusshSessionTransport::connect`.
-    #[test]
-    fn from_rsync_config_propagates_password_to_transport() {
-        use crate::rsync_over_ssh::AuthMethod;
-        use secrecy::{ExposeSecret, SecretString};
-        use std::path::PathBuf;
-        let dir = fresh_tempdir();
-        let key_path = dir.path().join("id_dummy");
-        std::fs::write(&key_path, b"-----BEGIN OPENSSH PRIVATE KEY-----\nfake\n").unwrap();
-
-        let cfg = RsyncConfig {
-            ssh_user: "tester".into(),
-            ssh_host: "example.invalid".into(),
-            ssh_port: Some(2222),
-            ssh_key_path: Some(key_path.clone()),
-            ssh_password: Some(SecretString::from("rsync-password".to_string())),
-            auth_method: AuthMethod::SshKey,
-            ..Default::default()
-        };
-        let transport =
-            AerorsyncDeltaTransport::from_rsync_config(&cfg, SshHostKeyPolicy::AcceptAny)
-                .expect("from_rsync_config should accept SshKey method with both materials");
-        assert_eq!(transport.ssh_config.host, "example.invalid");
-        assert_eq!(transport.ssh_config.port, 2222);
-        assert_eq!(transport.ssh_config.private_key_path, key_path);
-        let propagated = transport
-            .ssh_config
-            .auth_password
-            .as_ref()
-            .expect("ssh_password must be propagated");
-        assert_eq!(propagated.expose_secret(), "rsync-password");
-        // And the helper agrees:
-        assert!(transport.ssh_config.usable_password().is_some());
-        let _ = PathBuf::from("placeholder"); // silence unused import warning on some CI configs
-    }
-
-    /// Z.4.5 R1 dispatch step (2026-05-14): the boundary refusal of
-    /// `auth_method=Password` is gone. A password-only `RsyncConfig`
-    /// now produces a transport whose `auth_password` is set and whose
-    /// `private_key_path` is the empty placeholder (the russh leg
-    /// ignores the key path when `usable_password()` is Some).
-    #[test]
-    fn from_rsync_config_accepts_password_only_method() {
-        use crate::rsync_over_ssh::AuthMethod;
-        use secrecy::{ExposeSecret, SecretString};
-
-        let cfg = RsyncConfig {
-            ssh_user: "tester".into(),
-            ssh_host: "example.invalid".into(),
-            ssh_password: Some(SecretString::from("rsync-password".to_string())),
-            auth_method: AuthMethod::Password,
-            ..Default::default()
-        };
-        let transport =
-            AerorsyncDeltaTransport::from_rsync_config(&cfg, SshHostKeyPolicy::AcceptAny)
-                .expect("password-only RsyncConfig should now produce a transport");
-        // Empty placeholder (NOT a default ~/.ssh path): russh leg ignores it.
-        assert_eq!(
-            transport.ssh_config.private_key_path,
-            std::path::PathBuf::new(),
-            "password-only profile must not silently inject a default key path"
-        );
-        let propagated = transport
-            .ssh_config
-            .auth_password
-            .as_ref()
-            .expect("ssh_password must be propagated");
-        assert_eq!(propagated.expose_secret(), "rsync-password");
-        assert!(transport.ssh_config.usable_password().is_some());
-    }
-
-    /// SSH agent auth: a `RsyncConfig { auth_method: Agent }` with no key
-    /// and no password must produce a transport whose `auth_agent` flag
-    /// is set, no password propagated, and an empty key placeholder. The
-    /// russh leg resolves SSH_AUTH_SOCK at connect time; nothing static
-    /// is validated or injected here.
-    #[test]
-    fn from_rsync_config_agent_method_sets_auth_agent_flag() {
-        use crate::rsync_over_ssh::AuthMethod;
-
-        let cfg = RsyncConfig {
-            ssh_user: "tester".into(),
-            ssh_host: "example.invalid".into(),
-            ssh_key_path: None,
-            ssh_password: None,
-            auth_method: AuthMethod::Agent,
-            ..Default::default()
-        };
-        let transport =
-            AerorsyncDeltaTransport::from_rsync_config(&cfg, SshHostKeyPolicy::AcceptAny)
-                .expect("agent RsyncConfig should produce a transport");
-        assert!(
-            transport.ssh_config.auth_agent,
-            "auth_agent must be set for AuthMethod::Agent"
-        );
-        assert!(
-            transport.ssh_config.auth_password.is_none(),
-            "agent profile must not carry a password"
-        );
-        assert_eq!(
-            transport.ssh_config.private_key_path,
-            std::path::PathBuf::new(),
-            "agent profile must not inject a default key path"
-        );
-        assert!(
-            transport.ssh_config.prefers_russh_leg(),
-            "agent profile must route through the russh leg"
-        );
-    }
-
-    /// Z.4.5 R1 dispatch step: `validate_auth_material()` now gates the
-    /// boundary instead of the old hard refusal. A `Password` method
-    /// without a non-empty password surfaces `MissingPassword`, NOT
-    /// `PasswordAuthUnsupported` (which has been removed from the
-    /// boundary as of this step).
-    #[test]
-    fn from_rsync_config_password_method_without_password_returns_missing_password() {
-        use crate::rsync_over_ssh::AuthMethod;
-
-        let cfg = RsyncConfig {
-            ssh_user: "tester".into(),
-            ssh_host: "example.invalid".into(),
-            ssh_password: None,
-            ssh_key_path: Some(std::path::PathBuf::from("/tmp/key")),
-            auth_method: AuthMethod::Password,
-            ..Default::default()
-        };
-        match AerorsyncDeltaTransport::from_rsync_config(&cfg, SshHostKeyPolicy::AcceptAny) {
-            Err(RsyncError::MissingPassword) => {}
-            Err(other) => {
-                panic!("expected MissingPassword via validate_auth_material, got Err({other:?})")
-            }
-            Ok(_) => panic!("expected MissingPassword, got Ok(_)"),
-        }
-    }
-
-    /// Z.4.5 R1 dispatch step: empty SecretString must be rejected by
-    /// `validate_auth_material()` so a misconfigured profile cannot
-    /// reach the russh leg with a zero-length password.
-    #[test]
-    fn from_rsync_config_password_method_with_empty_password_returns_missing_password() {
-        use crate::rsync_over_ssh::AuthMethod;
-        use secrecy::SecretString;
-
-        let cfg = RsyncConfig {
-            ssh_user: "tester".into(),
-            ssh_host: "example.invalid".into(),
-            ssh_password: Some(SecretString::from(String::new())),
-            auth_method: AuthMethod::Password,
-            ..Default::default()
-        };
-        match AerorsyncDeltaTransport::from_rsync_config(&cfg, SshHostKeyPolicy::AcceptAny) {
-            Err(RsyncError::MissingPassword) => {}
-            Err(other) => panic!("expected MissingPassword, got Err({other:?})"),
-            Ok(_) => panic!("expected MissingPassword, got Ok(_)"),
-        }
-    }
-
-    /// Z.4.5 R1 dispatch step: a config that carries neither key nor
-    /// password is still rejected as `HardRejection`. This is the
-    /// "integration bug" guard from `validate_auth_material()`: it is
-    /// not a credential failure (which the user can fix with input) but
-    /// a wiring bug (the call site forgot to attach material). The
-    /// dispatch must not silently fall back to another transport.
-    #[test]
-    fn from_rsync_config_with_no_auth_material_is_hard_rejection() {
-        use crate::rsync_over_ssh::AuthMethod;
-
-        let cfg = RsyncConfig {
-            ssh_user: "tester".into(),
-            ssh_host: "example.invalid".into(),
-            ssh_password: None,
-            ssh_key_path: None,
-            auth_method: AuthMethod::SshKey,
-            ..Default::default()
-        };
-        match AerorsyncDeltaTransport::from_rsync_config(&cfg, SshHostKeyPolicy::AcceptAny) {
-            Err(RsyncError::HardRejection(message)) => {
-                assert!(message.contains("neither ssh_key_path nor ssh_password"));
-            }
-            Err(other) => panic!("expected HardRejection, got Err({other:?})"),
-            Ok(_) => panic!("expected HardRejection, got Ok(_)"),
-        }
     }
 
     /// Regression: WD MyCloud early-close and transient delta failures.

--- a/src-tauri/src/aerorsync/fixtures.rs
+++ b/src-tauri/src/aerorsync/fixtures.rs
@@ -358,7 +358,7 @@ impl RealRsyncBaselineByteTranscript {
 // Locale-tolerant number parsing: copy of `crate::number_parsing`, kept
 // identical by `number_parsing::tests::aerorsync_fixture_parsers_stay_identical`.
 // The module must not import the application (see
-// `tests::app_import_budget_matches_the_documented_inventory`), so the two
+// `tests::aerorsync_module_imports_nothing_from_the_app`), so the two
 // entry points and their three private helpers live here verbatim.
 // ---------------------------------------------------------------------------
 

--- a/src-tauri/src/aerorsync/live_tests.rs
+++ b/src-tauri/src/aerorsync/live_tests.rs
@@ -6,10 +6,21 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use crate::aerorsync::delta_transport_impl::AerorsyncDeltaTransport;
+
+/// The speedup these logs used to print came from the application
+/// statistics; the module reports the numbers it measured and the
+/// application computes the ratio. Same formula, so the log line keeps
+/// saying the same thing.
+fn speedup_of(report: &crate::aerorsync::types::TransferReport) -> f64 {
+    if report.session.bytes_sent > 0 {
+        report.total_size as f64 / report.session.bytes_sent as f64
+    } else {
+        1.0
+    }
+}
 use crate::aerorsync::remote_command::RemoteCommandSpec;
 use crate::aerorsync::ssh_transport::{SshHostKeyPolicy, SshTransportConfig};
 use crate::aerorsync::transport::RemoteExecRequest;
-use crate::delta_transport::DeltaTransport;
 
 fn env_path(name: &str) -> PathBuf {
     PathBuf::from(env::var(name).unwrap_or_else(|_| panic!("missing env var {name}")))
@@ -298,8 +309,8 @@ async fn live_real_rsync_native_delta_download_verifies_whole_file() {
 
     // Baseline is already the older basis on disk (harness seeds it). A
     // successful delta reconstructs `expected` and commits atomically.
-    let stats = transport
-        .download(&remote, &local)
+    let report = transport
+        .download_inner(&remote, &local, None)
         .await
         .unwrap_or_else(|e| panic!("native delta download against real rsync failed: {e:?}"));
 
@@ -309,23 +320,23 @@ async fn live_real_rsync_native_delta_download_verifies_whole_file() {
         "reconstructed local bytes must match the remote source"
     );
     assert_eq!(
-        stats.total_size,
+        report.total_size,
         expected.len() as u64,
-        "stats.total_size must equal reconstructed length"
+        "report.total_size must equal reconstructed length"
     );
     eprintln!(
         "live real-rsync native delta download (default/xxh128): total_size={} bytes_sent={} bytes_received={} speedup={:.2} duration_ms={}",
-        stats.total_size,
-        stats.bytes_sent,
-        stats.bytes_received,
-        stats.speedup,
-        stats.duration_ms
+        report.total_size,
+        report.session.bytes_sent,
+        report.session.bytes_received,
+        speedup_of(&report),
+        report.duration_ms
     );
     assert!(
-        stats.bytes_received < stats.total_size || stats.total_size < 4096,
+        report.session.bytes_received < report.total_size || report.total_size < 4096,
         "expected a real delta (bytes_received < total_size) for the 256 KiB near-identical basis; got bytes_received={} total={}",
-        stats.bytes_received,
-        stats.total_size
+        report.session.bytes_received,
+        report.total_size
     );
 }
 
@@ -353,25 +364,25 @@ async fn live_real_rsync_native_delta_download_md5_peer() {
     let (transport, remote, local, expected) =
         real_rsync_delta_download_inputs("RSNP_TEST_REAL_LOCAL_DOWNLOAD_FILE_MD5");
 
-    let result = transport.download(&remote, &local).await;
+    let result = transport.download_inner(&remote, &local, None).await;
     unsafe {
         env::remove_var("AEROFTP_RSYNC_CSUM_ALGOS");
     }
 
-    let stats = result.unwrap_or_else(|e| {
+    let report = result.unwrap_or_else(|e| {
         panic!("native delta download (md5 peer) against real rsync failed: {e:?}")
     });
     let got = fs::read(&local).expect("read reconstructed local target");
     assert_eq!(got, expected, "md5-peer reconstruction must match remote");
     eprintln!(
         "live real-rsync native delta download (md5): total_size={} bytes_sent={} bytes_received={} speedup={:.2}",
-        stats.total_size, stats.bytes_sent, stats.bytes_received, stats.speedup
+        report.total_size, report.session.bytes_sent, report.session.bytes_received, speedup_of(&report)
     );
     assert!(
-        stats.bytes_received < stats.total_size || stats.total_size < 4096,
+        report.session.bytes_received < report.total_size || report.total_size < 4096,
         "expected a real delta under md5 block-strong; got bytes_received={} total={}",
-        stats.bytes_received,
-        stats.total_size
+        report.session.bytes_received,
+        report.total_size
     );
 }
 
@@ -403,25 +414,25 @@ async fn live_real_rsync_native_delta_download_md4_peer() {
     let (transport, remote, local, expected) =
         real_rsync_delta_download_inputs("RSNP_TEST_REAL_LOCAL_DOWNLOAD_FILE_MD4");
 
-    let result = transport.download(&remote, &local).await;
+    let result = transport.download_inner(&remote, &local, None).await;
     unsafe {
         env::remove_var("AEROFTP_RSYNC_CSUM_ALGOS");
     }
 
-    let stats = result.unwrap_or_else(|e| {
+    let report = result.unwrap_or_else(|e| {
         panic!("native delta download (md4 peer) against real rsync failed: {e:?}")
     });
     let got = fs::read(&local).expect("read reconstructed local target");
     assert_eq!(got, expected, "md4-peer reconstruction must match remote");
     eprintln!(
         "live real-rsync native delta download (md4): total_size={} bytes_sent={} bytes_received={} speedup={:.2}",
-        stats.total_size, stats.bytes_sent, stats.bytes_received, stats.speedup
+        report.total_size, report.session.bytes_sent, report.session.bytes_received, speedup_of(&report)
     );
     assert!(
-        stats.bytes_received < stats.total_size || stats.total_size < 4096,
+        report.session.bytes_received < report.total_size || report.total_size < 4096,
         "expected a real delta under md4 block-strong; got bytes_received={} total={}",
-        stats.bytes_received,
-        stats.total_size
+        report.session.bytes_received,
+        report.total_size
     );
 }
 
@@ -447,25 +458,25 @@ async fn live_real_rsync_native_delta_download_sha1_peer() {
     let (transport, remote, local, expected) =
         real_rsync_delta_download_inputs("RSNP_TEST_REAL_LOCAL_DOWNLOAD_FILE_SHA1");
 
-    let result = transport.download(&remote, &local).await;
+    let result = transport.download_inner(&remote, &local, None).await;
     unsafe {
         env::remove_var("AEROFTP_RSYNC_CSUM_ALGOS");
     }
 
-    let stats = result.unwrap_or_else(|e| {
+    let report = result.unwrap_or_else(|e| {
         panic!("native delta download (sha1 peer) against real rsync failed: {e:?}")
     });
     let got = fs::read(&local).expect("read reconstructed local target");
     assert_eq!(got, expected, "sha1-peer reconstruction must match remote");
     eprintln!(
         "live real-rsync native delta download (sha1): total_size={} bytes_sent={} bytes_received={} speedup={:.2}",
-        stats.total_size, stats.bytes_sent, stats.bytes_received, stats.speedup
+        report.total_size, report.session.bytes_sent, report.session.bytes_received, speedup_of(&report)
     );
     assert!(
-        stats.bytes_received < stats.total_size || stats.total_size < 4096,
+        report.session.bytes_received < report.total_size || report.total_size < 4096,
         "expected a real delta under sha1 block-strong; got bytes_received={} total={}",
-        stats.bytes_received,
-        stats.total_size
+        report.session.bytes_received,
+        report.total_size
     );
 }
 
@@ -512,12 +523,12 @@ async fn live_real_rsync_native_download_completes_for_xxh64_and_xxh3_peers() {
         unsafe {
             env::set_var("AEROFTP_RSYNC_CSUM_ALGOS", algorithm);
         }
-        let result = transport.download(&remote, &local).await;
+        let result = transport.download_inner(&remote, &local, None).await;
         unsafe {
             env::remove_var("AEROFTP_RSYNC_CSUM_ALGOS");
         }
 
-        let stats = result.unwrap_or_else(|e| {
+        let report = result.unwrap_or_else(|e| {
             panic!("native download ({algorithm} peer) against real rsync failed: {e:?}")
         });
         let got = fs::read(&local).expect("read reconstructed local target");
@@ -525,18 +536,18 @@ async fn live_real_rsync_native_download_completes_for_xxh64_and_xxh3_peers() {
             got, expected,
             "{algorithm}-peer reconstruction must match remote"
         );
-        assert_eq!(stats.total_size, expected.len() as u64);
+        assert_eq!(report.total_size, expected.len() as u64);
         eprintln!(
             "live real-rsync native download ({algorithm}): total_size={} bytes_sent={} bytes_received={} copy_blocks={} speedup={:.2} duration_ms={}",
-            stats.total_size,
-            stats.bytes_sent,
-            stats.bytes_received,
-            stats.copy_blocks,
-            stats.speedup,
-            stats.duration_ms
+            report.total_size,
+            report.session.bytes_sent,
+            report.session.bytes_received,
+            report.session.copy_blocks,
+            speedup_of(&report),
+            report.duration_ms
         );
         assert!(
-            stats.copy_blocks > 0,
+            report.session.copy_blocks > 0,
             "{algorithm} download must decode at least one CopyRun block"
         );
     }
@@ -571,12 +582,12 @@ async fn live_real_rsync_native_upload_completes_for_xxh64_and_xxh3_peers() {
         unsafe {
             env::set_var("AEROFTP_RSYNC_CSUM_ALGOS", &algorithm);
         }
-        let result = transport.upload(&local, &remote).await;
+        let result = transport.upload_inner(&local, &remote, None).await;
         unsafe {
             env::remove_var("AEROFTP_RSYNC_CSUM_ALGOS");
         }
 
-        let stats = result.unwrap_or_else(|e| {
+        let report = result.unwrap_or_else(|e| {
             panic!("native upload ({algorithm} peer) against real rsync failed: {e:?}")
         });
         let got = fs::read(&remote_bind).expect("read reconstructed remote target");
@@ -584,18 +595,18 @@ async fn live_real_rsync_native_upload_completes_for_xxh64_and_xxh3_peers() {
             got, expected,
             "{algorithm}-peer reconstruction must match local source"
         );
-        assert_eq!(stats.total_size, expected.len() as u64);
+        assert_eq!(report.total_size, expected.len() as u64);
         eprintln!(
             "live real-rsync native upload ({algorithm}): total_size={} bytes_sent={} bytes_received={} copy_blocks={} speedup={:.2} duration_ms={}",
-            stats.total_size,
-            stats.bytes_sent,
-            stats.bytes_received,
-            stats.copy_blocks,
-            stats.speedup,
-            stats.duration_ms
+            report.total_size,
+            report.session.bytes_sent,
+            report.session.bytes_received,
+            report.session.copy_blocks,
+            speedup_of(&report),
+            report.duration_ms
         );
         assert!(
-            stats.copy_blocks > 0,
+            report.session.copy_blocks > 0,
             "{algorithm} upload must emit at least one CopyRun block"
         );
     }
@@ -638,12 +649,12 @@ async fn live_real_rsync_native_upload_completes_for_md4_and_sha1_peers() {
         unsafe {
             env::set_var("AEROFTP_RSYNC_CSUM_ALGOS", &algorithm);
         }
-        let result = transport.upload(&local, &remote).await;
+        let result = transport.upload_inner(&local, &remote, None).await;
         unsafe {
             env::remove_var("AEROFTP_RSYNC_CSUM_ALGOS");
         }
 
-        let stats = result.unwrap_or_else(|e| {
+        let report = result.unwrap_or_else(|e| {
             panic!("native upload ({algorithm} peer) against real rsync failed: {e:?}")
         });
         let got = fs::read(&remote_bind).expect("read reconstructed remote target");
@@ -651,18 +662,18 @@ async fn live_real_rsync_native_upload_completes_for_md4_and_sha1_peers() {
             got, expected,
             "{algorithm}-peer reconstruction must match local source"
         );
-        assert_eq!(stats.total_size, expected.len() as u64);
+        assert_eq!(report.total_size, expected.len() as u64);
         eprintln!(
             "live real-rsync native upload ({algorithm}): total_size={} bytes_sent={} bytes_received={} copy_blocks={} speedup={:.2} duration_ms={}",
-            stats.total_size,
-            stats.bytes_sent,
-            stats.bytes_received,
-            stats.copy_blocks,
-            stats.speedup,
-            stats.duration_ms
+            report.total_size,
+            report.session.bytes_sent,
+            report.session.bytes_received,
+            report.session.copy_blocks,
+            speedup_of(&report),
+            report.duration_ms
         );
         assert!(
-            stats.copy_blocks > 0,
+            report.session.copy_blocks > 0,
             "{algorithm} upload must emit at least one CopyRun block"
         );
     }

--- a/src-tauri/src/aerorsync/local_transport.rs
+++ b/src-tauri/src/aerorsync/local_transport.rs
@@ -1,7 +1,6 @@
 //! Z.2.1: Local-to-local delta transport.
 //!
-//! Implements [`DeltaTransport`] for the case where both endpoints are file
-//! system paths on the same host. Bypasses the wire protocol 31 entirely:
+//! The local case: both endpoints are file system paths on the same host. Bypasses the wire protocol 31 entirely:
 //! the delta engine runs in-process against two local files, with no SSH,
 //! no multiplex framing, no file-list encoding.
 //!
@@ -10,27 +9,28 @@
 //! - reuse [`write_atomic_chunked`] (from `streaming_writer`) for kill-9-safe
 //!   rename-last writes
 //! - memory cap at 256 MiB (`LOCAL_DELTA_MAX_IN_MEMORY_BYTES`): files larger
-//!   than this return `RsyncError::TransferFailed` and the caller falls back
-//!   to a plain `std::fs::copy`
-//! - min_file_size guard returns `RsyncError::TooSmall` so the caller can
-//!   bypass the delta overhead for small files
+//!   than this return a soft failure and the caller falls back to a
+//!   plain `std::fs::copy`
+//! - min_file_size guard returns `TransferError::TooSmall` so the caller
+//!   can bypass the delta overhead for small files
 //!
 //! No SSH, no remote: this transport's `name()` is `"aerorsync-local"` and
 //! its `probe_remote` returns a synthetic capability flag (`protocol: 31`)
-//! so the rest of the delta dispatch keeps working unchanged.
+//! so the rest of the delta dispatch keeps working unchanged. The trait
+//! implementation that carries these to the application lives in
+//! `aerorsync_adapter::local`.
 
 #![cfg(feature = "aerorsync")]
 
 use std::path::Path;
 use std::time::Instant;
 
-use async_trait::async_trait;
 use tokio::fs;
 
 use crate::aerorsync::delta_engine;
 use crate::aerorsync::streaming_writer::{write_atomic_chunked, write_atomic_chunked_sparse};
-use crate::delta_transport::DeltaTransport;
-use crate::rsync_over_ssh::{RsyncCapability, RsyncError, RsyncStats};
+use crate::aerorsync::transport::TransportProbe;
+use crate::aerorsync::types::{ProtocolVersion, SessionStats, TransferError, TransferReport};
 
 /// Memory cap for the local delta path. Source + baseline + reconstructed
 /// buffers are all held in memory; with 256 MiB we keep peak RSS bounded by
@@ -54,7 +54,8 @@ pub struct LocalDeltaTransport {
 
 impl LocalDeltaTransport {
     /// Construct with a minimum file size below which `TooSmall` is returned.
-    /// Caller typically uses [`crate::rsync_over_ssh::DEFAULT_MIN_FILE_SIZE`].
+    /// The caller passes its own minimum size gate; AeroFTP passes its
+    /// 1 MiB default.
     pub fn new(min_file_size: u64) -> Self {
         Self {
             min_file_size,
@@ -70,22 +71,29 @@ impl LocalDeltaTransport {
         self
     }
 
-    async fn transfer_inner(&self, src: &Path, dst: &Path) -> Result<RsyncStats, RsyncError> {
+    /// Run the local delta and report the outcome in the crate's own
+    /// types. The application adapter renders it: this transport's
+    /// numbers are not the remote one's, and the rendering differs with
+    /// them (see `aerorsync_adapter::local`).
+    pub(crate) async fn transfer(
+        &self,
+        src: &Path,
+        dst: &Path,
+    ) -> Result<TransferReport, TransferError> {
         let start = Instant::now();
 
-        let src_meta = fs::metadata(src).await.map_err(RsyncError::Io)?;
+        let src_meta = fs::metadata(src).await.map_err(TransferError::Io)?;
         let src_size = src_meta.len();
 
         if src_size < self.min_file_size {
-            return Err(RsyncError::TooSmall {
+            return Err(TransferError::TooSmall {
                 size: src_size,
                 threshold: self.min_file_size,
             });
         }
         if src_size > LOCAL_DELTA_MAX_IN_MEMORY_BYTES {
-            return Err(RsyncError::TransferFailed {
-                exit: 0,
-                stderr: format!(
+            return Err(TransferError::Soft {
+                detail: format!(
                     "local delta size {src_size} exceeds in-memory cap {LOCAL_DELTA_MAX_IN_MEMORY_BYTES}; fallback to classic copy"
                 ),
             });
@@ -95,10 +103,10 @@ impl LocalDeltaTransport {
         let baseline = match fs::read(dst).await {
             Ok(bytes) => bytes,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Vec::new(),
-            Err(e) => return Err(RsyncError::Io(e)),
+            Err(e) => return Err(TransferError::Io(e)),
         };
 
-        let source = fs::read(src).await.map_err(RsyncError::Io)?;
+        let source = fs::read(src).await.map_err(TransferError::Io)?;
 
         // Compute delta against baseline using the same engine the SSH path
         // uses; this keeps the local fast path bit-for-bit consistent with
@@ -115,9 +123,8 @@ impl LocalDeltaTransport {
         // output equals `source`.
         let reconstructed =
             delta_engine::apply_delta(&baseline, &ops, block_size).map_err(|e| {
-                RsyncError::TransferFailed {
-                    exit: 0,
-                    stderr: format!("local delta apply failed: {e}"),
+                TransferError::Soft {
+                    detail: format!("local delta apply failed: {e}"),
                 }
             })?;
 
@@ -171,65 +178,47 @@ impl LocalDeltaTransport {
             )
             .await
         }
-        .map_err(|e| RsyncError::TransferFailed {
-            exit: 0,
-            stderr: format!("local atomic write failed: {e:?}"),
+        .map_err(|e| TransferError::Soft {
+            detail: format!("local atomic write failed: {e:?}"),
         })?;
 
         let total_size = src_size;
         let duration_ms = start.elapsed().as_millis() as u64;
-        let speedup = if bytes_sent == 0 {
-            f64::INFINITY
-        } else {
-            total_size as f64 / bytes_sent as f64
-        };
 
-        Ok(RsyncStats {
-            bytes_sent,
-            bytes_received: src_size,
+        // `bytes_received` is the whole source: locally nothing travels,
+        // so the reconstructed size is what the destination received.
+        // `copy_blocks` stays 0 as it always did on this path. The
+        // speedup is not here on purpose: the local adapter computes it,
+        // because this transport reports an infinite speedup when
+        // nothing was sent and the remote one reports 1.0.
+        Ok(TransferReport {
+            session: SessionStats {
+                bytes_sent,
+                bytes_received: src_size,
+                copy_blocks: 0,
+                ..SessionStats::default()
+            },
             total_size,
-            speedup,
             duration_ms,
-            copy_blocks: 0,
             warnings: Vec::new(),
         })
     }
 }
 
-#[async_trait]
-impl DeltaTransport for LocalDeltaTransport {
-    fn name(&self) -> &'static str {
-        "aerorsync-local"
-    }
+/// Name this transport reports. The application adapter copies it into
+/// the trait implementation and a test pins the two together.
+pub const LOCAL_TRANSPORT_NAME: &str = "aerorsync-local";
 
-    async fn probe_remote(&self) -> Result<RsyncCapability, RsyncError> {
-        Ok(RsyncCapability {
-            version: "aerorsync local in-process".to_string(),
-            protocol: 31,
-        })
-    }
-
-    async fn probe_local(&self) -> Result<(), RsyncError> {
-        Ok(())
-    }
-
-    async fn upload(&self, local_path: &Path, remote_path: &str) -> Result<RsyncStats, RsyncError> {
-        // `remote_path` is interpreted as a local filesystem path.
-        self.transfer_inner(local_path, Path::new(remote_path))
-            .await
-    }
-
-    async fn download(
-        &self,
-        remote_path: &str,
-        local_path: &Path,
-    ) -> Result<RsyncStats, RsyncError> {
-        // Inverted direction: `remote_path` is the source on the local fs.
-        self.transfer_inner(Path::new(remote_path), local_path)
-            .await
+/// The synthetic probe of a transport that has no remote: the delta
+/// dispatch expects a capability record, and this one says "protocol 31,
+/// in process". The adapter renders it like any other probe.
+pub(crate) fn local_probe() -> TransportProbe {
+    TransportProbe {
+        remote_banner: "aerorsync local in-process".to_string(),
+        protocol: ProtocolVersion(31),
+        supports_remote_shell: false,
     }
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -247,16 +236,16 @@ mod tests {
         tokio::fs::write(&src, &payload).await.unwrap();
 
         let transport = LocalDeltaTransport::new(1024);
-        let stats = transport
-            .transfer_inner(src.as_path(), dst.as_path())
+        let report = transport
+            .transfer(src.as_path(), dst.as_path())
             .await
             .expect("happy path");
 
         let written = tokio::fs::read(&dst).await.unwrap();
         assert_eq!(written, payload);
-        assert_eq!(stats.total_size, payload.len() as u64);
+        assert_eq!(report.total_size, payload.len() as u64);
         // No baseline -> all bytes travelled as literal.
-        assert_eq!(stats.bytes_sent, payload.len() as u64);
+        assert_eq!(report.session.bytes_sent, payload.len() as u64);
     }
 
     #[tokio::test]
@@ -269,8 +258,8 @@ mod tests {
         tokio::fs::write(&dst, &payload).await.unwrap();
 
         let transport = LocalDeltaTransport::new(1024);
-        let stats = transport
-            .transfer_inner(src.as_path(), dst.as_path())
+        let report = transport
+            .transfer(src.as_path(), dst.as_path())
             .await
             .expect("identical baseline path");
 
@@ -280,9 +269,9 @@ mod tests {
         // because compute_signatures pads it; the savings ratio is the
         // metric that matters. Assert << 0.1% of total.
         assert!(
-            stats.bytes_sent < payload.len() as u64 / 1000,
+            report.session.bytes_sent < payload.len() as u64 / 1000,
             "identical baseline should emit << 0.1% literal bytes, got {}",
-            stats.bytes_sent
+            report.session.bytes_sent
         );
     }
 
@@ -300,17 +289,17 @@ mod tests {
         tokio::fs::write(&src, &payload).await.unwrap();
 
         let transport = LocalDeltaTransport::new(1024);
-        let stats = transport
-            .transfer_inner(src.as_path(), dst.as_path())
+        let report = transport
+            .transfer(src.as_path(), dst.as_path())
             .await
             .expect("localized change path");
 
         let written = tokio::fs::read(&dst).await.unwrap();
         assert_eq!(written, payload);
         assert!(
-            stats.bytes_sent < payload.len() as u64 / 4,
+            report.session.bytes_sent < payload.len() as u64 / 4,
             "localized change should match most blocks: sent {}",
-            stats.bytes_sent
+            report.session.bytes_sent
         );
     }
 
@@ -323,11 +312,11 @@ mod tests {
 
         let transport = LocalDeltaTransport::new(1024 * 1024);
         let err = transport
-            .transfer_inner(src.as_path(), dst.as_path())
+            .transfer(src.as_path(), dst.as_path())
             .await
             .expect_err("too small");
         match err {
-            RsyncError::TooSmall { size, threshold } => {
+            TransferError::TooSmall { size, threshold } => {
                 assert_eq!(size, 5);
                 assert_eq!(threshold, 1024 * 1024);
             }
@@ -343,11 +332,11 @@ mod tests {
 
         let transport = LocalDeltaTransport::new(1024);
         let err = transport
-            .transfer_inner(src.as_path(), dst.as_path())
+            .transfer(src.as_path(), dst.as_path())
             .await
             .expect_err("missing source");
         match err {
-            RsyncError::Io(io) => {
+            TransferError::Io(io) => {
                 assert_eq!(io.kind(), std::io::ErrorKind::NotFound);
             }
             other => panic!("expected Io NotFound, got {other:?}"),
@@ -367,48 +356,15 @@ mod tests {
 
         let transport = LocalDeltaTransport::new(1024);
         let err = transport
-            .transfer_inner(src.as_path(), dst.as_path())
+            .transfer(src.as_path(), dst.as_path())
             .await
             .expect_err("oversized");
         match err {
-            RsyncError::TransferFailed { stderr, .. } => {
-                assert!(stderr.contains("exceeds in-memory cap"));
+            TransferError::Soft { detail } => {
+                assert!(detail.contains("exceeds in-memory cap"));
             }
-            other => panic!("expected TransferFailed, got {other:?}"),
+            other => panic!("expected a soft error, got {other:?}"),
         }
-    }
-
-    #[tokio::test]
-    async fn upload_and_download_are_symmetric() {
-        let dir = tmp_dir();
-        let src = dir.path().join("a.bin");
-        let dst = dir.path().join("b.bin");
-        let payload = vec![0x55u8; 1_500_000];
-        tokio::fs::write(&src, &payload).await.unwrap();
-
-        let transport = LocalDeltaTransport::new(1024);
-        // upload semantics: local -> remote (interpreted as local fs path)
-        transport
-            .upload(&src, dst.to_string_lossy().as_ref())
-            .await
-            .expect("upload");
-        assert_eq!(tokio::fs::read(&dst).await.unwrap(), payload);
-
-        // download semantics: remote -> local
-        let dst2 = dir.path().join("c.bin");
-        transport
-            .download(src.to_string_lossy().as_ref(), &dst2)
-            .await
-            .expect("download");
-        assert_eq!(tokio::fs::read(&dst2).await.unwrap(), payload);
-    }
-
-    #[tokio::test]
-    async fn probe_remote_reports_local_capability() {
-        let transport = LocalDeltaTransport::new(1024);
-        let cap = transport.probe_remote().await.expect("probe");
-        assert_eq!(cap.protocol, 31);
-        assert!(cap.version.contains("local"));
     }
 
     #[tokio::test]
@@ -426,7 +382,7 @@ mod tests {
 
         let transport = LocalDeltaTransport::new(1024).with_sparse(true);
         transport
-            .transfer_inner(src.as_path(), dst.as_path())
+            .transfer(src.as_path(), dst.as_path())
             .await
             .expect("sparse transfer");
 
@@ -452,12 +408,12 @@ mod tests {
         tokio::fs::write(&src, &payload).await.unwrap();
 
         LocalDeltaTransport::new(1024)
-            .transfer_inner(src.as_path(), dense_dst.as_path())
+            .transfer(src.as_path(), dense_dst.as_path())
             .await
             .expect("dense transfer");
         LocalDeltaTransport::new(1024)
             .with_sparse(true)
-            .transfer_inner(src.as_path(), sparse_dst.as_path())
+            .transfer(src.as_path(), sparse_dst.as_path())
             .await
             .expect("sparse transfer");
 
@@ -488,7 +444,7 @@ mod tests {
 
         let transport = LocalDeltaTransport::new(1024);
         transport
-            .transfer_inner(src.as_path(), dst.as_path())
+            .transfer(src.as_path(), dst.as_path())
             .await
             .expect("transfer");
 

--- a/src-tauri/src/aerorsync/tests.rs
+++ b/src-tauri/src/aerorsync/tests.rs
@@ -2917,9 +2917,8 @@ fn production_unsafe_surface_matches_the_documented_count() {
 fn app_import_budget_matches_the_documented_inventory() {
     // (file, application module, occurrences). Update in the same commit
     // that removes a line, never to add one.
-    const DOCUMENTED: [(&str, &str, usize); 5] = [
+    const DOCUMENTED: [(&str, &str, usize); 4] = [
         ("delta_transport_impl.rs", "delta_transport", 1),
-        ("delta_transport_impl.rs", "rsync_over_ssh", 8),
         ("live_tests.rs", "delta_transport", 1),
         ("local_transport.rs", "delta_transport", 1),
         ("local_transport.rs", "rsync_over_ssh", 1),

--- a/src-tauri/src/aerorsync/tests.rs
+++ b/src-tauri/src/aerorsync/tests.rs
@@ -2892,17 +2892,23 @@ fn production_unsafe_surface_matches_the_documented_count() {
     assert_eq!(total, 19, "documented total in the parity docs is 19");
 }
 
-/// The aerorsync module is on its way to a standalone crate (Phase A of the
-/// standalone-crate plan). Every `crate::<application module>` line inside
-/// it is coupling the crate cannot carry, so the inventory below is a
-/// budget: it may only shrink. Unlike the `unsafe` count above, whole-file
+/// The module imports nothing from the application. That is the end state
+/// of the standalone-crate plan's first phase, and this is where it is
+/// enforced: every `crate::<application module>` line inside the module is
+/// coupling the crate cannot carry, and there are none left, so the
+/// inventory is empty and the assertion names the file and the line of
+/// anything that comes back. Unlike the `unsafe` count above, whole-file
 /// test harnesses are NOT excluded: in the crate, test code cannot import
 /// the application either.
 ///
+/// An empty inventory measured by a blind scan would be a false green, so
+/// every refusal the scan needs to stay honest is still here: the forms
+/// below fail the test outright rather than being counted.
+///
 /// The exclusion is `crate::aerorsync` compared as a whole identifier, never
-/// as a prefix: `crate::aerorsync_adapter`, the application-side adapter the
-/// A3 tranche creates, is an application import and must count, because the
-/// crate must never depend on its own adapter. Grouped imports
+/// as a prefix: `crate::aerorsync_adapter`, the application-side adapter,
+/// is an application import and must be refused, because the crate must
+/// never depend on its own adapter. Grouped imports
 /// (`use crate::{a, b}`) fail outright so a mixed group cannot hide an
 /// application module next to `aerorsync`; `super::super::` is the crate
 /// root seen from a module file and is refused for the same reason.
@@ -2914,13 +2920,7 @@ fn production_unsafe_surface_matches_the_documented_count() {
 /// with spaces is not handled here: `cargo fmt --check` rejects it before
 /// this test runs.
 #[test]
-fn app_import_budget_matches_the_documented_inventory() {
-    // (file, application module, occurrences). Update in the same commit
-    // that removes a line, never to add one.
-    const DOCUMENTED: [(&str, &str, usize); 2] = [
-        ("delta_transport_impl.rs", "delta_transport", 1),
-        ("live_tests.rs", "delta_transport", 1),
-    ];
+fn aerorsync_module_imports_nothing_from_the_app() {
     // Assembled from pieces so this file's own source does not trip the scan.
     let needle = ["crate", "::"].concat();
     let root_alias = ["super::", "super::"].concat();
@@ -2949,7 +2949,7 @@ fn app_import_budget_matches_the_documented_inventory() {
     }
 
     let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/aerorsync");
-    let mut found: Vec<(String, String, usize)> = Vec::new();
+    let mut found: Vec<(String, usize, String)> = Vec::new();
     let mut scanned = 0usize;
 
     for entry in std::fs::read_dir(&dir).expect("aerorsync module directory must be readable") {
@@ -3014,13 +3014,7 @@ fn app_import_budget_matches_the_documented_inventory() {
                     } else {
                         ident.clone()
                     };
-                    match found
-                        .iter_mut()
-                        .find(|(f, m, _)| *f == name && *m == module)
-                    {
-                        Some(hit) => hit.2 += 1,
-                        None => found.push((name.clone(), module, 1)),
-                    }
+                    found.push((name.clone(), lineno, module));
                 }
                 rest = &after[ident.len()..];
             }
@@ -3032,15 +3026,8 @@ fn app_import_budget_matches_the_documented_inventory() {
     );
 
     found.sort();
-    let mut expected: Vec<(String, String, usize)> = DOCUMENTED
-        .iter()
-        .map(|(f, m, n)| ((*f).to_string(), (*m).to_string(), *n))
-        .collect();
-    expected.sort();
-
-    assert_eq!(
-        found, expected,
-        "the module's import budget moved; it may only shrink, update the inventory in \
-         the same commit"
+    assert!(
+        found.is_empty(),
+        "the module imports the application: {found:?}"
     );
 }

--- a/src-tauri/src/aerorsync/tests.rs
+++ b/src-tauri/src/aerorsync/tests.rs
@@ -2903,7 +2903,14 @@ fn production_unsafe_surface_matches_the_documented_count() {
 ///
 /// An empty inventory measured by a blind scan would be a false green, so
 /// every refusal the scan needs to stay honest is still here: the forms
-/// below fail the test outright rather than being counted.
+/// below fail the test outright rather than being counted. That list is
+/// a syntactic denylist, and it is worth saying what that means: it
+/// refuses the ways of reaching the crate root we know how to spell, not
+/// every way that exists. A second reviewer got a green out of it with
+/// `use crate as app;`, which is why the rename of the root is refused
+/// now. The end state is a check that reads paths with a parser instead
+/// of substrings; until then, a new spelling that gets through belongs
+/// in this list the day it is found.
 ///
 /// The exclusion is `crate::aerorsync` compared as a whole identifier, never
 /// as a prefix: `crate::aerorsync_adapter`, the application-side adapter,
@@ -2933,6 +2940,14 @@ fn aerorsync_module_imports_nothing_from_the_app() {
         ["include", "!("].concat(),
         ["include_str", "!("].concat(),
         ["macro_rules", "!"].concat(),
+    ];
+    // Renaming the crate root reaches the application without ever writing
+    // the prefix this scan looks for: `use crate as app;` and then
+    // `app::settings`. Both spellings of the rename are refused where the
+    // alias is created, which is the only place a flat scan can see it.
+    let root_aliases = [
+        ["crate", " as "].concat(),
+        ["extern ", "crate self"].concat(),
     ];
 
     fn dir_holds_rust_source(dir: &std::path::Path) -> bool {
@@ -2979,6 +2994,22 @@ fn aerorsync_module_imports_nothing_from_the_app() {
                 "{name} uses `{hatch}`: the import scan reads one flat directory and cannot \
                  see through it"
             );
+        }
+        // Line-based and comment-skipping, unlike the hatches above: a
+        // doc-comment that explains the refusal must not trip it.
+        for (index, line) in src.lines().enumerate() {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("//") || trimmed.starts_with('*') {
+                continue;
+            }
+            for alias in &root_aliases {
+                assert!(
+                    !line.contains(alias.as_str()),
+                    "{name}:{}: renames the crate root with `{alias}`: an alias reaches the \
+                     application without ever spelling the prefix this scan counts",
+                    index + 1
+                );
+            }
         }
         for (index, line) in src.lines().enumerate() {
             let trimmed = line.trim_start();

--- a/src-tauri/src/aerorsync/tests.rs
+++ b/src-tauri/src/aerorsync/tests.rs
@@ -2917,11 +2917,9 @@ fn production_unsafe_surface_matches_the_documented_count() {
 fn app_import_budget_matches_the_documented_inventory() {
     // (file, application module, occurrences). Update in the same commit
     // that removes a line, never to add one.
-    const DOCUMENTED: [(&str, &str, usize); 4] = [
+    const DOCUMENTED: [(&str, &str, usize); 2] = [
         ("delta_transport_impl.rs", "delta_transport", 1),
         ("live_tests.rs", "delta_transport", 1),
-        ("local_transport.rs", "delta_transport", 1),
-        ("local_transport.rs", "rsync_over_ssh", 1),
     ];
     // Assembled from pieces so this file's own source does not trip the scan.
     let needle = ["crate", "::"].concat();

--- a/src-tauri/src/aerorsync_adapter/config.rs
+++ b/src-tauri/src/aerorsync_adapter/config.rs
@@ -1,0 +1,267 @@
+//! Turning an AeroFTP connection profile into a module transport.
+//!
+//! `RsyncConfig` is an application type, so the module cannot read it:
+//! this is where a profile becomes the crate's own `SshTransportConfig`.
+//! A free function and not an inherent method on purpose: once the module
+//! is a separate crate, an inherent block on a type from another crate is
+//! not allowed, and this file would be the one to break.
+
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+use crate::aerorsync::delta_transport_impl::AerorsyncDeltaTransport;
+use crate::aerorsync::ssh_transport::{SshHostKeyPolicy, SshTransportConfig};
+use crate::aerorsync::transport::RemoteExecRequest;
+use crate::rsync_over_ssh::{AuthMethod, RsyncConfig, RsyncError};
+
+/// Convenience constructor that maps the production `RsyncConfig`
+/// (used by `providers::sftp::delta_transport`) onto the prototype's
+/// `SshTransportConfig`. `host_key_policy` is provided by the caller
+/// so the factory (Zona B1) can honour whatever pinning the SFTP
+/// session established during connect.
+pub fn transport_from_rsync_config(
+    cfg: &RsyncConfig,
+    host_key_policy: SshHostKeyPolicy,
+) -> Result<AerorsyncDeltaTransport, RsyncError> {
+    // Z.4.5 R1 dispatch step (2026-05-14): the previous boundary
+    // refusal `Err(PasswordAuthUnsupported)` was a placeholder while
+    // the russh transport gained password auth. Now that
+    // `RusshSessionTransport::connect` branches on
+    // `SshTransportConfig::usable_password()`, the gate moves to
+    // `RsyncConfig::validate_auth_material()` which enforces:
+    //   - SshKey  → ssh_key_path required (else MissingKey)
+    //   - Password → ssh_password required and non-empty (else MissingPassword)
+    //   - Neither → HardRejection (integration bug, never silently retry)
+    // Callers that want password-based delta sync can now construct
+    // an `RsyncConfig { auth_method: Password, ssh_password: Some(_), .. }`
+    // and the russh leg picks it up. Subprocess `rsync_over_ssh::build_ssh_e_arg`
+    // still refuses Password upfront so the binary path never accidentally
+    // shells out without auth material.
+    cfg.validate_auth_material()?;
+
+    // Password-only profiles legitimately have no key path. The
+    // russh leg ignores `private_key_path` when `usable_password()`
+    // is Some, so an empty placeholder is safe; it is never opened
+    // or dereferenced. We MUST NOT default to `~/.ssh/id_rsa` or
+    // any other concrete path: that would silently load credentials
+    // the user did not opt into.
+    let key_path = cfg.ssh_key_path.clone().unwrap_or_default();
+    let ssh_config = SshTransportConfig {
+        host: cfg.ssh_host.clone(),
+        port: cfg.ssh_port.unwrap_or(22),
+        username: cfg.ssh_user.clone(),
+        private_key_path: key_path,
+        connect_timeout_ms: 10_000,
+        io_timeout_ms: 30_000,
+        worker_idle_poll_ms: 250,
+        max_frame_size: 1 << 20,
+        host_key_policy,
+        auth_password: cfg.ssh_password.clone(),
+        // An Agent profile carries no key/password; the russh leg
+        // resolves SSH_AUTH_SOCK at connect time. `prefers_russh_leg`
+        // then routes probe + single-shot through russh (libssh2 is
+        // pubkey-file-only).
+        auth_agent: matches!(cfg.auth_method, AuthMethod::Agent),
+        // B.1/B.4: probe stock `rsync --version` on the remote. The
+        // parser in `parse_probe_protocol` extracts the numeric
+        // protocol version from the multi-line banner. A missing
+        // `rsync` binary surfaces as exit != 0 and is mapped to
+        // `RsyncError::RemoteNotAvailable` (soft classic fallback);
+        // only `HostKeyRejected` escalates to `HardRejection`.
+        probe_request: RemoteExecRequest {
+            program: "rsync".into(),
+            args: vec!["--version".into()],
+            environment: Vec::new(),
+        },
+    };
+    Ok(AerorsyncDeltaTransport::new(ssh_config, cfg.min_file_size))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use secrecy::{ExposeSecret, SecretString};
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn fresh_tempdir() -> TempDir {
+        TempDir::new().expect("tempdir")
+    }
+
+    /// Z.4.5 R1: when the production [`RsyncConfig`] carries an SSH
+    /// password (a password-auth rsync-over-SSH profile), the
+    /// constructor MUST
+    /// propagate it onto [`SshTransportConfig::auth_password`] so the
+    /// russh leg can pick it up. The propagation is independent of the
+    /// `auth_method` discriminant: a profile may legitimately carry
+    /// both a key and a password (e.g. for paranoid two-factor setups
+    /// in the future); the actual selection happens inside
+    /// `RusshSessionTransport::connect`.
+    #[test]
+    fn from_rsync_config_propagates_password_to_transport() {
+        let dir = fresh_tempdir();
+        let key_path = dir.path().join("id_dummy");
+        std::fs::write(&key_path, b"-----BEGIN OPENSSH PRIVATE KEY-----\nfake\n").unwrap();
+
+        let cfg = RsyncConfig {
+            ssh_user: "tester".into(),
+            ssh_host: "example.invalid".into(),
+            ssh_port: Some(2222),
+            ssh_key_path: Some(key_path.clone()),
+            ssh_password: Some(SecretString::from("rsync-password".to_string())),
+            auth_method: AuthMethod::SshKey,
+            ..Default::default()
+        };
+        let transport = transport_from_rsync_config(&cfg, SshHostKeyPolicy::AcceptAny)
+            .expect("from_rsync_config should accept SshKey method with both materials");
+        assert_eq!(transport.ssh_config().host, "example.invalid");
+        assert_eq!(transport.ssh_config().port, 2222);
+        assert_eq!(transport.ssh_config().private_key_path, key_path);
+        let propagated = transport
+            .ssh_config()
+            .auth_password
+            .as_ref()
+            .expect("ssh_password must be propagated");
+        assert_eq!(propagated.expose_secret(), "rsync-password");
+        // And the helper agrees:
+        assert!(transport.ssh_config().usable_password().is_some());
+        let _ = PathBuf::from("placeholder"); // silence unused import warning on some CI configs
+    }
+
+    /// Z.4.5 R1 dispatch step (2026-05-14): the boundary refusal of
+    /// `auth_method=Password` is gone. A password-only `RsyncConfig`
+    /// now produces a transport whose `auth_password` is set and whose
+    /// `private_key_path` is the empty placeholder (the russh leg
+    /// ignores the key path when `usable_password()` is Some).
+    #[test]
+    fn from_rsync_config_accepts_password_only_method() {
+        let cfg = RsyncConfig {
+            ssh_user: "tester".into(),
+            ssh_host: "example.invalid".into(),
+            ssh_password: Some(SecretString::from("rsync-password".to_string())),
+            auth_method: AuthMethod::Password,
+            ..Default::default()
+        };
+        let transport = transport_from_rsync_config(&cfg, SshHostKeyPolicy::AcceptAny)
+            .expect("password-only RsyncConfig should now produce a transport");
+        // Empty placeholder (NOT a default ~/.ssh path): russh leg ignores it.
+        assert_eq!(
+            transport.ssh_config().private_key_path,
+            std::path::PathBuf::new(),
+            "password-only profile must not silently inject a default key path"
+        );
+        let propagated = transport
+            .ssh_config()
+            .auth_password
+            .as_ref()
+            .expect("ssh_password must be propagated");
+        assert_eq!(propagated.expose_secret(), "rsync-password");
+        assert!(transport.ssh_config().usable_password().is_some());
+    }
+
+    /// SSH agent auth: a `RsyncConfig { auth_method: Agent }` with no key
+    /// and no password must produce a transport whose `auth_agent` flag
+    /// is set, no password propagated, and an empty key placeholder. The
+    /// russh leg resolves SSH_AUTH_SOCK at connect time; nothing static
+    /// is validated or injected here.
+    #[test]
+    fn from_rsync_config_agent_method_sets_auth_agent_flag() {
+        let cfg = RsyncConfig {
+            ssh_user: "tester".into(),
+            ssh_host: "example.invalid".into(),
+            ssh_key_path: None,
+            ssh_password: None,
+            auth_method: AuthMethod::Agent,
+            ..Default::default()
+        };
+        let transport = transport_from_rsync_config(&cfg, SshHostKeyPolicy::AcceptAny)
+            .expect("agent RsyncConfig should produce a transport");
+        assert!(
+            transport.ssh_config().auth_agent,
+            "auth_agent must be set for AuthMethod::Agent"
+        );
+        assert!(
+            transport.ssh_config().auth_password.is_none(),
+            "agent profile must not carry a password"
+        );
+        assert_eq!(
+            transport.ssh_config().private_key_path,
+            std::path::PathBuf::new(),
+            "agent profile must not inject a default key path"
+        );
+        assert!(
+            transport.ssh_config().prefers_russh_leg(),
+            "agent profile must route through the russh leg"
+        );
+    }
+
+    /// Z.4.5 R1 dispatch step: `validate_auth_material()` now gates the
+    /// boundary instead of the old hard refusal. A `Password` method
+    /// without a non-empty password surfaces `MissingPassword`, NOT
+    /// `PasswordAuthUnsupported` (which has been removed from the
+    /// boundary as of this step).
+    #[test]
+    fn from_rsync_config_password_method_without_password_returns_missing_password() {
+        let cfg = RsyncConfig {
+            ssh_user: "tester".into(),
+            ssh_host: "example.invalid".into(),
+            ssh_password: None,
+            ssh_key_path: Some(std::path::PathBuf::from("/tmp/key")),
+            auth_method: AuthMethod::Password,
+            ..Default::default()
+        };
+        match transport_from_rsync_config(&cfg, SshHostKeyPolicy::AcceptAny) {
+            Err(RsyncError::MissingPassword) => {}
+            Err(other) => {
+                panic!("expected MissingPassword via validate_auth_material, got Err({other:?})")
+            }
+            Ok(_) => panic!("expected MissingPassword, got Ok(_)"),
+        }
+    }
+
+    /// Z.4.5 R1 dispatch step: empty SecretString must be rejected by
+    /// `validate_auth_material()` so a misconfigured profile cannot
+    /// reach the russh leg with a zero-length password.
+    #[test]
+    fn from_rsync_config_password_method_with_empty_password_returns_missing_password() {
+        use secrecy::SecretString;
+
+        let cfg = RsyncConfig {
+            ssh_user: "tester".into(),
+            ssh_host: "example.invalid".into(),
+            ssh_password: Some(SecretString::from(String::new())),
+            auth_method: AuthMethod::Password,
+            ..Default::default()
+        };
+        match transport_from_rsync_config(&cfg, SshHostKeyPolicy::AcceptAny) {
+            Err(RsyncError::MissingPassword) => {}
+            Err(other) => panic!("expected MissingPassword, got Err({other:?})"),
+            Ok(_) => panic!("expected MissingPassword, got Ok(_)"),
+        }
+    }
+
+    /// Z.4.5 R1 dispatch step: a config that carries neither key nor
+    /// password is still rejected as `HardRejection`. This is the
+    /// "integration bug" guard from `validate_auth_material()`: it is
+    /// not a credential failure (which the user can fix with input) but
+    /// a wiring bug (the call site forgot to attach material). The
+    /// dispatch must not silently fall back to another transport.
+    #[test]
+    fn from_rsync_config_with_no_auth_material_is_hard_rejection() {
+        let cfg = RsyncConfig {
+            ssh_user: "tester".into(),
+            ssh_host: "example.invalid".into(),
+            ssh_password: None,
+            ssh_key_path: None,
+            auth_method: AuthMethod::SshKey,
+            ..Default::default()
+        };
+        match transport_from_rsync_config(&cfg, SshHostKeyPolicy::AcceptAny) {
+            Err(RsyncError::HardRejection(message)) => {
+                assert!(message.contains("neither ssh_key_path nor ssh_password"));
+            }
+            Err(other) => panic!("expected HardRejection, got Err({other:?})"),
+            Ok(_) => panic!("expected HardRejection, got Ok(_)"),
+        }
+    }
+}

--- a/src-tauri/src/aerorsync_adapter/local.rs
+++ b/src-tauri/src/aerorsync_adapter/local.rs
@@ -1,0 +1,186 @@
+//! The application's `DeltaTransport` implementation for the local
+//! transport, and the rendering that goes with it.
+//!
+//! The local transport is not the remote one with the network taken out:
+//! it reports an infinite speedup when nothing had to be sent, and its
+//! soft failures carry exit code 0, because the caller reads them as "use
+//! the plain copy instead", not as a failed rsync. Both are visible to the
+//! user through `RsyncStats` and `RsyncError`, so they are reproduced here
+//! rather than folded into the shared rendering.
+
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+use std::path::Path;
+
+use async_trait::async_trait;
+
+use crate::aerorsync::local_transport::{local_probe, LocalDeltaTransport, LOCAL_TRANSPORT_NAME};
+use crate::aerorsync::types::{TransferError, TransferReport};
+use crate::aerorsync_adapter::errors::probe_to_capability;
+use crate::delta_transport::DeltaTransport;
+use crate::rsync_over_ssh::{RsyncCapability, RsyncError, RsyncStats};
+
+/// Render a local transfer's report. Same seven fields the local path
+/// always filled, including the infinite speedup when nothing was sent:
+/// on this path that is not a division by zero, it is the honest answer,
+/// because the destination was rebuilt without sending anything.
+fn local_report_to_rsync_stats(report: TransferReport) -> RsyncStats {
+    let speedup = if report.session.bytes_sent == 0 {
+        f64::INFINITY
+    } else {
+        report.total_size as f64 / report.session.bytes_sent as f64
+    };
+    RsyncStats {
+        bytes_sent: report.session.bytes_sent,
+        bytes_received: report.session.bytes_received,
+        total_size: report.total_size,
+        speedup,
+        duration_ms: report.duration_ms,
+        copy_blocks: report.session.copy_blocks,
+        warnings: report.warnings,
+    }
+}
+
+/// Render a local transfer's failure. The soft ones keep exit code 0,
+/// which is what this path has always reported: there is no rsync
+/// process here, and 0 is how the caller tells "nothing ran, fall back"
+/// apart from a real transfer failure.
+fn local_error_to_rsync(err: TransferError) -> RsyncError {
+    match err {
+        TransferError::Soft { detail } => RsyncError::TransferFailed {
+            exit: 0,
+            stderr: detail,
+        },
+        TransferError::Hard { detail } => RsyncError::HardRejection(detail),
+        TransferError::Io(io) => RsyncError::Io(io),
+        TransferError::TooSmall { size, threshold } => RsyncError::TooSmall { size, threshold },
+        // The local path has no driver, so it never builds this variant;
+        // the arm exists because the carrier is shared and a silent
+        // catch-all would hide the day it does.
+        TransferError::Native { error, committed } => RsyncError::HardRejection(format!(
+            "local delta reported a native error ({:?}, committed={}): {}",
+            error.kind, committed, error.detail
+        )),
+    }
+}
+
+#[async_trait]
+impl DeltaTransport for LocalDeltaTransport {
+    fn name(&self) -> &'static str {
+        LOCAL_TRANSPORT_NAME
+    }
+
+    async fn probe_remote(&self) -> Result<RsyncCapability, RsyncError> {
+        Ok(probe_to_capability(local_probe()))
+    }
+
+    async fn probe_local(&self) -> Result<(), RsyncError> {
+        Ok(())
+    }
+
+    async fn upload(&self, local_path: &Path, remote_path: &str) -> Result<RsyncStats, RsyncError> {
+        // `remote_path` is interpreted as a local filesystem path.
+        self.transfer(local_path, Path::new(remote_path))
+            .await
+            .map(local_report_to_rsync_stats)
+            .map_err(local_error_to_rsync)
+    }
+
+    async fn download(
+        &self,
+        remote_path: &str,
+        local_path: &Path,
+    ) -> Result<RsyncStats, RsyncError> {
+        // Inverted direction: `remote_path` is the source on the local fs.
+        self.transfer(Path::new(remote_path), local_path)
+            .await
+            .map(local_report_to_rsync_stats)
+            .map_err(local_error_to_rsync)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The trait says one name, the module owns it: if the copy in the
+    /// implementation and the constant ever drift, this fails.
+    #[test]
+    fn local_transport_name_matches_the_module_constant() {
+        let transport = LocalDeltaTransport::new(0);
+        assert_eq!(transport.name(), LOCAL_TRANSPORT_NAME);
+        assert_eq!(LOCAL_TRANSPORT_NAME, "aerorsync-local");
+    }
+
+    /// A local transfer that sent nothing reports an infinite speedup,
+    /// not the 1.0 the remote rendering uses. Both are deliberate and
+    /// this pins the difference.
+    #[test]
+    fn a_local_transfer_that_sent_nothing_reports_an_infinite_speedup() {
+        let stats = local_report_to_rsync_stats(TransferReport {
+            total_size: 4096,
+            ..TransferReport::default()
+        });
+        assert!(stats.speedup.is_infinite());
+        assert_eq!(stats.bytes_sent, 0);
+        assert_eq!(stats.total_size, 4096);
+    }
+
+    /// A soft local failure keeps exit code 0.
+    #[test]
+    fn a_soft_local_failure_keeps_exit_zero() {
+        match local_error_to_rsync(TransferError::Soft {
+            detail: "local delta apply failed: boom".into(),
+        }) {
+            RsyncError::TransferFailed { exit, stderr } => {
+                assert_eq!(exit, 0, "the local path has never reported -1");
+                assert_eq!(stderr, "local delta apply failed: boom");
+            }
+            other => panic!("expected TransferFailed, got {other:?}"),
+        }
+    }
+
+    /// Moved with the trait implementation it exercises: the local path
+    /// reports "protocol 31, in process" so the delta dispatch keeps
+    /// working without a remote.
+    #[tokio::test]
+    async fn probe_remote_reports_local_capability() {
+        let transport = LocalDeltaTransport::new(1024);
+        let cap = transport.probe_remote().await.expect("probe");
+        assert_eq!(cap.protocol, 31);
+        assert!(cap.version.contains("local"));
+    }
+
+    /// Moved with the trait implementation it exercises: upload writes
+    /// the second path and download reads it, which is the direction
+    /// inversion the two methods encode.
+    #[tokio::test]
+    async fn upload_and_download_are_symmetric() {
+        let dir = tmp_dir();
+        let src = dir.path().join("a.bin");
+        let dst = dir.path().join("b.bin");
+        let payload = vec![0x55u8; 1_500_000];
+        tokio::fs::write(&src, &payload).await.unwrap();
+
+        let transport = LocalDeltaTransport::new(1024);
+        // upload semantics: local -> remote (interpreted as local fs path)
+        transport
+            .upload(&src, dst.to_string_lossy().as_ref())
+            .await
+            .expect("upload");
+        assert_eq!(tokio::fs::read(&dst).await.unwrap(), payload);
+
+        // download semantics: remote -> local
+        let dst2 = dir.path().join("c.bin");
+        transport
+            .download(src.to_string_lossy().as_ref(), &dst2)
+            .await
+            .expect("download");
+        assert_eq!(tokio::fs::read(&dst2).await.unwrap(), payload);
+    }
+
+    fn tmp_dir() -> tempfile::TempDir {
+        tempfile::tempdir().expect("tempdir")
+    }
+}

--- a/src-tauri/src/aerorsync_adapter/mod.rs
+++ b/src-tauri/src/aerorsync_adapter/mod.rs
@@ -19,6 +19,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
 
+pub mod config;
 pub mod delta_transport;
 pub mod errors;
 
@@ -34,6 +35,9 @@ mod tests {
             "events",
             "fallback_policy",
             "progress",
+            // `config.rs` builds an `SshTransportConfig` out of an
+            // application profile, so it names the module that owns it.
+            "ssh_transport",
             "streaming_writer",
             "transport",
             "types",

--- a/src-tauri/src/aerorsync_adapter/mod.rs
+++ b/src-tauri/src/aerorsync_adapter/mod.rs
@@ -19,6 +19,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
 
+//! Files: `config.rs` turns an application profile into a module
+//! transport, `delta_transport.rs` and `local.rs` carry the two trait
+//! implementations, `errors.rs` holds the maps onto the application
+//! error, statistics and capability types.
+
 pub mod config;
 pub mod delta_transport;
 pub mod errors;
@@ -26,32 +31,63 @@ pub mod local;
 
 #[cfg(test)]
 mod tests {
-    /// The adapter may only reach the module through the surface the
-    /// module publishes on purpose. A new entry in this list is a
-    /// deliberate widening and belongs in the same commit that needs it.
+    /// The adapter declares what it reaches, in both directions.
+    ///
+    /// Toward the application: the module may not name it at all, so
+    /// every application import in the whole boundary is in this file,
+    /// and the list says which file names which module. Toward the
+    /// module: the set of `crate::aerorsync::` submodules the adapter
+    /// touches is the minimum public surface the crate will have to
+    /// expose once it is extracted, so it is written out now, while it
+    /// is small, and it is the starting inventory of that work.
+    ///
+    /// Both lists may only change in the commit that changes the
+    /// adapter, and the failure message says which side moved. The
+    /// adapter naming itself is neither: it is one file of this
+    /// directory reaching another, and it is skipped explicitly. The
+    /// scan is the module's own counter, copied rather than shared:
+    /// the adapter must not depend on the module's test code. Keep the
+    /// two in step.
     #[test]
-    fn aerorsync_adapter_reaches_only_the_module_public_surface() {
-        const ALLOWED: &[&str] = &[
+    fn aerorsync_adapter_declares_its_imports() {
+        /// Application modules the adapter names, file by file.
+        const TOWARD_THE_APPLICATION: &[(&str, &str)] = &[
+            ("config.rs", "rsync_over_ssh"),
+            ("delta_transport.rs", "delta_transport"),
+            ("delta_transport.rs", "rsync_over_ssh"),
+            ("errors.rs", "rsync_over_ssh"),
+            ("local.rs", "delta_transport"),
+            ("local.rs", "rsync_over_ssh"),
+        ];
+        /// Module submodules the adapter reaches. This is the crate's
+        /// minimum public surface after extraction.
+        const TOWARD_THE_MODULE: &[&str] = &[
             "delta_transport_impl",
-            "events",
             "fallback_policy",
-            // `local.rs` implements the trait for the local transport.
             "local_transport",
             "progress",
-            // `config.rs` builds an `SshTransportConfig` out of an
-            // application profile, so it names the module that owns it.
             "ssh_transport",
             "streaming_writer",
             "transport",
             "types",
         ];
+
         // Assembled so this file's own source does not trip the scan.
-        let needle = ["crate", "::aerorsync::"].concat();
+        let needle = ["crate", "::"].concat();
+        let module_prefix = ["crate", "::aerorsync::"].concat();
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/aerorsync_adapter");
+        let mut toward_app: Vec<(String, String)> = Vec::new();
+        let mut toward_module: Vec<String> = Vec::new();
         let mut scanned = 0usize;
-        let mut checked = 0usize;
+
         for entry in std::fs::read_dir(&dir).expect("adapter directory must be readable") {
             let path = entry.expect("readable dir entry").path();
+            assert!(
+                !path.is_dir(),
+                "{} is a subdirectory the flat scan cannot see; keep adapter sources in \
+                 src/aerorsync_adapter/ itself",
+                path.display()
+            );
             if path.extension().and_then(|e| e.to_str()) != Some("rs") {
                 continue;
             }
@@ -67,31 +103,70 @@ mod tests {
                 if trimmed.starts_with("//") || trimmed.starts_with('*') {
                     continue;
                 }
+                let lineno = index + 1;
                 let mut rest = line;
                 while let Some(at) = rest.find(needle.as_str()) {
                     let after = &rest[at + needle.len()..];
-                    let module: String = after
+                    assert!(
+                        !after.starts_with('{'),
+                        "{name}:{lineno}: split the grouped import; `use {needle}{{..}}` hides \
+                         which side of the boundary a path is on"
+                    );
+                    let ident: String = after
                         .chars()
                         .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
                         .collect();
-                    assert!(
-                        ALLOWED.contains(&module.as_str()),
-                        "{name}:{}: the adapter reaches `{module}`, which is not part of the \
-                         module surface it is allowed to see",
-                        index + 1
-                    );
-                    checked += 1;
-                    rest = &after[module.len()..];
+                    if ident == "aerorsync" {
+                        let tail = &rest[at..];
+                        assert!(
+                            tail.starts_with(module_prefix.as_str()),
+                            "{name}:{lineno}: name a submodule, not the module root"
+                        );
+                        let sub: String = tail[module_prefix.len()..]
+                            .chars()
+                            .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+                            .collect();
+                        if !toward_module.contains(&sub) {
+                            toward_module.push(sub);
+                        }
+                    } else if ident == "aerorsync_adapter" {
+                        // The adapter naming itself: one file reaching
+                        // another inside this directory is not a step
+                        // across the boundary, and the scan says so out
+                        // loud rather than folding it into either list.
+                    } else if !ident.is_empty() {
+                        let hit = (name.clone(), ident.clone());
+                        if !toward_app.contains(&hit) {
+                            toward_app.push(hit);
+                        }
+                    }
+                    rest = &after[ident.len()..];
                 }
             }
         }
+
         assert!(
-            scanned >= 3,
+            scanned >= 4,
             "the scan saw only {scanned} .rs files: is this still the adapter directory?"
         );
-        assert!(
-            checked > 0,
-            "the scan matched no module path at all: the needle no longer matches the code"
+
+        toward_app.sort();
+        let expected_app: Vec<(String, String)> = TOWARD_THE_APPLICATION
+            .iter()
+            .map(|(f, m)| ((*f).to_string(), (*m).to_string()))
+            .collect();
+        assert_eq!(
+            toward_app, expected_app,
+            "the adapter's application imports moved; declare them in the same commit"
+        );
+
+        toward_module.sort();
+        let expected_module: Vec<String> =
+            TOWARD_THE_MODULE.iter().map(|m| (*m).to_string()).collect();
+        assert_eq!(
+            toward_module, expected_module,
+            "the adapter reaches a different set of module submodules; this list is the \
+             crate's minimum public surface, so declare the change in the same commit"
         );
     }
 }

--- a/src-tauri/src/aerorsync_adapter/mod.rs
+++ b/src-tauri/src/aerorsync_adapter/mod.rs
@@ -6,7 +6,7 @@
 //! `RsyncCapability`. The direction of the dependency is one way. This
 //! adapter reads the module; the module never imports from here, and
 //! that is pinned by
-//! `aerorsync::tests::app_import_budget_matches_the_documented_inventory`,
+//! `aerorsync::tests::aerorsync_module_imports_nothing_from_the_app`,
 //! whose counter compares `aerorsync` as a whole identifier so
 //! `crate::aerorsync_adapter` inside the module would be a violation.
 //!
@@ -75,6 +75,24 @@ mod tests {
         // Assembled so this file's own source does not trip the scan.
         let needle = ["crate", "::"].concat();
         let module_prefix = ["crate", "::aerorsync::"].concat();
+        // The same refusals the module's own guard carries. They are here
+        // and not shared because the adapter must not depend on the
+        // module's test code; keep the two lists in step. A second
+        // reviewer got a green out of this test with two of these, an
+        // alias of the crate root and a `super` chain walking out of the
+        // directory, which is why they are all spelled out.
+        let root_alias_chain = ["super::", "super::"].concat();
+        let conditional_attribute = ["cfg_", "attr"].concat();
+        let escape_hatches = [
+            ["#[", "path"].concat(),
+            ["include", "!("].concat(),
+            ["include_str", "!("].concat(),
+            ["macro_rules", "!"].concat(),
+        ];
+        let root_aliases = [
+            ["crate", " as "].concat(),
+            ["extern ", "crate self"].concat(),
+        ];
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/aerorsync_adapter");
         let mut toward_app: Vec<(String, String)> = Vec::new();
         let mut toward_module: Vec<String> = Vec::new();
@@ -98,12 +116,45 @@ mod tests {
                 .expect("utf-8 file name")
                 .to_string();
             let src = std::fs::read_to_string(&path).expect("readable source file");
+            for hatch in &escape_hatches {
+                assert!(
+                    !src.contains(hatch.as_str()),
+                    "{name} uses `{hatch}`: the scan reads one flat directory and cannot see \
+                     through it"
+                );
+            }
+            // Line-based and comment-skipping, unlike the hatches above:
+            // a comment that explains the refusal must not trip it.
+            for (index, line) in src.lines().enumerate() {
+                let trimmed = line.trim_start();
+                if trimmed.starts_with("//") || trimmed.starts_with('*') {
+                    continue;
+                }
+                for alias in &root_aliases {
+                    assert!(
+                        !line.contains(alias.as_str()),
+                        "{name}:{}: renames the crate root with `{alias}`: an alias reaches \
+                         the application without ever spelling the prefix this scan reads",
+                        index + 1
+                    );
+                }
+            }
             for (index, line) in src.lines().enumerate() {
                 let trimmed = line.trim_start();
                 if trimmed.starts_with("//") || trimmed.starts_with('*') {
                     continue;
                 }
                 let lineno = index + 1;
+                assert!(
+                    !line.contains(root_alias_chain.as_str()),
+                    "{name}:{lineno}: `{root_alias_chain}` walks out of this directory to the \
+                     crate root; name what you reach"
+                );
+                assert!(
+                    !(line.contains(conditional_attribute.as_str()) && line.contains("path")),
+                    "{name}:{lineno}: `{conditional_attribute}` with a `path` key redirects a \
+                     module to a file the flat scan cannot see"
+                );
                 let mut rest = line;
                 while let Some(at) = rest.find(needle.as_str()) {
                     let after = &rest[at + needle.len()..];

--- a/src-tauri/src/aerorsync_adapter/mod.rs
+++ b/src-tauri/src/aerorsync_adapter/mod.rs
@@ -22,6 +22,7 @@
 pub mod config;
 pub mod delta_transport;
 pub mod errors;
+pub mod local;
 
 #[cfg(test)]
 mod tests {
@@ -34,6 +35,8 @@ mod tests {
             "delta_transport_impl",
             "events",
             "fallback_policy",
+            // `local.rs` implements the trait for the local transport.
+            "local_transport",
             "progress",
             // `config.rs` builds an `SshTransportConfig` out of an
             // application profile, so it names the module that owns it.

--- a/src-tauri/src/providers/sftp.rs
+++ b/src-tauri/src/providers/sftp.rs
@@ -671,7 +671,6 @@ impl SftpProvider {
             // independent socket.
             let native_mode = crate::settings::load_native_rsync_mode();
             if !matches!(native_mode, crate::settings::NativeRsyncMode::Classic) {
-                use crate::aerorsync::delta_transport_impl::AerorsyncDeltaTransport;
                 use crate::aerorsync::ssh_transport::SshHostKeyPolicy;
 
                 let host_key_policy = match self.accepted_host_key_sha256_hex() {
@@ -692,7 +691,10 @@ impl SftpProvider {
                     }
                 };
 
-                match AerorsyncDeltaTransport::from_rsync_config(&rsync_config, host_key_policy) {
+                match crate::aerorsync_adapter::config::transport_from_rsync_config(
+                    &rsync_config,
+                    host_key_policy,
+                ) {
                     Ok(transport) => {
                         // B4 / ACL B4: production metadata opt-ins follow live
                         // stock-rsync acceptance. fail_on_metadata_loss remains


### PR DESCRIPTION
## Description

Fourth and last tranche of the AeroRsync standalone-crate track, after #717, in three commits, each green on its own. At the end of it the module `src-tauri/src/aerorsync/` imports nothing from the application: no `crate::<application module>` line is left anywhere inside it, tests included, and that is now the assertion rather than a budget that may only shrink.

Three things moved to the application side. `from_rsync_config`, which read an `RsyncConfig` and returned an `RsyncError`, became the free function `aerorsync_adapter::config::transport_from_rsync_config`, with its body unchanged apart from the constructor it names; a free function and not an inherent method, because once the module is its own crate an inherent block on a type from another crate is not allowed, so an inherent method would compile today and fail at extraction. The local transport got the same treatment the remote one got in the previous tranche: `transfer` returns `TransferReport` and `TransferError`, and its `DeltaTransport` implementation lives in `aerorsync_adapter::local`. And the twenty tests that still reached the application did so through its delta-transport trait, so they now call the crate entry points directly.

The local transport keeps its own rendering, and that is the correction this tranche makes to its own plan. The plan expected one of its three soft failures to carry exit code -1 and the speedup to follow the remote formula. All three carry exit code 0, and the speedup is infinite when nothing had to be sent where the remote rendering reports 1.0. Both are visible to the user through `RsyncStats` and `RsyncError`, so the adapter renders this transport with its own two functions instead of folding it into the shared ones, and two tests pin the difference. Nothing is flattened onto the remote values.

Test names do not change, so the fifteen names the aerorsync workflow lists and the floors of 15 and 8 stay as they are, and both workflows have no diff. Assertions keep the same expected values on the same numbers, read from the crate types instead of the application ones. One assertion changed shape rather than value: the batch test used to check that `begin_batch` had not degraded to the application's no-op batch, and `open_batch` reports the failed handshake instead, because degrading is the adapter's decision and not the module's.

The budget test becomes `aerorsync_module_imports_nothing_from_the_app`: the documented inventory is gone, the assertion is that nothing was found, and what it collects is file, line and module, so a violation says where it is. Everything the scan needs to stay honest stays, because an empty inventory measured by a blind scan would be a false green: grouped imports, `super::super::`, a path attribute plain or smuggled through a conditional one, the include macros, `macro_rules`, subdirectories, and a floor on how many files were scanned. It was seen red twice, on a plain `use crate::settings;` and on `#[cfg(any())] use crate::aerorsync_adapter::config::...`, each time naming the file and the line.

The adapter now declares its perimeter in both directions. Toward the application: the six file-and-module pairs it names, which is the whole coupling of the boundary now that the module has none. Toward the module: the eight submodules it reaches, which is the minimum public surface the crate will have to expose once it is extracted, written out while it is still small. That test was seen red by adding an application import to `errors.rs`.

Nothing on the wire changes and no product behaviour changes. `providers/sftp.rs` is the only consumer that moves, by one call and one dropped import; `local_sync.rs`, `bin/aeroftp_cli.rs` and the integration tests keep compiling untouched, because the types they build and the traits they use are unchanged and an implementation is resolved crate-wide. `delta_transport.rs`, `rsync_over_ssh.rs`, `remote_command.rs`, `real_wire.rs`, `native_driver.rs`, `delta_sync_rsync.rs`, `sync.rs` and both workflows have no diff at all.

Counts: the module suite goes 689, 689, 692, 692 across the three commits, 0 failed, 15 ignored, zero skipped oracle pins; the three new tests are the local adapter's name pin, its infinite speedup and its exit code. The whole library suite goes from 3669 to 3672. Lane 3 was run locally against stock rsync 3.2.7: fifteen tests green. Every commit passed the gate on its own, including the compile check under the lane 3 flag and clippy with and without it, and the full pre-push gate is green on the final head.

Two things are recorded and not done here. Running the fifteen lane 3 tests in parallel against the local harness produced one failure inside an ssh setup command of the harness itself, not in the transfer path; serially all fifteen pass, and the same lane is green in CI. And the adapter's degradation to the no-op batch, when the handshake fails, has no direct test: it had none before either, and a test for it belongs with the next tranche.

## Type of Change
- [x] Refactor, byte-neutral: no wire encoding and no product behaviour changes
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] My code follows the project's code style
- [x] I have tested my changes
- [x] I have updated the documentation (if needed)
- [x] My changes generate no new warnings
- [x] Every commit is signed off (`git commit -s`), see [CONTRIBUTING](../CONTRIBUTING.md#sign-off-developer-certificate-of-origin)

## Related Issues

None. Fourth tranche of the AeroRsync standalone-crate track, after #717; the release tracker is updated at merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added native Aerorsync transfer configuration for password, key, and agent authentication.
  - Added local transfer support with capability detection and detailed transfer reporting.
  - Added read-only access to SSH configuration for native transfers.

- **Bug Fixes**
  - Improved validation and rejection of incomplete authentication credentials.
  - Preserved local-transfer fallback behavior for soft failures.

- **Documentation**
  - Documented Aerorsync integration boundaries and import restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->