### PR TITLE
docs(aerorsync): record the module's public surface as a measured baseline

### DIFF
--- a/src-tauri/src/aerorsync/PUBLIC-API-BASELINE.txt
+++ b/src-tauri/src/aerorsync/PUBLIC-API-BASELINE.txt
@@ -1,0 +1,2671 @@
+# Public surface of the module, measured, as a baseline. Not a gate yet.
+#
+# Generated with `cargo public-api --simplified` on the crate that
+# `scripts/aerorsync-emit.sh` emits, which is the module compiled as a crate of
+# its own. It is the CEILING of the standalone-crate work: what the module
+# would expose today if it were published as it stands.
+#
+# The FLOOR, measured from the consumers instead, is 17 named items across 7 of
+# the 24 public modules: what AeroFTP's own production code actually names.
+# Phase D closes the distance between the two. The measurements and their
+# limits are in the appendix, `D0-*`.
+#
+# To regenerate and see what changed:
+#
+#   bash scripts/aerorsync-emit.sh
+#   cd target/aerorsync-standalone
+#   cargo public-api --simplified > /tmp/now.txt
+#   diff <path to this file, minus this header> /tmp/now.txt
+#
+# Needs a nightly toolchain (rustdoc JSON) and `cargo install cargo-public-api`.
+#
+# Deliberately NOT wired into CI. A snapshot becomes a gate when there is an
+# agreed procedure for updating it, and that is a phase D1 decision: until the
+# facade is designed, every legitimate change would redden the lane and the file
+# would be updated without anyone reading the diff, which is worse than no gate.
+#
+# Items: 2643. Emitted from module state at 237e6b913.
+#
+pub mod aerorsync
+pub mod aerorsync::aerorsync
+pub mod aerorsync::aerorsync::acl_fs
+pub enum aerorsync::aerorsync::acl_fs::AclApplyOutcome
+pub aerorsync::aerorsync::acl_fs::AclApplyOutcome::Applied
+pub aerorsync::aerorsync::acl_fs::AclApplyOutcome::Failed
+pub aerorsync::aerorsync::acl_fs::AclApplyOutcome::Failed::message: alloc::string::String
+pub aerorsync::aerorsync::acl_fs::AclApplyOutcome::Unsupported
+pub aerorsync::aerorsync::acl_fs::AclApplyOutcome::Unsupported::warning: alloc::string::String
+impl core::clone::Clone for aerorsync::aerorsync::acl_fs::AclApplyOutcome
+pub fn aerorsync::aerorsync::acl_fs::AclApplyOutcome::clone(&self) -> aerorsync::aerorsync::acl_fs::AclApplyOutcome
+impl core::cmp::Eq for aerorsync::aerorsync::acl_fs::AclApplyOutcome
+impl core::cmp::PartialEq for aerorsync::aerorsync::acl_fs::AclApplyOutcome
+pub fn aerorsync::aerorsync::acl_fs::AclApplyOutcome::eq(&self, &aerorsync::aerorsync::acl_fs::AclApplyOutcome) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::acl_fs::AclApplyOutcome
+pub fn aerorsync::aerorsync::acl_fs::AclApplyOutcome::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::acl_fs::AclApplyOutcome
+impl core::marker::Freeze for aerorsync::aerorsync::acl_fs::AclApplyOutcome
+impl core::marker::Send for aerorsync::aerorsync::acl_fs::AclApplyOutcome
+impl core::marker::Sync for aerorsync::aerorsync::acl_fs::AclApplyOutcome
+impl core::marker::Unpin for aerorsync::aerorsync::acl_fs::AclApplyOutcome
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::acl_fs::AclApplyOutcome
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::acl_fs::AclApplyOutcome
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::acl_fs::AclApplyOutcome
+pub enum aerorsync::aerorsync::acl_fs::AclFsError
+pub aerorsync::aerorsync::acl_fs::AclFsError::Invalid
+pub aerorsync::aerorsync::acl_fs::AclFsError::Invalid::reason: alloc::string::String
+pub aerorsync::aerorsync::acl_fs::AclFsError::Io
+pub aerorsync::aerorsync::acl_fs::AclFsError::Io::message: alloc::string::String
+pub aerorsync::aerorsync::acl_fs::AclFsError::UnresolvedReference
+pub aerorsync::aerorsync::acl_fs::AclFsError::UnresolvedReference::index: u32
+pub aerorsync::aerorsync::acl_fs::AclFsError::Unsupported
+impl core::clone::Clone for aerorsync::aerorsync::acl_fs::AclFsError
+pub fn aerorsync::aerorsync::acl_fs::AclFsError::clone(&self) -> aerorsync::aerorsync::acl_fs::AclFsError
+impl core::cmp::Eq for aerorsync::aerorsync::acl_fs::AclFsError
+impl core::cmp::PartialEq for aerorsync::aerorsync::acl_fs::AclFsError
+pub fn aerorsync::aerorsync::acl_fs::AclFsError::eq(&self, &aerorsync::aerorsync::acl_fs::AclFsError) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::acl_fs::AclFsError
+pub fn aerorsync::aerorsync::acl_fs::AclFsError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for aerorsync::aerorsync::acl_fs::AclFsError
+pub fn aerorsync::aerorsync::acl_fs::AclFsError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::acl_fs::AclFsError
+impl core::marker::Freeze for aerorsync::aerorsync::acl_fs::AclFsError
+impl core::marker::Send for aerorsync::aerorsync::acl_fs::AclFsError
+impl core::marker::Sync for aerorsync::aerorsync::acl_fs::AclFsError
+impl core::marker::Unpin for aerorsync::aerorsync::acl_fs::AclFsError
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::acl_fs::AclFsError
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::acl_fs::AclFsError
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::acl_fs::AclFsError
+pub fn aerorsync::aerorsync::acl_fs::access_literal(&aerorsync::aerorsync::real_wire::FileListAcls) -> core::result::Result<&aerorsync::aerorsync::real_wire::RsyncAcl, aerorsync::aerorsync::acl_fs::AclFsError>
+pub fn aerorsync::aerorsync::acl_fs::apply_access_acl_fd(std::os::fd::raw::RawFd, &aerorsync::aerorsync::real_wire::FileListAcls, u32, bool) -> aerorsync::aerorsync::acl_fs::AclApplyOutcome
+pub fn aerorsync::aerorsync::acl_fs::ensure_linux_acl_support() -> core::result::Result<(), aerorsync::aerorsync::acl_fs::AclFsError>
+pub fn aerorsync::aerorsync::acl_fs::filesystem_acl_to_wire(aerorsync::aerorsync::real_wire::RsyncAcl, u32) -> core::result::Result<aerorsync::aerorsync::real_wire::FileListAcls, aerorsync::aerorsync::acl_fs::AclFsError>
+pub fn aerorsync::aerorsync::acl_fs::read_access_acl_fd(std::os::fd::raw::RawFd, u32) -> core::result::Result<aerorsync::aerorsync::real_wire::FileListAcls, aerorsync::aerorsync::acl_fs::AclFsError>
+pub fn aerorsync::aerorsync::acl_fs::read_access_acl_model_fd(std::os::fd::raw::RawFd) -> core::result::Result<aerorsync::aerorsync::real_wire::RsyncAcl, aerorsync::aerorsync::acl_fs::AclFsError>
+pub fn aerorsync::aerorsync::acl_fs::reconstruct_from_wire(&aerorsync::aerorsync::real_wire::RsyncAcl, u32) -> core::result::Result<aerorsync::aerorsync::real_wire::RsyncAcl, aerorsync::aerorsync::acl_fs::AclFsError>
+pub fn aerorsync::aerorsync::acl_fs::strip_perms_for_wire(&aerorsync::aerorsync::real_wire::RsyncAcl, u32) -> core::result::Result<aerorsync::aerorsync::real_wire::RsyncAcl, aerorsync::aerorsync::acl_fs::AclFsError>
+pub fn aerorsync::aerorsync::acl_fs::validate_outgoing_acls(bool, &aerorsync::aerorsync::real_wire::FileListEntry) -> core::result::Result<(), aerorsync::aerorsync::acl_fs::AclFsError>
+pub fn aerorsync::aerorsync::acl_fs::wire_acl_to_filesystem(&aerorsync::aerorsync::real_wire::FileListAcls, u32) -> core::result::Result<aerorsync::aerorsync::real_wire::RsyncAcl, aerorsync::aerorsync::acl_fs::AclFsError>
+pub mod aerorsync::aerorsync::delta_engine
+pub enum aerorsync::aerorsync::delta_engine::DeltaOp
+pub aerorsync::aerorsync::delta_engine::DeltaOp::CopyBlock(u32)
+pub aerorsync::aerorsync::delta_engine::DeltaOp::Literal(alloc::vec::Vec<u8>)
+impl core::clone::Clone for aerorsync::aerorsync::delta_engine::DeltaOp
+pub fn aerorsync::aerorsync::delta_engine::DeltaOp::clone(&self) -> aerorsync::aerorsync::delta_engine::DeltaOp
+impl core::convert::From<aerorsync::aerorsync::delta_engine::DeltaOp> for aerorsync::aerorsync::engine_adapter::EngineDeltaOp
+pub fn aerorsync::aerorsync::engine_adapter::EngineDeltaOp::from(aerorsync::aerorsync::delta_engine::DeltaOp) -> Self
+impl core::fmt::Debug for aerorsync::aerorsync::delta_engine::DeltaOp
+pub fn aerorsync::aerorsync::delta_engine::DeltaOp::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aerorsync::aerorsync::delta_engine::DeltaOp
+impl core::marker::Send for aerorsync::aerorsync::delta_engine::DeltaOp
+impl core::marker::Sync for aerorsync::aerorsync::delta_engine::DeltaOp
+impl core::marker::Unpin for aerorsync::aerorsync::delta_engine::DeltaOp
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::delta_engine::DeltaOp
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::delta_engine::DeltaOp
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::delta_engine::DeltaOp
+pub struct aerorsync::aerorsync::delta_engine::BlockSignature
+pub aerorsync::aerorsync::delta_engine::BlockSignature::index: u32
+pub aerorsync::aerorsync::delta_engine::BlockSignature::rolling: u32
+pub aerorsync::aerorsync::delta_engine::BlockSignature::size: u32
+pub aerorsync::aerorsync::delta_engine::BlockSignature::strong: [u8; 32]
+impl core::clone::Clone for aerorsync::aerorsync::delta_engine::BlockSignature
+pub fn aerorsync::aerorsync::delta_engine::BlockSignature::clone(&self) -> aerorsync::aerorsync::delta_engine::BlockSignature
+impl core::convert::From<&aerorsync::aerorsync::engine_adapter::EngineSignatureBlock> for aerorsync::aerorsync::delta_engine::BlockSignature
+pub fn aerorsync::aerorsync::delta_engine::BlockSignature::from(&aerorsync::aerorsync::engine_adapter::EngineSignatureBlock) -> Self
+impl core::convert::From<aerorsync::aerorsync::delta_engine::BlockSignature> for aerorsync::aerorsync::engine_adapter::EngineSignatureBlock
+pub fn aerorsync::aerorsync::engine_adapter::EngineSignatureBlock::from(aerorsync::aerorsync::delta_engine::BlockSignature) -> Self
+impl core::fmt::Debug for aerorsync::aerorsync::delta_engine::BlockSignature
+pub fn aerorsync::aerorsync::delta_engine::BlockSignature::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl serde_core::ser::Serialize for aerorsync::aerorsync::delta_engine::BlockSignature
+pub fn aerorsync::aerorsync::delta_engine::BlockSignature::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for aerorsync::aerorsync::delta_engine::BlockSignature
+pub fn aerorsync::aerorsync::delta_engine::BlockSignature::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for aerorsync::aerorsync::delta_engine::BlockSignature
+impl core::marker::Send for aerorsync::aerorsync::delta_engine::BlockSignature
+impl core::marker::Sync for aerorsync::aerorsync::delta_engine::BlockSignature
+impl core::marker::Unpin for aerorsync::aerorsync::delta_engine::BlockSignature
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::delta_engine::BlockSignature
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::delta_engine::BlockSignature
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::delta_engine::BlockSignature
+pub struct aerorsync::aerorsync::delta_engine::DeltaResult
+pub aerorsync::aerorsync::delta_engine::DeltaResult::block_size: usize
+pub aerorsync::aerorsync::delta_engine::DeltaResult::copy_blocks: u32
+pub aerorsync::aerorsync::delta_engine::DeltaResult::dest_size: u64
+pub aerorsync::aerorsync::delta_engine::DeltaResult::literal_bytes: u64
+pub aerorsync::aerorsync::delta_engine::DeltaResult::savings_ratio: f64
+pub aerorsync::aerorsync::delta_engine::DeltaResult::should_use_delta: bool
+pub aerorsync::aerorsync::delta_engine::DeltaResult::source_size: u64
+pub aerorsync::aerorsync::delta_engine::DeltaResult::total_delta_bytes: u64
+impl core::clone::Clone for aerorsync::aerorsync::delta_engine::DeltaResult
+pub fn aerorsync::aerorsync::delta_engine::DeltaResult::clone(&self) -> aerorsync::aerorsync::delta_engine::DeltaResult
+impl core::fmt::Debug for aerorsync::aerorsync::delta_engine::DeltaResult
+pub fn aerorsync::aerorsync::delta_engine::DeltaResult::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl serde_core::ser::Serialize for aerorsync::aerorsync::delta_engine::DeltaResult
+pub fn aerorsync::aerorsync::delta_engine::DeltaResult::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for aerorsync::aerorsync::delta_engine::DeltaResult
+pub fn aerorsync::aerorsync::delta_engine::DeltaResult::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for aerorsync::aerorsync::delta_engine::DeltaResult
+impl core::marker::Send for aerorsync::aerorsync::delta_engine::DeltaResult
+impl core::marker::Sync for aerorsync::aerorsync::delta_engine::DeltaResult
+impl core::marker::Unpin for aerorsync::aerorsync::delta_engine::DeltaResult
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::delta_engine::DeltaResult
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::delta_engine::DeltaResult
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::delta_engine::DeltaResult
+pub struct aerorsync::aerorsync::delta_engine::RollingChecksum
+impl aerorsync::aerorsync::delta_engine::RollingChecksum
+pub fn aerorsync::aerorsync::delta_engine::RollingChecksum::new(&[u8]) -> Self
+pub fn aerorsync::aerorsync::delta_engine::RollingChecksum::roll(&mut self, u8, u8)
+pub fn aerorsync::aerorsync::delta_engine::RollingChecksum::value(&self) -> u32
+impl core::clone::Clone for aerorsync::aerorsync::delta_engine::RollingChecksum
+pub fn aerorsync::aerorsync::delta_engine::RollingChecksum::clone(&self) -> aerorsync::aerorsync::delta_engine::RollingChecksum
+impl core::fmt::Debug for aerorsync::aerorsync::delta_engine::RollingChecksum
+pub fn aerorsync::aerorsync::delta_engine::RollingChecksum::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aerorsync::aerorsync::delta_engine::RollingChecksum
+impl core::marker::Send for aerorsync::aerorsync::delta_engine::RollingChecksum
+impl core::marker::Sync for aerorsync::aerorsync::delta_engine::RollingChecksum
+impl core::marker::Unpin for aerorsync::aerorsync::delta_engine::RollingChecksum
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::delta_engine::RollingChecksum
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::delta_engine::RollingChecksum
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::delta_engine::RollingChecksum
+pub struct aerorsync::aerorsync::delta_engine::SignatureTable
+pub aerorsync::aerorsync::delta_engine::SignatureTable::block_size: usize
+pub aerorsync::aerorsync::delta_engine::SignatureTable::file_size: u64
+pub aerorsync::aerorsync::delta_engine::SignatureTable::signatures: alloc::vec::Vec<aerorsync::aerorsync::delta_engine::BlockSignature>
+impl core::clone::Clone for aerorsync::aerorsync::delta_engine::SignatureTable
+pub fn aerorsync::aerorsync::delta_engine::SignatureTable::clone(&self) -> aerorsync::aerorsync::delta_engine::SignatureTable
+impl core::fmt::Debug for aerorsync::aerorsync::delta_engine::SignatureTable
+pub fn aerorsync::aerorsync::delta_engine::SignatureTable::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl serde_core::ser::Serialize for aerorsync::aerorsync::delta_engine::SignatureTable
+pub fn aerorsync::aerorsync::delta_engine::SignatureTable::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for aerorsync::aerorsync::delta_engine::SignatureTable
+pub fn aerorsync::aerorsync::delta_engine::SignatureTable::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for aerorsync::aerorsync::delta_engine::SignatureTable
+impl core::marker::Send for aerorsync::aerorsync::delta_engine::SignatureTable
+impl core::marker::Sync for aerorsync::aerorsync::delta_engine::SignatureTable
+impl core::marker::Unpin for aerorsync::aerorsync::delta_engine::SignatureTable
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::delta_engine::SignatureTable
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::delta_engine::SignatureTable
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::delta_engine::SignatureTable
+pub const aerorsync::aerorsync::delta_engine::DELTA_MIN_FILE_SIZE: u64
+pub fn aerorsync::aerorsync::delta_engine::apply_delta(&[u8], &[aerorsync::aerorsync::delta_engine::DeltaOp], usize) -> core::result::Result<alloc::vec::Vec<u8>, alloc::string::String>
+pub fn aerorsync::aerorsync::delta_engine::compute_block_size(u64) -> usize
+pub fn aerorsync::aerorsync::delta_engine::compute_delta(&[u8], &aerorsync::aerorsync::delta_engine::SignatureTable) -> (alloc::vec::Vec<aerorsync::aerorsync::delta_engine::DeltaOp>, aerorsync::aerorsync::delta_engine::DeltaResult)
+pub fn aerorsync::aerorsync::delta_engine::compute_signatures(&[u8], usize) -> aerorsync::aerorsync::delta_engine::SignatureTable
+pub fn aerorsync::aerorsync::delta_engine::compute_signatures_streaming<R: alloc::io::read::Read>(&mut R, usize) -> core::io::error::Result<aerorsync::aerorsync::delta_engine::SignatureTable>
+pub fn aerorsync::aerorsync::delta_engine::deserialize_delta(&[u8]) -> core::result::Result<alloc::vec::Vec<aerorsync::aerorsync::delta_engine::DeltaOp>, alloc::string::String>
+pub fn aerorsync::aerorsync::delta_engine::serialize_delta(&[aerorsync::aerorsync::delta_engine::DeltaOp]) -> alloc::vec::Vec<u8>
+pub fn aerorsync::aerorsync::delta_engine::strong_hash(&[u8]) -> [u8; 32]
+pub mod aerorsync::aerorsync::delta_transport_impl
+pub struct aerorsync::aerorsync::delta_transport_impl::AerorsyncBatch
+impl !core::marker::Freeze for aerorsync::aerorsync::delta_transport_impl::AerorsyncBatch
+impl core::marker::Send for aerorsync::aerorsync::delta_transport_impl::AerorsyncBatch
+impl core::marker::Sync for aerorsync::aerorsync::delta_transport_impl::AerorsyncBatch
+impl core::marker::Unpin for aerorsync::aerorsync::delta_transport_impl::AerorsyncBatch
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::delta_transport_impl::AerorsyncBatch
+impl !core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::delta_transport_impl::AerorsyncBatch
+impl !core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::delta_transport_impl::AerorsyncBatch
+pub struct aerorsync::aerorsync::delta_transport_impl::AerorsyncDeltaTransport
+impl aerorsync::aerorsync::delta_transport_impl::AerorsyncDeltaTransport
+pub fn aerorsync::aerorsync::delta_transport_impl::AerorsyncDeltaTransport::new(aerorsync::aerorsync::ssh_transport::SshTransportConfig, u64) -> Self
+pub fn aerorsync::aerorsync::delta_transport_impl::AerorsyncDeltaTransport::with_acls(self, bool) -> Self
+pub fn aerorsync::aerorsync::delta_transport_impl::AerorsyncDeltaTransport::with_fail_on_metadata_loss(self, bool) -> Self
+pub fn aerorsync::aerorsync::delta_transport_impl::AerorsyncDeltaTransport::with_xattrs(self, bool) -> Self
+impl aerorsync::aerorsync::delta_transport_impl::AerorsyncDeltaTransport
+pub fn aerorsync::aerorsync::delta_transport_impl::AerorsyncDeltaTransport::ssh_config(&self) -> &aerorsync::aerorsync::ssh_transport::SshTransportConfig
+impl core::marker::Freeze for aerorsync::aerorsync::delta_transport_impl::AerorsyncDeltaTransport
+impl core::marker::Send for aerorsync::aerorsync::delta_transport_impl::AerorsyncDeltaTransport
+impl core::marker::Sync for aerorsync::aerorsync::delta_transport_impl::AerorsyncDeltaTransport
+impl core::marker::Unpin for aerorsync::aerorsync::delta_transport_impl::AerorsyncDeltaTransport
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::delta_transport_impl::AerorsyncDeltaTransport
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::delta_transport_impl::AerorsyncDeltaTransport
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::delta_transport_impl::AerorsyncDeltaTransport
+pub mod aerorsync::aerorsync::engine_adapter
+pub enum aerorsync::aerorsync::engine_adapter::BlockStrongAlgo
+pub aerorsync::aerorsync::engine_adapter::BlockStrongAlgo::Md4
+pub aerorsync::aerorsync::engine_adapter::BlockStrongAlgo::Md4::seed: u32
+pub aerorsync::aerorsync::engine_adapter::BlockStrongAlgo::Md5
+pub aerorsync::aerorsync::engine_adapter::BlockStrongAlgo::Md5::proper_seed_order: bool
+pub aerorsync::aerorsync::engine_adapter::BlockStrongAlgo::Md5::seed: u32
+pub aerorsync::aerorsync::engine_adapter::BlockStrongAlgo::Sha1
+pub aerorsync::aerorsync::engine_adapter::BlockStrongAlgo::Sha1::seed: u32
+pub aerorsync::aerorsync::engine_adapter::BlockStrongAlgo::Sha256
+pub aerorsync::aerorsync::engine_adapter::BlockStrongAlgo::Unknown
+pub aerorsync::aerorsync::engine_adapter::BlockStrongAlgo::Xxh128
+pub aerorsync::aerorsync::engine_adapter::BlockStrongAlgo::Xxh128::seed: u64
+pub aerorsync::aerorsync::engine_adapter::BlockStrongAlgo::Xxh3_64
+pub aerorsync::aerorsync::engine_adapter::BlockStrongAlgo::Xxh3_64::seed: u64
+pub aerorsync::aerorsync::engine_adapter::BlockStrongAlgo::Xxh64
+pub aerorsync::aerorsync::engine_adapter::BlockStrongAlgo::Xxh64::seed: u64
+impl aerorsync::aerorsync::engine_adapter::BlockStrongAlgo
+pub fn aerorsync::aerorsync::engine_adapter::BlockStrongAlgo::digest(&self, &[u8]) -> [u8; 32]
+impl core::clone::Clone for aerorsync::aerorsync::engine_adapter::BlockStrongAlgo
+pub fn aerorsync::aerorsync::engine_adapter::BlockStrongAlgo::clone(&self) -> aerorsync::aerorsync::engine_adapter::BlockStrongAlgo
+impl core::cmp::Eq for aerorsync::aerorsync::engine_adapter::BlockStrongAlgo
+impl core::cmp::PartialEq for aerorsync::aerorsync::engine_adapter::BlockStrongAlgo
+pub fn aerorsync::aerorsync::engine_adapter::BlockStrongAlgo::eq(&self, &aerorsync::aerorsync::engine_adapter::BlockStrongAlgo) -> bool
+impl core::default::Default for aerorsync::aerorsync::engine_adapter::BlockStrongAlgo
+pub fn aerorsync::aerorsync::engine_adapter::BlockStrongAlgo::default() -> aerorsync::aerorsync::engine_adapter::BlockStrongAlgo
+impl core::fmt::Debug for aerorsync::aerorsync::engine_adapter::BlockStrongAlgo
+pub fn aerorsync::aerorsync::engine_adapter::BlockStrongAlgo::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for aerorsync::aerorsync::engine_adapter::BlockStrongAlgo
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::engine_adapter::BlockStrongAlgo
+impl core::marker::Freeze for aerorsync::aerorsync::engine_adapter::BlockStrongAlgo
+impl core::marker::Send for aerorsync::aerorsync::engine_adapter::BlockStrongAlgo
+impl core::marker::Sync for aerorsync::aerorsync::engine_adapter::BlockStrongAlgo
+impl core::marker::Unpin for aerorsync::aerorsync::engine_adapter::BlockStrongAlgo
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::engine_adapter::BlockStrongAlgo
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::engine_adapter::BlockStrongAlgo
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::engine_adapter::BlockStrongAlgo
+pub enum aerorsync::aerorsync::engine_adapter::DeltaInstructionConversionError
+pub aerorsync::aerorsync::engine_adapter::DeltaInstructionConversionError::EndOfFileIsFramingMarker
+impl core::clone::Clone for aerorsync::aerorsync::engine_adapter::DeltaInstructionConversionError
+pub fn aerorsync::aerorsync::engine_adapter::DeltaInstructionConversionError::clone(&self) -> aerorsync::aerorsync::engine_adapter::DeltaInstructionConversionError
+impl core::cmp::Eq for aerorsync::aerorsync::engine_adapter::DeltaInstructionConversionError
+impl core::cmp::PartialEq for aerorsync::aerorsync::engine_adapter::DeltaInstructionConversionError
+pub fn aerorsync::aerorsync::engine_adapter::DeltaInstructionConversionError::eq(&self, &aerorsync::aerorsync::engine_adapter::DeltaInstructionConversionError) -> bool
+impl core::error::Error for aerorsync::aerorsync::engine_adapter::DeltaInstructionConversionError
+impl core::fmt::Debug for aerorsync::aerorsync::engine_adapter::DeltaInstructionConversionError
+pub fn aerorsync::aerorsync::engine_adapter::DeltaInstructionConversionError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for aerorsync::aerorsync::engine_adapter::DeltaInstructionConversionError
+pub fn aerorsync::aerorsync::engine_adapter::DeltaInstructionConversionError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::engine_adapter::DeltaInstructionConversionError
+impl core::marker::Freeze for aerorsync::aerorsync::engine_adapter::DeltaInstructionConversionError
+impl core::marker::Send for aerorsync::aerorsync::engine_adapter::DeltaInstructionConversionError
+impl core::marker::Sync for aerorsync::aerorsync::engine_adapter::DeltaInstructionConversionError
+impl core::marker::Unpin for aerorsync::aerorsync::engine_adapter::DeltaInstructionConversionError
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::engine_adapter::DeltaInstructionConversionError
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::engine_adapter::DeltaInstructionConversionError
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::engine_adapter::DeltaInstructionConversionError
+pub enum aerorsync::aerorsync::engine_adapter::EngineDeltaOp
+pub aerorsync::aerorsync::engine_adapter::EngineDeltaOp::CopyBlock(u32)
+pub aerorsync::aerorsync::engine_adapter::EngineDeltaOp::Literal(alloc::vec::Vec<u8>)
+impl core::clone::Clone for aerorsync::aerorsync::engine_adapter::EngineDeltaOp
+pub fn aerorsync::aerorsync::engine_adapter::EngineDeltaOp::clone(&self) -> aerorsync::aerorsync::engine_adapter::EngineDeltaOp
+impl core::cmp::Eq for aerorsync::aerorsync::engine_adapter::EngineDeltaOp
+impl core::cmp::PartialEq for aerorsync::aerorsync::engine_adapter::EngineDeltaOp
+pub fn aerorsync::aerorsync::engine_adapter::EngineDeltaOp::eq(&self, &aerorsync::aerorsync::engine_adapter::EngineDeltaOp) -> bool
+impl core::convert::From<aerorsync::aerorsync::delta_engine::DeltaOp> for aerorsync::aerorsync::engine_adapter::EngineDeltaOp
+pub fn aerorsync::aerorsync::engine_adapter::EngineDeltaOp::from(aerorsync::aerorsync::delta_engine::DeltaOp) -> Self
+impl core::convert::From<aerorsync::aerorsync::engine_adapter::EngineDeltaOp> for aerorsync::aerorsync::engine_protocol_types::DeltaInstruction
+pub fn aerorsync::aerorsync::engine_protocol_types::DeltaInstruction::from(aerorsync::aerorsync::engine_adapter::EngineDeltaOp) -> Self
+impl core::convert::TryFrom<aerorsync::aerorsync::engine_protocol_types::DeltaInstruction> for aerorsync::aerorsync::engine_adapter::EngineDeltaOp
+pub type aerorsync::aerorsync::engine_adapter::EngineDeltaOp::Error = aerorsync::aerorsync::engine_adapter::DeltaInstructionConversionError
+pub fn aerorsync::aerorsync::engine_adapter::EngineDeltaOp::try_from(aerorsync::aerorsync::engine_protocol_types::DeltaInstruction) -> core::result::Result<Self, Self::Error>
+impl core::fmt::Debug for aerorsync::aerorsync::engine_adapter::EngineDeltaOp
+pub fn aerorsync::aerorsync::engine_adapter::EngineDeltaOp::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::engine_adapter::EngineDeltaOp
+impl core::marker::Freeze for aerorsync::aerorsync::engine_adapter::EngineDeltaOp
+impl core::marker::Send for aerorsync::aerorsync::engine_adapter::EngineDeltaOp
+impl core::marker::Sync for aerorsync::aerorsync::engine_adapter::EngineDeltaOp
+impl core::marker::Unpin for aerorsync::aerorsync::engine_adapter::EngineDeltaOp
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::engine_adapter::EngineDeltaOp
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::engine_adapter::EngineDeltaOp
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::engine_adapter::EngineDeltaOp
+pub struct aerorsync::aerorsync::engine_adapter::CurrentDeltaSyncBridge
+impl aerorsync::aerorsync::engine_adapter::CurrentDeltaSyncBridge
+pub fn aerorsync::aerorsync::engine_adapter::CurrentDeltaSyncBridge::new() -> Self
+impl aerorsync::aerorsync::engine_adapter::DeltaEngineAdapter for aerorsync::aerorsync::engine_adapter::CurrentDeltaSyncBridge
+pub fn aerorsync::aerorsync::engine_adapter::CurrentDeltaSyncBridge::apply_delta(&self, &[u8], &[aerorsync::aerorsync::engine_adapter::EngineDeltaOp], usize) -> core::result::Result<alloc::vec::Vec<u8>, alloc::string::String>
+pub fn aerorsync::aerorsync::engine_adapter::CurrentDeltaSyncBridge::build_signatures(&self, &[u8], usize) -> alloc::vec::Vec<aerorsync::aerorsync::engine_adapter::EngineSignatureBlock>
+pub fn aerorsync::aerorsync::engine_adapter::CurrentDeltaSyncBridge::compute_block_size(&self, u64) -> usize
+pub fn aerorsync::aerorsync::engine_adapter::CurrentDeltaSyncBridge::compute_delta(&self, &[u8], &[aerorsync::aerorsync::engine_adapter::EngineSignatureBlock], usize) -> aerorsync::aerorsync::engine_adapter::EngineDeltaPlan
+pub fn aerorsync::aerorsync::engine_adapter::CurrentDeltaSyncBridge::compute_delta_for_wire(&self, &[u8], &[aerorsync::aerorsync::engine_adapter::EngineSignatureBlock], usize, aerorsync::aerorsync::engine_adapter::BlockStrongAlgo) -> aerorsync::aerorsync::engine_adapter::EngineDeltaPlan
+impl core::default::Default for aerorsync::aerorsync::engine_adapter::CurrentDeltaSyncBridge
+pub fn aerorsync::aerorsync::engine_adapter::CurrentDeltaSyncBridge::default() -> aerorsync::aerorsync::engine_adapter::CurrentDeltaSyncBridge
+impl core::fmt::Debug for aerorsync::aerorsync::engine_adapter::CurrentDeltaSyncBridge
+pub fn aerorsync::aerorsync::engine_adapter::CurrentDeltaSyncBridge::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aerorsync::aerorsync::engine_adapter::CurrentDeltaSyncBridge
+impl core::marker::Send for aerorsync::aerorsync::engine_adapter::CurrentDeltaSyncBridge
+impl core::marker::Sync for aerorsync::aerorsync::engine_adapter::CurrentDeltaSyncBridge
+impl core::marker::Unpin for aerorsync::aerorsync::engine_adapter::CurrentDeltaSyncBridge
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::engine_adapter::CurrentDeltaSyncBridge
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::engine_adapter::CurrentDeltaSyncBridge
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::engine_adapter::CurrentDeltaSyncBridge
+pub struct aerorsync::aerorsync::engine_adapter::EngineDeltaPlan
+pub aerorsync::aerorsync::engine_adapter::EngineDeltaPlan::copy_blocks: u32
+pub aerorsync::aerorsync::engine_adapter::EngineDeltaPlan::literal_bytes: u64
+pub aerorsync::aerorsync::engine_adapter::EngineDeltaPlan::ops: alloc::vec::Vec<aerorsync::aerorsync::engine_adapter::EngineDeltaOp>
+pub aerorsync::aerorsync::engine_adapter::EngineDeltaPlan::savings_ratio: f64
+pub aerorsync::aerorsync::engine_adapter::EngineDeltaPlan::should_use_delta: bool
+pub aerorsync::aerorsync::engine_adapter::EngineDeltaPlan::total_delta_bytes: u64
+impl core::clone::Clone for aerorsync::aerorsync::engine_adapter::EngineDeltaPlan
+pub fn aerorsync::aerorsync::engine_adapter::EngineDeltaPlan::clone(&self) -> aerorsync::aerorsync::engine_adapter::EngineDeltaPlan
+impl core::cmp::PartialEq for aerorsync::aerorsync::engine_adapter::EngineDeltaPlan
+pub fn aerorsync::aerorsync::engine_adapter::EngineDeltaPlan::eq(&self, &aerorsync::aerorsync::engine_adapter::EngineDeltaPlan) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::engine_adapter::EngineDeltaPlan
+pub fn aerorsync::aerorsync::engine_adapter::EngineDeltaPlan::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::engine_adapter::EngineDeltaPlan
+impl core::marker::Freeze for aerorsync::aerorsync::engine_adapter::EngineDeltaPlan
+impl core::marker::Send for aerorsync::aerorsync::engine_adapter::EngineDeltaPlan
+impl core::marker::Sync for aerorsync::aerorsync::engine_adapter::EngineDeltaPlan
+impl core::marker::Unpin for aerorsync::aerorsync::engine_adapter::EngineDeltaPlan
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::engine_adapter::EngineDeltaPlan
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::engine_adapter::EngineDeltaPlan
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::engine_adapter::EngineDeltaPlan
+pub struct aerorsync::aerorsync::engine_adapter::EngineDeltaStats
+pub aerorsync::aerorsync::engine_adapter::EngineDeltaStats::copy_blocks: u32
+pub aerorsync::aerorsync::engine_adapter::EngineDeltaStats::literal_bytes: u64
+pub aerorsync::aerorsync::engine_adapter::EngineDeltaStats::source_bytes_consumed: u64
+impl core::clone::Clone for aerorsync::aerorsync::engine_adapter::EngineDeltaStats
+pub fn aerorsync::aerorsync::engine_adapter::EngineDeltaStats::clone(&self) -> aerorsync::aerorsync::engine_adapter::EngineDeltaStats
+impl core::cmp::Eq for aerorsync::aerorsync::engine_adapter::EngineDeltaStats
+impl core::cmp::PartialEq for aerorsync::aerorsync::engine_adapter::EngineDeltaStats
+pub fn aerorsync::aerorsync::engine_adapter::EngineDeltaStats::eq(&self, &aerorsync::aerorsync::engine_adapter::EngineDeltaStats) -> bool
+impl core::default::Default for aerorsync::aerorsync::engine_adapter::EngineDeltaStats
+pub fn aerorsync::aerorsync::engine_adapter::EngineDeltaStats::default() -> aerorsync::aerorsync::engine_adapter::EngineDeltaStats
+impl core::fmt::Debug for aerorsync::aerorsync::engine_adapter::EngineDeltaStats
+pub fn aerorsync::aerorsync::engine_adapter::EngineDeltaStats::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::engine_adapter::EngineDeltaStats
+impl core::marker::Freeze for aerorsync::aerorsync::engine_adapter::EngineDeltaStats
+impl core::marker::Send for aerorsync::aerorsync::engine_adapter::EngineDeltaStats
+impl core::marker::Sync for aerorsync::aerorsync::engine_adapter::EngineDeltaStats
+impl core::marker::Unpin for aerorsync::aerorsync::engine_adapter::EngineDeltaStats
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::engine_adapter::EngineDeltaStats
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::engine_adapter::EngineDeltaStats
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::engine_adapter::EngineDeltaStats
+pub struct aerorsync::aerorsync::engine_adapter::EngineSignatureBlock
+pub aerorsync::aerorsync::engine_adapter::EngineSignatureBlock::block_len: u32
+pub aerorsync::aerorsync::engine_adapter::EngineSignatureBlock::index: u32
+pub aerorsync::aerorsync::engine_adapter::EngineSignatureBlock::rolling: u32
+pub aerorsync::aerorsync::engine_adapter::EngineSignatureBlock::strong: [u8; 32]
+pub aerorsync::aerorsync::engine_adapter::EngineSignatureBlock::strong_len: u8
+impl core::clone::Clone for aerorsync::aerorsync::engine_adapter::EngineSignatureBlock
+pub fn aerorsync::aerorsync::engine_adapter::EngineSignatureBlock::clone(&self) -> aerorsync::aerorsync::engine_adapter::EngineSignatureBlock
+impl core::cmp::Eq for aerorsync::aerorsync::engine_adapter::EngineSignatureBlock
+impl core::cmp::PartialEq for aerorsync::aerorsync::engine_adapter::EngineSignatureBlock
+pub fn aerorsync::aerorsync::engine_adapter::EngineSignatureBlock::eq(&self, &aerorsync::aerorsync::engine_adapter::EngineSignatureBlock) -> bool
+impl core::convert::From<&aerorsync::aerorsync::engine_adapter::EngineSignatureBlock> for aerorsync::aerorsync::delta_engine::BlockSignature
+pub fn aerorsync::aerorsync::delta_engine::BlockSignature::from(&aerorsync::aerorsync::engine_adapter::EngineSignatureBlock) -> Self
+impl core::convert::From<aerorsync::aerorsync::delta_engine::BlockSignature> for aerorsync::aerorsync::engine_adapter::EngineSignatureBlock
+pub fn aerorsync::aerorsync::engine_adapter::EngineSignatureBlock::from(aerorsync::aerorsync::delta_engine::BlockSignature) -> Self
+impl core::convert::From<aerorsync::aerorsync::engine_adapter::EngineSignatureBlock> for aerorsync::aerorsync::engine_protocol_types::SignatureBlock
+pub fn aerorsync::aerorsync::engine_protocol_types::SignatureBlock::from(aerorsync::aerorsync::engine_adapter::EngineSignatureBlock) -> Self
+impl core::convert::From<aerorsync::aerorsync::engine_protocol_types::SignatureBlock> for aerorsync::aerorsync::engine_adapter::EngineSignatureBlock
+pub fn aerorsync::aerorsync::engine_adapter::EngineSignatureBlock::from(aerorsync::aerorsync::engine_protocol_types::SignatureBlock) -> Self
+impl core::fmt::Debug for aerorsync::aerorsync::engine_adapter::EngineSignatureBlock
+pub fn aerorsync::aerorsync::engine_adapter::EngineSignatureBlock::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::engine_adapter::EngineSignatureBlock
+impl core::marker::Freeze for aerorsync::aerorsync::engine_adapter::EngineSignatureBlock
+impl core::marker::Send for aerorsync::aerorsync::engine_adapter::EngineSignatureBlock
+impl core::marker::Sync for aerorsync::aerorsync::engine_adapter::EngineSignatureBlock
+impl core::marker::Unpin for aerorsync::aerorsync::engine_adapter::EngineSignatureBlock
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::engine_adapter::EngineSignatureBlock
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::engine_adapter::EngineSignatureBlock
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::engine_adapter::EngineSignatureBlock
+pub struct aerorsync::aerorsync::engine_adapter::FileBaseline
+impl aerorsync::aerorsync::engine_adapter::FileBaseline
+pub async fn aerorsync::aerorsync::engine_adapter::FileBaseline::open(&std::path::Path) -> core::io::error::Result<Self>
+pub fn aerorsync::aerorsync::engine_adapter::FileBaseline::path(&self) -> &std::path::Path
+impl aerorsync::aerorsync::engine_adapter::BaselineSource for aerorsync::aerorsync::engine_adapter::FileBaseline
+pub fn aerorsync::aerorsync::engine_adapter::FileBaseline::is_empty(&self) -> bool
+pub fn aerorsync::aerorsync::engine_adapter::FileBaseline::len(&self) -> u64
+pub fn aerorsync::aerorsync::engine_adapter::FileBaseline::read_block<'life0, 'async_trait>(&'life0 mut self, u32, u32) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::io::error::Result<alloc::vec::Vec<u8>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+impl !core::marker::Freeze for aerorsync::aerorsync::engine_adapter::FileBaseline
+impl core::marker::Send for aerorsync::aerorsync::engine_adapter::FileBaseline
+impl core::marker::Sync for aerorsync::aerorsync::engine_adapter::FileBaseline
+impl core::marker::Unpin for aerorsync::aerorsync::engine_adapter::FileBaseline
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::engine_adapter::FileBaseline
+impl !core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::engine_adapter::FileBaseline
+impl !core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::engine_adapter::FileBaseline
+pub struct aerorsync::aerorsync::engine_adapter::MemoryBaseline
+impl aerorsync::aerorsync::engine_adapter::MemoryBaseline
+pub fn aerorsync::aerorsync::engine_adapter::MemoryBaseline::as_slice(&self) -> &[u8]
+pub fn aerorsync::aerorsync::engine_adapter::MemoryBaseline::new(alloc::vec::Vec<u8>) -> Self
+impl aerorsync::aerorsync::engine_adapter::BaselineSource for aerorsync::aerorsync::engine_adapter::MemoryBaseline
+pub fn aerorsync::aerorsync::engine_adapter::MemoryBaseline::is_empty(&self) -> bool
+pub fn aerorsync::aerorsync::engine_adapter::MemoryBaseline::len(&self) -> u64
+pub fn aerorsync::aerorsync::engine_adapter::MemoryBaseline::read_block<'life0, 'async_trait>(&'life0 mut self, u32, u32) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::io::error::Result<alloc::vec::Vec<u8>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+impl core::marker::Freeze for aerorsync::aerorsync::engine_adapter::MemoryBaseline
+impl core::marker::Send for aerorsync::aerorsync::engine_adapter::MemoryBaseline
+impl core::marker::Sync for aerorsync::aerorsync::engine_adapter::MemoryBaseline
+impl core::marker::Unpin for aerorsync::aerorsync::engine_adapter::MemoryBaseline
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::engine_adapter::MemoryBaseline
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::engine_adapter::MemoryBaseline
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::engine_adapter::MemoryBaseline
+pub struct aerorsync::aerorsync::engine_adapter::RollingDeltaPlanProducer
+impl aerorsync::aerorsync::engine_adapter::RollingDeltaPlanProducer
+pub fn aerorsync::aerorsync::engine_adapter::RollingDeltaPlanProducer::new(usize, alloc::vec::Vec<aerorsync::aerorsync::engine_adapter::EngineSignatureBlock>) -> Self
+pub fn aerorsync::aerorsync::engine_adapter::RollingDeltaPlanProducer::with_strong_algo(usize, alloc::vec::Vec<aerorsync::aerorsync::engine_adapter::EngineSignatureBlock>, aerorsync::aerorsync::engine_adapter::BlockStrongAlgo) -> Self
+impl aerorsync::aerorsync::engine_adapter::DeltaPlanProducer for aerorsync::aerorsync::engine_adapter::RollingDeltaPlanProducer
+pub fn aerorsync::aerorsync::engine_adapter::RollingDeltaPlanProducer::drive_chunk(&mut self, &[u8], &mut alloc::vec::Vec<aerorsync::aerorsync::engine_adapter::EngineDeltaOp>)
+pub fn aerorsync::aerorsync::engine_adapter::RollingDeltaPlanProducer::finalize(&mut self, &mut alloc::vec::Vec<aerorsync::aerorsync::engine_adapter::EngineDeltaOp>)
+pub fn aerorsync::aerorsync::engine_adapter::RollingDeltaPlanProducer::stats(&self) -> &aerorsync::aerorsync::engine_adapter::EngineDeltaStats
+impl core::marker::Freeze for aerorsync::aerorsync::engine_adapter::RollingDeltaPlanProducer
+impl core::marker::Send for aerorsync::aerorsync::engine_adapter::RollingDeltaPlanProducer
+impl core::marker::Sync for aerorsync::aerorsync::engine_adapter::RollingDeltaPlanProducer
+impl core::marker::Unpin for aerorsync::aerorsync::engine_adapter::RollingDeltaPlanProducer
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::engine_adapter::RollingDeltaPlanProducer
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::engine_adapter::RollingDeltaPlanProducer
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::engine_adapter::RollingDeltaPlanProducer
+pub trait aerorsync::aerorsync::engine_adapter::BaselineSource: core::marker::Send
+pub fn aerorsync::aerorsync::engine_adapter::BaselineSource::is_empty(&self) -> bool
+pub fn aerorsync::aerorsync::engine_adapter::BaselineSource::len(&self) -> u64
+pub fn aerorsync::aerorsync::engine_adapter::BaselineSource::read_block<'life0, 'async_trait>(&'life0 mut self, u32, u32) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::io::error::Result<alloc::vec::Vec<u8>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+impl aerorsync::aerorsync::engine_adapter::BaselineSource for aerorsync::aerorsync::engine_adapter::FileBaseline
+pub fn aerorsync::aerorsync::engine_adapter::FileBaseline::is_empty(&self) -> bool
+pub fn aerorsync::aerorsync::engine_adapter::FileBaseline::len(&self) -> u64
+pub fn aerorsync::aerorsync::engine_adapter::FileBaseline::read_block<'life0, 'async_trait>(&'life0 mut self, u32, u32) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::io::error::Result<alloc::vec::Vec<u8>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+impl aerorsync::aerorsync::engine_adapter::BaselineSource for aerorsync::aerorsync::engine_adapter::MemoryBaseline
+pub fn aerorsync::aerorsync::engine_adapter::MemoryBaseline::is_empty(&self) -> bool
+pub fn aerorsync::aerorsync::engine_adapter::MemoryBaseline::len(&self) -> u64
+pub fn aerorsync::aerorsync::engine_adapter::MemoryBaseline::read_block<'life0, 'async_trait>(&'life0 mut self, u32, u32) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::io::error::Result<alloc::vec::Vec<u8>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub trait aerorsync::aerorsync::engine_adapter::DeltaEngineAdapter: core::marker::Send + core::marker::Sync
+pub fn aerorsync::aerorsync::engine_adapter::DeltaEngineAdapter::apply_delta(&self, &[u8], &[aerorsync::aerorsync::engine_adapter::EngineDeltaOp], usize) -> core::result::Result<alloc::vec::Vec<u8>, alloc::string::String>
+pub fn aerorsync::aerorsync::engine_adapter::DeltaEngineAdapter::build_signatures(&self, &[u8], usize) -> alloc::vec::Vec<aerorsync::aerorsync::engine_adapter::EngineSignatureBlock>
+pub fn aerorsync::aerorsync::engine_adapter::DeltaEngineAdapter::compute_block_size(&self, u64) -> usize
+pub fn aerorsync::aerorsync::engine_adapter::DeltaEngineAdapter::compute_delta(&self, &[u8], &[aerorsync::aerorsync::engine_adapter::EngineSignatureBlock], usize) -> aerorsync::aerorsync::engine_adapter::EngineDeltaPlan
+pub fn aerorsync::aerorsync::engine_adapter::DeltaEngineAdapter::compute_delta_for_wire(&self, &[u8], &[aerorsync::aerorsync::engine_adapter::EngineSignatureBlock], usize, aerorsync::aerorsync::engine_adapter::BlockStrongAlgo) -> aerorsync::aerorsync::engine_adapter::EngineDeltaPlan
+impl aerorsync::aerorsync::engine_adapter::DeltaEngineAdapter for aerorsync::aerorsync::engine_adapter::CurrentDeltaSyncBridge
+pub fn aerorsync::aerorsync::engine_adapter::CurrentDeltaSyncBridge::apply_delta(&self, &[u8], &[aerorsync::aerorsync::engine_adapter::EngineDeltaOp], usize) -> core::result::Result<alloc::vec::Vec<u8>, alloc::string::String>
+pub fn aerorsync::aerorsync::engine_adapter::CurrentDeltaSyncBridge::build_signatures(&self, &[u8], usize) -> alloc::vec::Vec<aerorsync::aerorsync::engine_adapter::EngineSignatureBlock>
+pub fn aerorsync::aerorsync::engine_adapter::CurrentDeltaSyncBridge::compute_block_size(&self, u64) -> usize
+pub fn aerorsync::aerorsync::engine_adapter::CurrentDeltaSyncBridge::compute_delta(&self, &[u8], &[aerorsync::aerorsync::engine_adapter::EngineSignatureBlock], usize) -> aerorsync::aerorsync::engine_adapter::EngineDeltaPlan
+pub fn aerorsync::aerorsync::engine_adapter::CurrentDeltaSyncBridge::compute_delta_for_wire(&self, &[u8], &[aerorsync::aerorsync::engine_adapter::EngineSignatureBlock], usize, aerorsync::aerorsync::engine_adapter::BlockStrongAlgo) -> aerorsync::aerorsync::engine_adapter::EngineDeltaPlan
+pub trait aerorsync::aerorsync::engine_adapter::DeltaPlanProducer: core::marker::Send
+pub fn aerorsync::aerorsync::engine_adapter::DeltaPlanProducer::drive_chunk(&mut self, &[u8], &mut alloc::vec::Vec<aerorsync::aerorsync::engine_adapter::EngineDeltaOp>)
+pub fn aerorsync::aerorsync::engine_adapter::DeltaPlanProducer::finalize(&mut self, &mut alloc::vec::Vec<aerorsync::aerorsync::engine_adapter::EngineDeltaOp>)
+pub fn aerorsync::aerorsync::engine_adapter::DeltaPlanProducer::stats(&self) -> &aerorsync::aerorsync::engine_adapter::EngineDeltaStats
+impl aerorsync::aerorsync::engine_adapter::DeltaPlanProducer for aerorsync::aerorsync::engine_adapter::RollingDeltaPlanProducer
+pub fn aerorsync::aerorsync::engine_adapter::RollingDeltaPlanProducer::drive_chunk(&mut self, &[u8], &mut alloc::vec::Vec<aerorsync::aerorsync::engine_adapter::EngineDeltaOp>)
+pub fn aerorsync::aerorsync::engine_adapter::RollingDeltaPlanProducer::finalize(&mut self, &mut alloc::vec::Vec<aerorsync::aerorsync::engine_adapter::EngineDeltaOp>)
+pub fn aerorsync::aerorsync::engine_adapter::RollingDeltaPlanProducer::stats(&self) -> &aerorsync::aerorsync::engine_adapter::EngineDeltaStats
+pub async fn aerorsync::aerorsync::engine_adapter::apply_delta_streaming<I, W>(&mut dyn aerorsync::aerorsync::engine_adapter::BaselineSource, I, usize, &mut W) -> core::io::error::Result<u64> where I: core::iter::traits::collect::IntoIterator<Item = aerorsync::aerorsync::engine_adapter::EngineDeltaOp>, <I as core::iter::traits::collect::IntoIterator>::IntoIter: core::marker::Send, W: tokio::io::async_write::AsyncWrite + core::marker::Send + core::marker::Unpin + ?core::marker::Sized
+pub async fn aerorsync::aerorsync::engine_adapter::build_signatures_streaming(&mut dyn aerorsync::aerorsync::engine_adapter::BaselineSource, usize) -> core::io::error::Result<alloc::vec::Vec<aerorsync::aerorsync::engine_adapter::EngineSignatureBlock>>
+pub fn aerorsync::aerorsync::engine_adapter::engine_ops_to_wire(alloc::vec::Vec<aerorsync::aerorsync::engine_adapter::EngineDeltaOp>) -> alloc::vec::Vec<aerorsync::aerorsync::engine_protocol_types::DeltaInstruction>
+pub fn aerorsync::aerorsync::engine_adapter::plan_delta_with_strong_algo(&[u8], alloc::vec::Vec<aerorsync::aerorsync::engine_adapter::EngineSignatureBlock>, usize, aerorsync::aerorsync::engine_adapter::BlockStrongAlgo) -> aerorsync::aerorsync::engine_adapter::EngineDeltaPlan
+pub mod aerorsync::aerorsync::engine_protocol_types
+pub enum aerorsync::aerorsync::engine_protocol_types::DeltaInstruction
+pub aerorsync::aerorsync::engine_protocol_types::DeltaInstruction::CopyBlock
+pub aerorsync::aerorsync::engine_protocol_types::DeltaInstruction::CopyBlock::index: u32
+pub aerorsync::aerorsync::engine_protocol_types::DeltaInstruction::EndOfFile
+pub aerorsync::aerorsync::engine_protocol_types::DeltaInstruction::Literal
+pub aerorsync::aerorsync::engine_protocol_types::DeltaInstruction::Literal::data: alloc::vec::Vec<u8>
+impl core::clone::Clone for aerorsync::aerorsync::engine_protocol_types::DeltaInstruction
+pub fn aerorsync::aerorsync::engine_protocol_types::DeltaInstruction::clone(&self) -> aerorsync::aerorsync::engine_protocol_types::DeltaInstruction
+impl core::cmp::Eq for aerorsync::aerorsync::engine_protocol_types::DeltaInstruction
+impl core::cmp::PartialEq for aerorsync::aerorsync::engine_protocol_types::DeltaInstruction
+pub fn aerorsync::aerorsync::engine_protocol_types::DeltaInstruction::eq(&self, &aerorsync::aerorsync::engine_protocol_types::DeltaInstruction) -> bool
+impl core::convert::From<aerorsync::aerorsync::engine_adapter::EngineDeltaOp> for aerorsync::aerorsync::engine_protocol_types::DeltaInstruction
+pub fn aerorsync::aerorsync::engine_protocol_types::DeltaInstruction::from(aerorsync::aerorsync::engine_adapter::EngineDeltaOp) -> Self
+impl core::convert::TryFrom<aerorsync::aerorsync::engine_protocol_types::DeltaInstruction> for aerorsync::aerorsync::engine_adapter::EngineDeltaOp
+pub type aerorsync::aerorsync::engine_adapter::EngineDeltaOp::Error = aerorsync::aerorsync::engine_adapter::DeltaInstructionConversionError
+pub fn aerorsync::aerorsync::engine_adapter::EngineDeltaOp::try_from(aerorsync::aerorsync::engine_protocol_types::DeltaInstruction) -> core::result::Result<Self, Self::Error>
+impl core::fmt::Debug for aerorsync::aerorsync::engine_protocol_types::DeltaInstruction
+pub fn aerorsync::aerorsync::engine_protocol_types::DeltaInstruction::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::engine_protocol_types::DeltaInstruction
+impl core::marker::Freeze for aerorsync::aerorsync::engine_protocol_types::DeltaInstruction
+impl core::marker::Send for aerorsync::aerorsync::engine_protocol_types::DeltaInstruction
+impl core::marker::Sync for aerorsync::aerorsync::engine_protocol_types::DeltaInstruction
+impl core::marker::Unpin for aerorsync::aerorsync::engine_protocol_types::DeltaInstruction
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::engine_protocol_types::DeltaInstruction
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::engine_protocol_types::DeltaInstruction
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::engine_protocol_types::DeltaInstruction
+pub struct aerorsync::aerorsync::engine_protocol_types::SignatureBlock
+pub aerorsync::aerorsync::engine_protocol_types::SignatureBlock::block_len: u32
+pub aerorsync::aerorsync::engine_protocol_types::SignatureBlock::index: u32
+pub aerorsync::aerorsync::engine_protocol_types::SignatureBlock::rolling: u32
+pub aerorsync::aerorsync::engine_protocol_types::SignatureBlock::strong: [u8; 32]
+impl core::clone::Clone for aerorsync::aerorsync::engine_protocol_types::SignatureBlock
+pub fn aerorsync::aerorsync::engine_protocol_types::SignatureBlock::clone(&self) -> aerorsync::aerorsync::engine_protocol_types::SignatureBlock
+impl core::cmp::Eq for aerorsync::aerorsync::engine_protocol_types::SignatureBlock
+impl core::cmp::PartialEq for aerorsync::aerorsync::engine_protocol_types::SignatureBlock
+pub fn aerorsync::aerorsync::engine_protocol_types::SignatureBlock::eq(&self, &aerorsync::aerorsync::engine_protocol_types::SignatureBlock) -> bool
+impl core::convert::From<aerorsync::aerorsync::engine_adapter::EngineSignatureBlock> for aerorsync::aerorsync::engine_protocol_types::SignatureBlock
+pub fn aerorsync::aerorsync::engine_protocol_types::SignatureBlock::from(aerorsync::aerorsync::engine_adapter::EngineSignatureBlock) -> Self
+impl core::convert::From<aerorsync::aerorsync::engine_protocol_types::SignatureBlock> for aerorsync::aerorsync::engine_adapter::EngineSignatureBlock
+pub fn aerorsync::aerorsync::engine_adapter::EngineSignatureBlock::from(aerorsync::aerorsync::engine_protocol_types::SignatureBlock) -> Self
+impl core::fmt::Debug for aerorsync::aerorsync::engine_protocol_types::SignatureBlock
+pub fn aerorsync::aerorsync::engine_protocol_types::SignatureBlock::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::engine_protocol_types::SignatureBlock
+impl core::marker::Freeze for aerorsync::aerorsync::engine_protocol_types::SignatureBlock
+impl core::marker::Send for aerorsync::aerorsync::engine_protocol_types::SignatureBlock
+impl core::marker::Sync for aerorsync::aerorsync::engine_protocol_types::SignatureBlock
+impl core::marker::Unpin for aerorsync::aerorsync::engine_protocol_types::SignatureBlock
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::engine_protocol_types::SignatureBlock
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::engine_protocol_types::SignatureBlock
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::engine_protocol_types::SignatureBlock
+pub mod aerorsync::aerorsync::events
+pub enum aerorsync::aerorsync::events::AerorsyncEvent
+pub aerorsync::aerorsync::events::AerorsyncEvent::Client
+pub aerorsync::aerorsync::events::AerorsyncEvent::Client::message: alloc::string::String
+pub aerorsync::aerorsync::events::AerorsyncEvent::Deleted
+pub aerorsync::aerorsync::events::AerorsyncEvent::Deleted::path: alloc::string::String
+pub aerorsync::aerorsync::events::AerorsyncEvent::Error
+pub aerorsync::aerorsync::events::AerorsyncEvent::Error::message: alloc::string::String
+pub aerorsync::aerorsync::events::AerorsyncEvent::ErrorExit
+pub aerorsync::aerorsync::events::AerorsyncEvent::ErrorExit::code: core::option::Option<u32>
+pub aerorsync::aerorsync::events::AerorsyncEvent::ErrorSocket
+pub aerorsync::aerorsync::events::AerorsyncEvent::ErrorSocket::message: alloc::string::String
+pub aerorsync::aerorsync::events::AerorsyncEvent::ErrorUtf8
+pub aerorsync::aerorsync::events::AerorsyncEvent::ErrorUtf8::message: alloc::string::String
+pub aerorsync::aerorsync::events::AerorsyncEvent::ErrorXfer
+pub aerorsync::aerorsync::events::AerorsyncEvent::ErrorXfer::message: alloc::string::String
+pub aerorsync::aerorsync::events::AerorsyncEvent::Info
+pub aerorsync::aerorsync::events::AerorsyncEvent::Info::message: alloc::string::String
+pub aerorsync::aerorsync::events::AerorsyncEvent::IoError
+pub aerorsync::aerorsync::events::AerorsyncEvent::IoError::flags: u32
+pub aerorsync::aerorsync::events::AerorsyncEvent::IoTimeout
+pub aerorsync::aerorsync::events::AerorsyncEvent::IoTimeout::seconds: u32
+pub aerorsync::aerorsync::events::AerorsyncEvent::Log
+pub aerorsync::aerorsync::events::AerorsyncEvent::Log::message: alloc::string::String
+pub aerorsync::aerorsync::events::AerorsyncEvent::NoSend
+pub aerorsync::aerorsync::events::AerorsyncEvent::NoSend::flist_index: u32
+pub aerorsync::aerorsync::events::AerorsyncEvent::Noop
+pub aerorsync::aerorsync::events::AerorsyncEvent::Redo
+pub aerorsync::aerorsync::events::AerorsyncEvent::Redo::flist_index: u32
+pub aerorsync::aerorsync::events::AerorsyncEvent::Stats
+pub aerorsync::aerorsync::events::AerorsyncEvent::Stats::total_read: u64
+pub aerorsync::aerorsync::events::AerorsyncEvent::Success
+pub aerorsync::aerorsync::events::AerorsyncEvent::Success::flist_index: u32
+pub aerorsync::aerorsync::events::AerorsyncEvent::Unknown
+pub aerorsync::aerorsync::events::AerorsyncEvent::Unknown::payload: alloc::vec::Vec<u8>
+pub aerorsync::aerorsync::events::AerorsyncEvent::Unknown::tag: u8
+pub aerorsync::aerorsync::events::AerorsyncEvent::Warning
+pub aerorsync::aerorsync::events::AerorsyncEvent::Warning::message: alloc::string::String
+impl aerorsync::aerorsync::events::AerorsyncEvent
+pub fn aerorsync::aerorsync::events::AerorsyncEvent::is_terminal(&self) -> bool
+pub fn aerorsync::aerorsync::events::AerorsyncEvent::message(&self) -> core::option::Option<&str>
+pub fn aerorsync::aerorsync::events::AerorsyncEvent::severity(&self) -> aerorsync::aerorsync::events::EventSeverity
+pub fn aerorsync::aerorsync::events::AerorsyncEvent::tag(&self) -> aerorsync::aerorsync::real_wire::MuxTag
+impl aerorsync::aerorsync::events::AerorsyncEvent
+pub fn aerorsync::aerorsync::events::AerorsyncEvent::notice(&self) -> core::option::Option<aerorsync::aerorsync::events::Notice>
+impl core::clone::Clone for aerorsync::aerorsync::events::AerorsyncEvent
+pub fn aerorsync::aerorsync::events::AerorsyncEvent::clone(&self) -> aerorsync::aerorsync::events::AerorsyncEvent
+impl core::cmp::Eq for aerorsync::aerorsync::events::AerorsyncEvent
+impl core::cmp::PartialEq for aerorsync::aerorsync::events::AerorsyncEvent
+pub fn aerorsync::aerorsync::events::AerorsyncEvent::eq(&self, &aerorsync::aerorsync::events::AerorsyncEvent) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::events::AerorsyncEvent
+pub fn aerorsync::aerorsync::events::AerorsyncEvent::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::events::AerorsyncEvent
+impl core::marker::Freeze for aerorsync::aerorsync::events::AerorsyncEvent
+impl core::marker::Send for aerorsync::aerorsync::events::AerorsyncEvent
+impl core::marker::Sync for aerorsync::aerorsync::events::AerorsyncEvent
+impl core::marker::Unpin for aerorsync::aerorsync::events::AerorsyncEvent
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::events::AerorsyncEvent
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::events::AerorsyncEvent
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::events::AerorsyncEvent
+pub enum aerorsync::aerorsync::events::EventSeverity
+pub aerorsync::aerorsync::events::EventSeverity::Error
+pub aerorsync::aerorsync::events::EventSeverity::Info
+pub aerorsync::aerorsync::events::EventSeverity::Terminal
+pub aerorsync::aerorsync::events::EventSeverity::Warning
+impl core::clone::Clone for aerorsync::aerorsync::events::EventSeverity
+pub fn aerorsync::aerorsync::events::EventSeverity::clone(&self) -> aerorsync::aerorsync::events::EventSeverity
+impl core::cmp::Eq for aerorsync::aerorsync::events::EventSeverity
+impl core::cmp::PartialEq for aerorsync::aerorsync::events::EventSeverity
+pub fn aerorsync::aerorsync::events::EventSeverity::eq(&self, &aerorsync::aerorsync::events::EventSeverity) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::events::EventSeverity
+pub fn aerorsync::aerorsync::events::EventSeverity::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for aerorsync::aerorsync::events::EventSeverity
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::events::EventSeverity
+impl core::marker::Freeze for aerorsync::aerorsync::events::EventSeverity
+impl core::marker::Send for aerorsync::aerorsync::events::EventSeverity
+impl core::marker::Sync for aerorsync::aerorsync::events::EventSeverity
+impl core::marker::Unpin for aerorsync::aerorsync::events::EventSeverity
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::events::EventSeverity
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::events::EventSeverity
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::events::EventSeverity
+pub enum aerorsync::aerorsync::events::Notice
+pub aerorsync::aerorsync::events::Notice::Error(alloc::string::String)
+pub aerorsync::aerorsync::events::Notice::Warning(alloc::string::String)
+impl core::clone::Clone for aerorsync::aerorsync::events::Notice
+pub fn aerorsync::aerorsync::events::Notice::clone(&self) -> aerorsync::aerorsync::events::Notice
+impl core::cmp::Eq for aerorsync::aerorsync::events::Notice
+impl core::cmp::PartialEq for aerorsync::aerorsync::events::Notice
+pub fn aerorsync::aerorsync::events::Notice::eq(&self, &aerorsync::aerorsync::events::Notice) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::events::Notice
+pub fn aerorsync::aerorsync::events::Notice::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::events::Notice
+impl core::marker::Freeze for aerorsync::aerorsync::events::Notice
+impl core::marker::Send for aerorsync::aerorsync::events::Notice
+impl core::marker::Sync for aerorsync::aerorsync::events::Notice
+impl core::marker::Unpin for aerorsync::aerorsync::events::Notice
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::events::Notice
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::events::Notice
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::events::Notice
+pub struct aerorsync::aerorsync::events::BailingSink
+pub aerorsync::aerorsync::events::BailingSink::before_terminal: alloc::vec::Vec<aerorsync::aerorsync::events::AerorsyncEvent>
+pub aerorsync::aerorsync::events::BailingSink::terminal: core::option::Option<aerorsync::aerorsync::events::AerorsyncEvent>
+pub aerorsync::aerorsync::events::BailingSink::trailing: alloc::vec::Vec<aerorsync::aerorsync::events::AerorsyncEvent>
+impl aerorsync::aerorsync::events::BailingSink
+pub fn aerorsync::aerorsync::events::BailingSink::bailed(&self) -> bool
+pub fn aerorsync::aerorsync::events::BailingSink::first_terminal(&self) -> core::option::Option<&aerorsync::aerorsync::events::AerorsyncEvent>
+impl aerorsync::aerorsync::events::EventSink for aerorsync::aerorsync::events::BailingSink
+pub fn aerorsync::aerorsync::events::BailingSink::handle(&mut self, aerorsync::aerorsync::events::AerorsyncEvent)
+pub fn aerorsync::aerorsync::events::BailingSink::on_error(&mut self, aerorsync::aerorsync::events::AerorsyncEvent)
+pub fn aerorsync::aerorsync::events::BailingSink::on_info(&mut self, aerorsync::aerorsync::events::AerorsyncEvent)
+pub fn aerorsync::aerorsync::events::BailingSink::on_terminal(&mut self, aerorsync::aerorsync::events::AerorsyncEvent)
+pub fn aerorsync::aerorsync::events::BailingSink::on_warning(&mut self, aerorsync::aerorsync::events::AerorsyncEvent)
+impl core::clone::Clone for aerorsync::aerorsync::events::BailingSink
+pub fn aerorsync::aerorsync::events::BailingSink::clone(&self) -> aerorsync::aerorsync::events::BailingSink
+impl core::default::Default for aerorsync::aerorsync::events::BailingSink
+pub fn aerorsync::aerorsync::events::BailingSink::default() -> aerorsync::aerorsync::events::BailingSink
+impl core::fmt::Debug for aerorsync::aerorsync::events::BailingSink
+pub fn aerorsync::aerorsync::events::BailingSink::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aerorsync::aerorsync::events::BailingSink
+impl core::marker::Send for aerorsync::aerorsync::events::BailingSink
+impl core::marker::Sync for aerorsync::aerorsync::events::BailingSink
+impl core::marker::Unpin for aerorsync::aerorsync::events::BailingSink
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::events::BailingSink
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::events::BailingSink
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::events::BailingSink
+pub struct aerorsync::aerorsync::events::CollectingSink
+pub aerorsync::aerorsync::events::CollectingSink::events: alloc::vec::Vec<aerorsync::aerorsync::events::AerorsyncEvent>
+impl aerorsync::aerorsync::events::EventSink for aerorsync::aerorsync::events::CollectingSink
+pub fn aerorsync::aerorsync::events::CollectingSink::handle(&mut self, aerorsync::aerorsync::events::AerorsyncEvent)
+pub fn aerorsync::aerorsync::events::CollectingSink::on_error(&mut self, aerorsync::aerorsync::events::AerorsyncEvent)
+pub fn aerorsync::aerorsync::events::CollectingSink::on_info(&mut self, aerorsync::aerorsync::events::AerorsyncEvent)
+pub fn aerorsync::aerorsync::events::CollectingSink::on_terminal(&mut self, aerorsync::aerorsync::events::AerorsyncEvent)
+pub fn aerorsync::aerorsync::events::CollectingSink::on_warning(&mut self, aerorsync::aerorsync::events::AerorsyncEvent)
+impl core::clone::Clone for aerorsync::aerorsync::events::CollectingSink
+pub fn aerorsync::aerorsync::events::CollectingSink::clone(&self) -> aerorsync::aerorsync::events::CollectingSink
+impl core::default::Default for aerorsync::aerorsync::events::CollectingSink
+pub fn aerorsync::aerorsync::events::CollectingSink::default() -> aerorsync::aerorsync::events::CollectingSink
+impl core::fmt::Debug for aerorsync::aerorsync::events::CollectingSink
+pub fn aerorsync::aerorsync::events::CollectingSink::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aerorsync::aerorsync::events::CollectingSink
+impl core::marker::Send for aerorsync::aerorsync::events::CollectingSink
+impl core::marker::Sync for aerorsync::aerorsync::events::CollectingSink
+impl core::marker::Unpin for aerorsync::aerorsync::events::CollectingSink
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::events::CollectingSink
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::events::CollectingSink
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::events::CollectingSink
+pub struct aerorsync::aerorsync::events::WarningCollector
+impl aerorsync::aerorsync::events::WarningCollector
+pub fn aerorsync::aerorsync::events::WarningCollector::new(alloc::sync::Arc<std::sync::poison::mutex::Mutex<alloc::vec::Vec<alloc::string::String>>>) -> Self
+impl aerorsync::aerorsync::events::EventSink for aerorsync::aerorsync::events::WarningCollector
+pub fn aerorsync::aerorsync::events::WarningCollector::handle(&mut self, aerorsync::aerorsync::events::AerorsyncEvent)
+pub fn aerorsync::aerorsync::events::WarningCollector::on_error(&mut self, aerorsync::aerorsync::events::AerorsyncEvent)
+pub fn aerorsync::aerorsync::events::WarningCollector::on_info(&mut self, aerorsync::aerorsync::events::AerorsyncEvent)
+pub fn aerorsync::aerorsync::events::WarningCollector::on_terminal(&mut self, aerorsync::aerorsync::events::AerorsyncEvent)
+pub fn aerorsync::aerorsync::events::WarningCollector::on_warning(&mut self, aerorsync::aerorsync::events::AerorsyncEvent)
+impl core::marker::Freeze for aerorsync::aerorsync::events::WarningCollector
+impl core::marker::Send for aerorsync::aerorsync::events::WarningCollector
+impl core::marker::Sync for aerorsync::aerorsync::events::WarningCollector
+impl core::marker::Unpin for aerorsync::aerorsync::events::WarningCollector
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::events::WarningCollector
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::events::WarningCollector
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::events::WarningCollector
+pub trait aerorsync::aerorsync::events::EventSink: core::marker::Send
+pub fn aerorsync::aerorsync::events::EventSink::handle(&mut self, aerorsync::aerorsync::events::AerorsyncEvent)
+pub fn aerorsync::aerorsync::events::EventSink::on_error(&mut self, aerorsync::aerorsync::events::AerorsyncEvent)
+pub fn aerorsync::aerorsync::events::EventSink::on_info(&mut self, aerorsync::aerorsync::events::AerorsyncEvent)
+pub fn aerorsync::aerorsync::events::EventSink::on_terminal(&mut self, aerorsync::aerorsync::events::AerorsyncEvent)
+pub fn aerorsync::aerorsync::events::EventSink::on_warning(&mut self, aerorsync::aerorsync::events::AerorsyncEvent)
+impl aerorsync::aerorsync::events::EventSink for aerorsync::aerorsync::events::BailingSink
+pub fn aerorsync::aerorsync::events::BailingSink::handle(&mut self, aerorsync::aerorsync::events::AerorsyncEvent)
+pub fn aerorsync::aerorsync::events::BailingSink::on_error(&mut self, aerorsync::aerorsync::events::AerorsyncEvent)
+pub fn aerorsync::aerorsync::events::BailingSink::on_info(&mut self, aerorsync::aerorsync::events::AerorsyncEvent)
+pub fn aerorsync::aerorsync::events::BailingSink::on_terminal(&mut self, aerorsync::aerorsync::events::AerorsyncEvent)
+pub fn aerorsync::aerorsync::events::BailingSink::on_warning(&mut self, aerorsync::aerorsync::events::AerorsyncEvent)
+impl aerorsync::aerorsync::events::EventSink for aerorsync::aerorsync::events::CollectingSink
+pub fn aerorsync::aerorsync::events::CollectingSink::handle(&mut self, aerorsync::aerorsync::events::AerorsyncEvent)
+pub fn aerorsync::aerorsync::events::CollectingSink::on_error(&mut self, aerorsync::aerorsync::events::AerorsyncEvent)
+pub fn aerorsync::aerorsync::events::CollectingSink::on_info(&mut self, aerorsync::aerorsync::events::AerorsyncEvent)
+pub fn aerorsync::aerorsync::events::CollectingSink::on_terminal(&mut self, aerorsync::aerorsync::events::AerorsyncEvent)
+pub fn aerorsync::aerorsync::events::CollectingSink::on_warning(&mut self, aerorsync::aerorsync::events::AerorsyncEvent)
+impl aerorsync::aerorsync::events::EventSink for aerorsync::aerorsync::events::WarningCollector
+pub fn aerorsync::aerorsync::events::WarningCollector::handle(&mut self, aerorsync::aerorsync::events::AerorsyncEvent)
+pub fn aerorsync::aerorsync::events::WarningCollector::on_error(&mut self, aerorsync::aerorsync::events::AerorsyncEvent)
+pub fn aerorsync::aerorsync::events::WarningCollector::on_info(&mut self, aerorsync::aerorsync::events::AerorsyncEvent)
+pub fn aerorsync::aerorsync::events::WarningCollector::on_terminal(&mut self, aerorsync::aerorsync::events::AerorsyncEvent)
+pub fn aerorsync::aerorsync::events::WarningCollector::on_warning(&mut self, aerorsync::aerorsync::events::AerorsyncEvent)
+pub fn aerorsync::aerorsync::events::classify_oob_frame(aerorsync::aerorsync::real_wire::MuxTag, &[u8]) -> aerorsync::aerorsync::events::AerorsyncEvent
+pub mod aerorsync::aerorsync::fallback_policy
+pub enum aerorsync::aerorsync::fallback_policy::FallbackVerdict
+pub aerorsync::aerorsync::fallback_policy::FallbackVerdict::AttemptClassicSftpFallback
+pub aerorsync::aerorsync::fallback_policy::FallbackVerdict::Cancel
+pub aerorsync::aerorsync::fallback_policy::FallbackVerdict::HardError
+impl core::clone::Clone for aerorsync::aerorsync::fallback_policy::FallbackVerdict
+pub fn aerorsync::aerorsync::fallback_policy::FallbackVerdict::clone(&self) -> aerorsync::aerorsync::fallback_policy::FallbackVerdict
+impl core::cmp::Eq for aerorsync::aerorsync::fallback_policy::FallbackVerdict
+impl core::cmp::PartialEq for aerorsync::aerorsync::fallback_policy::FallbackVerdict
+pub fn aerorsync::aerorsync::fallback_policy::FallbackVerdict::eq(&self, &aerorsync::aerorsync::fallback_policy::FallbackVerdict) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::fallback_policy::FallbackVerdict
+pub fn aerorsync::aerorsync::fallback_policy::FallbackVerdict::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for aerorsync::aerorsync::fallback_policy::FallbackVerdict
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::fallback_policy::FallbackVerdict
+impl core::marker::Freeze for aerorsync::aerorsync::fallback_policy::FallbackVerdict
+impl core::marker::Send for aerorsync::aerorsync::fallback_policy::FallbackVerdict
+impl core::marker::Sync for aerorsync::aerorsync::fallback_policy::FallbackVerdict
+impl core::marker::Unpin for aerorsync::aerorsync::fallback_policy::FallbackVerdict
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::fallback_policy::FallbackVerdict
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::fallback_policy::FallbackVerdict
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::fallback_policy::FallbackVerdict
+pub fn aerorsync::aerorsync::fallback_policy::classify_fallback(&aerorsync::aerorsync::types::AerorsyncError, bool) -> aerorsync::aerorsync::fallback_policy::FallbackVerdict
+pub mod aerorsync::aerorsync::fixtures
+pub struct aerorsync::aerorsync::fixtures::BaselineCounters
+pub aerorsync::aerorsync::fixtures::BaselineCounters::bytes_received: u64
+pub aerorsync::aerorsync::fixtures::BaselineCounters::bytes_sent: u64
+pub aerorsync::aerorsync::fixtures::BaselineCounters::literal_bytes: u64
+pub aerorsync::aerorsync::fixtures::BaselineCounters::matched_bytes: u64
+pub aerorsync::aerorsync::fixtures::BaselineCounters::speedup: core::option::Option<f64>
+pub aerorsync::aerorsync::fixtures::BaselineCounters::total_file_size: u64
+impl aerorsync::aerorsync::fixtures::BaselineCounters
+pub fn aerorsync::aerorsync::fixtures::BaselineCounters::invariants_hold(&self) -> bool
+pub fn aerorsync::aerorsync::fixtures::BaselineCounters::observed_download() -> Self
+pub fn aerorsync::aerorsync::fixtures::BaselineCounters::observed_upload() -> Self
+impl core::clone::Clone for aerorsync::aerorsync::fixtures::BaselineCounters
+pub fn aerorsync::aerorsync::fixtures::BaselineCounters::clone(&self) -> aerorsync::aerorsync::fixtures::BaselineCounters
+impl core::cmp::PartialEq for aerorsync::aerorsync::fixtures::BaselineCounters
+pub fn aerorsync::aerorsync::fixtures::BaselineCounters::eq(&self, &aerorsync::aerorsync::fixtures::BaselineCounters) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::fixtures::BaselineCounters
+pub fn aerorsync::aerorsync::fixtures::BaselineCounters::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::fixtures::BaselineCounters
+impl core::marker::Freeze for aerorsync::aerorsync::fixtures::BaselineCounters
+impl core::marker::Send for aerorsync::aerorsync::fixtures::BaselineCounters
+impl core::marker::Sync for aerorsync::aerorsync::fixtures::BaselineCounters
+impl core::marker::Unpin for aerorsync::aerorsync::fixtures::BaselineCounters
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::fixtures::BaselineCounters
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::fixtures::BaselineCounters
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::fixtures::BaselineCounters
+pub struct aerorsync::aerorsync::fixtures::RealRsyncBaselineByteTranscript
+pub aerorsync::aerorsync::fixtures::RealRsyncBaselineByteTranscript::download_client_to_server: alloc::vec::Vec<u8>
+pub aerorsync::aerorsync::fixtures::RealRsyncBaselineByteTranscript::download_server_to_client: alloc::vec::Vec<u8>
+pub aerorsync::aerorsync::fixtures::RealRsyncBaselineByteTranscript::upload_client_to_server: alloc::vec::Vec<u8>
+pub aerorsync::aerorsync::fixtures::RealRsyncBaselineByteTranscript::upload_server_to_client: alloc::vec::Vec<u8>
+impl aerorsync::aerorsync::fixtures::RealRsyncBaselineByteTranscript
+pub fn aerorsync::aerorsync::fixtures::RealRsyncBaselineByteTranscript::try_load_frozen() -> core::option::Option<Self>
+pub fn aerorsync::aerorsync::fixtures::RealRsyncBaselineByteTranscript::upload_greeting_protocol_version_le(&self) -> core::option::Option<u32>
+impl core::clone::Clone for aerorsync::aerorsync::fixtures::RealRsyncBaselineByteTranscript
+pub fn aerorsync::aerorsync::fixtures::RealRsyncBaselineByteTranscript::clone(&self) -> aerorsync::aerorsync::fixtures::RealRsyncBaselineByteTranscript
+impl core::fmt::Debug for aerorsync::aerorsync::fixtures::RealRsyncBaselineByteTranscript
+pub fn aerorsync::aerorsync::fixtures::RealRsyncBaselineByteTranscript::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aerorsync::aerorsync::fixtures::RealRsyncBaselineByteTranscript
+impl core::marker::Send for aerorsync::aerorsync::fixtures::RealRsyncBaselineByteTranscript
+impl core::marker::Sync for aerorsync::aerorsync::fixtures::RealRsyncBaselineByteTranscript
+impl core::marker::Unpin for aerorsync::aerorsync::fixtures::RealRsyncBaselineByteTranscript
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::fixtures::RealRsyncBaselineByteTranscript
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::fixtures::RealRsyncBaselineByteTranscript
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::fixtures::RealRsyncBaselineByteTranscript
+pub struct aerorsync::aerorsync::fixtures::RealRsyncTranscriptPaths
+pub aerorsync::aerorsync::fixtures::RealRsyncTranscriptPaths::download_capture_in: std::path::PathBuf
+pub aerorsync::aerorsync::fixtures::RealRsyncTranscriptPaths::download_capture_out: std::path::PathBuf
+pub aerorsync::aerorsync::fixtures::RealRsyncTranscriptPaths::download_client_stdout: std::path::PathBuf
+pub aerorsync::aerorsync::fixtures::RealRsyncTranscriptPaths::download_remote_command: std::path::PathBuf
+pub aerorsync::aerorsync::fixtures::RealRsyncTranscriptPaths::summary_env: std::path::PathBuf
+pub aerorsync::aerorsync::fixtures::RealRsyncTranscriptPaths::upload_capture_in: std::path::PathBuf
+pub aerorsync::aerorsync::fixtures::RealRsyncTranscriptPaths::upload_capture_out: std::path::PathBuf
+pub aerorsync::aerorsync::fixtures::RealRsyncTranscriptPaths::upload_client_stdout: std::path::PathBuf
+pub aerorsync::aerorsync::fixtures::RealRsyncTranscriptPaths::upload_remote_command: std::path::PathBuf
+impl aerorsync::aerorsync::fixtures::RealRsyncTranscriptPaths
+pub fn aerorsync::aerorsync::fixtures::RealRsyncTranscriptPaths::appears_complete(&self) -> bool
+pub fn aerorsync::aerorsync::fixtures::RealRsyncTranscriptPaths::rooted_at(impl core::convert::AsRef<std::path::Path>) -> Self
+impl core::clone::Clone for aerorsync::aerorsync::fixtures::RealRsyncTranscriptPaths
+pub fn aerorsync::aerorsync::fixtures::RealRsyncTranscriptPaths::clone(&self) -> aerorsync::aerorsync::fixtures::RealRsyncTranscriptPaths
+impl core::cmp::Eq for aerorsync::aerorsync::fixtures::RealRsyncTranscriptPaths
+impl core::cmp::PartialEq for aerorsync::aerorsync::fixtures::RealRsyncTranscriptPaths
+pub fn aerorsync::aerorsync::fixtures::RealRsyncTranscriptPaths::eq(&self, &aerorsync::aerorsync::fixtures::RealRsyncTranscriptPaths) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::fixtures::RealRsyncTranscriptPaths
+pub fn aerorsync::aerorsync::fixtures::RealRsyncTranscriptPaths::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::fixtures::RealRsyncTranscriptPaths
+impl core::marker::Freeze for aerorsync::aerorsync::fixtures::RealRsyncTranscriptPaths
+impl core::marker::Send for aerorsync::aerorsync::fixtures::RealRsyncTranscriptPaths
+impl core::marker::Sync for aerorsync::aerorsync::fixtures::RealRsyncTranscriptPaths
+impl core::marker::Unpin for aerorsync::aerorsync::fixtures::RealRsyncTranscriptPaths
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::fixtures::RealRsyncTranscriptPaths
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::fixtures::RealRsyncTranscriptPaths
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::fixtures::RealRsyncTranscriptPaths
+pub const aerorsync::aerorsync::fixtures::BASELINE_DOWNLOAD_BYTES_RECEIVED: u64
+pub const aerorsync::aerorsync::fixtures::BASELINE_DOWNLOAD_BYTES_SENT: u64
+pub const aerorsync::aerorsync::fixtures::BASELINE_LITERAL_BYTES: u64
+pub const aerorsync::aerorsync::fixtures::BASELINE_MATCHED_BYTES: u64
+pub const aerorsync::aerorsync::fixtures::BASELINE_SPEEDUP: f64
+pub const aerorsync::aerorsync::fixtures::BASELINE_TOTAL_FILE_SIZE: u64
+pub const aerorsync::aerorsync::fixtures::BASELINE_UPLOAD_BYTES_RECEIVED: u64
+pub const aerorsync::aerorsync::fixtures::BASELINE_UPLOAD_BYTES_SENT: u64
+pub const aerorsync::aerorsync::fixtures::DOWNLOAD_REMOTE_COMMAND: &str
+pub const aerorsync::aerorsync::fixtures::OBSERVED_RSYNC_BANNER: &str
+pub const aerorsync::aerorsync::fixtures::OBSERVED_SSH_BANNER: &str
+pub const aerorsync::aerorsync::fixtures::REAL_RSYNC_FROZEN_TRANSCRIPT_REL: &str
+pub const aerorsync::aerorsync::fixtures::REAL_RSYNC_LANE_PORT: u16
+pub const aerorsync::aerorsync::fixtures::REAL_RSYNC_LANE_WORKDIR: &str
+pub const aerorsync::aerorsync::fixtures::UPLOAD_REMOTE_COMMAND: &str
+pub fn aerorsync::aerorsync::fixtures::parse_stats_block(&str) -> aerorsync::aerorsync::fixtures::BaselineCounters
+pub mod aerorsync::aerorsync::frame_io
+pub fn aerorsync::aerorsync::frame_io::read_length_prefixed_frame<R: alloc::io::read::Read>(&mut R, usize) -> core::io::error::Result<alloc::vec::Vec<u8>>
+pub fn aerorsync::aerorsync::frame_io::write_length_prefixed_frame<W: core::io::write::Write>(&mut W, &[u8]) -> core::io::error::Result<()>
+pub mod aerorsync::aerorsync::local_transport
+pub struct aerorsync::aerorsync::local_transport::LocalDeltaTransport
+impl aerorsync::aerorsync::local_transport::LocalDeltaTransport
+pub fn aerorsync::aerorsync::local_transport::LocalDeltaTransport::new(u64) -> Self
+pub fn aerorsync::aerorsync::local_transport::LocalDeltaTransport::with_sparse(self, bool) -> Self
+impl core::marker::Freeze for aerorsync::aerorsync::local_transport::LocalDeltaTransport
+impl core::marker::Send for aerorsync::aerorsync::local_transport::LocalDeltaTransport
+impl core::marker::Sync for aerorsync::aerorsync::local_transport::LocalDeltaTransport
+impl core::marker::Unpin for aerorsync::aerorsync::local_transport::LocalDeltaTransport
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::local_transport::LocalDeltaTransport
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::local_transport::LocalDeltaTransport
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::local_transport::LocalDeltaTransport
+pub const aerorsync::aerorsync::local_transport::LOCAL_DELTA_MAX_IN_MEMORY_BYTES: u64
+pub const aerorsync::aerorsync::local_transport::LOCAL_TRANSPORT_NAME: &str
+pub mod aerorsync::aerorsync::mock
+pub enum aerorsync::aerorsync::mock::OpenRawStreamBehavior
+pub aerorsync::aerorsync::mock::OpenRawStreamBehavior::Fail(alloc::string::String)
+pub aerorsync::aerorsync::mock::OpenRawStreamBehavior::Success
+pub aerorsync::aerorsync::mock::OpenRawStreamBehavior::Success::inbound: alloc::vec::Vec<u8>
+impl core::clone::Clone for aerorsync::aerorsync::mock::OpenRawStreamBehavior
+pub fn aerorsync::aerorsync::mock::OpenRawStreamBehavior::clone(&self) -> aerorsync::aerorsync::mock::OpenRawStreamBehavior
+impl core::fmt::Debug for aerorsync::aerorsync::mock::OpenRawStreamBehavior
+pub fn aerorsync::aerorsync::mock::OpenRawStreamBehavior::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aerorsync::aerorsync::mock::OpenRawStreamBehavior
+impl core::marker::Send for aerorsync::aerorsync::mock::OpenRawStreamBehavior
+impl core::marker::Sync for aerorsync::aerorsync::mock::OpenRawStreamBehavior
+impl core::marker::Unpin for aerorsync::aerorsync::mock::OpenRawStreamBehavior
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::mock::OpenRawStreamBehavior
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::mock::OpenRawStreamBehavior
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::mock::OpenRawStreamBehavior
+pub enum aerorsync::aerorsync::mock::OpenStreamBehavior
+pub aerorsync::aerorsync::mock::OpenStreamBehavior::Fail(alloc::string::String)
+pub aerorsync::aerorsync::mock::OpenStreamBehavior::Success
+pub aerorsync::aerorsync::mock::OpenStreamBehavior::Success::inbound: alloc::vec::Vec<alloc::vec::Vec<u8>>
+impl core::clone::Clone for aerorsync::aerorsync::mock::OpenStreamBehavior
+pub fn aerorsync::aerorsync::mock::OpenStreamBehavior::clone(&self) -> aerorsync::aerorsync::mock::OpenStreamBehavior
+impl core::fmt::Debug for aerorsync::aerorsync::mock::OpenStreamBehavior
+pub fn aerorsync::aerorsync::mock::OpenStreamBehavior::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aerorsync::aerorsync::mock::OpenStreamBehavior
+impl core::marker::Send for aerorsync::aerorsync::mock::OpenStreamBehavior
+impl core::marker::Sync for aerorsync::aerorsync::mock::OpenStreamBehavior
+impl core::marker::Unpin for aerorsync::aerorsync::mock::OpenStreamBehavior
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::mock::OpenStreamBehavior
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::mock::OpenStreamBehavior
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::mock::OpenStreamBehavior
+pub enum aerorsync::aerorsync::mock::ReadExhaustedBehavior
+pub aerorsync::aerorsync::mock::ReadExhaustedBehavior::EmptyFrame
+pub aerorsync::aerorsync::mock::ReadExhaustedBehavior::Error
+impl core::clone::Clone for aerorsync::aerorsync::mock::ReadExhaustedBehavior
+pub fn aerorsync::aerorsync::mock::ReadExhaustedBehavior::clone(&self) -> aerorsync::aerorsync::mock::ReadExhaustedBehavior
+impl core::fmt::Debug for aerorsync::aerorsync::mock::ReadExhaustedBehavior
+pub fn aerorsync::aerorsync::mock::ReadExhaustedBehavior::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for aerorsync::aerorsync::mock::ReadExhaustedBehavior
+impl core::marker::Freeze for aerorsync::aerorsync::mock::ReadExhaustedBehavior
+impl core::marker::Send for aerorsync::aerorsync::mock::ReadExhaustedBehavior
+impl core::marker::Sync for aerorsync::aerorsync::mock::ReadExhaustedBehavior
+impl core::marker::Unpin for aerorsync::aerorsync::mock::ReadExhaustedBehavior
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::mock::ReadExhaustedBehavior
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::mock::ReadExhaustedBehavior
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::mock::ReadExhaustedBehavior
+pub struct aerorsync::aerorsync::mock::MockRawStream
+impl aerorsync::aerorsync::mock::MockRawStream
+pub fn aerorsync::aerorsync::mock::MockRawStream::attach_cancel_flag(&mut self, alloc::sync::Arc<core::sync::atomic::AtomicBool>)
+impl aerorsync::aerorsync::transport::RawByteStream for aerorsync::aerorsync::mock::MockRawStream
+pub fn aerorsync::aerorsync::mock::MockRawStream::read_bytes<'life0, 'async_trait>(&'life0 mut self, usize) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<alloc::vec::Vec<u8>, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::mock::MockRawStream::shutdown<'life0, 'async_trait>(&'life0 mut self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::mock::MockRawStream::write_bytes<'life0, 'life1, 'async_trait>(&'life0 mut self, &'life1 [u8]) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+impl core::marker::Freeze for aerorsync::aerorsync::mock::MockRawStream
+impl core::marker::Send for aerorsync::aerorsync::mock::MockRawStream
+impl core::marker::Sync for aerorsync::aerorsync::mock::MockRawStream
+impl core::marker::Unpin for aerorsync::aerorsync::mock::MockRawStream
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::mock::MockRawStream
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::mock::MockRawStream
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::mock::MockRawStream
+pub struct aerorsync::aerorsync::mock::MockRemoteShellTransport
+pub aerorsync::aerorsync::mock::MockRemoteShellTransport::cancel_called: aerorsync::aerorsync::mock::ShutdownFlag
+pub aerorsync::aerorsync::mock::MockRemoteShellTransport::config: aerorsync::aerorsync::mock::MockTransportConfig
+pub aerorsync::aerorsync::mock::MockRemoteShellTransport::last_exec: alloc::sync::Arc<std::sync::poison::mutex::Mutex<core::option::Option<aerorsync::aerorsync::transport::RemoteExecRequest>>>
+pub aerorsync::aerorsync::mock::MockRemoteShellTransport::last_outbound: alloc::sync::Arc<std::sync::poison::mutex::Mutex<core::option::Option<aerorsync::aerorsync::mock::OutboundBuffer>>>
+pub aerorsync::aerorsync::mock::MockRemoteShellTransport::last_raw_outbound: alloc::sync::Arc<std::sync::poison::mutex::Mutex<core::option::Option<aerorsync::aerorsync::mock::RawOutboundBuffer>>>
+pub aerorsync::aerorsync::mock::MockRemoteShellTransport::last_raw_shutdown: alloc::sync::Arc<std::sync::poison::mutex::Mutex<core::option::Option<aerorsync::aerorsync::mock::ShutdownFlag>>>
+pub aerorsync::aerorsync::mock::MockRemoteShellTransport::last_shutdown: alloc::sync::Arc<std::sync::poison::mutex::Mutex<core::option::Option<aerorsync::aerorsync::mock::ShutdownFlag>>>
+impl aerorsync::aerorsync::mock::MockRemoteShellTransport
+pub fn aerorsync::aerorsync::mock::MockRemoteShellTransport::cancel_was_called(&self) -> bool
+pub fn aerorsync::aerorsync::mock::MockRemoteShellTransport::captured_outbound(&self) -> alloc::vec::Vec<alloc::vec::Vec<u8>>
+pub fn aerorsync::aerorsync::mock::MockRemoteShellTransport::last_exec_request(&self) -> core::option::Option<aerorsync::aerorsync::transport::RemoteExecRequest>
+pub fn aerorsync::aerorsync::mock::MockRemoteShellTransport::new(aerorsync::aerorsync::mock::MockTransportConfig) -> Self
+pub fn aerorsync::aerorsync::mock::MockRemoteShellTransport::shutdown_was_called(&self) -> bool
+impl aerorsync::aerorsync::mock::MockRemoteShellTransport
+pub fn aerorsync::aerorsync::mock::MockRemoteShellTransport::captured_raw_outbound(&self) -> alloc::vec::Vec<u8>
+impl aerorsync::aerorsync::transport::RawRemoteShellTransport for aerorsync::aerorsync::mock::MockRemoteShellTransport
+pub type aerorsync::aerorsync::mock::MockRemoteShellTransport::RawStream = aerorsync::aerorsync::mock::MockRawStream
+pub fn aerorsync::aerorsync::mock::MockRemoteShellTransport::open_raw_stream<'life0, 'async_trait>(&'life0 self, aerorsync::aerorsync::transport::RemoteExecRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<Self::RawStream, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+impl aerorsync::aerorsync::transport::RemoteShellTransport for aerorsync::aerorsync::mock::MockRemoteShellTransport
+pub type aerorsync::aerorsync::mock::MockRemoteShellTransport::Stream = aerorsync::aerorsync::mock::MockStream
+pub fn aerorsync::aerorsync::mock::MockRemoteShellTransport::cancel<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::mock::MockRemoteShellTransport::cancel_handle(&self) -> aerorsync::aerorsync::transport::CancelHandle
+pub fn aerorsync::aerorsync::mock::MockRemoteShellTransport::exec<'life0, 'async_trait>(&'life0 self, aerorsync::aerorsync::transport::RemoteExecRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<aerorsync::aerorsync::transport::RemoteCommandOutput, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::mock::MockRemoteShellTransport::open_stream<'life0, 'async_trait>(&'life0 self, aerorsync::aerorsync::transport::RemoteExecRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<Self::Stream, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::mock::MockRemoteShellTransport::probe<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<aerorsync::aerorsync::transport::TransportProbe, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+impl core::marker::Freeze for aerorsync::aerorsync::mock::MockRemoteShellTransport
+impl core::marker::Send for aerorsync::aerorsync::mock::MockRemoteShellTransport
+impl core::marker::Sync for aerorsync::aerorsync::mock::MockRemoteShellTransport
+impl core::marker::Unpin for aerorsync::aerorsync::mock::MockRemoteShellTransport
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::mock::MockRemoteShellTransport
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::mock::MockRemoteShellTransport
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::mock::MockRemoteShellTransport
+pub struct aerorsync::aerorsync::mock::MockStream
+pub aerorsync::aerorsync::mock::MockStream::inbound: alloc::collections::vec_deque::VecDeque<alloc::vec::Vec<u8>>
+pub aerorsync::aerorsync::mock::MockStream::outbound: aerorsync::aerorsync::mock::OutboundBuffer
+pub aerorsync::aerorsync::mock::MockStream::read_exhausted: aerorsync::aerorsync::mock::ReadExhaustedBehavior
+pub aerorsync::aerorsync::mock::MockStream::shutdown_called: aerorsync::aerorsync::mock::ShutdownFlag
+impl aerorsync::aerorsync::mock::MockStream
+pub fn aerorsync::aerorsync::mock::MockStream::new(alloc::vec::Vec<alloc::vec::Vec<u8>>, aerorsync::aerorsync::mock::ReadExhaustedBehavior) -> (Self, aerorsync::aerorsync::mock::OutboundBuffer, aerorsync::aerorsync::mock::ShutdownFlag)
+impl aerorsync::aerorsync::transport::BidirectionalByteStream for aerorsync::aerorsync::mock::MockStream
+pub fn aerorsync::aerorsync::mock::MockStream::read_frame<'life0, 'async_trait>(&'life0 mut self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<alloc::vec::Vec<u8>, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::mock::MockStream::shutdown<'life0, 'async_trait>(&'life0 mut self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::mock::MockStream::write_frame<'life0, 'life1, 'async_trait>(&'life0 mut self, &'life1 [u8]) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+impl core::fmt::Debug for aerorsync::aerorsync::mock::MockStream
+pub fn aerorsync::aerorsync::mock::MockStream::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aerorsync::aerorsync::mock::MockStream
+impl core::marker::Send for aerorsync::aerorsync::mock::MockStream
+impl core::marker::Sync for aerorsync::aerorsync::mock::MockStream
+impl core::marker::Unpin for aerorsync::aerorsync::mock::MockStream
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::mock::MockStream
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::mock::MockStream
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::mock::MockStream
+pub struct aerorsync::aerorsync::mock::MockTransportConfig
+pub aerorsync::aerorsync::mock::MockTransportConfig::exec_output: aerorsync::aerorsync::transport::RemoteCommandOutput
+pub aerorsync::aerorsync::mock::MockTransportConfig::probe: aerorsync::aerorsync::transport::TransportProbe
+pub aerorsync::aerorsync::mock::MockTransportConfig::raw_exhausted_detail: core::option::Option<alloc::string::String>
+pub aerorsync::aerorsync::mock::MockTransportConfig::raw_stream_behavior: core::option::Option<aerorsync::aerorsync::mock::OpenRawStreamBehavior>
+pub aerorsync::aerorsync::mock::MockTransportConfig::read_exhausted: aerorsync::aerorsync::mock::ReadExhaustedBehavior
+pub aerorsync::aerorsync::mock::MockTransportConfig::stream_behavior: aerorsync::aerorsync::mock::OpenStreamBehavior
+impl aerorsync::aerorsync::mock::MockTransportConfig
+pub fn aerorsync::aerorsync::mock::MockTransportConfig::healthy_download() -> Self
+pub fn aerorsync::aerorsync::mock::MockTransportConfig::healthy_upload() -> Self
+pub fn aerorsync::aerorsync::mock::MockTransportConfig::stream_open_fails() -> Self
+pub fn aerorsync::aerorsync::mock::MockTransportConfig::with_raw_exhausted_detail(self, impl core::convert::Into<alloc::string::String>) -> Self
+pub fn aerorsync::aerorsync::mock::MockTransportConfig::with_raw_inbound(self, alloc::vec::Vec<u8>) -> Self
+impl core::clone::Clone for aerorsync::aerorsync::mock::MockTransportConfig
+pub fn aerorsync::aerorsync::mock::MockTransportConfig::clone(&self) -> aerorsync::aerorsync::mock::MockTransportConfig
+impl core::fmt::Debug for aerorsync::aerorsync::mock::MockTransportConfig
+pub fn aerorsync::aerorsync::mock::MockTransportConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aerorsync::aerorsync::mock::MockTransportConfig
+impl core::marker::Send for aerorsync::aerorsync::mock::MockTransportConfig
+impl core::marker::Sync for aerorsync::aerorsync::mock::MockTransportConfig
+impl core::marker::Unpin for aerorsync::aerorsync::mock::MockTransportConfig
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::mock::MockTransportConfig
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::mock::MockTransportConfig
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::mock::MockTransportConfig
+pub type aerorsync::aerorsync::mock::OutboundBuffer = alloc::sync::Arc<std::sync::poison::mutex::Mutex<alloc::vec::Vec<alloc::vec::Vec<u8>>>>
+pub type aerorsync::aerorsync::mock::RawOutboundBuffer = alloc::sync::Arc<std::sync::poison::mutex::Mutex<alloc::vec::Vec<u8>>>
+pub type aerorsync::aerorsync::mock::ShutdownFlag = alloc::sync::Arc<std::sync::poison::mutex::Mutex<bool>>
+pub mod aerorsync::aerorsync::native_driver
+pub enum aerorsync::aerorsync::native_driver::AerorsyncSessionPhase
+pub aerorsync::aerorsync::native_driver::AerorsyncSessionPhase::ClientPreambleRecvd
+pub aerorsync::aerorsync::native_driver::AerorsyncSessionPhase::Complete
+pub aerorsync::aerorsync::native_driver::AerorsyncSessionPhase::DeltaReceived
+pub aerorsync::aerorsync::native_driver::AerorsyncSessionPhase::DeltaReceiving
+pub aerorsync::aerorsync::native_driver::AerorsyncSessionPhase::DeltaSending
+pub aerorsync::aerorsync::native_driver::AerorsyncSessionPhase::DeltaSent
+pub aerorsync::aerorsync::native_driver::AerorsyncSessionPhase::Failed
+pub aerorsync::aerorsync::native_driver::AerorsyncSessionPhase::FileListReceived
+pub aerorsync::aerorsync::native_driver::AerorsyncSessionPhase::FileListReceiving
+pub aerorsync::aerorsync::native_driver::AerorsyncSessionPhase::FileListSending
+pub aerorsync::aerorsync::native_driver::AerorsyncSessionPhase::FileListSent
+pub aerorsync::aerorsync::native_driver::AerorsyncSessionPhase::PreConnect
+pub aerorsync::aerorsync::native_driver::AerorsyncSessionPhase::ProbeOk
+pub aerorsync::aerorsync::native_driver::AerorsyncSessionPhase::RawStreamOpen
+pub aerorsync::aerorsync::native_driver::AerorsyncSessionPhase::ServerPreambleSent
+pub aerorsync::aerorsync::native_driver::AerorsyncSessionPhase::Stub
+pub aerorsync::aerorsync::native_driver::AerorsyncSessionPhase::SumBlocksReceiving
+pub aerorsync::aerorsync::native_driver::AerorsyncSessionPhase::SumBlocksSent
+pub aerorsync::aerorsync::native_driver::AerorsyncSessionPhase::SumHeadReceiving
+pub aerorsync::aerorsync::native_driver::AerorsyncSessionPhase::SumHeadSent
+pub aerorsync::aerorsync::native_driver::AerorsyncSessionPhase::SummaryReceived
+pub aerorsync::aerorsync::native_driver::AerorsyncSessionPhase::SummaryReceiving
+impl core::clone::Clone for aerorsync::aerorsync::native_driver::AerorsyncSessionPhase
+pub fn aerorsync::aerorsync::native_driver::AerorsyncSessionPhase::clone(&self) -> aerorsync::aerorsync::native_driver::AerorsyncSessionPhase
+impl core::cmp::Eq for aerorsync::aerorsync::native_driver::AerorsyncSessionPhase
+impl core::cmp::PartialEq for aerorsync::aerorsync::native_driver::AerorsyncSessionPhase
+pub fn aerorsync::aerorsync::native_driver::AerorsyncSessionPhase::eq(&self, &aerorsync::aerorsync::native_driver::AerorsyncSessionPhase) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::native_driver::AerorsyncSessionPhase
+pub fn aerorsync::aerorsync::native_driver::AerorsyncSessionPhase::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for aerorsync::aerorsync::native_driver::AerorsyncSessionPhase
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::native_driver::AerorsyncSessionPhase
+impl core::marker::Freeze for aerorsync::aerorsync::native_driver::AerorsyncSessionPhase
+impl core::marker::Send for aerorsync::aerorsync::native_driver::AerorsyncSessionPhase
+impl core::marker::Sync for aerorsync::aerorsync::native_driver::AerorsyncSessionPhase
+impl core::marker::Unpin for aerorsync::aerorsync::native_driver::AerorsyncSessionPhase
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::native_driver::AerorsyncSessionPhase
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::native_driver::AerorsyncSessionPhase
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::native_driver::AerorsyncSessionPhase
+pub struct aerorsync::aerorsync::native_driver::AerorsyncDriver<T: aerorsync::aerorsync::transport::RawRemoteShellTransport>
+impl<T: aerorsync::aerorsync::transport::RawRemoteShellTransport> aerorsync::aerorsync::native_driver::AerorsyncDriver<T>
+pub fn aerorsync::aerorsync::native_driver::AerorsyncDriver<T>::cancel_handle(&self) -> aerorsync::aerorsync::transport::CancelHandle
+pub fn aerorsync::aerorsync::native_driver::AerorsyncDriver<T>::checksum_seed(&self) -> u32
+pub fn aerorsync::aerorsync::native_driver::AerorsyncDriver<T>::committed(&self) -> bool
+pub fn aerorsync::aerorsync::native_driver::AerorsyncDriver<T>::compat_flags(&self) -> i32
+pub fn aerorsync::aerorsync::native_driver::AerorsyncDriver<T>::data_bytes_consumed(&self) -> u64
+pub fn aerorsync::aerorsync::native_driver::AerorsyncDriver<T>::downloaded_entry(&self) -> core::option::Option<&aerorsync::aerorsync::real_wire::FileListEntry>
+pub async fn aerorsync::aerorsync::native_driver::AerorsyncDriver<T>::drive_download(&mut self, aerorsync::aerorsync::remote_command::RemoteCommandSpec, &[u8], &dyn aerorsync::aerorsync::engine_adapter::DeltaEngineAdapter, &mut dyn aerorsync::aerorsync::events::EventSink) -> core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>
+pub async fn aerorsync::aerorsync::native_driver::AerorsyncDriver<T>::drive_download_through_delta(&mut self, aerorsync::aerorsync::remote_command::RemoteCommandSpec, &[u8], &dyn aerorsync::aerorsync::engine_adapter::DeltaEngineAdapter, &mut dyn aerorsync::aerorsync::events::EventSink) -> core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>
+pub async fn aerorsync::aerorsync::native_driver::AerorsyncDriver<T>::drive_download_through_delta_streaming(&mut self, aerorsync::aerorsync::remote_command::RemoteCommandSpec, &mut dyn aerorsync::aerorsync::engine_adapter::BaselineSource, &mut (dyn tokio::io::async_write::AsyncWrite + core::marker::Send + core::marker::Unpin), &dyn aerorsync::aerorsync::engine_adapter::DeltaEngineAdapter, &mut dyn aerorsync::aerorsync::events::EventSink) -> core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>
+pub async fn aerorsync::aerorsync::native_driver::AerorsyncDriver<T>::drive_upload(&mut self, aerorsync::aerorsync::remote_command::RemoteCommandSpec, aerorsync::aerorsync::real_wire::FileListEntry, &[u8], &dyn aerorsync::aerorsync::engine_adapter::DeltaEngineAdapter, &mut dyn aerorsync::aerorsync::events::EventSink) -> core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>
+pub async fn aerorsync::aerorsync::native_driver::AerorsyncDriver<T>::drive_upload_symlink(&mut self, aerorsync::aerorsync::remote_command::RemoteCommandSpec, aerorsync::aerorsync::real_wire::FileListEntry, &mut dyn aerorsync::aerorsync::events::EventSink) -> core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>
+pub async fn aerorsync::aerorsync::native_driver::AerorsyncDriver<T>::drive_upload_through_delta(&mut self, aerorsync::aerorsync::remote_command::RemoteCommandSpec, aerorsync::aerorsync::real_wire::FileListEntry, &[u8], &dyn aerorsync::aerorsync::engine_adapter::DeltaEngineAdapter, &mut dyn aerorsync::aerorsync::events::EventSink) -> core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>
+pub async fn aerorsync::aerorsync::native_driver::AerorsyncDriver<T>::drive_upload_through_delta_streaming<R>(&mut self, aerorsync::aerorsync::remote_command::RemoteCommandSpec, aerorsync::aerorsync::real_wire::FileListEntry, R, u64, &dyn aerorsync::aerorsync::engine_adapter::DeltaEngineAdapter, &mut dyn aerorsync::aerorsync::events::EventSink) -> core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError> where R: tokio::io::async_read::AsyncRead + tokio::io::async_seek::AsyncSeek + core::marker::Unpin + core::marker::Send
+pub fn aerorsync::aerorsync::native_driver::AerorsyncDriver<T>::file_list(&self) -> &[aerorsync::aerorsync::real_wire::FileListEntry]
+pub async fn aerorsync::aerorsync::native_driver::AerorsyncDriver<T>::finish_session(&mut self, &mut dyn aerorsync::aerorsync::events::EventSink) -> core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>
+pub fn aerorsync::aerorsync::native_driver::AerorsyncDriver<T>::last_iflags(&self) -> u16
+pub fn aerorsync::aerorsync::native_driver::AerorsyncDriver<T>::negotiated_checksum_algo(&self) -> core::option::Option<&str>
+pub fn aerorsync::aerorsync::native_driver::AerorsyncDriver<T>::negotiated_checksum_algos(&self) -> &str
+pub fn aerorsync::aerorsync::native_driver::AerorsyncDriver<T>::negotiated_compression_algo(&self) -> core::option::Option<&str>
+pub fn aerorsync::aerorsync::native_driver::AerorsyncDriver<T>::negotiated_compression_algos(&self) -> &str
+pub fn aerorsync::aerorsync::native_driver::AerorsyncDriver<T>::new(T, aerorsync::aerorsync::transport::CancelHandle) -> Self
+pub fn aerorsync::aerorsync::native_driver::AerorsyncDriver<T>::phase(&self) -> aerorsync::aerorsync::native_driver::AerorsyncSessionPhase
+pub fn aerorsync::aerorsync::native_driver::AerorsyncDriver<T>::protocol_version(&self) -> u32
+pub fn aerorsync::aerorsync::native_driver::AerorsyncDriver<T>::received_file_checksum(&self) -> core::option::Option<&[u8]>
+pub fn aerorsync::aerorsync::native_driver::AerorsyncDriver<T>::received_raw_bytes(&self) -> u64
+pub fn aerorsync::aerorsync::native_driver::AerorsyncDriver<T>::received_signatures(&self) -> &[aerorsync::aerorsync::real_wire::SumBlock]
+pub fn aerorsync::aerorsync::native_driver::AerorsyncDriver<T>::received_sum_head(&self) -> core::option::Option<&aerorsync::aerorsync::real_wire::SumHead>
+pub fn aerorsync::aerorsync::native_driver::AerorsyncDriver<T>::received_summary(&self) -> core::option::Option<&aerorsync::aerorsync::real_wire::SummaryFrame>
+pub fn aerorsync::aerorsync::native_driver::AerorsyncDriver<T>::reconstructed(&self) -> core::option::Option<&[u8]>
+pub fn aerorsync::aerorsync::native_driver::AerorsyncDriver<T>::sent_data_bytes(&self) -> u64
+pub fn aerorsync::aerorsync::native_driver::AerorsyncDriver<T>::sent_signatures(&self) -> &[aerorsync::aerorsync::real_wire::SumBlock]
+pub fn aerorsync::aerorsync::native_driver::AerorsyncDriver<T>::sent_sum_head(&self) -> core::option::Option<&aerorsync::aerorsync::real_wire::SumHead>
+pub fn aerorsync::aerorsync::native_driver::AerorsyncDriver<T>::session_role(&self) -> core::option::Option<aerorsync::aerorsync::types::SessionRole>
+pub fn aerorsync::aerorsync::native_driver::AerorsyncDriver<T>::session_stats(&self) -> &aerorsync::aerorsync::types::SessionStats
+pub fn aerorsync::aerorsync::native_driver::AerorsyncDriver<T>::with_preamble_profile(self, aerorsync::aerorsync::native_driver::PreambleProfile) -> Self
+pub fn aerorsync::aerorsync::native_driver::AerorsyncDriver<T>::with_progress_sink(self, core::option::Option<aerorsync::aerorsync::progress::ProgressSink>) -> Self
+impl<T> core::marker::Freeze for aerorsync::aerorsync::native_driver::AerorsyncDriver<T> where T: core::marker::Freeze, core::option::Option<<T as aerorsync::aerorsync::transport::RawRemoteShellTransport>::RawStream>: core::marker::Freeze
+impl<T> core::marker::Send for aerorsync::aerorsync::native_driver::AerorsyncDriver<T> where core::option::Option<<T as aerorsync::aerorsync::transport::RawRemoteShellTransport>::RawStream>: core::marker::Send
+impl<T> !core::marker::Sync for aerorsync::aerorsync::native_driver::AerorsyncDriver<T>
+impl<T> core::marker::Unpin for aerorsync::aerorsync::native_driver::AerorsyncDriver<T> where T: core::marker::Unpin, core::option::Option<<T as aerorsync::aerorsync::transport::RawRemoteShellTransport>::RawStream>: core::marker::Unpin
+impl<T> core::marker::UnsafeUnpin for aerorsync::aerorsync::native_driver::AerorsyncDriver<T> where T: core::marker::UnsafeUnpin, core::option::Option<<T as aerorsync::aerorsync::transport::RawRemoteShellTransport>::RawStream>: core::marker::UnsafeUnpin
+impl<T> !core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::native_driver::AerorsyncDriver<T>
+impl<T> !core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::native_driver::AerorsyncDriver<T>
+pub struct aerorsync::aerorsync::native_driver::PreambleProfile
+pub aerorsync::aerorsync::native_driver::PreambleProfile::checksum_algos: alloc::string::String
+pub aerorsync::aerorsync::native_driver::PreambleProfile::compression_algos: alloc::string::String
+impl aerorsync::aerorsync::native_driver::PreambleProfile
+pub fn aerorsync::aerorsync::native_driver::PreambleProfile::for_host(&str) -> Self
+pub fn aerorsync::aerorsync::native_driver::PreambleProfile::with_env_overrides(self) -> Self
+impl core::clone::Clone for aerorsync::aerorsync::native_driver::PreambleProfile
+pub fn aerorsync::aerorsync::native_driver::PreambleProfile::clone(&self) -> aerorsync::aerorsync::native_driver::PreambleProfile
+impl core::cmp::Eq for aerorsync::aerorsync::native_driver::PreambleProfile
+impl core::cmp::PartialEq for aerorsync::aerorsync::native_driver::PreambleProfile
+pub fn aerorsync::aerorsync::native_driver::PreambleProfile::eq(&self, &aerorsync::aerorsync::native_driver::PreambleProfile) -> bool
+impl core::default::Default for aerorsync::aerorsync::native_driver::PreambleProfile
+pub fn aerorsync::aerorsync::native_driver::PreambleProfile::default() -> Self
+impl core::fmt::Debug for aerorsync::aerorsync::native_driver::PreambleProfile
+pub fn aerorsync::aerorsync::native_driver::PreambleProfile::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::native_driver::PreambleProfile
+impl core::marker::Freeze for aerorsync::aerorsync::native_driver::PreambleProfile
+impl core::marker::Send for aerorsync::aerorsync::native_driver::PreambleProfile
+impl core::marker::Sync for aerorsync::aerorsync::native_driver::PreambleProfile
+impl core::marker::Unpin for aerorsync::aerorsync::native_driver::PreambleProfile
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::native_driver::PreambleProfile
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::native_driver::PreambleProfile
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::native_driver::PreambleProfile
+pub mod aerorsync::aerorsync::progress
+pub type aerorsync::aerorsync::progress::ProgressSink = alloc::boxed::Box<(dyn core::ops::function::FnMut(u64, u64) + core::marker::Send)>
+pub mod aerorsync::aerorsync::real_wire
+pub enum aerorsync::aerorsync::real_wire::AclPrincipal
+pub aerorsync::aerorsync::real_wire::AclPrincipal::Group
+pub aerorsync::aerorsync::real_wire::AclPrincipal::User
+impl core::clone::Clone for aerorsync::aerorsync::real_wire::AclPrincipal
+pub fn aerorsync::aerorsync::real_wire::AclPrincipal::clone(&self) -> aerorsync::aerorsync::real_wire::AclPrincipal
+impl core::cmp::Eq for aerorsync::aerorsync::real_wire::AclPrincipal
+impl core::cmp::PartialEq for aerorsync::aerorsync::real_wire::AclPrincipal
+pub fn aerorsync::aerorsync::real_wire::AclPrincipal::eq(&self, &aerorsync::aerorsync::real_wire::AclPrincipal) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::real_wire::AclPrincipal
+pub fn aerorsync::aerorsync::real_wire::AclPrincipal::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for aerorsync::aerorsync::real_wire::AclPrincipal
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::real_wire::AclPrincipal
+impl core::marker::Freeze for aerorsync::aerorsync::real_wire::AclPrincipal
+impl core::marker::Send for aerorsync::aerorsync::real_wire::AclPrincipal
+impl core::marker::Sync for aerorsync::aerorsync::real_wire::AclPrincipal
+impl core::marker::Unpin for aerorsync::aerorsync::real_wire::AclPrincipal
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::real_wire::AclPrincipal
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::real_wire::AclPrincipal
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::real_wire::AclPrincipal
+pub enum aerorsync::aerorsync::real_wire::AclWireEntry
+pub aerorsync::aerorsync::real_wire::AclWireEntry::Literal(aerorsync::aerorsync::real_wire::RsyncAcl)
+pub aerorsync::aerorsync::real_wire::AclWireEntry::Reference(u32)
+impl core::clone::Clone for aerorsync::aerorsync::real_wire::AclWireEntry
+pub fn aerorsync::aerorsync::real_wire::AclWireEntry::clone(&self) -> aerorsync::aerorsync::real_wire::AclWireEntry
+impl core::cmp::Eq for aerorsync::aerorsync::real_wire::AclWireEntry
+impl core::cmp::PartialEq for aerorsync::aerorsync::real_wire::AclWireEntry
+pub fn aerorsync::aerorsync::real_wire::AclWireEntry::eq(&self, &aerorsync::aerorsync::real_wire::AclWireEntry) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::real_wire::AclWireEntry
+pub fn aerorsync::aerorsync::real_wire::AclWireEntry::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::real_wire::AclWireEntry
+impl core::marker::Freeze for aerorsync::aerorsync::real_wire::AclWireEntry
+impl core::marker::Send for aerorsync::aerorsync::real_wire::AclWireEntry
+impl core::marker::Sync for aerorsync::aerorsync::real_wire::AclWireEntry
+impl core::marker::Unpin for aerorsync::aerorsync::real_wire::AclWireEntry
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::real_wire::AclWireEntry
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::real_wire::AclWireEntry
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::real_wire::AclWireEntry
+pub enum aerorsync::aerorsync::real_wire::DeltaOp
+pub aerorsync::aerorsync::real_wire::DeltaOp::CopyRun
+pub aerorsync::aerorsync::real_wire::DeltaOp::CopyRun::run_length: u16
+pub aerorsync::aerorsync::real_wire::DeltaOp::CopyRun::start_token_index: i32
+pub aerorsync::aerorsync::real_wire::DeltaOp::Literal
+pub aerorsync::aerorsync::real_wire::DeltaOp::Literal::compressed_payload: alloc::vec::Vec<u8>
+impl core::clone::Clone for aerorsync::aerorsync::real_wire::DeltaOp
+pub fn aerorsync::aerorsync::real_wire::DeltaOp::clone(&self) -> aerorsync::aerorsync::real_wire::DeltaOp
+impl core::cmp::Eq for aerorsync::aerorsync::real_wire::DeltaOp
+impl core::cmp::PartialEq for aerorsync::aerorsync::real_wire::DeltaOp
+pub fn aerorsync::aerorsync::real_wire::DeltaOp::eq(&self, &aerorsync::aerorsync::real_wire::DeltaOp) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::real_wire::DeltaOp
+pub fn aerorsync::aerorsync::real_wire::DeltaOp::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::real_wire::DeltaOp
+impl core::marker::Freeze for aerorsync::aerorsync::real_wire::DeltaOp
+impl core::marker::Send for aerorsync::aerorsync::real_wire::DeltaOp
+impl core::marker::Sync for aerorsync::aerorsync::real_wire::DeltaOp
+impl core::marker::Unpin for aerorsync::aerorsync::real_wire::DeltaOp
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::real_wire::DeltaOp
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::real_wire::DeltaOp
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::real_wire::DeltaOp
+pub enum aerorsync::aerorsync::real_wire::DeltaOpOutcome
+pub aerorsync::aerorsync::real_wire::DeltaOpOutcome::EndFlag
+pub aerorsync::aerorsync::real_wire::DeltaOpOutcome::Op(aerorsync::aerorsync::real_wire::DeltaOp)
+impl core::clone::Clone for aerorsync::aerorsync::real_wire::DeltaOpOutcome
+pub fn aerorsync::aerorsync::real_wire::DeltaOpOutcome::clone(&self) -> aerorsync::aerorsync::real_wire::DeltaOpOutcome
+impl core::cmp::Eq for aerorsync::aerorsync::real_wire::DeltaOpOutcome
+impl core::cmp::PartialEq for aerorsync::aerorsync::real_wire::DeltaOpOutcome
+pub fn aerorsync::aerorsync::real_wire::DeltaOpOutcome::eq(&self, &aerorsync::aerorsync::real_wire::DeltaOpOutcome) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::real_wire::DeltaOpOutcome
+pub fn aerorsync::aerorsync::real_wire::DeltaOpOutcome::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::real_wire::DeltaOpOutcome
+impl core::marker::Freeze for aerorsync::aerorsync::real_wire::DeltaOpOutcome
+impl core::marker::Send for aerorsync::aerorsync::real_wire::DeltaOpOutcome
+impl core::marker::Sync for aerorsync::aerorsync::real_wire::DeltaOpOutcome
+impl core::marker::Unpin for aerorsync::aerorsync::real_wire::DeltaOpOutcome
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::real_wire::DeltaOpOutcome
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::real_wire::DeltaOpOutcome
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::real_wire::DeltaOpOutcome
+pub enum aerorsync::aerorsync::real_wire::FileListDecodeOutcome
+pub aerorsync::aerorsync::real_wire::FileListDecodeOutcome::EndOfList
+pub aerorsync::aerorsync::real_wire::FileListDecodeOutcome::EndOfList::io_error: i32
+pub aerorsync::aerorsync::real_wire::FileListDecodeOutcome::Entry(aerorsync::aerorsync::real_wire::FileListEntry)
+impl core::clone::Clone for aerorsync::aerorsync::real_wire::FileListDecodeOutcome
+pub fn aerorsync::aerorsync::real_wire::FileListDecodeOutcome::clone(&self) -> aerorsync::aerorsync::real_wire::FileListDecodeOutcome
+impl core::cmp::Eq for aerorsync::aerorsync::real_wire::FileListDecodeOutcome
+impl core::cmp::PartialEq for aerorsync::aerorsync::real_wire::FileListDecodeOutcome
+pub fn aerorsync::aerorsync::real_wire::FileListDecodeOutcome::eq(&self, &aerorsync::aerorsync::real_wire::FileListDecodeOutcome) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::real_wire::FileListDecodeOutcome
+pub fn aerorsync::aerorsync::real_wire::FileListDecodeOutcome::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::real_wire::FileListDecodeOutcome
+impl core::marker::Freeze for aerorsync::aerorsync::real_wire::FileListDecodeOutcome
+impl core::marker::Send for aerorsync::aerorsync::real_wire::FileListDecodeOutcome
+impl core::marker::Sync for aerorsync::aerorsync::real_wire::FileListDecodeOutcome
+impl core::marker::Unpin for aerorsync::aerorsync::real_wire::FileListDecodeOutcome
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::real_wire::FileListDecodeOutcome
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::real_wire::FileListDecodeOutcome
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::real_wire::FileListDecodeOutcome
+pub enum aerorsync::aerorsync::real_wire::MuxPoll
+pub aerorsync::aerorsync::real_wire::MuxPoll::Data(alloc::vec::Vec<u8>)
+pub aerorsync::aerorsync::real_wire::MuxPoll::Oob(aerorsync::aerorsync::events::AerorsyncEvent)
+pub aerorsync::aerorsync::real_wire::MuxPoll::Terminal(aerorsync::aerorsync::events::AerorsyncEvent)
+impl core::clone::Clone for aerorsync::aerorsync::real_wire::MuxPoll
+pub fn aerorsync::aerorsync::real_wire::MuxPoll::clone(&self) -> aerorsync::aerorsync::real_wire::MuxPoll
+impl core::cmp::Eq for aerorsync::aerorsync::real_wire::MuxPoll
+impl core::cmp::PartialEq for aerorsync::aerorsync::real_wire::MuxPoll
+pub fn aerorsync::aerorsync::real_wire::MuxPoll::eq(&self, &aerorsync::aerorsync::real_wire::MuxPoll) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::real_wire::MuxPoll
+pub fn aerorsync::aerorsync::real_wire::MuxPoll::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::real_wire::MuxPoll
+impl core::marker::Freeze for aerorsync::aerorsync::real_wire::MuxPoll
+impl core::marker::Send for aerorsync::aerorsync::real_wire::MuxPoll
+impl core::marker::Sync for aerorsync::aerorsync::real_wire::MuxPoll
+impl core::marker::Unpin for aerorsync::aerorsync::real_wire::MuxPoll
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::real_wire::MuxPoll
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::real_wire::MuxPoll
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::real_wire::MuxPoll
+pub enum aerorsync::aerorsync::real_wire::MuxTag
+pub aerorsync::aerorsync::real_wire::MuxTag::Client
+pub aerorsync::aerorsync::real_wire::MuxTag::Data
+pub aerorsync::aerorsync::real_wire::MuxTag::Deleted
+pub aerorsync::aerorsync::real_wire::MuxTag::Error
+pub aerorsync::aerorsync::real_wire::MuxTag::ErrorExit
+pub aerorsync::aerorsync::real_wire::MuxTag::ErrorSocket
+pub aerorsync::aerorsync::real_wire::MuxTag::ErrorUtf8
+pub aerorsync::aerorsync::real_wire::MuxTag::ErrorXfer
+pub aerorsync::aerorsync::real_wire::MuxTag::Info
+pub aerorsync::aerorsync::real_wire::MuxTag::IoError
+pub aerorsync::aerorsync::real_wire::MuxTag::IoTimeout
+pub aerorsync::aerorsync::real_wire::MuxTag::Log
+pub aerorsync::aerorsync::real_wire::MuxTag::NoSend
+pub aerorsync::aerorsync::real_wire::MuxTag::Noop
+pub aerorsync::aerorsync::real_wire::MuxTag::Redo
+pub aerorsync::aerorsync::real_wire::MuxTag::Stats
+pub aerorsync::aerorsync::real_wire::MuxTag::Success
+pub aerorsync::aerorsync::real_wire::MuxTag::Unknown(u8)
+pub aerorsync::aerorsync::real_wire::MuxTag::Warning
+impl aerorsync::aerorsync::real_wire::MuxTag
+pub fn aerorsync::aerorsync::real_wire::MuxTag::code(&self) -> u8
+pub fn aerorsync::aerorsync::real_wire::MuxTag::from_code(u8) -> Self
+impl core::clone::Clone for aerorsync::aerorsync::real_wire::MuxTag
+pub fn aerorsync::aerorsync::real_wire::MuxTag::clone(&self) -> aerorsync::aerorsync::real_wire::MuxTag
+impl core::cmp::Eq for aerorsync::aerorsync::real_wire::MuxTag
+impl core::cmp::PartialEq for aerorsync::aerorsync::real_wire::MuxTag
+pub fn aerorsync::aerorsync::real_wire::MuxTag::eq(&self, &aerorsync::aerorsync::real_wire::MuxTag) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::real_wire::MuxTag
+pub fn aerorsync::aerorsync::real_wire::MuxTag::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for aerorsync::aerorsync::real_wire::MuxTag
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::real_wire::MuxTag
+impl core::marker::Freeze for aerorsync::aerorsync::real_wire::MuxTag
+impl core::marker::Send for aerorsync::aerorsync::real_wire::MuxTag
+impl core::marker::Sync for aerorsync::aerorsync::real_wire::MuxTag
+impl core::marker::Unpin for aerorsync::aerorsync::real_wire::MuxTag
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::real_wire::MuxTag
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::real_wire::MuxTag
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::real_wire::MuxTag
+pub enum aerorsync::aerorsync::real_wire::RealWireError
+pub aerorsync::aerorsync::real_wire::RealWireError::DeflateDecompressionFailed
+pub aerorsync::aerorsync::real_wire::RealWireError::DeflateDecompressionFailed::reason: alloc::string::String
+pub aerorsync::aerorsync::real_wire::RealWireError::DeltaTokenOutOfRange
+pub aerorsync::aerorsync::real_wire::RealWireError::DeltaTokenOutOfRange::block_count: i32
+pub aerorsync::aerorsync::real_wire::RealWireError::DeltaTokenOutOfRange::token_index: i32
+pub aerorsync::aerorsync::real_wire::RealWireError::DeltaTokenTruncated
+pub aerorsync::aerorsync::real_wire::RealWireError::DeltaTokenTruncated::at: &'static str
+pub aerorsync::aerorsync::real_wire::RealWireError::DeltaTokenTruncated::available: usize
+pub aerorsync::aerorsync::real_wire::RealWireError::DeltaTokenTruncated::needed: usize
+pub aerorsync::aerorsync::real_wire::RealWireError::InvalidAclField
+pub aerorsync::aerorsync::real_wire::RealWireError::InvalidAclField::available: usize
+pub aerorsync::aerorsync::real_wire::RealWireError::InvalidAclField::declared: i64
+pub aerorsync::aerorsync::real_wire::RealWireError::InvalidAclField::field: &'static str
+pub aerorsync::aerorsync::real_wire::RealWireError::InvalidAlgoListLen
+pub aerorsync::aerorsync::real_wire::RealWireError::InvalidAlgoListLen::available: usize
+pub aerorsync::aerorsync::real_wire::RealWireError::InvalidAlgoListLen::declared: usize
+pub aerorsync::aerorsync::real_wire::RealWireError::InvalidMuxHeader
+pub aerorsync::aerorsync::real_wire::RealWireError::InvalidMuxHeader::raw_high_byte: u8
+pub aerorsync::aerorsync::real_wire::RealWireError::InvalidNameLen
+pub aerorsync::aerorsync::real_wire::RealWireError::InvalidNameLen::available: usize
+pub aerorsync::aerorsync::real_wire::RealWireError::InvalidNameLen::declared: usize
+pub aerorsync::aerorsync::real_wire::RealWireError::InvalidProtocolVersion
+pub aerorsync::aerorsync::real_wire::RealWireError::InvalidProtocolVersion::value: u32
+pub aerorsync::aerorsync::real_wire::RealWireError::InvalidXattrField
+pub aerorsync::aerorsync::real_wire::RealWireError::InvalidXattrField::available: usize
+pub aerorsync::aerorsync::real_wire::RealWireError::InvalidXattrField::declared: i64
+pub aerorsync::aerorsync::real_wire::RealWireError::InvalidXattrField::field: &'static str
+pub aerorsync::aerorsync::real_wire::RealWireError::NdxTruncated
+pub aerorsync::aerorsync::real_wire::RealWireError::NdxTruncated::form: &'static str
+pub aerorsync::aerorsync::real_wire::RealWireError::NonAsciiAlgoList
+pub aerorsync::aerorsync::real_wire::RealWireError::NonAsciiAlgoList::byte: u8
+pub aerorsync::aerorsync::real_wire::RealWireError::NonAsciiAlgoList::offset: usize
+pub aerorsync::aerorsync::real_wire::RealWireError::NonUtf8Name
+pub aerorsync::aerorsync::real_wire::RealWireError::NonUtf8Name::offset: usize
+pub aerorsync::aerorsync::real_wire::RealWireError::SameNamePrefixTooLong
+pub aerorsync::aerorsync::real_wire::RealWireError::SameNamePrefixTooLong::l1: usize
+pub aerorsync::aerorsync::real_wire::RealWireError::SameNamePrefixTooLong::previous_len: usize
+pub aerorsync::aerorsync::real_wire::RealWireError::SameNameWithoutPrevious
+pub aerorsync::aerorsync::real_wire::RealWireError::SumHeadFieldOutOfRange
+pub aerorsync::aerorsync::real_wire::RealWireError::SumHeadFieldOutOfRange::field: &'static str
+pub aerorsync::aerorsync::real_wire::RealWireError::SumHeadFieldOutOfRange::max: i32
+pub aerorsync::aerorsync::real_wire::RealWireError::SumHeadFieldOutOfRange::value: i32
+pub aerorsync::aerorsync::real_wire::RealWireError::TruncatedBuffer
+pub aerorsync::aerorsync::real_wire::RealWireError::TruncatedBuffer::at: &'static str
+pub aerorsync::aerorsync::real_wire::RealWireError::TruncatedBuffer::available: usize
+pub aerorsync::aerorsync::real_wire::RealWireError::TruncatedBuffer::needed: usize
+pub aerorsync::aerorsync::real_wire::RealWireError::UnsupportedCompressor
+pub aerorsync::aerorsync::real_wire::RealWireError::UnsupportedCompressor::chosen: alloc::string::String
+pub aerorsync::aerorsync::real_wire::RealWireError::VarintOverflow
+pub aerorsync::aerorsync::real_wire::RealWireError::VarintOverflow::first_byte: u8
+pub aerorsync::aerorsync::real_wire::RealWireError::XattrAbbrevUnsupported
+pub aerorsync::aerorsync::real_wire::RealWireError::XattrAbbrevUnsupported::reference: i64
+pub aerorsync::aerorsync::real_wire::RealWireError::XattrDatumDigestMismatch
+pub aerorsync::aerorsync::real_wire::RealWireError::XattrDatumDigestMismatch::name: alloc::string::String
+pub aerorsync::aerorsync::real_wire::RealWireError::XattrDatumSectionInvalid
+pub aerorsync::aerorsync::real_wire::RealWireError::XattrDatumSectionInvalid::field: &'static str
+pub aerorsync::aerorsync::real_wire::RealWireError::XattrDatumSectionInvalid::value: i64
+pub aerorsync::aerorsync::real_wire::RealWireError::XattrDatumUnexpected
+pub aerorsync::aerorsync::real_wire::RealWireError::XattrDatumUnexpected::name: alloc::string::String
+pub aerorsync::aerorsync::real_wire::RealWireError::XattrDatumUnexpected::reason: &'static str
+pub aerorsync::aerorsync::real_wire::RealWireError::XattrNameNotNulTerminated
+pub aerorsync::aerorsync::real_wire::RealWireError::XattrNameNotNulTerminated::name_len: usize
+pub aerorsync::aerorsync::real_wire::RealWireError::ZstdDecompressionFailed
+pub aerorsync::aerorsync::real_wire::RealWireError::ZstdDecompressionFailed::reason: alloc::string::String
+impl core::clone::Clone for aerorsync::aerorsync::real_wire::RealWireError
+pub fn aerorsync::aerorsync::real_wire::RealWireError::clone(&self) -> aerorsync::aerorsync::real_wire::RealWireError
+impl core::cmp::Eq for aerorsync::aerorsync::real_wire::RealWireError
+impl core::cmp::PartialEq for aerorsync::aerorsync::real_wire::RealWireError
+pub fn aerorsync::aerorsync::real_wire::RealWireError::eq(&self, &aerorsync::aerorsync::real_wire::RealWireError) -> bool
+impl core::error::Error for aerorsync::aerorsync::real_wire::RealWireError
+impl core::fmt::Debug for aerorsync::aerorsync::real_wire::RealWireError
+pub fn aerorsync::aerorsync::real_wire::RealWireError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for aerorsync::aerorsync::real_wire::RealWireError
+pub fn aerorsync::aerorsync::real_wire::RealWireError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::real_wire::RealWireError
+impl core::marker::Freeze for aerorsync::aerorsync::real_wire::RealWireError
+impl core::marker::Send for aerorsync::aerorsync::real_wire::RealWireError
+impl core::marker::Sync for aerorsync::aerorsync::real_wire::RealWireError
+impl core::marker::Unpin for aerorsync::aerorsync::real_wire::RealWireError
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::real_wire::RealWireError
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::real_wire::RealWireError
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::real_wire::RealWireError
+pub enum aerorsync::aerorsync::real_wire::XattrDatum
+pub aerorsync::aerorsync::real_wire::XattrDatum::Deferred
+pub aerorsync::aerorsync::real_wire::XattrDatum::Deferred::digest: [u8; 16]
+pub aerorsync::aerorsync::real_wire::XattrDatum::Deferred::len: usize
+pub aerorsync::aerorsync::real_wire::XattrDatum::Inline(alloc::vec::Vec<u8>)
+impl aerorsync::aerorsync::real_wire::XattrDatum
+pub fn aerorsync::aerorsync::real_wire::XattrDatum::bytes(&self) -> core::option::Option<&[u8]>
+pub fn aerorsync::aerorsync::real_wire::XattrDatum::is_empty(&self) -> bool
+pub fn aerorsync::aerorsync::real_wire::XattrDatum::is_out_of_band(&self) -> bool
+pub fn aerorsync::aerorsync::real_wire::XattrDatum::len(&self) -> usize
+impl core::clone::Clone for aerorsync::aerorsync::real_wire::XattrDatum
+pub fn aerorsync::aerorsync::real_wire::XattrDatum::clone(&self) -> aerorsync::aerorsync::real_wire::XattrDatum
+impl core::cmp::Eq for aerorsync::aerorsync::real_wire::XattrDatum
+impl core::cmp::PartialEq for aerorsync::aerorsync::real_wire::XattrDatum
+pub fn aerorsync::aerorsync::real_wire::XattrDatum::eq(&self, &aerorsync::aerorsync::real_wire::XattrDatum) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::real_wire::XattrDatum
+pub fn aerorsync::aerorsync::real_wire::XattrDatum::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::real_wire::XattrDatum
+impl core::marker::Freeze for aerorsync::aerorsync::real_wire::XattrDatum
+impl core::marker::Send for aerorsync::aerorsync::real_wire::XattrDatum
+impl core::marker::Sync for aerorsync::aerorsync::real_wire::XattrDatum
+impl core::marker::Unpin for aerorsync::aerorsync::real_wire::XattrDatum
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::real_wire::XattrDatum
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::real_wire::XattrDatum
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::real_wire::XattrDatum
+pub struct aerorsync::aerorsync::real_wire::AclNamedEntry
+pub aerorsync::aerorsync::real_wire::AclNamedEntry::access: u8
+pub aerorsync::aerorsync::real_wire::AclNamedEntry::id: u32
+pub aerorsync::aerorsync::real_wire::AclNamedEntry::name: core::option::Option<alloc::string::String>
+pub aerorsync::aerorsync::real_wire::AclNamedEntry::principal: aerorsync::aerorsync::real_wire::AclPrincipal
+impl core::clone::Clone for aerorsync::aerorsync::real_wire::AclNamedEntry
+pub fn aerorsync::aerorsync::real_wire::AclNamedEntry::clone(&self) -> aerorsync::aerorsync::real_wire::AclNamedEntry
+impl core::cmp::Eq for aerorsync::aerorsync::real_wire::AclNamedEntry
+impl core::cmp::PartialEq for aerorsync::aerorsync::real_wire::AclNamedEntry
+pub fn aerorsync::aerorsync::real_wire::AclNamedEntry::eq(&self, &aerorsync::aerorsync::real_wire::AclNamedEntry) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::real_wire::AclNamedEntry
+pub fn aerorsync::aerorsync::real_wire::AclNamedEntry::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::real_wire::AclNamedEntry
+impl core::marker::Freeze for aerorsync::aerorsync::real_wire::AclNamedEntry
+impl core::marker::Send for aerorsync::aerorsync::real_wire::AclNamedEntry
+impl core::marker::Sync for aerorsync::aerorsync::real_wire::AclNamedEntry
+impl core::marker::Unpin for aerorsync::aerorsync::real_wire::AclNamedEntry
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::real_wire::AclNamedEntry
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::real_wire::AclNamedEntry
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::real_wire::AclNamedEntry
+pub struct aerorsync::aerorsync::real_wire::ClassifiedReassemblyReport
+pub aerorsync::aerorsync::real_wire::ClassifiedReassemblyReport::app_stream: alloc::vec::Vec<u8>
+pub aerorsync::aerorsync::real_wire::ClassifiedReassemblyReport::consumed_bytes: usize
+pub aerorsync::aerorsync::real_wire::ClassifiedReassemblyReport::events: alloc::vec::Vec<aerorsync::aerorsync::events::AerorsyncEvent>
+pub aerorsync::aerorsync::real_wire::ClassifiedReassemblyReport::frames_consumed: usize
+pub aerorsync::aerorsync::real_wire::ClassifiedReassemblyReport::terminal: core::option::Option<aerorsync::aerorsync::events::AerorsyncEvent>
+impl core::clone::Clone for aerorsync::aerorsync::real_wire::ClassifiedReassemblyReport
+pub fn aerorsync::aerorsync::real_wire::ClassifiedReassemblyReport::clone(&self) -> aerorsync::aerorsync::real_wire::ClassifiedReassemblyReport
+impl core::cmp::Eq for aerorsync::aerorsync::real_wire::ClassifiedReassemblyReport
+impl core::cmp::PartialEq for aerorsync::aerorsync::real_wire::ClassifiedReassemblyReport
+pub fn aerorsync::aerorsync::real_wire::ClassifiedReassemblyReport::eq(&self, &aerorsync::aerorsync::real_wire::ClassifiedReassemblyReport) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::real_wire::ClassifiedReassemblyReport
+pub fn aerorsync::aerorsync::real_wire::ClassifiedReassemblyReport::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::real_wire::ClassifiedReassemblyReport
+impl core::marker::Freeze for aerorsync::aerorsync::real_wire::ClassifiedReassemblyReport
+impl core::marker::Send for aerorsync::aerorsync::real_wire::ClassifiedReassemblyReport
+impl core::marker::Sync for aerorsync::aerorsync::real_wire::ClassifiedReassemblyReport
+impl core::marker::Unpin for aerorsync::aerorsync::real_wire::ClassifiedReassemblyReport
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::real_wire::ClassifiedReassemblyReport
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::real_wire::ClassifiedReassemblyReport
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::real_wire::ClassifiedReassemblyReport
+pub struct aerorsync::aerorsync::real_wire::ClientPreamble
+pub aerorsync::aerorsync::real_wire::ClientPreamble::checksum_algos: alloc::string::String
+pub aerorsync::aerorsync::real_wire::ClientPreamble::compression_algos: alloc::string::String
+pub aerorsync::aerorsync::real_wire::ClientPreamble::consumed: usize
+pub aerorsync::aerorsync::real_wire::ClientPreamble::protocol_version: u32
+impl core::clone::Clone for aerorsync::aerorsync::real_wire::ClientPreamble
+pub fn aerorsync::aerorsync::real_wire::ClientPreamble::clone(&self) -> aerorsync::aerorsync::real_wire::ClientPreamble
+impl core::cmp::Eq for aerorsync::aerorsync::real_wire::ClientPreamble
+impl core::cmp::PartialEq for aerorsync::aerorsync::real_wire::ClientPreamble
+pub fn aerorsync::aerorsync::real_wire::ClientPreamble::eq(&self, &aerorsync::aerorsync::real_wire::ClientPreamble) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::real_wire::ClientPreamble
+pub fn aerorsync::aerorsync::real_wire::ClientPreamble::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::real_wire::ClientPreamble
+impl core::marker::Freeze for aerorsync::aerorsync::real_wire::ClientPreamble
+impl core::marker::Send for aerorsync::aerorsync::real_wire::ClientPreamble
+impl core::marker::Sync for aerorsync::aerorsync::real_wire::ClientPreamble
+impl core::marker::Unpin for aerorsync::aerorsync::real_wire::ClientPreamble
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::real_wire::ClientPreamble
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::real_wire::ClientPreamble
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::real_wire::ClientPreamble
+pub struct aerorsync::aerorsync::real_wire::DeflateLiteralStreamEncoder
+impl aerorsync::aerorsync::real_wire::DeflateLiteralStreamEncoder
+pub fn aerorsync::aerorsync::real_wire::DeflateLiteralStreamEncoder::compress_literal(&mut self, &[u8]) -> core::result::Result<alloc::vec::Vec<u8>, aerorsync::aerorsync::real_wire::RealWireError>
+pub fn aerorsync::aerorsync::real_wire::DeflateLiteralStreamEncoder::new() -> Self
+impl core::default::Default for aerorsync::aerorsync::real_wire::DeflateLiteralStreamEncoder
+pub fn aerorsync::aerorsync::real_wire::DeflateLiteralStreamEncoder::default() -> Self
+impl core::marker::Freeze for aerorsync::aerorsync::real_wire::DeflateLiteralStreamEncoder
+impl core::marker::Send for aerorsync::aerorsync::real_wire::DeflateLiteralStreamEncoder
+impl core::marker::Sync for aerorsync::aerorsync::real_wire::DeflateLiteralStreamEncoder
+impl core::marker::Unpin for aerorsync::aerorsync::real_wire::DeflateLiteralStreamEncoder
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::real_wire::DeflateLiteralStreamEncoder
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::real_wire::DeflateLiteralStreamEncoder
+impl !core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::real_wire::DeflateLiteralStreamEncoder
+pub struct aerorsync::aerorsync::real_wire::DeltaStreamReport
+pub aerorsync::aerorsync::real_wire::DeltaStreamReport::file_checksum: alloc::vec::Vec<u8>
+pub aerorsync::aerorsync::real_wire::DeltaStreamReport::ops: alloc::vec::Vec<aerorsync::aerorsync::real_wire::DeltaOp>
+impl core::clone::Clone for aerorsync::aerorsync::real_wire::DeltaStreamReport
+pub fn aerorsync::aerorsync::real_wire::DeltaStreamReport::clone(&self) -> aerorsync::aerorsync::real_wire::DeltaStreamReport
+impl core::cmp::Eq for aerorsync::aerorsync::real_wire::DeltaStreamReport
+impl core::cmp::PartialEq for aerorsync::aerorsync::real_wire::DeltaStreamReport
+pub fn aerorsync::aerorsync::real_wire::DeltaStreamReport::eq(&self, &aerorsync::aerorsync::real_wire::DeltaStreamReport) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::real_wire::DeltaStreamReport
+pub fn aerorsync::aerorsync::real_wire::DeltaStreamReport::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::real_wire::DeltaStreamReport
+impl core::marker::Freeze for aerorsync::aerorsync::real_wire::DeltaStreamReport
+impl core::marker::Send for aerorsync::aerorsync::real_wire::DeltaStreamReport
+impl core::marker::Sync for aerorsync::aerorsync::real_wire::DeltaStreamReport
+impl core::marker::Unpin for aerorsync::aerorsync::real_wire::DeltaStreamReport
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::real_wire::DeltaStreamReport
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::real_wire::DeltaStreamReport
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::real_wire::DeltaStreamReport
+pub struct aerorsync::aerorsync::real_wire::DeltaStreamState
+impl aerorsync::aerorsync::real_wire::DeltaStreamState
+pub fn aerorsync::aerorsync::real_wire::DeltaStreamState::last_run_end(&self) -> i32
+pub fn aerorsync::aerorsync::real_wire::DeltaStreamState::new() -> Self
+impl core::clone::Clone for aerorsync::aerorsync::real_wire::DeltaStreamState
+pub fn aerorsync::aerorsync::real_wire::DeltaStreamState::clone(&self) -> aerorsync::aerorsync::real_wire::DeltaStreamState
+impl core::cmp::Eq for aerorsync::aerorsync::real_wire::DeltaStreamState
+impl core::cmp::PartialEq for aerorsync::aerorsync::real_wire::DeltaStreamState
+pub fn aerorsync::aerorsync::real_wire::DeltaStreamState::eq(&self, &aerorsync::aerorsync::real_wire::DeltaStreamState) -> bool
+impl core::default::Default for aerorsync::aerorsync::real_wire::DeltaStreamState
+pub fn aerorsync::aerorsync::real_wire::DeltaStreamState::default() -> aerorsync::aerorsync::real_wire::DeltaStreamState
+impl core::fmt::Debug for aerorsync::aerorsync::real_wire::DeltaStreamState
+pub fn aerorsync::aerorsync::real_wire::DeltaStreamState::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for aerorsync::aerorsync::real_wire::DeltaStreamState
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::real_wire::DeltaStreamState
+impl core::marker::Freeze for aerorsync::aerorsync::real_wire::DeltaStreamState
+impl core::marker::Send for aerorsync::aerorsync::real_wire::DeltaStreamState
+impl core::marker::Sync for aerorsync::aerorsync::real_wire::DeltaStreamState
+impl core::marker::Unpin for aerorsync::aerorsync::real_wire::DeltaStreamState
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::real_wire::DeltaStreamState
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::real_wire::DeltaStreamState
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::real_wire::DeltaStreamState
+pub struct aerorsync::aerorsync::real_wire::FileListAcls
+pub aerorsync::aerorsync::real_wire::FileListAcls::access: aerorsync::aerorsync::real_wire::AclWireEntry
+pub aerorsync::aerorsync::real_wire::FileListAcls::default: core::option::Option<aerorsync::aerorsync::real_wire::AclWireEntry>
+impl core::clone::Clone for aerorsync::aerorsync::real_wire::FileListAcls
+pub fn aerorsync::aerorsync::real_wire::FileListAcls::clone(&self) -> aerorsync::aerorsync::real_wire::FileListAcls
+impl core::cmp::Eq for aerorsync::aerorsync::real_wire::FileListAcls
+impl core::cmp::PartialEq for aerorsync::aerorsync::real_wire::FileListAcls
+pub fn aerorsync::aerorsync::real_wire::FileListAcls::eq(&self, &aerorsync::aerorsync::real_wire::FileListAcls) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::real_wire::FileListAcls
+pub fn aerorsync::aerorsync::real_wire::FileListAcls::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::real_wire::FileListAcls
+impl core::marker::Freeze for aerorsync::aerorsync::real_wire::FileListAcls
+impl core::marker::Send for aerorsync::aerorsync::real_wire::FileListAcls
+impl core::marker::Sync for aerorsync::aerorsync::real_wire::FileListAcls
+impl core::marker::Unpin for aerorsync::aerorsync::real_wire::FileListAcls
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::real_wire::FileListAcls
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::real_wire::FileListAcls
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::real_wire::FileListAcls
+pub struct aerorsync::aerorsync::real_wire::FileListDecodeOptions<'a>
+pub aerorsync::aerorsync::real_wire::FileListDecodeOptions::always_checksum: bool
+pub aerorsync::aerorsync::real_wire::FileListDecodeOptions::csum_len: usize
+pub aerorsync::aerorsync::real_wire::FileListDecodeOptions::preserve_acls: bool
+pub aerorsync::aerorsync::real_wire::FileListDecodeOptions::preserve_gid: bool
+pub aerorsync::aerorsync::real_wire::FileListDecodeOptions::preserve_uid: bool
+pub aerorsync::aerorsync::real_wire::FileListDecodeOptions::preserve_xattrs: bool
+pub aerorsync::aerorsync::real_wire::FileListDecodeOptions::previous_name: core::option::Option<&'a str>
+pub aerorsync::aerorsync::real_wire::FileListDecodeOptions::protocol: u32
+pub aerorsync::aerorsync::real_wire::FileListDecodeOptions::xfer_flags_as_varint: bool
+impl<'a> aerorsync::aerorsync::real_wire::FileListDecodeOptions<'a>
+pub fn aerorsync::aerorsync::real_wire::FileListDecodeOptions<'a>::frozen_oracle_default() -> Self
+impl<'a> core::clone::Clone for aerorsync::aerorsync::real_wire::FileListDecodeOptions<'a>
+pub fn aerorsync::aerorsync::real_wire::FileListDecodeOptions<'a>::clone(&self) -> aerorsync::aerorsync::real_wire::FileListDecodeOptions<'a>
+impl<'a> core::fmt::Debug for aerorsync::aerorsync::real_wire::FileListDecodeOptions<'a>
+pub fn aerorsync::aerorsync::real_wire::FileListDecodeOptions<'a>::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<'a> core::marker::Freeze for aerorsync::aerorsync::real_wire::FileListDecodeOptions<'a>
+impl<'a> core::marker::Send for aerorsync::aerorsync::real_wire::FileListDecodeOptions<'a>
+impl<'a> core::marker::Sync for aerorsync::aerorsync::real_wire::FileListDecodeOptions<'a>
+impl<'a> core::marker::Unpin for aerorsync::aerorsync::real_wire::FileListDecodeOptions<'a>
+impl<'a> core::marker::UnsafeUnpin for aerorsync::aerorsync::real_wire::FileListDecodeOptions<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::real_wire::FileListDecodeOptions<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::real_wire::FileListDecodeOptions<'a>
+pub struct aerorsync::aerorsync::real_wire::FileListEntry
+pub aerorsync::aerorsync::real_wire::FileListEntry::acls: core::option::Option<aerorsync::aerorsync::real_wire::FileListAcls>
+pub aerorsync::aerorsync::real_wire::FileListEntry::checksum: alloc::vec::Vec<u8>
+pub aerorsync::aerorsync::real_wire::FileListEntry::flags: u32
+pub aerorsync::aerorsync::real_wire::FileListEntry::gid: core::option::Option<i64>
+pub aerorsync::aerorsync::real_wire::FileListEntry::gid_name: core::option::Option<alloc::string::String>
+pub aerorsync::aerorsync::real_wire::FileListEntry::mode: u32
+pub aerorsync::aerorsync::real_wire::FileListEntry::mtime: i64
+pub aerorsync::aerorsync::real_wire::FileListEntry::mtime_nsec: core::option::Option<i32>
+pub aerorsync::aerorsync::real_wire::FileListEntry::path: alloc::string::String
+pub aerorsync::aerorsync::real_wire::FileListEntry::size: i64
+pub aerorsync::aerorsync::real_wire::FileListEntry::symlink_target: core::option::Option<alloc::string::String>
+pub aerorsync::aerorsync::real_wire::FileListEntry::uid: core::option::Option<i64>
+pub aerorsync::aerorsync::real_wire::FileListEntry::uid_name: core::option::Option<alloc::string::String>
+pub aerorsync::aerorsync::real_wire::FileListEntry::xattrs: core::option::Option<alloc::vec::Vec<aerorsync::aerorsync::real_wire::XattrPair>>
+impl core::clone::Clone for aerorsync::aerorsync::real_wire::FileListEntry
+pub fn aerorsync::aerorsync::real_wire::FileListEntry::clone(&self) -> aerorsync::aerorsync::real_wire::FileListEntry
+impl core::cmp::Eq for aerorsync::aerorsync::real_wire::FileListEntry
+impl core::cmp::PartialEq for aerorsync::aerorsync::real_wire::FileListEntry
+pub fn aerorsync::aerorsync::real_wire::FileListEntry::eq(&self, &aerorsync::aerorsync::real_wire::FileListEntry) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::real_wire::FileListEntry
+pub fn aerorsync::aerorsync::real_wire::FileListEntry::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::real_wire::FileListEntry
+impl core::marker::Freeze for aerorsync::aerorsync::real_wire::FileListEntry
+impl core::marker::Send for aerorsync::aerorsync::real_wire::FileListEntry
+impl core::marker::Sync for aerorsync::aerorsync::real_wire::FileListEntry
+impl core::marker::Unpin for aerorsync::aerorsync::real_wire::FileListEntry
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::real_wire::FileListEntry
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::real_wire::FileListEntry
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::real_wire::FileListEntry
+pub struct aerorsync::aerorsync::real_wire::MuxDemuxer<'a>
+impl<'a> aerorsync::aerorsync::real_wire::MuxDemuxer<'a>
+pub fn aerorsync::aerorsync::real_wire::MuxDemuxer<'a>::new(&'a [u8]) -> Self
+pub fn aerorsync::aerorsync::real_wire::MuxDemuxer<'a>::position(&self) -> usize
+pub fn aerorsync::aerorsync::real_wire::MuxDemuxer<'a>::remaining(&self) -> &'a [u8]
+impl<'a> core::iter::traits::iterator::Iterator for aerorsync::aerorsync::real_wire::MuxDemuxer<'a>
+pub type aerorsync::aerorsync::real_wire::MuxDemuxer<'a>::Item = core::result::Result<(aerorsync::aerorsync::real_wire::MuxHeader, &'a [u8]), aerorsync::aerorsync::real_wire::RealWireError>
+pub fn aerorsync::aerorsync::real_wire::MuxDemuxer<'a>::next(&mut self) -> core::option::Option<Self::Item>
+impl<'a> core::marker::Freeze for aerorsync::aerorsync::real_wire::MuxDemuxer<'a>
+impl<'a> core::marker::Send for aerorsync::aerorsync::real_wire::MuxDemuxer<'a>
+impl<'a> core::marker::Sync for aerorsync::aerorsync::real_wire::MuxDemuxer<'a>
+impl<'a> core::marker::Unpin for aerorsync::aerorsync::real_wire::MuxDemuxer<'a>
+impl<'a> core::marker::UnsafeUnpin for aerorsync::aerorsync::real_wire::MuxDemuxer<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::real_wire::MuxDemuxer<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::real_wire::MuxDemuxer<'a>
+pub struct aerorsync::aerorsync::real_wire::MuxHeader
+pub aerorsync::aerorsync::real_wire::MuxHeader::length: u32
+pub aerorsync::aerorsync::real_wire::MuxHeader::tag: aerorsync::aerorsync::real_wire::MuxTag
+impl aerorsync::aerorsync::real_wire::MuxHeader
+pub fn aerorsync::aerorsync::real_wire::MuxHeader::decode([u8; 4]) -> core::result::Result<Self, aerorsync::aerorsync::real_wire::RealWireError>
+pub fn aerorsync::aerorsync::real_wire::MuxHeader::encode(&self) -> [u8; 4]
+impl core::clone::Clone for aerorsync::aerorsync::real_wire::MuxHeader
+pub fn aerorsync::aerorsync::real_wire::MuxHeader::clone(&self) -> aerorsync::aerorsync::real_wire::MuxHeader
+impl core::cmp::Eq for aerorsync::aerorsync::real_wire::MuxHeader
+impl core::cmp::PartialEq for aerorsync::aerorsync::real_wire::MuxHeader
+pub fn aerorsync::aerorsync::real_wire::MuxHeader::eq(&self, &aerorsync::aerorsync::real_wire::MuxHeader) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::real_wire::MuxHeader
+pub fn aerorsync::aerorsync::real_wire::MuxHeader::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::real_wire::MuxHeader
+impl core::marker::Freeze for aerorsync::aerorsync::real_wire::MuxHeader
+impl core::marker::Send for aerorsync::aerorsync::real_wire::MuxHeader
+impl core::marker::Sync for aerorsync::aerorsync::real_wire::MuxHeader
+impl core::marker::Unpin for aerorsync::aerorsync::real_wire::MuxHeader
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::real_wire::MuxHeader
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::real_wire::MuxHeader
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::real_wire::MuxHeader
+pub struct aerorsync::aerorsync::real_wire::MuxStreamReader
+impl aerorsync::aerorsync::real_wire::MuxStreamReader
+pub fn aerorsync::aerorsync::real_wire::MuxStreamReader::buffered(&self) -> usize
+pub fn aerorsync::aerorsync::real_wire::MuxStreamReader::data_bytes_consumed(&self) -> u64
+pub fn aerorsync::aerorsync::real_wire::MuxStreamReader::feed(&mut self, &[u8])
+pub fn aerorsync::aerorsync::real_wire::MuxStreamReader::new() -> Self
+pub fn aerorsync::aerorsync::real_wire::MuxStreamReader::poll_frame(&mut self) -> core::option::Option<core::result::Result<aerorsync::aerorsync::real_wire::MuxPoll, aerorsync::aerorsync::real_wire::RealWireError>>
+pub fn aerorsync::aerorsync::real_wire::MuxStreamReader::terminal_seen(&self) -> bool
+impl core::default::Default for aerorsync::aerorsync::real_wire::MuxStreamReader
+pub fn aerorsync::aerorsync::real_wire::MuxStreamReader::default() -> aerorsync::aerorsync::real_wire::MuxStreamReader
+impl core::fmt::Debug for aerorsync::aerorsync::real_wire::MuxStreamReader
+pub fn aerorsync::aerorsync::real_wire::MuxStreamReader::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aerorsync::aerorsync::real_wire::MuxStreamReader
+impl core::marker::Send for aerorsync::aerorsync::real_wire::MuxStreamReader
+impl core::marker::Sync for aerorsync::aerorsync::real_wire::MuxStreamReader
+impl core::marker::Unpin for aerorsync::aerorsync::real_wire::MuxStreamReader
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::real_wire::MuxStreamReader
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::real_wire::MuxStreamReader
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::real_wire::MuxStreamReader
+pub struct aerorsync::aerorsync::real_wire::NdxState
+impl aerorsync::aerorsync::real_wire::NdxState
+pub fn aerorsync::aerorsync::real_wire::NdxState::new() -> Self
+pub fn aerorsync::aerorsync::real_wire::NdxState::prev_negative(&self) -> i32
+pub fn aerorsync::aerorsync::real_wire::NdxState::prev_positive(&self) -> i32
+impl core::clone::Clone for aerorsync::aerorsync::real_wire::NdxState
+pub fn aerorsync::aerorsync::real_wire::NdxState::clone(&self) -> aerorsync::aerorsync::real_wire::NdxState
+impl core::cmp::Eq for aerorsync::aerorsync::real_wire::NdxState
+impl core::cmp::PartialEq for aerorsync::aerorsync::real_wire::NdxState
+pub fn aerorsync::aerorsync::real_wire::NdxState::eq(&self, &aerorsync::aerorsync::real_wire::NdxState) -> bool
+impl core::default::Default for aerorsync::aerorsync::real_wire::NdxState
+pub fn aerorsync::aerorsync::real_wire::NdxState::default() -> Self
+impl core::fmt::Debug for aerorsync::aerorsync::real_wire::NdxState
+pub fn aerorsync::aerorsync::real_wire::NdxState::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for aerorsync::aerorsync::real_wire::NdxState
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::real_wire::NdxState
+impl core::marker::Freeze for aerorsync::aerorsync::real_wire::NdxState
+impl core::marker::Send for aerorsync::aerorsync::real_wire::NdxState
+impl core::marker::Sync for aerorsync::aerorsync::real_wire::NdxState
+impl core::marker::Unpin for aerorsync::aerorsync::real_wire::NdxState
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::real_wire::NdxState
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::real_wire::NdxState
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::real_wire::NdxState
+pub struct aerorsync::aerorsync::real_wire::ReassemblyReport
+pub aerorsync::aerorsync::real_wire::ReassemblyReport::app_stream: alloc::vec::Vec<u8>
+pub aerorsync::aerorsync::real_wire::ReassemblyReport::frames_consumed: usize
+pub aerorsync::aerorsync::real_wire::ReassemblyReport::oob_frames: alloc::vec::Vec<(aerorsync::aerorsync::real_wire::MuxTag, alloc::vec::Vec<u8>)>
+pub aerorsync::aerorsync::real_wire::ReassemblyReport::out_of_band: alloc::vec::Vec<(aerorsync::aerorsync::real_wire::MuxTag, u32)>
+impl core::clone::Clone for aerorsync::aerorsync::real_wire::ReassemblyReport
+pub fn aerorsync::aerorsync::real_wire::ReassemblyReport::clone(&self) -> aerorsync::aerorsync::real_wire::ReassemblyReport
+impl core::cmp::Eq for aerorsync::aerorsync::real_wire::ReassemblyReport
+impl core::cmp::PartialEq for aerorsync::aerorsync::real_wire::ReassemblyReport
+pub fn aerorsync::aerorsync::real_wire::ReassemblyReport::eq(&self, &aerorsync::aerorsync::real_wire::ReassemblyReport) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::real_wire::ReassemblyReport
+pub fn aerorsync::aerorsync::real_wire::ReassemblyReport::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::real_wire::ReassemblyReport
+impl core::marker::Freeze for aerorsync::aerorsync::real_wire::ReassemblyReport
+impl core::marker::Send for aerorsync::aerorsync::real_wire::ReassemblyReport
+impl core::marker::Sync for aerorsync::aerorsync::real_wire::ReassemblyReport
+impl core::marker::Unpin for aerorsync::aerorsync::real_wire::ReassemblyReport
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::real_wire::ReassemblyReport
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::real_wire::ReassemblyReport
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::real_wire::ReassemblyReport
+pub struct aerorsync::aerorsync::real_wire::RsyncAcl
+pub aerorsync::aerorsync::real_wire::RsyncAcl::group_obj: core::option::Option<u8>
+pub aerorsync::aerorsync::real_wire::RsyncAcl::mask_obj: core::option::Option<u8>
+pub aerorsync::aerorsync::real_wire::RsyncAcl::names: alloc::vec::Vec<aerorsync::aerorsync::real_wire::AclNamedEntry>
+pub aerorsync::aerorsync::real_wire::RsyncAcl::other_obj: core::option::Option<u8>
+pub aerorsync::aerorsync::real_wire::RsyncAcl::user_obj: core::option::Option<u8>
+impl aerorsync::aerorsync::real_wire::RsyncAcl
+pub fn aerorsync::aerorsync::real_wire::RsyncAcl::empty() -> Self
+impl core::clone::Clone for aerorsync::aerorsync::real_wire::RsyncAcl
+pub fn aerorsync::aerorsync::real_wire::RsyncAcl::clone(&self) -> aerorsync::aerorsync::real_wire::RsyncAcl
+impl core::cmp::Eq for aerorsync::aerorsync::real_wire::RsyncAcl
+impl core::cmp::PartialEq for aerorsync::aerorsync::real_wire::RsyncAcl
+pub fn aerorsync::aerorsync::real_wire::RsyncAcl::eq(&self, &aerorsync::aerorsync::real_wire::RsyncAcl) -> bool
+impl core::default::Default for aerorsync::aerorsync::real_wire::RsyncAcl
+pub fn aerorsync::aerorsync::real_wire::RsyncAcl::default() -> aerorsync::aerorsync::real_wire::RsyncAcl
+impl core::fmt::Debug for aerorsync::aerorsync::real_wire::RsyncAcl
+pub fn aerorsync::aerorsync::real_wire::RsyncAcl::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::real_wire::RsyncAcl
+impl core::marker::Freeze for aerorsync::aerorsync::real_wire::RsyncAcl
+impl core::marker::Send for aerorsync::aerorsync::real_wire::RsyncAcl
+impl core::marker::Sync for aerorsync::aerorsync::real_wire::RsyncAcl
+impl core::marker::Unpin for aerorsync::aerorsync::real_wire::RsyncAcl
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::real_wire::RsyncAcl
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::real_wire::RsyncAcl
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::real_wire::RsyncAcl
+pub struct aerorsync::aerorsync::real_wire::ServerPreamble
+pub aerorsync::aerorsync::real_wire::ServerPreamble::checksum_algos: alloc::string::String
+pub aerorsync::aerorsync::real_wire::ServerPreamble::checksum_seed: u32
+pub aerorsync::aerorsync::real_wire::ServerPreamble::compat_flags: i32
+pub aerorsync::aerorsync::real_wire::ServerPreamble::compression_algos: alloc::string::String
+pub aerorsync::aerorsync::real_wire::ServerPreamble::consumed: usize
+pub aerorsync::aerorsync::real_wire::ServerPreamble::protocol_version: u32
+impl core::clone::Clone for aerorsync::aerorsync::real_wire::ServerPreamble
+pub fn aerorsync::aerorsync::real_wire::ServerPreamble::clone(&self) -> aerorsync::aerorsync::real_wire::ServerPreamble
+impl core::cmp::Eq for aerorsync::aerorsync::real_wire::ServerPreamble
+impl core::cmp::PartialEq for aerorsync::aerorsync::real_wire::ServerPreamble
+pub fn aerorsync::aerorsync::real_wire::ServerPreamble::eq(&self, &aerorsync::aerorsync::real_wire::ServerPreamble) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::real_wire::ServerPreamble
+pub fn aerorsync::aerorsync::real_wire::ServerPreamble::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::real_wire::ServerPreamble
+impl core::marker::Freeze for aerorsync::aerorsync::real_wire::ServerPreamble
+impl core::marker::Send for aerorsync::aerorsync::real_wire::ServerPreamble
+impl core::marker::Sync for aerorsync::aerorsync::real_wire::ServerPreamble
+impl core::marker::Unpin for aerorsync::aerorsync::real_wire::ServerPreamble
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::real_wire::ServerPreamble
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::real_wire::ServerPreamble
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::real_wire::ServerPreamble
+pub struct aerorsync::aerorsync::real_wire::SumBlock
+pub aerorsync::aerorsync::real_wire::SumBlock::rolling: u32
+pub aerorsync::aerorsync::real_wire::SumBlock::strong: alloc::vec::Vec<u8>
+impl core::clone::Clone for aerorsync::aerorsync::real_wire::SumBlock
+pub fn aerorsync::aerorsync::real_wire::SumBlock::clone(&self) -> aerorsync::aerorsync::real_wire::SumBlock
+impl core::cmp::Eq for aerorsync::aerorsync::real_wire::SumBlock
+impl core::cmp::PartialEq for aerorsync::aerorsync::real_wire::SumBlock
+pub fn aerorsync::aerorsync::real_wire::SumBlock::eq(&self, &aerorsync::aerorsync::real_wire::SumBlock) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::real_wire::SumBlock
+pub fn aerorsync::aerorsync::real_wire::SumBlock::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::real_wire::SumBlock
+impl core::marker::Freeze for aerorsync::aerorsync::real_wire::SumBlock
+impl core::marker::Send for aerorsync::aerorsync::real_wire::SumBlock
+impl core::marker::Sync for aerorsync::aerorsync::real_wire::SumBlock
+impl core::marker::Unpin for aerorsync::aerorsync::real_wire::SumBlock
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::real_wire::SumBlock
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::real_wire::SumBlock
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::real_wire::SumBlock
+pub struct aerorsync::aerorsync::real_wire::SumHead
+pub aerorsync::aerorsync::real_wire::SumHead::block_length: i32
+pub aerorsync::aerorsync::real_wire::SumHead::checksum_length: i32
+pub aerorsync::aerorsync::real_wire::SumHead::count: i32
+pub aerorsync::aerorsync::real_wire::SumHead::remainder_length: i32
+impl core::clone::Clone for aerorsync::aerorsync::real_wire::SumHead
+pub fn aerorsync::aerorsync::real_wire::SumHead::clone(&self) -> aerorsync::aerorsync::real_wire::SumHead
+impl core::cmp::Eq for aerorsync::aerorsync::real_wire::SumHead
+impl core::cmp::PartialEq for aerorsync::aerorsync::real_wire::SumHead
+pub fn aerorsync::aerorsync::real_wire::SumHead::eq(&self, &aerorsync::aerorsync::real_wire::SumHead) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::real_wire::SumHead
+pub fn aerorsync::aerorsync::real_wire::SumHead::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for aerorsync::aerorsync::real_wire::SumHead
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::real_wire::SumHead
+impl core::marker::Freeze for aerorsync::aerorsync::real_wire::SumHead
+impl core::marker::Send for aerorsync::aerorsync::real_wire::SumHead
+impl core::marker::Sync for aerorsync::aerorsync::real_wire::SumHead
+impl core::marker::Unpin for aerorsync::aerorsync::real_wire::SumHead
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::real_wire::SumHead
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::real_wire::SumHead
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::real_wire::SumHead
+pub struct aerorsync::aerorsync::real_wire::SummaryFrame
+pub aerorsync::aerorsync::real_wire::SummaryFrame::flist_buildtime: core::option::Option<i64>
+pub aerorsync::aerorsync::real_wire::SummaryFrame::flist_xfertime: core::option::Option<i64>
+pub aerorsync::aerorsync::real_wire::SummaryFrame::total_read: i64
+pub aerorsync::aerorsync::real_wire::SummaryFrame::total_size: i64
+pub aerorsync::aerorsync::real_wire::SummaryFrame::total_written: i64
+impl core::clone::Clone for aerorsync::aerorsync::real_wire::SummaryFrame
+pub fn aerorsync::aerorsync::real_wire::SummaryFrame::clone(&self) -> aerorsync::aerorsync::real_wire::SummaryFrame
+impl core::cmp::Eq for aerorsync::aerorsync::real_wire::SummaryFrame
+impl core::cmp::PartialEq for aerorsync::aerorsync::real_wire::SummaryFrame
+pub fn aerorsync::aerorsync::real_wire::SummaryFrame::eq(&self, &aerorsync::aerorsync::real_wire::SummaryFrame) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::real_wire::SummaryFrame
+pub fn aerorsync::aerorsync::real_wire::SummaryFrame::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::real_wire::SummaryFrame
+impl core::marker::Freeze for aerorsync::aerorsync::real_wire::SummaryFrame
+impl core::marker::Send for aerorsync::aerorsync::real_wire::SummaryFrame
+impl core::marker::Sync for aerorsync::aerorsync::real_wire::SummaryFrame
+impl core::marker::Unpin for aerorsync::aerorsync::real_wire::SummaryFrame
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::real_wire::SummaryFrame
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::real_wire::SummaryFrame
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::real_wire::SummaryFrame
+pub struct aerorsync::aerorsync::real_wire::XattrPair
+pub aerorsync::aerorsync::real_wire::XattrPair::datum: aerorsync::aerorsync::real_wire::XattrDatum
+pub aerorsync::aerorsync::real_wire::XattrPair::name: alloc::string::String
+impl aerorsync::aerorsync::real_wire::XattrPair
+pub fn aerorsync::aerorsync::real_wire::XattrPair::inline(impl core::convert::Into<alloc::string::String>, impl core::convert::Into<alloc::vec::Vec<u8>>) -> Self
+impl core::clone::Clone for aerorsync::aerorsync::real_wire::XattrPair
+pub fn aerorsync::aerorsync::real_wire::XattrPair::clone(&self) -> aerorsync::aerorsync::real_wire::XattrPair
+impl core::cmp::Eq for aerorsync::aerorsync::real_wire::XattrPair
+impl core::cmp::PartialEq for aerorsync::aerorsync::real_wire::XattrPair
+pub fn aerorsync::aerorsync::real_wire::XattrPair::eq(&self, &aerorsync::aerorsync::real_wire::XattrPair) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::real_wire::XattrPair
+pub fn aerorsync::aerorsync::real_wire::XattrPair::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::real_wire::XattrPair
+impl core::marker::Freeze for aerorsync::aerorsync::real_wire::XattrPair
+impl core::marker::Send for aerorsync::aerorsync::real_wire::XattrPair
+impl core::marker::Sync for aerorsync::aerorsync::real_wire::XattrPair
+impl core::marker::Unpin for aerorsync::aerorsync::real_wire::XattrPair
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::real_wire::XattrPair
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::real_wire::XattrPair
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::real_wire::XattrPair
+pub struct aerorsync::aerorsync::real_wire::ZstdLiteralStreamEncoder
+impl aerorsync::aerorsync::real_wire::ZstdLiteralStreamEncoder
+pub fn aerorsync::aerorsync::real_wire::ZstdLiteralStreamEncoder::compress_literal(&mut self, &[u8]) -> core::result::Result<alloc::vec::Vec<u8>, aerorsync::aerorsync::real_wire::RealWireError>
+pub fn aerorsync::aerorsync::real_wire::ZstdLiteralStreamEncoder::new() -> core::result::Result<Self, aerorsync::aerorsync::real_wire::RealWireError>
+impl core::marker::Freeze for aerorsync::aerorsync::real_wire::ZstdLiteralStreamEncoder
+impl core::marker::Send for aerorsync::aerorsync::real_wire::ZstdLiteralStreamEncoder
+impl core::marker::Sync for aerorsync::aerorsync::real_wire::ZstdLiteralStreamEncoder
+impl core::marker::Unpin for aerorsync::aerorsync::real_wire::ZstdLiteralStreamEncoder
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::real_wire::ZstdLiteralStreamEncoder
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::real_wire::ZstdLiteralStreamEncoder
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::real_wire::ZstdLiteralStreamEncoder
+pub const aerorsync::aerorsync::real_wire::ACL_ACCESS_MAX: u8
+pub const aerorsync::aerorsync::real_wire::ACL_NAME_FOLLOWS: u8
+pub const aerorsync::aerorsync::real_wire::ACL_NAME_IS_USER: u8
+pub const aerorsync::aerorsync::real_wire::ACL_XBITS_FLAGS_MASK: u8
+pub const aerorsync::aerorsync::real_wire::ACL_XBITS_MAX: u8
+pub const aerorsync::aerorsync::real_wire::ACL_XMIT_FLAGS_MASK: u8
+pub const aerorsync::aerorsync::real_wire::ACL_XMIT_GROUP_OBJ: u8
+pub const aerorsync::aerorsync::real_wire::ACL_XMIT_MASK_OBJ: u8
+pub const aerorsync::aerorsync::real_wire::ACL_XMIT_NAME_LIST: u8
+pub const aerorsync::aerorsync::real_wire::ACL_XMIT_OTHER_OBJ: u8
+pub const aerorsync::aerorsync::real_wire::ACL_XMIT_USER_OBJ: u8
+pub const aerorsync::aerorsync::real_wire::CHECKSUM_SEED_LEN: usize
+pub const aerorsync::aerorsync::real_wire::INT_BYTE_EXTRA: [u8; 64]
+pub const aerorsync::aerorsync::real_wire::MAX_ACL_NAMED_ENTRIES: usize
+pub const aerorsync::aerorsync::real_wire::MAX_ACL_NAME_LEN: usize
+pub const aerorsync::aerorsync::real_wire::MAX_DELTA_LITERAL_LEN: usize
+pub const aerorsync::aerorsync::real_wire::MAX_FULL_DATUM: usize
+pub const aerorsync::aerorsync::real_wire::MAX_XATTR_NAME_LEN: usize
+pub const aerorsync::aerorsync::real_wire::MAX_XATTR_PAIRS: usize
+pub const aerorsync::aerorsync::real_wire::MAX_XATTR_TOTAL_BYTES: usize
+pub const aerorsync::aerorsync::real_wire::MPLEX_BASE: u8
+pub const aerorsync::aerorsync::real_wire::MUX_HEADER_LEN: usize
+pub const aerorsync::aerorsync::real_wire::NDX_DEL_STATS: i32
+pub const aerorsync::aerorsync::real_wire::NDX_DONE: i32
+pub const aerorsync::aerorsync::real_wire::NDX_FLIST_EOF: i32
+pub const aerorsync::aerorsync::real_wire::NDX_FLIST_OFFSET: i32
+pub const aerorsync::aerorsync::real_wire::PROTOCOL_SUMMARY_ADDS_FLIST_TIMES: u32
+pub const aerorsync::aerorsync::real_wire::PROTOCOL_SUMMARY_SWITCHES_TO_VARLONG: u32
+pub const aerorsync::aerorsync::real_wire::PROTOCOL_VERSION_LEN: usize
+pub const aerorsync::aerorsync::real_wire::SUMMARY_VARLONG_MIN_BYTES: u8
+pub const aerorsync::aerorsync::real_wire::SUM_HEAD_MAX_BLOCK_LEN_PROTO30PLUS: i32
+pub const aerorsync::aerorsync::real_wire::SUM_HEAD_MAX_DIGEST_LEN: i32
+pub const aerorsync::aerorsync::real_wire::S_IFDIR: u32
+pub const aerorsync::aerorsync::real_wire::S_IFLNK: u32
+pub const aerorsync::aerorsync::real_wire::S_IFMT: u32
+pub const aerorsync::aerorsync::real_wire::TOKENRUN_LONG: u8
+pub const aerorsync::aerorsync::real_wire::TOKENRUN_REL: u8
+pub const aerorsync::aerorsync::real_wire::TOKEN_DEFLATED_DATA: u8
+pub const aerorsync::aerorsync::real_wire::TOKEN_END_FLAG: u8
+pub const aerorsync::aerorsync::real_wire::TOKEN_LONG: u8
+pub const aerorsync::aerorsync::real_wire::TOKEN_REL: u8
+pub const aerorsync::aerorsync::real_wire::XATTR_DIGEST_LEN: usize
+pub const aerorsync::aerorsync::real_wire::XMIT_EXTENDED_FLAGS: u32
+pub const aerorsync::aerorsync::real_wire::XMIT_GROUP_NAME_FOLLOWS: u32
+pub const aerorsync::aerorsync::real_wire::XMIT_HLINKED: u32
+pub const aerorsync::aerorsync::real_wire::XMIT_HLINK_FIRST: u32
+pub const aerorsync::aerorsync::real_wire::XMIT_IO_ERROR_ENDLIST: u32
+pub const aerorsync::aerorsync::real_wire::XMIT_LONG_NAME: u32
+pub const aerorsync::aerorsync::real_wire::XMIT_MOD_NSEC: u32
+pub const aerorsync::aerorsync::real_wire::XMIT_NO_CONTENT_DIR: u32
+pub const aerorsync::aerorsync::real_wire::XMIT_SAME_ATIME: u32
+pub const aerorsync::aerorsync::real_wire::XMIT_SAME_GID: u32
+pub const aerorsync::aerorsync::real_wire::XMIT_SAME_MODE: u32
+pub const aerorsync::aerorsync::real_wire::XMIT_SAME_NAME: u32
+pub const aerorsync::aerorsync::real_wire::XMIT_SAME_RDEV_MAJOR: u32
+pub const aerorsync::aerorsync::real_wire::XMIT_SAME_TIME: u32
+pub const aerorsync::aerorsync::real_wire::XMIT_SAME_UID: u32
+pub const aerorsync::aerorsync::real_wire::XMIT_TOP_DIR: u32
+pub const aerorsync::aerorsync::real_wire::XMIT_USER_NAME_FOLLOWS: u32
+pub fn aerorsync::aerorsync::real_wire::compress_deflate_literal_stream(&[&[u8]]) -> core::result::Result<alloc::vec::Vec<alloc::vec::Vec<u8>>, aerorsync::aerorsync::real_wire::RealWireError>
+pub fn aerorsync::aerorsync::real_wire::compress_zstd_literal_stream(&[&[u8]]) -> core::result::Result<alloc::vec::Vec<alloc::vec::Vec<u8>>, aerorsync::aerorsync::real_wire::RealWireError>
+pub fn aerorsync::aerorsync::real_wire::decode_client_preamble(&[u8]) -> core::result::Result<aerorsync::aerorsync::real_wire::ClientPreamble, aerorsync::aerorsync::real_wire::RealWireError>
+pub fn aerorsync::aerorsync::real_wire::decode_delta_op(&[u8], &mut aerorsync::aerorsync::real_wire::DeltaStreamState) -> core::result::Result<(aerorsync::aerorsync::real_wire::DeltaOpOutcome, usize), aerorsync::aerorsync::real_wire::RealWireError>
+pub fn aerorsync::aerorsync::real_wire::decode_delta_stream(&[u8], usize, core::option::Option<i32>) -> core::result::Result<(aerorsync::aerorsync::real_wire::DeltaStreamReport, usize), aerorsync::aerorsync::real_wire::RealWireError>
+pub fn aerorsync::aerorsync::real_wire::decode_file_checksum(&[u8], usize) -> core::result::Result<(alloc::vec::Vec<u8>, usize), aerorsync::aerorsync::real_wire::RealWireError>
+pub fn aerorsync::aerorsync::real_wire::decode_file_list_entry(&[u8], &aerorsync::aerorsync::real_wire::FileListDecodeOptions<'_>) -> core::result::Result<(aerorsync::aerorsync::real_wire::FileListDecodeOutcome, usize), aerorsync::aerorsync::real_wire::RealWireError>
+pub fn aerorsync::aerorsync::real_wire::decode_item_flags(&[u8]) -> core::result::Result<(u16, usize), aerorsync::aerorsync::real_wire::RealWireError>
+pub fn aerorsync::aerorsync::real_wire::decode_ndx(&[u8], &mut aerorsync::aerorsync::real_wire::NdxState) -> core::result::Result<(i32, usize), aerorsync::aerorsync::real_wire::RealWireError>
+pub fn aerorsync::aerorsync::real_wire::decode_protocol_version(&[u8]) -> core::result::Result<(u32, usize), aerorsync::aerorsync::real_wire::RealWireError>
+pub fn aerorsync::aerorsync::real_wire::decode_server_preamble(&[u8]) -> core::result::Result<aerorsync::aerorsync::real_wire::ServerPreamble, aerorsync::aerorsync::real_wire::RealWireError>
+pub fn aerorsync::aerorsync::real_wire::decode_sum_block(&[u8], usize) -> core::result::Result<(aerorsync::aerorsync::real_wire::SumBlock, usize), aerorsync::aerorsync::real_wire::RealWireError>
+pub fn aerorsync::aerorsync::real_wire::decode_sum_head(&[u8]) -> core::result::Result<(aerorsync::aerorsync::real_wire::SumHead, usize), aerorsync::aerorsync::real_wire::RealWireError>
+pub fn aerorsync::aerorsync::real_wire::decode_summary_frame(&[u8], u32) -> core::result::Result<(aerorsync::aerorsync::real_wire::SummaryFrame, usize), aerorsync::aerorsync::real_wire::RealWireError>
+pub fn aerorsync::aerorsync::real_wire::decode_varint(&[u8]) -> core::result::Result<(i64, usize), aerorsync::aerorsync::real_wire::RealWireError>
+pub fn aerorsync::aerorsync::real_wire::decode_varlong(&[u8], u8) -> core::result::Result<(i64, usize), aerorsync::aerorsync::real_wire::RealWireError>
+pub fn aerorsync::aerorsync::real_wire::decompress_deflate_literal_stream(&[&[u8]]) -> core::result::Result<alloc::vec::Vec<u8>, aerorsync::aerorsync::real_wire::RealWireError>
+pub fn aerorsync::aerorsync::real_wire::decompress_deflate_literal_stream_boundaries(&[&[u8]]) -> core::result::Result<alloc::vec::Vec<alloc::vec::Vec<u8>>, aerorsync::aerorsync::real_wire::RealWireError>
+pub fn aerorsync::aerorsync::real_wire::decompress_zstd_literal_stream(&[&[u8]]) -> core::result::Result<alloc::vec::Vec<u8>, aerorsync::aerorsync::real_wire::RealWireError>
+pub fn aerorsync::aerorsync::real_wire::decompress_zstd_literal_stream_boundaries(&[&[u8]]) -> core::result::Result<alloc::vec::Vec<alloc::vec::Vec<u8>>, aerorsync::aerorsync::real_wire::RealWireError>
+pub fn aerorsync::aerorsync::real_wire::encode_client_preamble(&aerorsync::aerorsync::real_wire::ClientPreamble) -> alloc::vec::Vec<u8>
+pub fn aerorsync::aerorsync::real_wire::encode_delta_op(&aerorsync::aerorsync::real_wire::DeltaOp, &mut aerorsync::aerorsync::real_wire::DeltaStreamState) -> alloc::vec::Vec<u8>
+pub fn aerorsync::aerorsync::real_wire::encode_delta_stream(&aerorsync::aerorsync::real_wire::DeltaStreamReport) -> alloc::vec::Vec<u8>
+pub fn aerorsync::aerorsync::real_wire::encode_file_checksum(&[u8]) -> alloc::vec::Vec<u8>
+pub fn aerorsync::aerorsync::real_wire::encode_file_list_entry(&aerorsync::aerorsync::real_wire::FileListEntry, &aerorsync::aerorsync::real_wire::FileListDecodeOptions<'_>) -> alloc::vec::Vec<u8>
+pub fn aerorsync::aerorsync::real_wire::encode_file_list_terminator(&aerorsync::aerorsync::real_wire::FileListDecodeOptions<'_>) -> alloc::vec::Vec<u8>
+pub fn aerorsync::aerorsync::real_wire::encode_item_flags(u16) -> [u8; 2]
+pub fn aerorsync::aerorsync::real_wire::encode_ndx(i32, &mut aerorsync::aerorsync::real_wire::NdxState) -> alloc::vec::Vec<u8>
+pub fn aerorsync::aerorsync::real_wire::encode_protocol_version(u32) -> [u8; 4]
+pub fn aerorsync::aerorsync::real_wire::encode_server_preamble(&aerorsync::aerorsync::real_wire::ServerPreamble) -> alloc::vec::Vec<u8>
+pub fn aerorsync::aerorsync::real_wire::encode_sum_block(&aerorsync::aerorsync::real_wire::SumBlock) -> alloc::vec::Vec<u8>
+pub fn aerorsync::aerorsync::real_wire::encode_sum_head(&aerorsync::aerorsync::real_wire::SumHead) -> [u8; 16]
+pub fn aerorsync::aerorsync::real_wire::encode_summary_frame(&aerorsync::aerorsync::real_wire::SummaryFrame, u32) -> alloc::vec::Vec<u8>
+pub fn aerorsync::aerorsync::real_wire::encode_varint(i32) -> alloc::vec::Vec<u8>
+pub fn aerorsync::aerorsync::real_wire::encode_varlong(i64, u8) -> alloc::vec::Vec<u8>
+pub fn aerorsync::aerorsync::real_wire::encode_xattr_datum_section(&[aerorsync::aerorsync::real_wire::XattrPair]) -> alloc::vec::Vec<u8>
+pub fn aerorsync::aerorsync::real_wire::is_directory_mode(u32) -> bool
+pub fn aerorsync::aerorsync::real_wire::is_symlink_mode(u32) -> bool
+pub fn aerorsync::aerorsync::real_wire::reassemble_msg_data(&[u8]) -> core::result::Result<aerorsync::aerorsync::real_wire::ReassemblyReport, aerorsync::aerorsync::real_wire::RealWireError>
+pub fn aerorsync::aerorsync::real_wire::reassemble_until_terminal(&[u8]) -> core::result::Result<aerorsync::aerorsync::real_wire::ClassifiedReassemblyReport, aerorsync::aerorsync::real_wire::RealWireError>
+pub fn aerorsync::aerorsync::real_wire::reassemble_with_events(&[u8]) -> core::result::Result<aerorsync::aerorsync::real_wire::ClassifiedReassemblyReport, aerorsync::aerorsync::real_wire::RealWireError>
+pub fn aerorsync::aerorsync::real_wire::resolve_xattr_datum_section(&[u8], &mut [aerorsync::aerorsync::real_wire::XattrPair]) -> core::result::Result<usize, aerorsync::aerorsync::real_wire::RealWireError>
+pub fn aerorsync::aerorsync::real_wire::xattr_value_digest(&[u8]) -> [u8; 16]
+pub mod aerorsync::aerorsync::remote_command
+pub enum aerorsync::aerorsync::remote_command::RemoteCommandFlavor
+pub aerorsync::aerorsync::remote_command::RemoteCommandFlavor::AerorsyncServe
+pub aerorsync::aerorsync::remote_command::RemoteCommandFlavor::WrapperParity
+impl core::clone::Clone for aerorsync::aerorsync::remote_command::RemoteCommandFlavor
+pub fn aerorsync::aerorsync::remote_command::RemoteCommandFlavor::clone(&self) -> aerorsync::aerorsync::remote_command::RemoteCommandFlavor
+impl core::cmp::Eq for aerorsync::aerorsync::remote_command::RemoteCommandFlavor
+impl core::cmp::PartialEq for aerorsync::aerorsync::remote_command::RemoteCommandFlavor
+pub fn aerorsync::aerorsync::remote_command::RemoteCommandFlavor::eq(&self, &aerorsync::aerorsync::remote_command::RemoteCommandFlavor) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::remote_command::RemoteCommandFlavor
+pub fn aerorsync::aerorsync::remote_command::RemoteCommandFlavor::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for aerorsync::aerorsync::remote_command::RemoteCommandFlavor
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::remote_command::RemoteCommandFlavor
+impl core::marker::Freeze for aerorsync::aerorsync::remote_command::RemoteCommandFlavor
+impl core::marker::Send for aerorsync::aerorsync::remote_command::RemoteCommandFlavor
+impl core::marker::Sync for aerorsync::aerorsync::remote_command::RemoteCommandFlavor
+impl core::marker::Unpin for aerorsync::aerorsync::remote_command::RemoteCommandFlavor
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::remote_command::RemoteCommandFlavor
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::remote_command::RemoteCommandFlavor
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::remote_command::RemoteCommandFlavor
+pub struct aerorsync::aerorsync::remote_command::RemoteCommandSpec
+pub aerorsync::aerorsync::remote_command::RemoteCommandSpec::emit_stats: bool
+pub aerorsync::aerorsync::remote_command::RemoteCommandSpec::flavor: aerorsync::aerorsync::remote_command::RemoteCommandFlavor
+pub aerorsync::aerorsync::remote_command::RemoteCommandSpec::preserve_acls: bool
+pub aerorsync::aerorsync::remote_command::RemoteCommandSpec::preserve_xattrs: bool
+pub aerorsync::aerorsync::remote_command::RemoteCommandSpec::remote_role: aerorsync::aerorsync::types::SessionRole
+pub aerorsync::aerorsync::remote_command::RemoteCommandSpec::remote_target: alloc::string::String
+impl aerorsync::aerorsync::remote_command::RemoteCommandSpec
+pub fn aerorsync::aerorsync::remote_command::RemoteCommandSpec::aerorsync_download(impl core::convert::Into<alloc::string::String>) -> Self
+pub fn aerorsync::aerorsync::remote_command::RemoteCommandSpec::aerorsync_upload(impl core::convert::Into<alloc::string::String>) -> Self
+pub fn aerorsync::aerorsync::remote_command::RemoteCommandSpec::download(impl core::convert::Into<alloc::string::String>) -> Self
+pub fn aerorsync::aerorsync::remote_command::RemoteCommandSpec::to_args(&self) -> alloc::vec::Vec<alloc::string::String>
+pub fn aerorsync::aerorsync::remote_command::RemoteCommandSpec::to_command_line(&self) -> alloc::string::String
+pub fn aerorsync::aerorsync::remote_command::RemoteCommandSpec::to_exec_request(&self) -> aerorsync::aerorsync::transport::RemoteExecRequest
+pub fn aerorsync::aerorsync::remote_command::RemoteCommandSpec::upload(impl core::convert::Into<alloc::string::String>) -> Self
+pub fn aerorsync::aerorsync::remote_command::RemoteCommandSpec::with_acls(self, bool) -> Self
+pub fn aerorsync::aerorsync::remote_command::RemoteCommandSpec::with_xattrs(self, bool) -> Self
+impl core::clone::Clone for aerorsync::aerorsync::remote_command::RemoteCommandSpec
+pub fn aerorsync::aerorsync::remote_command::RemoteCommandSpec::clone(&self) -> aerorsync::aerorsync::remote_command::RemoteCommandSpec
+impl core::cmp::Eq for aerorsync::aerorsync::remote_command::RemoteCommandSpec
+impl core::cmp::PartialEq for aerorsync::aerorsync::remote_command::RemoteCommandSpec
+pub fn aerorsync::aerorsync::remote_command::RemoteCommandSpec::eq(&self, &aerorsync::aerorsync::remote_command::RemoteCommandSpec) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::remote_command::RemoteCommandSpec
+pub fn aerorsync::aerorsync::remote_command::RemoteCommandSpec::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::remote_command::RemoteCommandSpec
+impl core::marker::Freeze for aerorsync::aerorsync::remote_command::RemoteCommandSpec
+impl core::marker::Send for aerorsync::aerorsync::remote_command::RemoteCommandSpec
+impl core::marker::Sync for aerorsync::aerorsync::remote_command::RemoteCommandSpec
+impl core::marker::Unpin for aerorsync::aerorsync::remote_command::RemoteCommandSpec
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::remote_command::RemoteCommandSpec
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::remote_command::RemoteCommandSpec
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::remote_command::RemoteCommandSpec
+pub const aerorsync::aerorsync::remote_command::AERORSYNC_SERVER_PROGRAM: &str
+pub const aerorsync::aerorsync::remote_command::OBSERVED_COMPACT_FLAGS: &str
+pub const aerorsync::aerorsync::remote_command::OBSERVED_COMPACT_FLAGS_ACL: &str
+pub const aerorsync::aerorsync::remote_command::OBSERVED_COMPACT_FLAGS_ACL_XATTR: &str
+pub const aerorsync::aerorsync::remote_command::OBSERVED_COMPACT_FLAGS_XATTR: &str
+pub const aerorsync::aerorsync::remote_command::PRODUCT_COMPACT_FLAGS: &str
+pub const aerorsync::aerorsync::remote_command::PRODUCT_COMPACT_FLAGS_ACL: &str
+pub const aerorsync::aerorsync::remote_command::PRODUCT_COMPACT_FLAGS_ACL_XATTR: &str
+pub const aerorsync::aerorsync::remote_command::PRODUCT_COMPACT_FLAGS_XATTR: &str
+pub const aerorsync::aerorsync::remote_command::REMOTE_WORKDIR_PLACEHOLDER: &str
+pub fn aerorsync::aerorsync::remote_command::compact_flags_for(bool, bool) -> &'static str
+pub mod aerorsync::aerorsync::russh_session_transport
+pub struct aerorsync::aerorsync::russh_session_transport::RusshHandler
+impl russh::client::Handler for aerorsync::aerorsync::russh_session_transport::RusshHandler
+pub type aerorsync::aerorsync::russh_session_transport::RusshHandler::Error = russh::Error
+pub async fn aerorsync::aerorsync::russh_session_transport::RusshHandler::check_server_key(&mut self, &russh::cert::PublicKeyOrCertificate) -> core::result::Result<bool, Self::Error>
+impl core::marker::Freeze for aerorsync::aerorsync::russh_session_transport::RusshHandler
+impl core::marker::Send for aerorsync::aerorsync::russh_session_transport::RusshHandler
+impl core::marker::Sync for aerorsync::aerorsync::russh_session_transport::RusshHandler
+impl core::marker::Unpin for aerorsync::aerorsync::russh_session_transport::RusshHandler
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::russh_session_transport::RusshHandler
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::russh_session_transport::RusshHandler
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::russh_session_transport::RusshHandler
+pub struct aerorsync::aerorsync::russh_session_transport::RusshRawStream
+impl aerorsync::aerorsync::transport::RawByteStream for aerorsync::aerorsync::russh_session_transport::RusshRawStream
+pub fn aerorsync::aerorsync::russh_session_transport::RusshRawStream::read_bytes<'life0, 'async_trait>(&'life0 mut self, usize) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<alloc::vec::Vec<u8>, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::russh_session_transport::RusshRawStream::shutdown<'life0, 'async_trait>(&'life0 mut self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::russh_session_transport::RusshRawStream::write_bytes<'life0, 'life1, 'async_trait>(&'life0 mut self, &'life1 [u8]) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+impl core::marker::Freeze for aerorsync::aerorsync::russh_session_transport::RusshRawStream
+impl core::marker::Send for aerorsync::aerorsync::russh_session_transport::RusshRawStream
+impl core::marker::Sync for aerorsync::aerorsync::russh_session_transport::RusshRawStream
+impl core::marker::Unpin for aerorsync::aerorsync::russh_session_transport::RusshRawStream
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::russh_session_transport::RusshRawStream
+impl !core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::russh_session_transport::RusshRawStream
+impl !core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::russh_session_transport::RusshRawStream
+pub struct aerorsync::aerorsync::russh_session_transport::RusshSessionTransport
+impl aerorsync::aerorsync::russh_session_transport::RusshSessionTransport
+pub async fn aerorsync::aerorsync::russh_session_transport::RusshSessionTransport::cancel(&self)
+pub async fn aerorsync::aerorsync::russh_session_transport::RusshSessionTransport::close(&self) -> core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>
+pub async fn aerorsync::aerorsync::russh_session_transport::RusshSessionTransport::connect(aerorsync::aerorsync::ssh_transport::SshTransportConfig) -> core::result::Result<Self, aerorsync::aerorsync::types::AerorsyncError>
+pub fn aerorsync::aerorsync::russh_session_transport::RusshSessionTransport::endpoint_host(&self) -> &str
+pub fn aerorsync::aerorsync::russh_session_transport::RusshSessionTransport::handshake_count(&self) -> u32
+pub async fn aerorsync::aerorsync::russh_session_transport::RusshSessionTransport::open_raw_channel(&self, aerorsync::aerorsync::transport::RemoteExecRequest) -> core::result::Result<aerorsync::aerorsync::russh_session_transport::RusshRawStream, aerorsync::aerorsync::types::AerorsyncError>
+pub fn aerorsync::aerorsync::russh_session_transport::RusshSessionTransport::raw_open_count(&self) -> u32
+pub async fn aerorsync::aerorsync::russh_session_transport::RusshSessionTransport::reconnect(&self) -> core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>
+pub fn aerorsync::aerorsync::russh_session_transport::RusshSessionTransport::share_session(&self) -> Self
+impl aerorsync::aerorsync::transport::RawRemoteShellTransport for aerorsync::aerorsync::russh_session_transport::RusshSessionTransport
+pub type aerorsync::aerorsync::russh_session_transport::RusshSessionTransport::RawStream = aerorsync::aerorsync::russh_session_transport::RusshRawStream
+pub fn aerorsync::aerorsync::russh_session_transport::RusshSessionTransport::open_raw_stream<'life0, 'async_trait>(&'life0 self, aerorsync::aerorsync::transport::RemoteExecRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<Self::RawStream, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+impl aerorsync::aerorsync::transport::RemoteShellTransport for aerorsync::aerorsync::russh_session_transport::RusshSessionTransport
+pub type aerorsync::aerorsync::russh_session_transport::RusshSessionTransport::Stream = aerorsync::aerorsync::russh_session_transport::RusshUnusedStream
+pub fn aerorsync::aerorsync::russh_session_transport::RusshSessionTransport::cancel<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::russh_session_transport::RusshSessionTransport::cancel_handle(&self) -> aerorsync::aerorsync::transport::CancelHandle
+pub fn aerorsync::aerorsync::russh_session_transport::RusshSessionTransport::exec<'life0, 'async_trait>(&'life0 self, aerorsync::aerorsync::transport::RemoteExecRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<aerorsync::aerorsync::transport::RemoteCommandOutput, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::russh_session_transport::RusshSessionTransport::open_stream<'life0, 'async_trait>(&'life0 self, aerorsync::aerorsync::transport::RemoteExecRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<Self::Stream, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::russh_session_transport::RusshSessionTransport::probe<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<aerorsync::aerorsync::transport::TransportProbe, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+impl core::marker::Freeze for aerorsync::aerorsync::russh_session_transport::RusshSessionTransport
+impl core::marker::Send for aerorsync::aerorsync::russh_session_transport::RusshSessionTransport
+impl core::marker::Sync for aerorsync::aerorsync::russh_session_transport::RusshSessionTransport
+impl core::marker::Unpin for aerorsync::aerorsync::russh_session_transport::RusshSessionTransport
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::russh_session_transport::RusshSessionTransport
+impl !core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::russh_session_transport::RusshSessionTransport
+impl !core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::russh_session_transport::RusshSessionTransport
+pub struct aerorsync::aerorsync::russh_session_transport::RusshUnusedStream
+impl aerorsync::aerorsync::transport::BidirectionalByteStream for aerorsync::aerorsync::russh_session_transport::RusshUnusedStream
+pub fn aerorsync::aerorsync::russh_session_transport::RusshUnusedStream::read_frame<'life0, 'async_trait>(&'life0 mut self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<alloc::vec::Vec<u8>, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::russh_session_transport::RusshUnusedStream::shutdown<'life0, 'async_trait>(&'life0 mut self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::russh_session_transport::RusshUnusedStream::write_frame<'life0, 'life1, 'async_trait>(&'life0 mut self, &'life1 [u8]) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+impl core::marker::Freeze for aerorsync::aerorsync::russh_session_transport::RusshUnusedStream
+impl core::marker::Send for aerorsync::aerorsync::russh_session_transport::RusshUnusedStream
+impl core::marker::Sync for aerorsync::aerorsync::russh_session_transport::RusshUnusedStream
+impl core::marker::Unpin for aerorsync::aerorsync::russh_session_transport::RusshUnusedStream
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::russh_session_transport::RusshUnusedStream
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::russh_session_transport::RusshUnusedStream
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::russh_session_transport::RusshUnusedStream
+pub mod aerorsync::aerorsync::shell_escape
+pub fn aerorsync::aerorsync::shell_escape::shell_escape_posix(&str) -> alloc::string::String
+pub mod aerorsync::aerorsync::ssh_transport
+pub enum aerorsync::aerorsync::ssh_transport::SshHostKeyPolicy
+pub aerorsync::aerorsync::ssh_transport::SshHostKeyPolicy::AcceptAny
+pub aerorsync::aerorsync::ssh_transport::SshHostKeyPolicy::PinnedFingerprintSha256
+pub aerorsync::aerorsync::ssh_transport::SshHostKeyPolicy::PinnedFingerprintSha256::sha256_hex: alloc::string::String
+impl aerorsync::aerorsync::ssh_transport::SshHostKeyPolicy
+pub fn aerorsync::aerorsync::ssh_transport::SshHostKeyPolicy::pinned_hex(impl core::convert::Into<alloc::string::String>) -> Self
+impl core::clone::Clone for aerorsync::aerorsync::ssh_transport::SshHostKeyPolicy
+pub fn aerorsync::aerorsync::ssh_transport::SshHostKeyPolicy::clone(&self) -> aerorsync::aerorsync::ssh_transport::SshHostKeyPolicy
+impl core::cmp::Eq for aerorsync::aerorsync::ssh_transport::SshHostKeyPolicy
+impl core::cmp::PartialEq for aerorsync::aerorsync::ssh_transport::SshHostKeyPolicy
+pub fn aerorsync::aerorsync::ssh_transport::SshHostKeyPolicy::eq(&self, &aerorsync::aerorsync::ssh_transport::SshHostKeyPolicy) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::ssh_transport::SshHostKeyPolicy
+pub fn aerorsync::aerorsync::ssh_transport::SshHostKeyPolicy::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::ssh_transport::SshHostKeyPolicy
+impl core::marker::Freeze for aerorsync::aerorsync::ssh_transport::SshHostKeyPolicy
+impl core::marker::Send for aerorsync::aerorsync::ssh_transport::SshHostKeyPolicy
+impl core::marker::Sync for aerorsync::aerorsync::ssh_transport::SshHostKeyPolicy
+impl core::marker::Unpin for aerorsync::aerorsync::ssh_transport::SshHostKeyPolicy
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::ssh_transport::SshHostKeyPolicy
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::ssh_transport::SshHostKeyPolicy
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::ssh_transport::SshHostKeyPolicy
+pub struct aerorsync::aerorsync::ssh_transport::SshProtoStream
+impl aerorsync::aerorsync::transport::BidirectionalByteStream for aerorsync::aerorsync::ssh_transport::SshProtoStream
+pub fn aerorsync::aerorsync::ssh_transport::SshProtoStream::read_frame<'life0, 'async_trait>(&'life0 mut self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<alloc::vec::Vec<u8>, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::ssh_transport::SshProtoStream::shutdown<'life0, 'async_trait>(&'life0 mut self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::ssh_transport::SshProtoStream::write_frame<'life0, 'life1, 'async_trait>(&'life0 mut self, &'life1 [u8]) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+impl core::marker::Freeze for aerorsync::aerorsync::ssh_transport::SshProtoStream
+impl core::marker::Send for aerorsync::aerorsync::ssh_transport::SshProtoStream
+impl core::marker::Sync for aerorsync::aerorsync::ssh_transport::SshProtoStream
+impl core::marker::Unpin for aerorsync::aerorsync::ssh_transport::SshProtoStream
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::ssh_transport::SshProtoStream
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::ssh_transport::SshProtoStream
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::ssh_transport::SshProtoStream
+pub struct aerorsync::aerorsync::ssh_transport::SshRawStream
+impl aerorsync::aerorsync::transport::RawByteStream for aerorsync::aerorsync::ssh_transport::SshRawStream
+pub fn aerorsync::aerorsync::ssh_transport::SshRawStream::read_bytes<'life0, 'async_trait>(&'life0 mut self, usize) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<alloc::vec::Vec<u8>, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::ssh_transport::SshRawStream::shutdown<'life0, 'async_trait>(&'life0 mut self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::ssh_transport::SshRawStream::write_bytes<'life0, 'life1, 'async_trait>(&'life0 mut self, &'life1 [u8]) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+impl core::marker::Freeze for aerorsync::aerorsync::ssh_transport::SshRawStream
+impl core::marker::Send for aerorsync::aerorsync::ssh_transport::SshRawStream
+impl core::marker::Sync for aerorsync::aerorsync::ssh_transport::SshRawStream
+impl core::marker::Unpin for aerorsync::aerorsync::ssh_transport::SshRawStream
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::ssh_transport::SshRawStream
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::ssh_transport::SshRawStream
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::ssh_transport::SshRawStream
+pub struct aerorsync::aerorsync::ssh_transport::SshRemoteShellTransport
+impl aerorsync::aerorsync::ssh_transport::SshRemoteShellTransport
+pub fn aerorsync::aerorsync::ssh_transport::SshRemoteShellTransport::new(aerorsync::aerorsync::ssh_transport::SshTransportConfig) -> Self
+impl aerorsync::aerorsync::transport::RawRemoteShellTransport for aerorsync::aerorsync::ssh_transport::SshRemoteShellTransport
+pub type aerorsync::aerorsync::ssh_transport::SshRemoteShellTransport::RawStream = aerorsync::aerorsync::ssh_transport::SshRawStream
+pub fn aerorsync::aerorsync::ssh_transport::SshRemoteShellTransport::open_raw_stream<'life0, 'async_trait>(&'life0 self, aerorsync::aerorsync::transport::RemoteExecRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<Self::RawStream, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+impl aerorsync::aerorsync::transport::RemoteShellTransport for aerorsync::aerorsync::ssh_transport::SshRemoteShellTransport
+pub type aerorsync::aerorsync::ssh_transport::SshRemoteShellTransport::Stream = aerorsync::aerorsync::ssh_transport::SshProtoStream
+pub fn aerorsync::aerorsync::ssh_transport::SshRemoteShellTransport::cancel<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::ssh_transport::SshRemoteShellTransport::cancel_handle(&self) -> aerorsync::aerorsync::transport::CancelHandle
+pub fn aerorsync::aerorsync::ssh_transport::SshRemoteShellTransport::exec<'life0, 'async_trait>(&'life0 self, aerorsync::aerorsync::transport::RemoteExecRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<aerorsync::aerorsync::transport::RemoteCommandOutput, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::ssh_transport::SshRemoteShellTransport::open_stream<'life0, 'async_trait>(&'life0 self, aerorsync::aerorsync::transport::RemoteExecRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<Self::Stream, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::ssh_transport::SshRemoteShellTransport::probe<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<aerorsync::aerorsync::transport::TransportProbe, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+impl core::marker::Freeze for aerorsync::aerorsync::ssh_transport::SshRemoteShellTransport
+impl core::marker::Send for aerorsync::aerorsync::ssh_transport::SshRemoteShellTransport
+impl core::marker::Sync for aerorsync::aerorsync::ssh_transport::SshRemoteShellTransport
+impl core::marker::Unpin for aerorsync::aerorsync::ssh_transport::SshRemoteShellTransport
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::ssh_transport::SshRemoteShellTransport
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::ssh_transport::SshRemoteShellTransport
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::ssh_transport::SshRemoteShellTransport
+pub struct aerorsync::aerorsync::ssh_transport::SshTransportConfig
+pub aerorsync::aerorsync::ssh_transport::SshTransportConfig::auth_agent: bool
+pub aerorsync::aerorsync::ssh_transport::SshTransportConfig::auth_password: core::option::Option<secrecy::SecretString>
+pub aerorsync::aerorsync::ssh_transport::SshTransportConfig::connect_timeout_ms: u64
+pub aerorsync::aerorsync::ssh_transport::SshTransportConfig::host: alloc::string::String
+pub aerorsync::aerorsync::ssh_transport::SshTransportConfig::host_key_policy: aerorsync::aerorsync::ssh_transport::SshHostKeyPolicy
+pub aerorsync::aerorsync::ssh_transport::SshTransportConfig::io_timeout_ms: u64
+pub aerorsync::aerorsync::ssh_transport::SshTransportConfig::max_frame_size: usize
+pub aerorsync::aerorsync::ssh_transport::SshTransportConfig::port: u16
+pub aerorsync::aerorsync::ssh_transport::SshTransportConfig::private_key_path: std::path::PathBuf
+pub aerorsync::aerorsync::ssh_transport::SshTransportConfig::probe_request: aerorsync::aerorsync::transport::RemoteExecRequest
+pub aerorsync::aerorsync::ssh_transport::SshTransportConfig::username: alloc::string::String
+pub aerorsync::aerorsync::ssh_transport::SshTransportConfig::worker_idle_poll_ms: u64
+impl aerorsync::aerorsync::ssh_transport::SshTransportConfig
+pub fn aerorsync::aerorsync::ssh_transport::SshTransportConfig::localhost_test(std::path::PathBuf, usize) -> Self
+pub fn aerorsync::aerorsync::ssh_transport::SshTransportConfig::prefers_russh_leg(&self) -> bool
+pub fn aerorsync::aerorsync::ssh_transport::SshTransportConfig::usable_password(&self) -> core::option::Option<&secrecy::SecretString>
+impl core::clone::Clone for aerorsync::aerorsync::ssh_transport::SshTransportConfig
+pub fn aerorsync::aerorsync::ssh_transport::SshTransportConfig::clone(&self) -> aerorsync::aerorsync::ssh_transport::SshTransportConfig
+impl core::fmt::Debug for aerorsync::aerorsync::ssh_transport::SshTransportConfig
+pub fn aerorsync::aerorsync::ssh_transport::SshTransportConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aerorsync::aerorsync::ssh_transport::SshTransportConfig
+impl core::marker::Send for aerorsync::aerorsync::ssh_transport::SshTransportConfig
+impl core::marker::Sync for aerorsync::aerorsync::ssh_transport::SshTransportConfig
+impl core::marker::Unpin for aerorsync::aerorsync::ssh_transport::SshTransportConfig
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::ssh_transport::SshTransportConfig
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::ssh_transport::SshTransportConfig
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::ssh_transport::SshTransportConfig
+pub const aerorsync::aerorsync::ssh_transport::AERORSYNC_HOST_KEY_ALGS: &str
+pub mod aerorsync::aerorsync::streaming_writer
+pub enum aerorsync::aerorsync::streaming_writer::WriteAtomicError
+pub aerorsync::aerorsync::streaming_writer::WriteAtomicError::PostOpen
+pub aerorsync::aerorsync::streaming_writer::WriteAtomicError::PostOpen::source: core::io::error::Error
+pub aerorsync::aerorsync::streaming_writer::WriteAtomicError::PostOpen::stage: &'static str
+pub aerorsync::aerorsync::streaming_writer::WriteAtomicError::PreOpen(core::io::error::Error)
+impl core::fmt::Debug for aerorsync::aerorsync::streaming_writer::WriteAtomicError
+pub fn aerorsync::aerorsync::streaming_writer::WriteAtomicError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aerorsync::aerorsync::streaming_writer::WriteAtomicError
+impl core::marker::Send for aerorsync::aerorsync::streaming_writer::WriteAtomicError
+impl core::marker::Sync for aerorsync::aerorsync::streaming_writer::WriteAtomicError
+impl core::marker::Unpin for aerorsync::aerorsync::streaming_writer::WriteAtomicError
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::streaming_writer::WriteAtomicError
+impl !core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::streaming_writer::WriteAtomicError
+impl !core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::streaming_writer::WriteAtomicError
+pub struct aerorsync::aerorsync::streaming_writer::StreamingAtomicWriter
+impl aerorsync::aerorsync::streaming_writer::StreamingAtomicWriter
+pub fn aerorsync::aerorsync::streaming_writer::StreamingAtomicWriter::bytes_written(&self) -> u64
+pub fn aerorsync::aerorsync::streaming_writer::StreamingAtomicWriter::committed(&self) -> bool
+pub async fn aerorsync::aerorsync::streaming_writer::StreamingAtomicWriter::finalize(self, core::option::Option<u32>, core::option::Option<(i64, u32)>, core::option::Option<alloc::vec::Vec<aerorsync::aerorsync::real_wire::XattrPair>>, core::option::Option<aerorsync::aerorsync::real_wire::FileListAcls>, bool) -> core::result::Result<alloc::vec::Vec<alloc::string::String>, aerorsync::aerorsync::streaming_writer::WriteAtomicError>
+pub async fn aerorsync::aerorsync::streaming_writer::StreamingAtomicWriter::new(&std::path::Path) -> core::io::error::Result<Self>
+pub fn aerorsync::aerorsync::streaming_writer::StreamingAtomicWriter::temp_path(&self) -> &std::path::Path
+impl tokio::io::async_write::AsyncWrite for aerorsync::aerorsync::streaming_writer::StreamingAtomicWriter
+pub fn aerorsync::aerorsync::streaming_writer::StreamingAtomicWriter::poll_flush(core::pin::Pin<&mut Self>, &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<core::io::error::Result<()>>
+pub fn aerorsync::aerorsync::streaming_writer::StreamingAtomicWriter::poll_shutdown(core::pin::Pin<&mut Self>, &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<core::io::error::Result<()>>
+pub fn aerorsync::aerorsync::streaming_writer::StreamingAtomicWriter::poll_write(core::pin::Pin<&mut Self>, &mut core::task::wake::Context<'_>, &[u8]) -> core::task::poll::Poll<core::io::error::Result<usize>>
+impl !core::marker::Freeze for aerorsync::aerorsync::streaming_writer::StreamingAtomicWriter
+impl core::marker::Send for aerorsync::aerorsync::streaming_writer::StreamingAtomicWriter
+impl core::marker::Sync for aerorsync::aerorsync::streaming_writer::StreamingAtomicWriter
+impl core::marker::Unpin for aerorsync::aerorsync::streaming_writer::StreamingAtomicWriter
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::streaming_writer::StreamingAtomicWriter
+impl !core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::streaming_writer::StreamingAtomicWriter
+impl !core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::streaming_writer::StreamingAtomicWriter
+pub async fn aerorsync::aerorsync::streaming_writer::write_atomic_chunked(&std::path::Path, &[u8], usize, core::option::Option<core::time::Duration>, core::option::Option<u32>, core::option::Option<(i64, core::option::Option<i32>)>) -> core::result::Result<(), aerorsync::aerorsync::streaming_writer::WriteAtomicError>
+pub async fn aerorsync::aerorsync::streaming_writer::write_atomic_chunked_sparse(&std::path::Path, &[u8], usize, core::option::Option<core::time::Duration>, core::option::Option<u32>, core::option::Option<(i64, core::option::Option<i32>)>) -> core::result::Result<(), aerorsync::aerorsync::streaming_writer::WriteAtomicError>
+pub mod aerorsync::aerorsync::transport
+pub struct aerorsync::aerorsync::transport::CancelHandle
+impl aerorsync::aerorsync::transport::CancelHandle
+pub fn aerorsync::aerorsync::transport::CancelHandle::cancel(&self)
+pub fn aerorsync::aerorsync::transport::CancelHandle::inert() -> Self
+pub fn aerorsync::aerorsync::transport::CancelHandle::new(alloc::sync::Arc<core::sync::atomic::AtomicBool>, core::option::Option<alloc::sync::Arc<(dyn core::ops::function::Fn() + core::marker::Send + core::marker::Sync)>>) -> Self
+pub fn aerorsync::aerorsync::transport::CancelHandle::requested(&self) -> bool
+impl core::clone::Clone for aerorsync::aerorsync::transport::CancelHandle
+pub fn aerorsync::aerorsync::transport::CancelHandle::clone(&self) -> aerorsync::aerorsync::transport::CancelHandle
+impl core::fmt::Debug for aerorsync::aerorsync::transport::CancelHandle
+pub fn aerorsync::aerorsync::transport::CancelHandle::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aerorsync::aerorsync::transport::CancelHandle
+impl core::marker::Send for aerorsync::aerorsync::transport::CancelHandle
+impl core::marker::Sync for aerorsync::aerorsync::transport::CancelHandle
+impl core::marker::Unpin for aerorsync::aerorsync::transport::CancelHandle
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::transport::CancelHandle
+impl !core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::transport::CancelHandle
+impl !core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::transport::CancelHandle
+pub struct aerorsync::aerorsync::transport::RemoteCommandOutput
+pub aerorsync::aerorsync::transport::RemoteCommandOutput::exit_code: i32
+pub aerorsync::aerorsync::transport::RemoteCommandOutput::stderr: alloc::vec::Vec<u8>
+pub aerorsync::aerorsync::transport::RemoteCommandOutput::stdout: alloc::vec::Vec<u8>
+impl core::clone::Clone for aerorsync::aerorsync::transport::RemoteCommandOutput
+pub fn aerorsync::aerorsync::transport::RemoteCommandOutput::clone(&self) -> aerorsync::aerorsync::transport::RemoteCommandOutput
+impl core::cmp::Eq for aerorsync::aerorsync::transport::RemoteCommandOutput
+impl core::cmp::PartialEq for aerorsync::aerorsync::transport::RemoteCommandOutput
+pub fn aerorsync::aerorsync::transport::RemoteCommandOutput::eq(&self, &aerorsync::aerorsync::transport::RemoteCommandOutput) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::transport::RemoteCommandOutput
+pub fn aerorsync::aerorsync::transport::RemoteCommandOutput::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::transport::RemoteCommandOutput
+impl core::marker::Freeze for aerorsync::aerorsync::transport::RemoteCommandOutput
+impl core::marker::Send for aerorsync::aerorsync::transport::RemoteCommandOutput
+impl core::marker::Sync for aerorsync::aerorsync::transport::RemoteCommandOutput
+impl core::marker::Unpin for aerorsync::aerorsync::transport::RemoteCommandOutput
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::transport::RemoteCommandOutput
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::transport::RemoteCommandOutput
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::transport::RemoteCommandOutput
+pub struct aerorsync::aerorsync::transport::RemoteExecRequest
+pub aerorsync::aerorsync::transport::RemoteExecRequest::args: alloc::vec::Vec<alloc::string::String>
+pub aerorsync::aerorsync::transport::RemoteExecRequest::environment: alloc::vec::Vec<(alloc::string::String, alloc::string::String)>
+pub aerorsync::aerorsync::transport::RemoteExecRequest::program: alloc::string::String
+impl aerorsync::aerorsync::transport::RemoteExecRequest
+pub fn aerorsync::aerorsync::transport::RemoteExecRequest::full_command_line(&self) -> alloc::string::String
+impl core::clone::Clone for aerorsync::aerorsync::transport::RemoteExecRequest
+pub fn aerorsync::aerorsync::transport::RemoteExecRequest::clone(&self) -> aerorsync::aerorsync::transport::RemoteExecRequest
+impl core::cmp::Eq for aerorsync::aerorsync::transport::RemoteExecRequest
+impl core::cmp::PartialEq for aerorsync::aerorsync::transport::RemoteExecRequest
+pub fn aerorsync::aerorsync::transport::RemoteExecRequest::eq(&self, &aerorsync::aerorsync::transport::RemoteExecRequest) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::transport::RemoteExecRequest
+pub fn aerorsync::aerorsync::transport::RemoteExecRequest::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::transport::RemoteExecRequest
+impl core::marker::Freeze for aerorsync::aerorsync::transport::RemoteExecRequest
+impl core::marker::Send for aerorsync::aerorsync::transport::RemoteExecRequest
+impl core::marker::Sync for aerorsync::aerorsync::transport::RemoteExecRequest
+impl core::marker::Unpin for aerorsync::aerorsync::transport::RemoteExecRequest
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::transport::RemoteExecRequest
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::transport::RemoteExecRequest
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::transport::RemoteExecRequest
+pub struct aerorsync::aerorsync::transport::TransportProbe
+pub aerorsync::aerorsync::transport::TransportProbe::protocol: aerorsync::aerorsync::types::ProtocolVersion
+pub aerorsync::aerorsync::transport::TransportProbe::remote_banner: alloc::string::String
+pub aerorsync::aerorsync::transport::TransportProbe::supports_remote_shell: bool
+impl core::clone::Clone for aerorsync::aerorsync::transport::TransportProbe
+pub fn aerorsync::aerorsync::transport::TransportProbe::clone(&self) -> aerorsync::aerorsync::transport::TransportProbe
+impl core::cmp::Eq for aerorsync::aerorsync::transport::TransportProbe
+impl core::cmp::PartialEq for aerorsync::aerorsync::transport::TransportProbe
+pub fn aerorsync::aerorsync::transport::TransportProbe::eq(&self, &aerorsync::aerorsync::transport::TransportProbe) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::transport::TransportProbe
+pub fn aerorsync::aerorsync::transport::TransportProbe::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::transport::TransportProbe
+impl core::marker::Freeze for aerorsync::aerorsync::transport::TransportProbe
+impl core::marker::Send for aerorsync::aerorsync::transport::TransportProbe
+impl core::marker::Sync for aerorsync::aerorsync::transport::TransportProbe
+impl core::marker::Unpin for aerorsync::aerorsync::transport::TransportProbe
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::transport::TransportProbe
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::transport::TransportProbe
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::transport::TransportProbe
+pub trait aerorsync::aerorsync::transport::BidirectionalByteStream: core::marker::Send
+pub fn aerorsync::aerorsync::transport::BidirectionalByteStream::read_frame<'life0, 'async_trait>(&'life0 mut self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<alloc::vec::Vec<u8>, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::transport::BidirectionalByteStream::shutdown<'life0, 'async_trait>(&'life0 mut self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::transport::BidirectionalByteStream::write_frame<'life0, 'life1, 'async_trait>(&'life0 mut self, &'life1 [u8]) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+impl aerorsync::aerorsync::transport::BidirectionalByteStream for aerorsync::aerorsync::mock::MockStream
+pub fn aerorsync::aerorsync::mock::MockStream::read_frame<'life0, 'async_trait>(&'life0 mut self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<alloc::vec::Vec<u8>, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::mock::MockStream::shutdown<'life0, 'async_trait>(&'life0 mut self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::mock::MockStream::write_frame<'life0, 'life1, 'async_trait>(&'life0 mut self, &'life1 [u8]) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+impl aerorsync::aerorsync::transport::BidirectionalByteStream for aerorsync::aerorsync::russh_session_transport::RusshUnusedStream
+pub fn aerorsync::aerorsync::russh_session_transport::RusshUnusedStream::read_frame<'life0, 'async_trait>(&'life0 mut self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<alloc::vec::Vec<u8>, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::russh_session_transport::RusshUnusedStream::shutdown<'life0, 'async_trait>(&'life0 mut self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::russh_session_transport::RusshUnusedStream::write_frame<'life0, 'life1, 'async_trait>(&'life0 mut self, &'life1 [u8]) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+impl aerorsync::aerorsync::transport::BidirectionalByteStream for aerorsync::aerorsync::ssh_transport::SshProtoStream
+pub fn aerorsync::aerorsync::ssh_transport::SshProtoStream::read_frame<'life0, 'async_trait>(&'life0 mut self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<alloc::vec::Vec<u8>, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::ssh_transport::SshProtoStream::shutdown<'life0, 'async_trait>(&'life0 mut self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::ssh_transport::SshProtoStream::write_frame<'life0, 'life1, 'async_trait>(&'life0 mut self, &'life1 [u8]) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub trait aerorsync::aerorsync::transport::RawByteStream: core::marker::Send
+pub fn aerorsync::aerorsync::transport::RawByteStream::read_bytes<'life0, 'async_trait>(&'life0 mut self, usize) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<alloc::vec::Vec<u8>, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::transport::RawByteStream::shutdown<'life0, 'async_trait>(&'life0 mut self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::transport::RawByteStream::write_bytes<'life0, 'life1, 'async_trait>(&'life0 mut self, &'life1 [u8]) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+impl aerorsync::aerorsync::transport::RawByteStream for aerorsync::aerorsync::mock::MockRawStream
+pub fn aerorsync::aerorsync::mock::MockRawStream::read_bytes<'life0, 'async_trait>(&'life0 mut self, usize) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<alloc::vec::Vec<u8>, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::mock::MockRawStream::shutdown<'life0, 'async_trait>(&'life0 mut self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::mock::MockRawStream::write_bytes<'life0, 'life1, 'async_trait>(&'life0 mut self, &'life1 [u8]) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+impl aerorsync::aerorsync::transport::RawByteStream for aerorsync::aerorsync::russh_session_transport::RusshRawStream
+pub fn aerorsync::aerorsync::russh_session_transport::RusshRawStream::read_bytes<'life0, 'async_trait>(&'life0 mut self, usize) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<alloc::vec::Vec<u8>, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::russh_session_transport::RusshRawStream::shutdown<'life0, 'async_trait>(&'life0 mut self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::russh_session_transport::RusshRawStream::write_bytes<'life0, 'life1, 'async_trait>(&'life0 mut self, &'life1 [u8]) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+impl aerorsync::aerorsync::transport::RawByteStream for aerorsync::aerorsync::ssh_transport::SshRawStream
+pub fn aerorsync::aerorsync::ssh_transport::SshRawStream::read_bytes<'life0, 'async_trait>(&'life0 mut self, usize) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<alloc::vec::Vec<u8>, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::ssh_transport::SshRawStream::shutdown<'life0, 'async_trait>(&'life0 mut self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::ssh_transport::SshRawStream::write_bytes<'life0, 'life1, 'async_trait>(&'life0 mut self, &'life1 [u8]) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub trait aerorsync::aerorsync::transport::RawRemoteShellTransport: aerorsync::aerorsync::transport::RemoteShellTransport
+pub type aerorsync::aerorsync::transport::RawRemoteShellTransport::RawStream: aerorsync::aerorsync::transport::RawByteStream + core::marker::Send
+pub fn aerorsync::aerorsync::transport::RawRemoteShellTransport::open_raw_stream<'life0, 'async_trait>(&'life0 self, aerorsync::aerorsync::transport::RemoteExecRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<Self::RawStream, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+impl aerorsync::aerorsync::transport::RawRemoteShellTransport for aerorsync::aerorsync::mock::MockRemoteShellTransport
+pub type aerorsync::aerorsync::mock::MockRemoteShellTransport::RawStream = aerorsync::aerorsync::mock::MockRawStream
+pub fn aerorsync::aerorsync::mock::MockRemoteShellTransport::open_raw_stream<'life0, 'async_trait>(&'life0 self, aerorsync::aerorsync::transport::RemoteExecRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<Self::RawStream, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+impl aerorsync::aerorsync::transport::RawRemoteShellTransport for aerorsync::aerorsync::russh_session_transport::RusshSessionTransport
+pub type aerorsync::aerorsync::russh_session_transport::RusshSessionTransport::RawStream = aerorsync::aerorsync::russh_session_transport::RusshRawStream
+pub fn aerorsync::aerorsync::russh_session_transport::RusshSessionTransport::open_raw_stream<'life0, 'async_trait>(&'life0 self, aerorsync::aerorsync::transport::RemoteExecRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<Self::RawStream, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+impl aerorsync::aerorsync::transport::RawRemoteShellTransport for aerorsync::aerorsync::ssh_transport::SshRemoteShellTransport
+pub type aerorsync::aerorsync::ssh_transport::SshRemoteShellTransport::RawStream = aerorsync::aerorsync::ssh_transport::SshRawStream
+pub fn aerorsync::aerorsync::ssh_transport::SshRemoteShellTransport::open_raw_stream<'life0, 'async_trait>(&'life0 self, aerorsync::aerorsync::transport::RemoteExecRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<Self::RawStream, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub trait aerorsync::aerorsync::transport::RemoteShellTransport: core::marker::Send + core::marker::Sync
+pub type aerorsync::aerorsync::transport::RemoteShellTransport::Stream: aerorsync::aerorsync::transport::BidirectionalByteStream + core::marker::Send
+pub fn aerorsync::aerorsync::transport::RemoteShellTransport::cancel<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::transport::RemoteShellTransport::cancel_handle(&self) -> aerorsync::aerorsync::transport::CancelHandle
+pub fn aerorsync::aerorsync::transport::RemoteShellTransport::exec<'life0, 'async_trait>(&'life0 self, aerorsync::aerorsync::transport::RemoteExecRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<aerorsync::aerorsync::transport::RemoteCommandOutput, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::transport::RemoteShellTransport::open_stream<'life0, 'async_trait>(&'life0 self, aerorsync::aerorsync::transport::RemoteExecRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<Self::Stream, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::transport::RemoteShellTransport::probe<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<aerorsync::aerorsync::transport::TransportProbe, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+impl aerorsync::aerorsync::transport::RemoteShellTransport for aerorsync::aerorsync::mock::MockRemoteShellTransport
+pub type aerorsync::aerorsync::mock::MockRemoteShellTransport::Stream = aerorsync::aerorsync::mock::MockStream
+pub fn aerorsync::aerorsync::mock::MockRemoteShellTransport::cancel<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::mock::MockRemoteShellTransport::cancel_handle(&self) -> aerorsync::aerorsync::transport::CancelHandle
+pub fn aerorsync::aerorsync::mock::MockRemoteShellTransport::exec<'life0, 'async_trait>(&'life0 self, aerorsync::aerorsync::transport::RemoteExecRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<aerorsync::aerorsync::transport::RemoteCommandOutput, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::mock::MockRemoteShellTransport::open_stream<'life0, 'async_trait>(&'life0 self, aerorsync::aerorsync::transport::RemoteExecRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<Self::Stream, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::mock::MockRemoteShellTransport::probe<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<aerorsync::aerorsync::transport::TransportProbe, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+impl aerorsync::aerorsync::transport::RemoteShellTransport for aerorsync::aerorsync::russh_session_transport::RusshSessionTransport
+pub type aerorsync::aerorsync::russh_session_transport::RusshSessionTransport::Stream = aerorsync::aerorsync::russh_session_transport::RusshUnusedStream
+pub fn aerorsync::aerorsync::russh_session_transport::RusshSessionTransport::cancel<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::russh_session_transport::RusshSessionTransport::cancel_handle(&self) -> aerorsync::aerorsync::transport::CancelHandle
+pub fn aerorsync::aerorsync::russh_session_transport::RusshSessionTransport::exec<'life0, 'async_trait>(&'life0 self, aerorsync::aerorsync::transport::RemoteExecRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<aerorsync::aerorsync::transport::RemoteCommandOutput, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::russh_session_transport::RusshSessionTransport::open_stream<'life0, 'async_trait>(&'life0 self, aerorsync::aerorsync::transport::RemoteExecRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<Self::Stream, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::russh_session_transport::RusshSessionTransport::probe<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<aerorsync::aerorsync::transport::TransportProbe, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+impl aerorsync::aerorsync::transport::RemoteShellTransport for aerorsync::aerorsync::ssh_transport::SshRemoteShellTransport
+pub type aerorsync::aerorsync::ssh_transport::SshRemoteShellTransport::Stream = aerorsync::aerorsync::ssh_transport::SshProtoStream
+pub fn aerorsync::aerorsync::ssh_transport::SshRemoteShellTransport::cancel<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<(), aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::ssh_transport::SshRemoteShellTransport::cancel_handle(&self) -> aerorsync::aerorsync::transport::CancelHandle
+pub fn aerorsync::aerorsync::ssh_transport::SshRemoteShellTransport::exec<'life0, 'async_trait>(&'life0 self, aerorsync::aerorsync::transport::RemoteExecRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<aerorsync::aerorsync::transport::RemoteCommandOutput, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::ssh_transport::SshRemoteShellTransport::open_stream<'life0, 'async_trait>(&'life0 self, aerorsync::aerorsync::transport::RemoteExecRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<Self::Stream, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn aerorsync::aerorsync::ssh_transport::SshRemoteShellTransport::probe<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<aerorsync::aerorsync::transport::TransportProbe, aerorsync::aerorsync::types::AerorsyncError>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub mod aerorsync::aerorsync::types
+pub enum aerorsync::aerorsync::types::AerorsyncErrorKind
+pub aerorsync::aerorsync::types::AerorsyncErrorKind::Cancelled
+pub aerorsync::aerorsync::types::AerorsyncErrorKind::HostKeyRejected
+pub aerorsync::aerorsync::types::AerorsyncErrorKind::IllegalStateTransition
+pub aerorsync::aerorsync::types::AerorsyncErrorKind::Internal
+pub aerorsync::aerorsync::types::AerorsyncErrorKind::InvalidFrame
+pub aerorsync::aerorsync::types::AerorsyncErrorKind::NegotiationFailed
+pub aerorsync::aerorsync::types::AerorsyncErrorKind::PlannerRejected
+pub aerorsync::aerorsync::types::AerorsyncErrorKind::RemoteError
+pub aerorsync::aerorsync::types::AerorsyncErrorKind::TransportFailure
+pub aerorsync::aerorsync::types::AerorsyncErrorKind::UnexpectedMessage
+pub aerorsync::aerorsync::types::AerorsyncErrorKind::UnsupportedVersion
+impl core::clone::Clone for aerorsync::aerorsync::types::AerorsyncErrorKind
+pub fn aerorsync::aerorsync::types::AerorsyncErrorKind::clone(&self) -> aerorsync::aerorsync::types::AerorsyncErrorKind
+impl core::cmp::Eq for aerorsync::aerorsync::types::AerorsyncErrorKind
+impl core::cmp::PartialEq for aerorsync::aerorsync::types::AerorsyncErrorKind
+pub fn aerorsync::aerorsync::types::AerorsyncErrorKind::eq(&self, &aerorsync::aerorsync::types::AerorsyncErrorKind) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::types::AerorsyncErrorKind
+pub fn aerorsync::aerorsync::types::AerorsyncErrorKind::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for aerorsync::aerorsync::types::AerorsyncErrorKind
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::types::AerorsyncErrorKind
+impl serde_core::ser::Serialize for aerorsync::aerorsync::types::AerorsyncErrorKind
+pub fn aerorsync::aerorsync::types::AerorsyncErrorKind::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for aerorsync::aerorsync::types::AerorsyncErrorKind
+pub fn aerorsync::aerorsync::types::AerorsyncErrorKind::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for aerorsync::aerorsync::types::AerorsyncErrorKind
+impl core::marker::Send for aerorsync::aerorsync::types::AerorsyncErrorKind
+impl core::marker::Sync for aerorsync::aerorsync::types::AerorsyncErrorKind
+impl core::marker::Unpin for aerorsync::aerorsync::types::AerorsyncErrorKind
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::types::AerorsyncErrorKind
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::types::AerorsyncErrorKind
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::types::AerorsyncErrorKind
+pub enum aerorsync::aerorsync::types::FeatureFlag
+pub aerorsync::aerorsync::types::FeatureFlag::DeltaTransfer
+pub aerorsync::aerorsync::types::FeatureFlag::IncrementalFileList
+pub aerorsync::aerorsync::types::FeatureFlag::PreserveTimes
+pub aerorsync::aerorsync::types::FeatureFlag::ResumeMarkers
+pub aerorsync::aerorsync::types::FeatureFlag::StructuredErrors
+impl core::clone::Clone for aerorsync::aerorsync::types::FeatureFlag
+pub fn aerorsync::aerorsync::types::FeatureFlag::clone(&self) -> aerorsync::aerorsync::types::FeatureFlag
+impl core::cmp::Eq for aerorsync::aerorsync::types::FeatureFlag
+impl core::cmp::PartialEq for aerorsync::aerorsync::types::FeatureFlag
+pub fn aerorsync::aerorsync::types::FeatureFlag::eq(&self, &aerorsync::aerorsync::types::FeatureFlag) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::types::FeatureFlag
+pub fn aerorsync::aerorsync::types::FeatureFlag::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::types::FeatureFlag
+impl serde_core::ser::Serialize for aerorsync::aerorsync::types::FeatureFlag
+pub fn aerorsync::aerorsync::types::FeatureFlag::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for aerorsync::aerorsync::types::FeatureFlag
+pub fn aerorsync::aerorsync::types::FeatureFlag::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for aerorsync::aerorsync::types::FeatureFlag
+impl core::marker::Send for aerorsync::aerorsync::types::FeatureFlag
+impl core::marker::Sync for aerorsync::aerorsync::types::FeatureFlag
+impl core::marker::Unpin for aerorsync::aerorsync::types::FeatureFlag
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::types::FeatureFlag
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::types::FeatureFlag
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::types::FeatureFlag
+pub enum aerorsync::aerorsync::types::SessionRole
+pub aerorsync::aerorsync::types::SessionRole::Receiver
+pub aerorsync::aerorsync::types::SessionRole::Sender
+impl aerorsync::aerorsync::types::SessionRole
+pub fn aerorsync::aerorsync::types::SessionRole::as_flag_bit(self) -> u16
+pub fn aerorsync::aerorsync::types::SessionRole::is_remote_sender(self) -> bool
+impl core::clone::Clone for aerorsync::aerorsync::types::SessionRole
+pub fn aerorsync::aerorsync::types::SessionRole::clone(&self) -> aerorsync::aerorsync::types::SessionRole
+impl core::cmp::Eq for aerorsync::aerorsync::types::SessionRole
+impl core::cmp::PartialEq for aerorsync::aerorsync::types::SessionRole
+pub fn aerorsync::aerorsync::types::SessionRole::eq(&self, &aerorsync::aerorsync::types::SessionRole) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::types::SessionRole
+pub fn aerorsync::aerorsync::types::SessionRole::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for aerorsync::aerorsync::types::SessionRole
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::types::SessionRole
+impl serde_core::ser::Serialize for aerorsync::aerorsync::types::SessionRole
+pub fn aerorsync::aerorsync::types::SessionRole::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for aerorsync::aerorsync::types::SessionRole
+pub fn aerorsync::aerorsync::types::SessionRole::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for aerorsync::aerorsync::types::SessionRole
+impl core::marker::Send for aerorsync::aerorsync::types::SessionRole
+impl core::marker::Sync for aerorsync::aerorsync::types::SessionRole
+impl core::marker::Unpin for aerorsync::aerorsync::types::SessionRole
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::types::SessionRole
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::types::SessionRole
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::types::SessionRole
+pub enum aerorsync::aerorsync::types::TransferError
+pub aerorsync::aerorsync::types::TransferError::Hard
+pub aerorsync::aerorsync::types::TransferError::Hard::detail: alloc::string::String
+pub aerorsync::aerorsync::types::TransferError::Io(core::io::error::Error)
+pub aerorsync::aerorsync::types::TransferError::Native
+pub aerorsync::aerorsync::types::TransferError::Native::committed: bool
+pub aerorsync::aerorsync::types::TransferError::Native::error: aerorsync::aerorsync::types::AerorsyncError
+pub aerorsync::aerorsync::types::TransferError::Soft
+pub aerorsync::aerorsync::types::TransferError::Soft::detail: alloc::string::String
+pub aerorsync::aerorsync::types::TransferError::TooSmall
+pub aerorsync::aerorsync::types::TransferError::TooSmall::size: u64
+pub aerorsync::aerorsync::types::TransferError::TooSmall::threshold: u64
+impl aerorsync::aerorsync::types::TransferError
+pub fn aerorsync::aerorsync::types::TransferError::is_transient_channel_drop(&self) -> bool
+pub fn aerorsync::aerorsync::types::TransferError::variant_name(&self) -> &'static str
+pub fn aerorsync::aerorsync::types::TransferError::verdict(&self) -> core::option::Option<aerorsync::aerorsync::fallback_policy::FallbackVerdict>
+impl core::error::Error for aerorsync::aerorsync::types::TransferError
+impl core::fmt::Debug for aerorsync::aerorsync::types::TransferError
+pub fn aerorsync::aerorsync::types::TransferError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for aerorsync::aerorsync::types::TransferError
+pub fn aerorsync::aerorsync::types::TransferError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aerorsync::aerorsync::types::TransferError
+impl core::marker::Send for aerorsync::aerorsync::types::TransferError
+impl core::marker::Sync for aerorsync::aerorsync::types::TransferError
+impl core::marker::Unpin for aerorsync::aerorsync::types::TransferError
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::types::TransferError
+impl !core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::types::TransferError
+impl !core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::types::TransferError
+pub enum aerorsync::aerorsync::types::TransferStrategy
+pub aerorsync::aerorsync::types::TransferStrategy::Delta
+pub aerorsync::aerorsync::types::TransferStrategy::FullCopy
+pub aerorsync::aerorsync::types::TransferStrategy::Skip
+impl core::clone::Clone for aerorsync::aerorsync::types::TransferStrategy
+pub fn aerorsync::aerorsync::types::TransferStrategy::clone(&self) -> aerorsync::aerorsync::types::TransferStrategy
+impl core::cmp::Eq for aerorsync::aerorsync::types::TransferStrategy
+impl core::cmp::PartialEq for aerorsync::aerorsync::types::TransferStrategy
+pub fn aerorsync::aerorsync::types::TransferStrategy::eq(&self, &aerorsync::aerorsync::types::TransferStrategy) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::types::TransferStrategy
+pub fn aerorsync::aerorsync::types::TransferStrategy::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for aerorsync::aerorsync::types::TransferStrategy
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::types::TransferStrategy
+impl serde_core::ser::Serialize for aerorsync::aerorsync::types::TransferStrategy
+pub fn aerorsync::aerorsync::types::TransferStrategy::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for aerorsync::aerorsync::types::TransferStrategy
+pub fn aerorsync::aerorsync::types::TransferStrategy::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for aerorsync::aerorsync::types::TransferStrategy
+impl core::marker::Send for aerorsync::aerorsync::types::TransferStrategy
+impl core::marker::Sync for aerorsync::aerorsync::types::TransferStrategy
+impl core::marker::Unpin for aerorsync::aerorsync::types::TransferStrategy
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::types::TransferStrategy
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::types::TransferStrategy
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::types::TransferStrategy
+pub enum aerorsync::aerorsync::types::TransportErrorClass
+pub aerorsync::aerorsync::types::TransportErrorClass::CleanEof
+impl core::clone::Clone for aerorsync::aerorsync::types::TransportErrorClass
+pub fn aerorsync::aerorsync::types::TransportErrorClass::clone(&self) -> aerorsync::aerorsync::types::TransportErrorClass
+impl core::cmp::Eq for aerorsync::aerorsync::types::TransportErrorClass
+impl core::cmp::PartialEq for aerorsync::aerorsync::types::TransportErrorClass
+pub fn aerorsync::aerorsync::types::TransportErrorClass::eq(&self, &aerorsync::aerorsync::types::TransportErrorClass) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::types::TransportErrorClass
+pub fn aerorsync::aerorsync::types::TransportErrorClass::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for aerorsync::aerorsync::types::TransportErrorClass
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::types::TransportErrorClass
+impl serde_core::ser::Serialize for aerorsync::aerorsync::types::TransportErrorClass
+pub fn aerorsync::aerorsync::types::TransportErrorClass::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for aerorsync::aerorsync::types::TransportErrorClass
+pub fn aerorsync::aerorsync::types::TransportErrorClass::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for aerorsync::aerorsync::types::TransportErrorClass
+impl core::marker::Send for aerorsync::aerorsync::types::TransportErrorClass
+impl core::marker::Sync for aerorsync::aerorsync::types::TransportErrorClass
+impl core::marker::Unpin for aerorsync::aerorsync::types::TransportErrorClass
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::types::TransportErrorClass
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::types::TransportErrorClass
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::types::TransportErrorClass
+pub struct aerorsync::aerorsync::types::AerorsyncConfig
+pub aerorsync::aerorsync::types::AerorsyncConfig::allow_compression: bool
+pub aerorsync::aerorsync::types::AerorsyncConfig::allow_preserve_times: bool
+pub aerorsync::aerorsync::types::AerorsyncConfig::io_timeout_ms: u64
+pub aerorsync::aerorsync::types::AerorsyncConfig::max_frame_size: usize
+pub aerorsync::aerorsync::types::AerorsyncConfig::min_delta_file_size: u64
+pub aerorsync::aerorsync::types::AerorsyncConfig::protocol: aerorsync::aerorsync::types::ProtocolVersion
+impl core::clone::Clone for aerorsync::aerorsync::types::AerorsyncConfig
+pub fn aerorsync::aerorsync::types::AerorsyncConfig::clone(&self) -> aerorsync::aerorsync::types::AerorsyncConfig
+impl core::default::Default for aerorsync::aerorsync::types::AerorsyncConfig
+pub fn aerorsync::aerorsync::types::AerorsyncConfig::default() -> Self
+impl core::fmt::Debug for aerorsync::aerorsync::types::AerorsyncConfig
+pub fn aerorsync::aerorsync::types::AerorsyncConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl serde_core::ser::Serialize for aerorsync::aerorsync::types::AerorsyncConfig
+pub fn aerorsync::aerorsync::types::AerorsyncConfig::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for aerorsync::aerorsync::types::AerorsyncConfig
+pub fn aerorsync::aerorsync::types::AerorsyncConfig::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for aerorsync::aerorsync::types::AerorsyncConfig
+impl core::marker::Send for aerorsync::aerorsync::types::AerorsyncConfig
+impl core::marker::Sync for aerorsync::aerorsync::types::AerorsyncConfig
+impl core::marker::Unpin for aerorsync::aerorsync::types::AerorsyncConfig
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::types::AerorsyncConfig
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::types::AerorsyncConfig
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::types::AerorsyncConfig
+pub struct aerorsync::aerorsync::types::AerorsyncError
+pub aerorsync::aerorsync::types::AerorsyncError::detail: alloc::string::String
+pub aerorsync::aerorsync::types::AerorsyncError::kind: aerorsync::aerorsync::types::AerorsyncErrorKind
+pub aerorsync::aerorsync::types::AerorsyncError::transport_class: core::option::Option<aerorsync::aerorsync::types::TransportErrorClass>
+impl aerorsync::aerorsync::types::AerorsyncError
+pub fn aerorsync::aerorsync::types::AerorsyncError::cancelled(impl core::convert::Into<alloc::string::String>) -> Self
+pub fn aerorsync::aerorsync::types::AerorsyncError::from_oob_event(&aerorsync::aerorsync::events::AerorsyncEvent) -> Self
+pub fn aerorsync::aerorsync::types::AerorsyncError::host_key_rejected(impl core::convert::Into<alloc::string::String>) -> Self
+pub fn aerorsync::aerorsync::types::AerorsyncError::illegal_transition(impl core::convert::Into<alloc::string::String>) -> Self
+pub fn aerorsync::aerorsync::types::AerorsyncError::invalid_frame(impl core::convert::Into<alloc::string::String>) -> Self
+pub fn aerorsync::aerorsync::types::AerorsyncError::is_clean_transport_eof(&self) -> bool
+pub fn aerorsync::aerorsync::types::AerorsyncError::new(aerorsync::aerorsync::types::AerorsyncErrorKind, impl core::convert::Into<alloc::string::String>) -> Self
+pub fn aerorsync::aerorsync::types::AerorsyncError::remote(u16, impl core::convert::Into<alloc::string::String>) -> Self
+pub fn aerorsync::aerorsync::types::AerorsyncError::transport(impl core::convert::Into<alloc::string::String>) -> Self
+pub fn aerorsync::aerorsync::types::AerorsyncError::transport_clean_eof(impl core::convert::Into<alloc::string::String>) -> Self
+pub fn aerorsync::aerorsync::types::AerorsyncError::unexpected_message(impl core::convert::Into<alloc::string::String>) -> Self
+pub fn aerorsync::aerorsync::types::AerorsyncError::unsupported_version(impl core::convert::Into<alloc::string::String>) -> Self
+impl core::clone::Clone for aerorsync::aerorsync::types::AerorsyncError
+pub fn aerorsync::aerorsync::types::AerorsyncError::clone(&self) -> aerorsync::aerorsync::types::AerorsyncError
+impl core::error::Error for aerorsync::aerorsync::types::AerorsyncError
+impl core::fmt::Debug for aerorsync::aerorsync::types::AerorsyncError
+pub fn aerorsync::aerorsync::types::AerorsyncError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for aerorsync::aerorsync::types::AerorsyncError
+pub fn aerorsync::aerorsync::types::AerorsyncError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl serde_core::ser::Serialize for aerorsync::aerorsync::types::AerorsyncError
+pub fn aerorsync::aerorsync::types::AerorsyncError::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for aerorsync::aerorsync::types::AerorsyncError
+pub fn aerorsync::aerorsync::types::AerorsyncError::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for aerorsync::aerorsync::types::AerorsyncError
+impl core::marker::Send for aerorsync::aerorsync::types::AerorsyncError
+impl core::marker::Sync for aerorsync::aerorsync::types::AerorsyncError
+impl core::marker::Unpin for aerorsync::aerorsync::types::AerorsyncError
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::types::AerorsyncError
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::types::AerorsyncError
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::types::AerorsyncError
+pub struct aerorsync::aerorsync::types::FileEntry
+pub aerorsync::aerorsync::types::FileEntry::is_dir: bool
+pub aerorsync::aerorsync::types::FileEntry::mode: u32
+pub aerorsync::aerorsync::types::FileEntry::modified_unix_secs: i64
+pub aerorsync::aerorsync::types::FileEntry::path: alloc::string::String
+pub aerorsync::aerorsync::types::FileEntry::size: u64
+impl core::clone::Clone for aerorsync::aerorsync::types::FileEntry
+pub fn aerorsync::aerorsync::types::FileEntry::clone(&self) -> aerorsync::aerorsync::types::FileEntry
+impl core::cmp::Eq for aerorsync::aerorsync::types::FileEntry
+impl core::cmp::PartialEq for aerorsync::aerorsync::types::FileEntry
+pub fn aerorsync::aerorsync::types::FileEntry::eq(&self, &aerorsync::aerorsync::types::FileEntry) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::types::FileEntry
+pub fn aerorsync::aerorsync::types::FileEntry::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::types::FileEntry
+impl serde_core::ser::Serialize for aerorsync::aerorsync::types::FileEntry
+pub fn aerorsync::aerorsync::types::FileEntry::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for aerorsync::aerorsync::types::FileEntry
+pub fn aerorsync::aerorsync::types::FileEntry::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for aerorsync::aerorsync::types::FileEntry
+impl core::marker::Send for aerorsync::aerorsync::types::FileEntry
+impl core::marker::Sync for aerorsync::aerorsync::types::FileEntry
+impl core::marker::Unpin for aerorsync::aerorsync::types::FileEntry
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::types::FileEntry
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::types::FileEntry
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::types::FileEntry
+pub struct aerorsync::aerorsync::types::ProtocolVersion(pub u32)
+impl aerorsync::aerorsync::types::ProtocolVersion
+pub const aerorsync::aerorsync::types::ProtocolVersion::CURRENT: Self
+pub const aerorsync::aerorsync::types::ProtocolVersion::MAX_SUPPORTED: Self
+pub const aerorsync::aerorsync::types::ProtocolVersion::MIN_SUPPORTED: Self
+pub fn aerorsync::aerorsync::types::ProtocolVersion::as_u32(self) -> u32
+pub fn aerorsync::aerorsync::types::ProtocolVersion::is_supported(self) -> bool
+impl core::clone::Clone for aerorsync::aerorsync::types::ProtocolVersion
+pub fn aerorsync::aerorsync::types::ProtocolVersion::clone(&self) -> aerorsync::aerorsync::types::ProtocolVersion
+impl core::cmp::Eq for aerorsync::aerorsync::types::ProtocolVersion
+impl core::cmp::Ord for aerorsync::aerorsync::types::ProtocolVersion
+pub fn aerorsync::aerorsync::types::ProtocolVersion::cmp(&self, &aerorsync::aerorsync::types::ProtocolVersion) -> core::cmp::Ordering
+impl core::cmp::PartialEq for aerorsync::aerorsync::types::ProtocolVersion
+pub fn aerorsync::aerorsync::types::ProtocolVersion::eq(&self, &aerorsync::aerorsync::types::ProtocolVersion) -> bool
+impl core::cmp::PartialOrd for aerorsync::aerorsync::types::ProtocolVersion
+pub fn aerorsync::aerorsync::types::ProtocolVersion::partial_cmp(&self, &aerorsync::aerorsync::types::ProtocolVersion) -> core::option::Option<core::cmp::Ordering>
+impl core::fmt::Debug for aerorsync::aerorsync::types::ProtocolVersion
+pub fn aerorsync::aerorsync::types::ProtocolVersion::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for aerorsync::aerorsync::types::ProtocolVersion
+pub fn aerorsync::aerorsync::types::ProtocolVersion::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for aerorsync::aerorsync::types::ProtocolVersion
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::types::ProtocolVersion
+impl serde_core::ser::Serialize for aerorsync::aerorsync::types::ProtocolVersion
+pub fn aerorsync::aerorsync::types::ProtocolVersion::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for aerorsync::aerorsync::types::ProtocolVersion
+pub fn aerorsync::aerorsync::types::ProtocolVersion::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for aerorsync::aerorsync::types::ProtocolVersion
+impl core::marker::Send for aerorsync::aerorsync::types::ProtocolVersion
+impl core::marker::Sync for aerorsync::aerorsync::types::ProtocolVersion
+impl core::marker::Unpin for aerorsync::aerorsync::types::ProtocolVersion
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::types::ProtocolVersion
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::types::ProtocolVersion
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::types::ProtocolVersion
+pub struct aerorsync::aerorsync::types::SessionStats
+pub aerorsync::aerorsync::types::SessionStats::bytes_received: u64
+pub aerorsync::aerorsync::types::SessionStats::bytes_sent: u64
+pub aerorsync::aerorsync::types::SessionStats::copy_blocks: u64
+pub aerorsync::aerorsync::types::SessionStats::files_delta: u64
+pub aerorsync::aerorsync::types::SessionStats::files_full_copy: u64
+pub aerorsync::aerorsync::types::SessionStats::files_seen: u64
+pub aerorsync::aerorsync::types::SessionStats::files_skipped: u64
+pub aerorsync::aerorsync::types::SessionStats::literal_bytes: u64
+pub aerorsync::aerorsync::types::SessionStats::matched_bytes: u64
+impl core::clone::Clone for aerorsync::aerorsync::types::SessionStats
+pub fn aerorsync::aerorsync::types::SessionStats::clone(&self) -> aerorsync::aerorsync::types::SessionStats
+impl core::cmp::Eq for aerorsync::aerorsync::types::SessionStats
+impl core::cmp::PartialEq for aerorsync::aerorsync::types::SessionStats
+pub fn aerorsync::aerorsync::types::SessionStats::eq(&self, &aerorsync::aerorsync::types::SessionStats) -> bool
+impl core::default::Default for aerorsync::aerorsync::types::SessionStats
+pub fn aerorsync::aerorsync::types::SessionStats::default() -> aerorsync::aerorsync::types::SessionStats
+impl core::fmt::Debug for aerorsync::aerorsync::types::SessionStats
+pub fn aerorsync::aerorsync::types::SessionStats::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::types::SessionStats
+impl serde_core::ser::Serialize for aerorsync::aerorsync::types::SessionStats
+pub fn aerorsync::aerorsync::types::SessionStats::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for aerorsync::aerorsync::types::SessionStats
+pub fn aerorsync::aerorsync::types::SessionStats::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for aerorsync::aerorsync::types::SessionStats
+impl core::marker::Send for aerorsync::aerorsync::types::SessionStats
+impl core::marker::Sync for aerorsync::aerorsync::types::SessionStats
+impl core::marker::Unpin for aerorsync::aerorsync::types::SessionStats
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::types::SessionStats
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::types::SessionStats
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::types::SessionStats
+pub struct aerorsync::aerorsync::types::TransferReport
+pub aerorsync::aerorsync::types::TransferReport::duration_ms: u64
+pub aerorsync::aerorsync::types::TransferReport::session: aerorsync::aerorsync::types::SessionStats
+pub aerorsync::aerorsync::types::TransferReport::total_size: u64
+pub aerorsync::aerorsync::types::TransferReport::warnings: alloc::vec::Vec<alloc::string::String>
+impl core::clone::Clone for aerorsync::aerorsync::types::TransferReport
+pub fn aerorsync::aerorsync::types::TransferReport::clone(&self) -> aerorsync::aerorsync::types::TransferReport
+impl core::default::Default for aerorsync::aerorsync::types::TransferReport
+pub fn aerorsync::aerorsync::types::TransferReport::default() -> aerorsync::aerorsync::types::TransferReport
+impl core::fmt::Debug for aerorsync::aerorsync::types::TransferReport
+pub fn aerorsync::aerorsync::types::TransferReport::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for aerorsync::aerorsync::types::TransferReport
+impl core::marker::Send for aerorsync::aerorsync::types::TransferReport
+impl core::marker::Sync for aerorsync::aerorsync::types::TransferReport
+impl core::marker::Unpin for aerorsync::aerorsync::types::TransferReport
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::types::TransferReport
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::types::TransferReport
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::types::TransferReport
+pub const aerorsync::aerorsync::types::TRANSIENT_DENY_DETAILS: &[&str]
+pub const aerorsync::aerorsync::types::TRANSIENT_KINDS: &[aerorsync::aerorsync::types::AerorsyncErrorKind]
+pub const aerorsync::aerorsync::types::TRANSIENT_SOFT_DETAILS: &[&str]
+pub mod aerorsync::aerorsync::xattr_fs
+pub enum aerorsync::aerorsync::xattr_fs::XattrApplyOutcome
+pub aerorsync::aerorsync::xattr_fs::XattrApplyOutcome::Applied
+pub aerorsync::aerorsync::xattr_fs::XattrApplyOutcome::Applied::count: usize
+pub aerorsync::aerorsync::xattr_fs::XattrApplyOutcome::Failed
+pub aerorsync::aerorsync::xattr_fs::XattrApplyOutcome::Failed::message: alloc::string::String
+pub aerorsync::aerorsync::xattr_fs::XattrApplyOutcome::Unsupported
+pub aerorsync::aerorsync::xattr_fs::XattrApplyOutcome::Unsupported::warnings: alloc::vec::Vec<alloc::string::String>
+impl core::clone::Clone for aerorsync::aerorsync::xattr_fs::XattrApplyOutcome
+pub fn aerorsync::aerorsync::xattr_fs::XattrApplyOutcome::clone(&self) -> aerorsync::aerorsync::xattr_fs::XattrApplyOutcome
+impl core::cmp::Eq for aerorsync::aerorsync::xattr_fs::XattrApplyOutcome
+impl core::cmp::PartialEq for aerorsync::aerorsync::xattr_fs::XattrApplyOutcome
+pub fn aerorsync::aerorsync::xattr_fs::XattrApplyOutcome::eq(&self, &aerorsync::aerorsync::xattr_fs::XattrApplyOutcome) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::xattr_fs::XattrApplyOutcome
+pub fn aerorsync::aerorsync::xattr_fs::XattrApplyOutcome::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::xattr_fs::XattrApplyOutcome
+impl core::marker::Freeze for aerorsync::aerorsync::xattr_fs::XattrApplyOutcome
+impl core::marker::Send for aerorsync::aerorsync::xattr_fs::XattrApplyOutcome
+impl core::marker::Sync for aerorsync::aerorsync::xattr_fs::XattrApplyOutcome
+impl core::marker::Unpin for aerorsync::aerorsync::xattr_fs::XattrApplyOutcome
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::xattr_fs::XattrApplyOutcome
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::xattr_fs::XattrApplyOutcome
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::xattr_fs::XattrApplyOutcome
+pub enum aerorsync::aerorsync::xattr_fs::XattrSanitizeError
+pub aerorsync::aerorsync::xattr_fs::XattrSanitizeError::DeferredUnresolved
+pub aerorsync::aerorsync::xattr_fs::XattrSanitizeError::DeferredUnresolved::name: alloc::string::String
+pub aerorsync::aerorsync::xattr_fs::XattrSanitizeError::EmptyName
+pub aerorsync::aerorsync::xattr_fs::XattrSanitizeError::NameTooLong
+pub aerorsync::aerorsync::xattr_fs::XattrSanitizeError::NameTooLong::len: usize
+pub aerorsync::aerorsync::xattr_fs::XattrSanitizeError::NamespaceNotAllowed
+pub aerorsync::aerorsync::xattr_fs::XattrSanitizeError::NamespaceNotAllowed::name: alloc::string::String
+pub aerorsync::aerorsync::xattr_fs::XattrSanitizeError::TooManyPairs
+pub aerorsync::aerorsync::xattr_fs::XattrSanitizeError::TooManyPairs::count: usize
+pub aerorsync::aerorsync::xattr_fs::XattrSanitizeError::TotalBytesTooLarge
+pub aerorsync::aerorsync::xattr_fs::XattrSanitizeError::TotalBytesTooLarge::total: usize
+impl core::clone::Clone for aerorsync::aerorsync::xattr_fs::XattrSanitizeError
+pub fn aerorsync::aerorsync::xattr_fs::XattrSanitizeError::clone(&self) -> aerorsync::aerorsync::xattr_fs::XattrSanitizeError
+impl core::cmp::Eq for aerorsync::aerorsync::xattr_fs::XattrSanitizeError
+impl core::cmp::PartialEq for aerorsync::aerorsync::xattr_fs::XattrSanitizeError
+pub fn aerorsync::aerorsync::xattr_fs::XattrSanitizeError::eq(&self, &aerorsync::aerorsync::xattr_fs::XattrSanitizeError) -> bool
+impl core::fmt::Debug for aerorsync::aerorsync::xattr_fs::XattrSanitizeError
+pub fn aerorsync::aerorsync::xattr_fs::XattrSanitizeError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for aerorsync::aerorsync::xattr_fs::XattrSanitizeError
+pub fn aerorsync::aerorsync::xattr_fs::XattrSanitizeError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for aerorsync::aerorsync::xattr_fs::XattrSanitizeError
+impl core::marker::Freeze for aerorsync::aerorsync::xattr_fs::XattrSanitizeError
+impl core::marker::Send for aerorsync::aerorsync::xattr_fs::XattrSanitizeError
+impl core::marker::Sync for aerorsync::aerorsync::xattr_fs::XattrSanitizeError
+impl core::marker::Unpin for aerorsync::aerorsync::xattr_fs::XattrSanitizeError
+impl core::marker::UnsafeUnpin for aerorsync::aerorsync::xattr_fs::XattrSanitizeError
+impl core::panic::unwind_safe::RefUnwindSafe for aerorsync::aerorsync::xattr_fs::XattrSanitizeError
+impl core::panic::unwind_safe::UnwindSafe for aerorsync::aerorsync::xattr_fs::XattrSanitizeError
+pub const aerorsync::aerorsync::xattr_fs::MAX_XATTR_NAME_LEN: usize
+pub const aerorsync::aerorsync::xattr_fs::MAX_XATTR_PAIRS: usize
+pub const aerorsync::aerorsync::xattr_fs::MAX_XATTR_TOTAL_BYTES: usize
+pub const aerorsync::aerorsync::xattr_fs::USER_XATTR_PREFIX: &str
+pub fn aerorsync::aerorsync::xattr_fs::apply_xattrs(&std::path::Path, &[aerorsync::aerorsync::real_wire::XattrPair], bool) -> aerorsync::aerorsync::xattr_fs::XattrApplyOutcome
+pub fn aerorsync::aerorsync::xattr_fs::fs_supports_xattrs(&std::path::Path) -> bool
+pub fn aerorsync::aerorsync::xattr_fs::read_user_xattrs(&std::path::Path) -> core::option::Option<alloc::vec::Vec<aerorsync::aerorsync::real_wire::XattrPair>>
+pub fn aerorsync::aerorsync::xattr_fs::sanitize_xattrs_for_apply(&[aerorsync::aerorsync::real_wire::XattrPair]) -> core::result::Result<alloc::vec::Vec<(alloc::string::String, alloc::vec::Vec<u8>)>, aerorsync::aerorsync::xattr_fs::XattrSanitizeError>
+pub const aerorsync::aerorsync::CURRENT_PROTOCOL_VERSION: u32


### PR DESCRIPTION
## Description

Phase D of the standalone-crate plan has to close the distance between what the `aerorsync` module exposes and what it should expose. Until now neither end of that distance had a number, and the one I had been using was the wrong kind of measurement.

The dead-code inventory produced by the standalone lane cannot supply it. Its 45 lines are deduplicated diagnostic headlines rather than items: one line names four methods, another names none at all, and one pair was the same site reported twice across the lib and lib-test targets. More important, the metric is blind to everything that is already public, and the module declares 24 `pub mod` and 742 `pub` declarations across its 25 files. An item that is already public produces no dead-code warning. So the method I had proposed, declare the entry points public and recompile, would have measured internal reachability inside a surface that was public all along: the number would have fallen, and that would have looked like progress.

Both ends are now measured, by two different instruments.

**The floor**, measured from the consumers: every `crate::aerorsync::` reference in AeroFTP's sources outside the module, with production separated from tests by position inside `#[cfg(test)]` regions. 29 references in 10 files, of which AeroFTP's production code names **17 items across 7** of the 24 public modules. Nineteen of the references go through the adapter that phase A built as the boundary; five production references reach the module directly, which is a fact phase D1 needs in front of it rather than a defect to fix in passing.

**The ceiling**, measured from the crate: `cargo public-api --simplified` on what `scripts/aerorsync-emit.sh` emits, which is the module compiled as a crate of its own. **2643 items**: 133 named types, 687 functions and methods, 99 constants, behind 24 public modules.

The crate exposes about a hundred and fifty times what its only consumer uses. This file is the second number, frozen, so that phases B and C show whether the surface grows instead of that being discovered at the end. The header carries the command to regenerate and diff it.

## Not a gate

Deliberately not wired into CI. A snapshot becomes a gate when there is an agreed procedure for updating it, and that is a phase D1 decision. Before the facade is designed, every legitimate change would redden the lane and the file would be updated without anyone reading the diff, which is worse than having no gate. Regenerating it also needs a nightly toolchain and `cargo-public-api`, neither of which the lane installs today.

## Verified

The emitted crate is byte-identical with and without this file: 49 entries, manifest `e43a56d2`, because the emitter copies only `.rs` sources. `cargo fmt --check` clean. No production code, no workflow, no build configuration is touched: this adds one text file next to the module's README.

## Type of Change
- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] CI reliability
