### PR TITLE
B2: measure the server-reported digest before SSE-B2 lands; R2: reach the eu and us jurisdictions

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -51,7 +51,7 @@ Legend:
 
 | Provider | Unit | Live (auto) | Live (manual) | Notes |
 |----------|:----:|:-----------:|---------------|-------|
-| Backblaze B2 | yes | yes (multipart 250 MB, 5.1 GB rename) | env-gated CI | Best automated cloud coverage |
+| Backblaze B2 | yes | yes (multipart 250 MB, 5.1 GB rename, server-reported digests) | env-gated CI | Best automated cloud coverage. Both code paths: the native B2 API and the S3-compatible endpoint (`integration_b2_s3_compat`, needs `AEROFTP_TEST_B2_S3_ENDPOINT` as well) |
 | Google Drive | yes | - | v4.0.0 (multipart 500 MiB) | |
 | Dropbox | yes | - | v4.0.0 (upload sessions) | |
 | OneDrive | yes | - | v4.0.0 (session upload) | |

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -109,6 +109,14 @@ const integrationLanes = [
       why: 'set AEROFTP_TEST_B2_KEY_ID, AEROFTP_TEST_B2_KEY, AEROFTP_TEST_B2_BUCKET to enable',
     },
   },
+  {
+    name: 'integration_b2_s3_compat',
+    desc: 'b2 through its s3-compatible endpoint',
+    gate: {
+      probe: async () => hasEnv('AEROFTP_TEST_B2_KEY_ID', 'AEROFTP_TEST_B2_KEY', 'AEROFTP_TEST_B2_BUCKET', 'AEROFTP_TEST_B2_S3_ENDPOINT'),
+      why: 'set AEROFTP_TEST_B2_KEY_ID, AEROFTP_TEST_B2_KEY, AEROFTP_TEST_B2_BUCKET, AEROFTP_TEST_B2_S3_ENDPOINT to enable',
+    },
+  },
   { name: 'dag_s3_multipart', desc: 's3 multipart upload dag', gate: VAULT },
   { name: 'dag_s3_server_side_copy', desc: 's3 server-side copy dag', gate: VAULT },
   { name: 'dag_webdav_copy', desc: 'webdav copy dag', gate: VAULT },

--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -23368,6 +23368,7 @@ fn scrub_options_for_mode(opts: &mut serde_json::Map<String, serde_json::Value>)
         "anonymous",
         "bucket",
         "accountId",
+        "jurisdiction",
         // WebDAV mode
         "webdavScheme",
         "verifyCert",

--- a/src-tauri/src/bridge_shared.rs
+++ b/src-tauri/src/bridge_shared.rs
@@ -668,6 +668,17 @@ mod tests {
             map_s3_provider_from_endpoint("https://abc.r2.cloudflarestorage.com"),
             "cloudflare-r2"
         );
+        // A jurisdiction-scoped bucket has an extra segment in the host. It is
+        // still R2, and the bridge must not fall through to `custom-s3` and
+        // lose the preset's defaults (path-style, region `auto`).
+        assert_eq!(
+            map_s3_provider_from_endpoint("https://abc.eu.r2.cloudflarestorage.com"),
+            "cloudflare-r2"
+        );
+        assert_eq!(
+            map_s3_provider_from_endpoint("https://abc.us.r2.cloudflarestorage.com"),
+            "cloudflare-r2"
+        );
         assert_eq!(
             map_s3_provider_from_endpoint("https://s3.wasabisys.com/bucket"),
             "wasabi"

--- a/src-tauri/src/profile_loader.rs
+++ b/src-tauri/src/profile_loader.rs
@@ -250,10 +250,26 @@ fn s3_profile_static_endpoint(provider_id: &str) -> Option<&'static str> {
     }
 }
 
+/// Endpoint host segment for a Cloudflare R2 jurisdiction code.
+///
+/// `eu` and `us` are the two jurisdictions R2 publishes; everything else,
+/// including the empty string, is the default placement and contributes no
+/// segment. Kept deliberately total (no `Option`): the caller substitutes into
+/// a host template, where "unknown" and "not set" must both mean the default
+/// endpoint rather than a failure to resolve. Mirrors `jurisdictionSegment` in
+/// `src/providers/registry.ts`.
+pub fn r2_jurisdiction_segment(value: &str) -> &'static str {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "eu" => ".eu",
+        "us" => ".us",
+        _ => "",
+    }
+}
+
 fn s3_profile_endpoint_template(provider_id: &str) -> Option<&'static str> {
     match provider_id {
         "mega-s4" => Some("s3.{region}.s4.mega.io"),
-        "cloudflare-r2" => Some("{accountId}.r2.cloudflarestorage.com"),
+        "cloudflare-r2" => Some("{accountId}{jurisdiction}.r2.cloudflarestorage.com"),
         "google-cloud-storage" => Some("https://storage.googleapis.com"),
         "wasabi" => Some("https://s3.{region}.wasabisys.com"),
         "alibaba-oss" => Some("https://oss-{region}.aliyuncs.com"),
@@ -333,6 +349,21 @@ pub fn apply_s3_profile_defaults(
         if endpoint.contains("{region}") {
             let region = extra.get("region").map(String::as_str)?;
             endpoint = endpoint.replace("{region}", region);
+        }
+
+        // Jurisdiction: a bucket created in one answers ONLY on its own host
+        // (`<account>.eu.r2.cloudflarestorage.com`). An absent or unknown value
+        // is the default (no segment), never an error: every profile saved
+        // before this option existed has no such key and must keep resolving to
+        // the host it resolved to before.
+        if endpoint.contains("{jurisdiction}") {
+            let segment = r2_jurisdiction_segment(
+                extra
+                    .get("jurisdiction")
+                    .map(String::as_str)
+                    .unwrap_or_default(),
+            );
+            endpoint = endpoint.replace("{jurisdiction}", segment);
         }
 
         if endpoint.contains("{accountId}") {
@@ -538,6 +569,79 @@ mod tests {
             extra.get(S3_ENDPOINT_SOURCE_META_KEY).map(String::as_str),
             Some("profile")
         );
+    }
+
+    #[test]
+    fn r2_profile_without_jurisdiction_resolves_the_default_endpoint() {
+        // The regression this guards: every R2 profile saved before the
+        // jurisdiction option existed carries no such key, and the template now
+        // has a `{jurisdiction}` placeholder. An unresolved placeholder makes
+        // `apply_s3_profile_defaults` return None, which would leave those
+        // profiles with no endpoint at all.
+        let profile = json!({
+            "providerId": "cloudflare-r2",
+            "options": { "accountId": "a1b2c3d4e5f6", "bucket": "my-r2-bucket" }
+        });
+        let mut extra = HashMap::new();
+        apply_profile_options(&mut extra, &profile);
+        let endpoint = apply_s3_profile_defaults(&mut extra, Some("cloudflare-r2"));
+        assert_eq!(
+            endpoint.as_deref(),
+            Some("a1b2c3d4e5f6.r2.cloudflarestorage.com")
+        );
+    }
+
+    #[test]
+    fn r2_jurisdiction_selects_its_own_endpoint_host() {
+        for (code, expected) in [
+            ("eu", "a1b2c3d4e5f6.eu.r2.cloudflarestorage.com"),
+            ("us", "a1b2c3d4e5f6.us.r2.cloudflarestorage.com"),
+            // Unknown and empty both mean "no jurisdiction": a value this build
+            // does not know must not strand the profile without an endpoint.
+            ("", "a1b2c3d4e5f6.r2.cloudflarestorage.com"),
+            ("mars", "a1b2c3d4e5f6.r2.cloudflarestorage.com"),
+            // The user picked it from a list, but a profile can be hand-edited
+            // or come from an import, so case is not assumed.
+            ("EU", "a1b2c3d4e5f6.eu.r2.cloudflarestorage.com"),
+        ] {
+            let profile = json!({
+                "providerId": "cloudflare-r2",
+                "options": {
+                    "accountId": "a1b2c3d4e5f6",
+                    "bucket": "my-r2-bucket",
+                    "jurisdiction": code,
+                }
+            });
+            let mut extra = HashMap::new();
+            apply_profile_options(&mut extra, &profile);
+            let endpoint = apply_s3_profile_defaults(&mut extra, Some("cloudflare-r2"));
+            assert_eq!(
+                endpoint.as_deref(),
+                Some(expected),
+                "jurisdiction {:?} resolved to the wrong host",
+                code
+            );
+        }
+    }
+
+    #[test]
+    fn r2_endpoint_saved_on_the_profile_wins_over_the_jurisdiction() {
+        // An endpoint already on the profile is pass-through everywhere else in
+        // this function; the jurisdiction must not start overriding it, or a
+        // user who unlocked the endpoint field to type a host by hand would
+        // have it silently rewritten.
+        let profile = json!({
+            "providerId": "cloudflare-r2",
+            "options": {
+                "accountId": "a1b2c3d4e5f6",
+                "jurisdiction": "eu",
+                "endpoint": "https://r2.example.test",
+            }
+        });
+        let mut extra = HashMap::new();
+        apply_profile_options(&mut extra, &profile);
+        let endpoint = apply_s3_profile_defaults(&mut extra, Some("cloudflare-r2"));
+        assert_eq!(endpoint.as_deref(), Some("https://r2.example.test"));
     }
 
     #[test]

--- a/src-tauri/tests/integration_b2.rs
+++ b/src-tauri/tests/integration_b2.rs
@@ -212,15 +212,21 @@ async fn small_upload_download_checksum_match_and_cleanup() {
     // with no error anywhere, and every byte-comparison test stays green.
     let digests = p.checksum(&format!("/{}", key)).await.expect("checksum");
     report_server_digest("single-part", &digests);
-    assert_eq!(
-        digests.get("sha1").map(String::as_str),
-        Some(sha1_hex(&payload).as_str()),
-        "B2 stopped reporting the single-part contentSha1 (or reported a different one)"
-    );
+    let reported_sha1 = digests.get("sha1").cloned();
 
+    // Clean up BEFORE asserting: a digest that stopped being reported is the
+    // failure this assertion exists to catch, so it is expected to fire one
+    // day, and a panic above the cleanup would leave the run's objects in the
+    // bucket in exactly that case.
     cleanup_prefix(&mut p, &prefix).await;
     let _ = tokio::fs::remove_dir_all(&local_dir).await;
     p.disconnect().await.ok();
+
+    assert_eq!(
+        reported_sha1.as_deref(),
+        Some(sha1_hex(&payload).as_str()),
+        "B2 stopped reporting the single-part contentSha1 (or reported a different one)"
+    );
 }
 
 #[tokio::test]
@@ -278,17 +284,21 @@ async fn large_upload_forces_chunked_workflow_and_round_trips() {
     // digest. Either change is worth failing on and looking at.
     let digests = p.checksum(&format!("/{}", key)).await.expect("checksum");
     report_server_digest("large-multipart", &digests);
-    match digests.get("sha1") {
-        None => {}
-        Some(reported) => assert_eq!(
-            reported, &expected_sha1,
-            "B2 began reporting a digest for a large file, and it is not the content SHA-1"
-        ),
-    }
+    let reported_sha1 = digests.get("sha1").cloned();
 
+    // Cleanup first: the leftover here would be a 250 MB object, and this
+    // assertion is the one meant to fire if the service changes what it
+    // publishes for a large file.
     cleanup_prefix(&mut p, &prefix).await;
     let _ = tokio::fs::remove_dir_all(&local_dir).await;
     p.disconnect().await.ok();
+
+    if let Some(reported) = reported_sha1 {
+        assert_eq!(
+            reported, expected_sha1,
+            "B2 began reporting a digest for a large file, and it is not the content SHA-1"
+        );
+    }
 }
 
 /// PD-UP-1: the large-file path now uploads parts concurrently through the
@@ -408,15 +418,17 @@ async fn rename_moves_file_and_source_disappears() {
         .await
         .expect("checksum");
     report_server_digest("server-side-copy", &digests);
-    assert_eq!(
-        digests.get("sha1").map(String::as_str),
-        Some(sha1_hex(payload).as_str()),
-        "the server-side copy lost or changed the content SHA-1"
-    );
+    let reported_sha1 = digests.get("sha1").cloned();
 
     cleanup_prefix(&mut p, &prefix).await;
     let _ = tokio::fs::remove_dir_all(&local_dir).await;
     p.disconnect().await.ok();
+
+    assert_eq!(
+        reported_sha1.as_deref(),
+        Some(sha1_hex(payload).as_str()),
+        "the server-side copy lost or changed the content SHA-1"
+    );
 }
 
 #[tokio::test]

--- a/src-tauri/tests/integration_b2.rs
+++ b/src-tauri/tests/integration_b2.rs
@@ -84,6 +84,40 @@ fn sha256_hex(bytes: &[u8]) -> String {
     s
 }
 
+fn sha1_hex(bytes: &[u8]) -> String {
+    use sha1::Sha1;
+    let mut h = Sha1::new();
+    h.update(bytes);
+    let d = h.finalize();
+    let mut s = String::with_capacity(d.len() * 2);
+    for b in d {
+        s.push_str(&format!("{:02x}", b));
+    }
+    s
+}
+
+/// Print one server-reported digest on a line that is easy to find in
+/// `--nocapture` output and easy to diff between two runs.
+///
+/// This exists because of a dated change on the service side: from 2026-09-14
+/// Backblaze encrypts new uploads with SSE-B2 by default. What that does to the
+/// digest B2 reports is not something to assume, and the answer is only
+/// measurable while a bucket still holds objects written before the change. The
+/// assertions below fail if the digest disappears; this line records what it
+/// actually was, so a run from before the change and a run from after it can be
+/// compared rather than argued about.
+fn report_server_digest(label: &str, digests: &std::collections::HashMap<String, String>) {
+    if digests.is_empty() {
+        eprintln!("[b2-digest-baseline] {label}: (none reported)");
+        return;
+    }
+    let mut pairs: Vec<_> = digests.iter().collect();
+    pairs.sort();
+    for (algo, value) in pairs {
+        eprintln!("[b2-digest-baseline] {label}: {algo}={value}");
+    }
+}
+
 async fn read_local_sha256(path: &std::path::Path) -> String {
     let bytes = tokio::fs::read(path).await.expect("read local for sha256");
     sha256_hex(&bytes)
@@ -171,6 +205,19 @@ async fn small_upload_download_checksum_match_and_cleanup() {
     let actual_sha = read_local_sha256(&local_out).await;
     assert_eq!(actual_sha, expected_sha, "round-trip checksum mismatch");
 
+    // The round trip above proves the BYTES survive. It says nothing about the
+    // digest B2 reports for the object, which is what `sync`, `dedupe` and
+    // `verify` read instead of downloading. Assert that separately: a digest
+    // that silently stops being reported degrades those three to size+mtime
+    // with no error anywhere, and every byte-comparison test stays green.
+    let digests = p.checksum(&format!("/{}", key)).await.expect("checksum");
+    report_server_digest("single-part", &digests);
+    assert_eq!(
+        digests.get("sha1").map(String::as_str),
+        Some(sha1_hex(&payload).as_str()),
+        "B2 stopped reporting the single-part contentSha1 (or reported a different one)"
+    );
+
     cleanup_prefix(&mut p, &prefix).await;
     let _ = tokio::fs::remove_dir_all(&local_dir).await;
     p.disconnect().await.ok();
@@ -198,6 +245,7 @@ async fn large_upload_forces_chunked_workflow_and_round_trips() {
         *b = ((i.wrapping_mul(2654435761)) & 0xff) as u8;
     }
     let expected_sha = sha256_hex(&payload);
+    let expected_sha1 = sha1_hex(&payload);
 
     let local_dir = std::env::temp_dir().join(format!("aeroftp-it-large-{}", std::process::id()));
     tokio::fs::create_dir_all(&local_dir)
@@ -221,6 +269,22 @@ async fn large_upload_forces_chunked_workflow_and_round_trips() {
         actual_sha, expected_sha,
         "large round-trip checksum mismatch"
     );
+
+    // A large file carries `contentSha1: "none"`, so the provider reports NO
+    // digest here. That is the documented behaviour (`B2_UNVERIFIED` in the
+    // checksum matrix) and it is asserted, not merely tolerated: if B2 ever
+    // starts reporting one it must be the real SHA-1 of the content and not an
+    // opaque value that would pass the 40-hex shape check and be published as a
+    // digest. Either change is worth failing on and looking at.
+    let digests = p.checksum(&format!("/{}", key)).await.expect("checksum");
+    report_server_digest("large-multipart", &digests);
+    match digests.get("sha1") {
+        None => {}
+        Some(reported) => assert_eq!(
+            reported, &expected_sha1,
+            "B2 began reporting a digest for a large file, and it is not the content SHA-1"
+        ),
+    }
 
     cleanup_prefix(&mut p, &prefix).await;
     let _ = tokio::fs::remove_dir_all(&local_dir).await;
@@ -314,9 +378,8 @@ async fn rename_moves_file_and_source_disappears() {
         .await
         .expect("mk tmp dir");
     let local_in = local_dir.join("rename-payload.txt");
-    tokio::fs::write(&local_in, b"rename payload\n")
-        .await
-        .expect("write");
+    let payload: &[u8] = b"rename payload\n";
+    tokio::fs::write(&local_in, payload).await.expect("write");
 
     p.upload(local_in.to_str().unwrap(), &format!("/{}", src_key), None)
         .await
@@ -333,6 +396,22 @@ async fn rename_moves_file_and_source_disappears() {
     assert!(
         p.exists(&format!("/{}", dst_key)).await.unwrap_or(false),
         "destination key missing after rename"
+    );
+
+    // A rename is a server-side copy (`b2_copy_file`), so the destination is an
+    // object B2 wrote itself. Whether it keeps the source's digest is a property
+    // of the copy path, and it is the path most likely to change when the
+    // service starts encrypting what it writes: the source of these bytes is
+    // another object, not an upload carrying a client-computed SHA-1.
+    let digests = p
+        .checksum(&format!("/{}", dst_key))
+        .await
+        .expect("checksum");
+    report_server_digest("server-side-copy", &digests);
+    assert_eq!(
+        digests.get("sha1").map(String::as_str),
+        Some(sha1_hex(payload).as_str()),
+        "the server-side copy lost or changed the content SHA-1"
     );
 
     cleanup_prefix(&mut p, &prefix).await;

--- a/src-tauri/tests/integration_b2_s3_compat.rs
+++ b/src-tauri/tests/integration_b2_s3_compat.rs
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+//! Live checks for Backblaze B2 reached through its **S3-compatible** endpoint,
+//! which is a different code path from the native B2 provider covered by
+//! `integration_b2.rs`: the native path reads B2's own `contentSha1`, this one
+//! reads the S3 `ETag` and accepts it only when it is exactly 32 hex characters
+//! (`etag_to_md5` in `providers/s3.rs`), omitting anything else rather than
+//! publishing a value that is not an MD5.
+//!
+//! Why this file exists, and why now. From **2026-09-14** Backblaze encrypts
+//! new uploads and copies with SSE-B2 by default. On AWS, SSE-S3 leaves the
+//! ETag equal to the object MD5 for single-part objects, and only SSE-KMS and
+//! SSE-C make it opaque, which is what the published caveat for the S3 ETag
+//! says. Whether B2 behaves the same through its S3 layer is not something to
+//! assume: if its ETag becomes opaque, `etag_to_md5` correctly returns nothing,
+//! the digest quietly disappears, and `sync`, `dedupe` and `verify` fall back
+//! to size and mtime with no error raised anywhere. These tests fail when that
+//! happens, and print what the server actually reported so a run from before
+//! the change can be compared with one from after it.
+//!
+//! Marked `#[ignore]`, and additionally gated on a throw-away bucket's
+//! credentials plus the S3 endpoint for the bucket's region:
+//!
+//! ```bash
+//! export AEROFTP_TEST_B2_KEY_ID=K00xxxxxxxxxxxxxxxxxx
+//! export AEROFTP_TEST_B2_KEY=K00yyyyyyyyyyyyyyyyyyyy
+//! export AEROFTP_TEST_B2_BUCKET=aeroftp-test-bucket
+//! export AEROFTP_TEST_B2_S3_ENDPOINT=https://s3.eu-central-003.backblazeb2.com
+//! cd src-tauri
+//! cargo test --test integration_b2_s3_compat -- --ignored --nocapture
+//! ```
+//!
+//! The region is read out of the endpoint host (`s3.<region>.backblazeb2.com`)
+//! and can be overridden with `AEROFTP_TEST_B2_S3_REGION`. Traffic is a couple
+//! of MB per run.
+
+use ftp_client_gui_lib::providers::s3::S3Provider;
+use ftp_client_gui_lib::providers::types::S3Config;
+use ftp_client_gui_lib::providers::StorageProvider;
+use md5::Md5;
+use secrecy::SecretString;
+use sha2::Digest;
+use std::collections::HashMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+struct Creds {
+    key_id: String,
+    key: String,
+    bucket: String,
+    endpoint: String,
+    region: String,
+}
+
+/// Region for SigV4, from `AEROFTP_TEST_B2_S3_REGION` or read out of the B2 S3
+/// endpoint host, which is `s3.<region>.backblazeb2.com`. Returns `None` when
+/// neither is available: signing with a guessed region fails at connect with an
+/// authentication error that would look like bad credentials.
+fn region_for(endpoint: &str) -> Option<String> {
+    if let Ok(explicit) = std::env::var("AEROFTP_TEST_B2_S3_REGION") {
+        if !explicit.trim().is_empty() {
+            return Some(explicit.trim().to_string());
+        }
+    }
+    let host = endpoint
+        .trim()
+        .trim_start_matches("https://")
+        .trim_start_matches("http://");
+    let mut parts = host.split('.');
+    match (parts.next(), parts.next()) {
+        (Some("s3"), Some(region)) if !region.is_empty() => Some(region.to_string()),
+        _ => None,
+    }
+}
+
+fn skip_unless_creds(test_name: &str) -> Option<Creds> {
+    let key_id = std::env::var("AEROFTP_TEST_B2_KEY_ID").unwrap_or_default();
+    let key = std::env::var("AEROFTP_TEST_B2_KEY").unwrap_or_default();
+    let bucket = std::env::var("AEROFTP_TEST_B2_BUCKET").unwrap_or_default();
+    let endpoint = std::env::var("AEROFTP_TEST_B2_S3_ENDPOINT").unwrap_or_default();
+    if key_id.is_empty() || key.is_empty() || bucket.is_empty() || endpoint.is_empty() {
+        eprintln!(
+            "[{}] skipped: set AEROFTP_TEST_B2_KEY_ID, AEROFTP_TEST_B2_KEY, AEROFTP_TEST_B2_BUCKET and AEROFTP_TEST_B2_S3_ENDPOINT to enable",
+            test_name
+        );
+        return None;
+    }
+    let Some(region) = region_for(&endpoint) else {
+        eprintln!(
+            "[{}] skipped: cannot read a region out of {:?}; set AEROFTP_TEST_B2_S3_REGION",
+            test_name, endpoint
+        );
+        return None;
+    };
+    Some(Creds {
+        key_id,
+        key,
+        bucket,
+        endpoint,
+        region,
+    })
+}
+
+fn make_provider(c: &Creds) -> S3Provider {
+    S3Provider::new(S3Config {
+        endpoint: Some(c.endpoint.clone()),
+        region: c.region.clone(),
+        access_key_id: c.key_id.clone(),
+        secret_access_key: SecretString::from(c.key.clone()),
+        session_token: None,
+        role_arn: None,
+        role_external_id: None,
+        role_session_name: None,
+        role_duration_seconds: None,
+        role_mfa_serial: None,
+        role_mfa_token_code: None,
+        bucket: c.bucket.clone(),
+        prefix: None,
+        // B2's S3 layer serves buckets path-style, matching the `backblaze`
+        // preset's own default.
+        path_style: true,
+        storage_class: None,
+        // Deliberately not set: the point is what the SERVICE does by default,
+        // which is what a user's profile will hit from 2026-09-14 onwards.
+        sse_mode: None,
+        sse_kms_key_id: None,
+        verify_cert: true,
+    })
+    .expect("build S3 provider for the B2 S3-compatible endpoint")
+}
+
+fn md5_hex(bytes: &[u8]) -> String {
+    let mut h = Md5::new();
+    h.update(bytes);
+    format!("{:x}", h.finalize())
+}
+
+fn run_prefix(label: &str) -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!("aeroftp-it/{}-{}/", label, nanos)
+}
+
+fn report(label: &str, digests: &HashMap<String, String>) {
+    if digests.is_empty() {
+        eprintln!("[b2-s3-digest-baseline] {label}: (none reported)");
+        return;
+    }
+    let mut pairs: Vec<_> = digests.iter().collect();
+    pairs.sort();
+    for (algo, value) in pairs {
+        eprintln!("[b2-s3-digest-baseline] {label}: {algo}={value}");
+    }
+}
+
+async fn write_temp(name: &str, bytes: &[u8]) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!("aeroftp-b2s3-{}", std::process::id()));
+    tokio::fs::create_dir_all(&dir).await.expect("mk tmp dir");
+    let path = dir.join(name);
+    tokio::fs::write(&path, bytes).await.expect("write temp");
+    path
+}
+
+#[tokio::test]
+#[ignore = "requires AEROFTP_TEST_B2_* env + AEROFTP_TEST_B2_S3_ENDPOINT"]
+async fn single_part_object_still_reports_its_etag_as_the_content_md5() {
+    let Some(creds) =
+        skip_unless_creds("single_part_object_still_reports_its_etag_as_the_content_md5")
+    else {
+        return;
+    };
+    let prefix = run_prefix("b2s3-single");
+    let key = format!("{}hello.bin", prefix);
+    let mut p = make_provider(&creds);
+    p.connect().await.expect("connect");
+
+    let payload: Vec<u8> = (0..1024 * 1024).map(|i| (i & 0xff) as u8).collect();
+    let local = write_temp("upload.bin", &payload).await;
+
+    p.upload(local.to_str().unwrap(), &format!("/{}", key), None)
+        .await
+        .expect("upload");
+
+    let digests = p.checksum(&format!("/{}", key)).await.expect("checksum");
+    report("single-part", &digests);
+    assert_eq!(
+        digests.get("md5").map(String::as_str),
+        Some(md5_hex(&payload).as_str()),
+        "B2's S3 ETag is no longer the object MD5 for a single-part upload: the digest is gone and \
+         sync/dedupe/verify silently fall back to size and mtime"
+    );
+
+    let _ = p.delete(&format!("/{}", key)).await;
+    let _ = tokio::fs::remove_file(&local).await;
+    p.disconnect().await.ok();
+}
+
+#[tokio::test]
+#[ignore = "requires AEROFTP_TEST_B2_* env + AEROFTP_TEST_B2_S3_ENDPOINT"]
+async fn server_side_copy_keeps_the_etag_usable() {
+    let Some(creds) = skip_unless_creds("server_side_copy_keeps_the_etag_usable") else {
+        return;
+    };
+    let prefix = run_prefix("b2s3-copy");
+    let src = format!("{}original.bin", prefix);
+    let dst = format!("{}renamed.bin", prefix);
+    let mut p = make_provider(&creds);
+    p.connect().await.expect("connect");
+
+    let payload = b"b2 s3-compat copy payload\n".to_vec();
+    let local = write_temp("copy.bin", &payload).await;
+    p.upload(local.to_str().unwrap(), &format!("/{}", src), None)
+        .await
+        .expect("upload");
+
+    // A rename here is a server-side copy: the destination bytes are written by
+    // the service, not uploaded by us, which is the case most exposed to a
+    // change in how the service writes objects.
+    p.rename(&format!("/{}", src), &format!("/{}", dst))
+        .await
+        .expect("rename");
+
+    let digests = p.checksum(&format!("/{}", dst)).await.expect("checksum");
+    report("server-side-copy", &digests);
+    assert_eq!(
+        digests.get("md5").map(String::as_str),
+        Some(md5_hex(&payload).as_str()),
+        "the server-side copy's ETag is no longer the content MD5"
+    );
+
+    let _ = p.delete(&format!("/{}", dst)).await;
+    let _ = tokio::fs::remove_file(&local).await;
+    p.disconnect().await.ok();
+}

--- a/src-tauri/tests/integration_b2_s3_compat.rs
+++ b/src-tauri/tests/integration_b2_s3_compat.rs
@@ -185,16 +185,22 @@ async fn single_part_object_still_reports_its_etag_as_the_content_md5() {
 
     let digests = p.checksum(&format!("/{}", key)).await.expect("checksum");
     report("single-part", &digests);
+    let reported = digests.get("md5").cloned();
+
+    // Clean up BEFORE asserting. A changed digest is the failure this test
+    // exists to catch, so the assertion below is expected to fire one day, and
+    // a panic above the delete would leave the object behind in exactly the
+    // case the test was written for.
+    let _ = p.delete(&format!("/{}", key)).await;
+    let _ = tokio::fs::remove_file(&local).await;
+    p.disconnect().await.ok();
+
     assert_eq!(
-        digests.get("md5").map(String::as_str),
+        reported.as_deref(),
         Some(md5_hex(&payload).as_str()),
         "B2's S3 ETag is no longer the object MD5 for a single-part upload: the digest is gone and \
          sync/dedupe/verify silently fall back to size and mtime"
     );
-
-    let _ = p.delete(&format!("/{}", key)).await;
-    let _ = tokio::fs::remove_file(&local).await;
-    p.disconnect().await.ok();
 }
 
 #[tokio::test]
@@ -224,13 +230,15 @@ async fn server_side_copy_keeps_the_etag_usable() {
 
     let digests = p.checksum(&format!("/{}", dst)).await.expect("checksum");
     report("server-side-copy", &digests);
-    assert_eq!(
-        digests.get("md5").map(String::as_str),
-        Some(md5_hex(&payload).as_str()),
-        "the server-side copy's ETag is no longer the content MD5"
-    );
+    let reported = digests.get("md5").cloned();
 
     let _ = p.delete(&format!("/{}", dst)).await;
     let _ = tokio::fs::remove_file(&local).await;
     p.disconnect().await.ok();
+
+    assert_eq!(
+        reported.as_deref(),
+        Some(md5_hex(&payload).as_str()),
+        "the server-side copy's ETag is no longer the content MD5"
+    );
 }

--- a/src/components/ConnectionScreen.tsx
+++ b/src/components/ConnectionScreen.tsx
@@ -43,7 +43,7 @@ import { OAuthConnect } from './OAuthConnect';
 import { ProviderSelector } from './ProviderSelector';
 import { AlertDialog } from './Dialogs';
 import { IconPickerDialog } from './IconPickerDialog';
-import { getProviderById, resolveS3Endpoint, ProviderConfig } from '../providers';
+import { getProviderById, resolveS3Endpoint, s3TemplateParams, parseS3EndpointParams, ProviderConfig } from '../providers';
 import { isBlompAuthUrl, swiftOptionsForAuthUrl } from './swiftAuthUrl';
 import { getProviderDocsUrl, PROVIDER_DOCS_INDEX } from '../providers/docsLinks';
 import { getMegaConnectionMode, normalizeMegaOptions } from '../utils/providerConnectionMeta';
@@ -2210,14 +2210,18 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
         if (profile.protocol === 's3' && profile.providerId) {
             const provider = getProviderById(profile.providerId);
             if (provider) {
-                // Extract accountId from old-format endpoint (e.g. Cloudflare R2 migration)
+                // Recover template parameters from an endpoint saved before the
+                // corresponding field existed (Cloudflare R2 account id, and the
+                // jurisdiction added later). Only fields the profile is missing
+                // are filled in: what the profile already states wins.
                 const template = provider.defaults?.endpointTemplate;
-                if (template?.includes('{accountId}') && profileOptions.endpoint && !profileOptions.accountId) {
-                    // Reverse-extract accountId from stored endpoint using template pattern
-                    const templateRegex = template.replace('{accountId}', '(.+)').replace(/\./g, '\\.');
-                    const match = profileOptions.endpoint.match(new RegExp(templateRegex));
-                    if (match?.[1]) {
-                        profileOptions = { ...profileOptions, accountId: match[1] };
+                if (template?.includes('{accountId}') && profileOptions.endpoint) {
+                    const recovered = parseS3EndpointParams(provider.id, profileOptions.endpoint);
+                    if (recovered.accountId && !profileOptions.accountId) {
+                        profileOptions = { ...profileOptions, accountId: recovered.accountId };
+                    }
+                    if (recovered.jurisdiction && !profileOptions.jurisdiction) {
+                        profileOptions = { ...profileOptions, jurisdiction: recovered.jurisdiction };
                     }
                 }
 
@@ -2230,7 +2234,7 @@ export const ConnectionScreen: React.FC<ConnectionScreenProps> = ({
                             effectiveRegion = regionField.options[0].value;
                         }
                     }
-                    const extraParams = profileOptions.accountId ? { accountId: profileOptions.accountId } : undefined;
+                    const extraParams = s3TemplateParams(profileOptions);
                     const resolvedEndpoint = provider.defaults?.endpoint
                         || resolveS3Endpoint(provider.id, effectiveRegion, extraParams)
                         || undefined;

--- a/src/components/ProtocolSelector.tsx
+++ b/src/components/ProtocolSelector.tsx
@@ -28,7 +28,7 @@ import {
 } from 'lucide-react';
 import { ProviderType, FtpTlsMode } from '../types';
 import { useTranslation } from '../i18n';
-import { getProviderById, resolveS3Endpoint } from '../providers';
+import { getProviderById, resolveS3Endpoint, jurisdictionSegment, s3TemplateParams } from '../providers';
 import { CopyLinkButton } from './common/CopyLinkButton';
 import { DiscoverableTargetField, type ConnectionTarget } from './common/DiscoverableTargetField';
 import { GoogleDriveLogo, GooglePhotosLogo, DropboxLogo, OneDriveLogo, BoxLogo, PCloudLogo, AzureLogo, FilenLogo, FourSharedLogo, ZohoWorkDriveLogo, InternxtLogo, KDriveLogo, JottacloudLogo, DrimeCloudLogo, FileLuLogo, KoofrLogo, OpenDriveLogo, YandexDiskLogo, GitHubLogo, BlompLogo, FeliCloudLogo, TabDigitalLogo, ImmichLogo, ImageKitLogo, UploadcareLogo, CloudinaryLogo } from './ProviderLogos';
@@ -687,6 +687,7 @@ interface ProtocolFieldsProps {
         region?: string;
         endpoint?: string;
         accountId?: string;
+        jurisdiction?: string;
         pathStyle?: boolean;
         // S3 temporary credentials (AWS STS AssumeRole / SSO), issue #301
         sessionToken?: string;
@@ -848,6 +849,7 @@ export const ProtocolFields: React.FC<ProtocolFieldsProps> = ({
         const regionField = providerConfig?.fields?.find(f => f.key === 'region');
         const endpointField = providerConfig?.fields?.find(f => f.key === 'endpoint');
         const accountIdField = providerConfig?.fields?.find(f => f.key === 'accountId');
+        const jurisdictionField = providerConfig?.fields?.find(f => f.key === 'jurisdiction');
         const hasRegionSelect = regionField?.type === 'select' && regionField?.options;
 
         // Endpoint architecture:
@@ -863,17 +865,28 @@ export const ProtocolFields: React.FC<ProtocolFieldsProps> = ({
 
         // For accountId templates, extract the fixed suffix (e.g. ".r2.cloudflarestorage.com")
         const endpointFixedPart = hasAccountIdTemplate
-            ? providerConfig!.defaults!.endpointTemplate!.replace(/\{accountId\}/, '')
+            ? providerConfig!.defaults!.endpointTemplate!
+                .replace(/\{accountId\}/, '')
+                .replace(/\{jurisdiction\}/, jurisdictionSegment(options.jurisdiction))
             : undefined;
 
         // Show endpoint row: for accountId providers show fixed part inline, otherwise full endpoint
         const showEndpoint = (hasPresetEndpoint && !hasAccountIdTemplate) || hasUserEndpointField;
 
+        // Every handler that recomputes the endpoint must pass the WHOLE set of
+        // template parameters, not just the one it changed: a template can carry
+        // more than one placeholder (R2 carries accountId and jurisdiction), and
+        // an omitted one either resolves to a stale value or leaves the endpoint
+        // unresolved. `override` is what this particular edit changed, since
+        // `options` still holds the pre-edit value.
+        const endpointExtraParams = (override?: Record<string, string>): Record<string, string> | undefined =>
+            s3TemplateParams({ ...options, ...(override || {}) });
+
         // Region change handler: for endpointTemplate providers, also recompute endpoint
         const handleRegionChange = (newRegion: string) => {
             const updatedOptions = { ...options, region: newRegion };
             if (hasEndpointTemplate && selectedProviderId) {
-                const computed = resolveS3Endpoint(selectedProviderId, newRegion, options.accountId ? { accountId: options.accountId } : undefined);
+                const computed = resolveS3Endpoint(selectedProviderId, newRegion, endpointExtraParams());
                 if (computed) updatedOptions.endpoint = computed;
             }
             onChange(updatedOptions);
@@ -883,7 +896,18 @@ export const ProtocolFields: React.FC<ProtocolFieldsProps> = ({
         const handleAccountIdChange = (newAccountId: string) => {
             const updatedOptions = { ...options, accountId: newAccountId };
             if (hasEndpointTemplate && selectedProviderId) {
-                const computed = resolveS3Endpoint(selectedProviderId, options.region, newAccountId ? { accountId: newAccountId } : undefined);
+                const computed = resolveS3Endpoint(selectedProviderId, options.region, endpointExtraParams({ accountId: newAccountId }));
+                if (computed) updatedOptions.endpoint = computed;
+            }
+            onChange(updatedOptions);
+        };
+
+        // Jurisdiction change handler: an R2 bucket created in a jurisdiction
+        // answers only on that host, so the endpoint is recomputed with it.
+        const handleJurisdictionChange = (newJurisdiction: string) => {
+            const updatedOptions = { ...options, jurisdiction: newJurisdiction || undefined };
+            if (hasEndpointTemplate && selectedProviderId) {
+                const computed = resolveS3Endpoint(selectedProviderId, options.region, endpointExtraParams({ jurisdiction: newJurisdiction }));
                 if (computed) updatedOptions.endpoint = computed;
             }
             onChange(updatedOptions);
@@ -1131,14 +1155,38 @@ export const ProtocolFields: React.FC<ProtocolFieldsProps> = ({
                                     required={accountIdField.required}
                                 />
                                 {endpointFixedPart && (
-                                    <span className="px-3 py-2.5 bg-gray-100 dark:bg-gray-600 border border-gray-300 dark:border-gray-600 rounded-r-lg text-sm text-gray-500 dark:text-gray-300 whitespace-nowrap">
-                                        {endpointFixedPart}
-                                    </span>
+                                    jurisdictionField?.options?.length ? (
+                                        /* The suffix is not fixed for this preset: the jurisdiction
+                                           chooses it, so it is picked here and the user reads the
+                                           host they will actually get. */
+                                        <select
+                                            value={options.jurisdiction || ''}
+                                            onChange={(e) => handleJurisdictionChange(e.target.value)}
+                                            disabled={disabled}
+                                            aria-label={jurisdictionField.label || 'Jurisdiction'}
+                                            className="px-3 py-2.5 bg-gray-100 dark:bg-gray-600 border border-gray-300 dark:border-gray-600 rounded-r-lg text-sm text-gray-600 dark:text-gray-200 whitespace-nowrap"
+                                        >
+                                            {jurisdictionField.options.map(opt => (
+                                                <option key={opt.value} value={opt.value}>
+                                                    {providerConfig!.defaults!.endpointTemplate!
+                                                        .replace(/\{accountId\}/, '')
+                                                        .replace(/\{jurisdiction\}/, jurisdictionSegment(opt.value))}
+                                                </option>
+                                            ))}
+                                        </select>
+                                    ) : (
+                                        <span className="px-3 py-2.5 bg-gray-100 dark:bg-gray-600 border border-gray-300 dark:border-gray-600 rounded-r-lg text-sm text-gray-500 dark:text-gray-300 whitespace-nowrap">
+                                            {endpointFixedPart}
+                                        </span>
+                                    )
                                 )}
                             </div>
                         )}
                         {!isEditing && accountIdField.helpText && !presetUnlocked['endpointSuffix'] && (
                             <p className="text-xs text-gray-500 mt-1">{accountIdField.helpText}</p>
+                        )}
+                        {!isEditing && jurisdictionField?.helpText && !presetUnlocked['endpointSuffix'] && (
+                            <p className="text-xs text-gray-500 mt-1">{jurisdictionField.helpText}</p>
                         )}
                     </div>
                 )}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -25,4 +25,8 @@ export {
     getAllProviders,
     getStableProviders,
     resolveS3Endpoint,
+    jurisdictionSegment,
+    s3TemplateParams,
+    parseS3EndpointParams,
+    R2_JURISDICTIONS,
 } from './registry';

--- a/src/providers/r2Jurisdiction.test.ts
+++ b/src/providers/r2Jurisdiction.test.ts
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+import { describe, it, expect } from 'vitest';
+import {
+    R2_JURISDICTIONS,
+    getProviderById,
+    jurisdictionSegment,
+    parseS3EndpointParams,
+    resolveS3Endpoint,
+    s3TemplateParams,
+} from './registry';
+
+describe('Cloudflare R2 jurisdiction', () => {
+    it('resolves the default endpoint when no jurisdiction is stored', () => {
+        // Every R2 profile saved before this option existed has no such key. The
+        // template gained a `{jurisdiction}` placeholder, and an unresolved
+        // placeholder makes resolveS3Endpoint return null, so this is the case
+        // that decides whether those profiles keep working.
+        expect(resolveS3Endpoint('cloudflare-r2', 'auto', { accountId: 'a1b2c3d4e5f6' }))
+            .toBe('a1b2c3d4e5f6.r2.cloudflarestorage.com');
+    });
+
+    it('puts each jurisdiction in its own endpoint host', () => {
+        expect(resolveS3Endpoint('cloudflare-r2', 'auto', { accountId: 'acc', jurisdiction: 'eu' }))
+            .toBe('acc.eu.r2.cloudflarestorage.com');
+        expect(resolveS3Endpoint('cloudflare-r2', 'auto', { accountId: 'acc', jurisdiction: 'us' }))
+            .toBe('acc.us.r2.cloudflarestorage.com');
+    });
+
+    it('treats an unknown or empty jurisdiction as the default placement', () => {
+        // Not defensiveness for its own sake: a hand-edited profile or an import
+        // can carry anything, and the wrong answer here is a profile with no
+        // endpoint rather than a profile pointing somewhere odd.
+        for (const value of ['', '   ', 'mars', undefined]) {
+            expect(jurisdictionSegment(value)).toBe('');
+        }
+        expect(resolveS3Endpoint('cloudflare-r2', 'auto', { accountId: 'acc', jurisdiction: 'mars' }))
+            .toBe('acc.r2.cloudflarestorage.com');
+    });
+
+    it('accepts the jurisdiction code in any case', () => {
+        expect(jurisdictionSegment('EU')).toBe('.eu');
+        expect(jurisdictionSegment(' Us ')).toBe('.us');
+    });
+
+    it('offers exactly the jurisdictions the preset lists, default first', () => {
+        const field = getProviderById('cloudflare-r2')?.fields?.find(f => f.key === 'jurisdiction');
+        expect(field?.type).toBe('select');
+        expect(field?.options?.map(o => o.value)).toEqual(R2_JURISDICTIONS.map(j => j.value));
+        // The default must stay first: it is what a profile with no stored value
+        // shows, and what the select falls back to.
+        expect(R2_JURISDICTIONS[0].value).toBe('');
+        expect(R2_JURISDICTIONS[0].segment).toBe('');
+    });
+
+    it('carries every template parameter, not just the one being edited', () => {
+        // The defect this guards: a caller that rebuilt the endpoint passing only
+        // the field it had just changed dropped the other one, producing a host
+        // for the wrong account or the wrong jurisdiction.
+        expect(s3TemplateParams({ accountId: 'acc', jurisdiction: 'eu' }))
+            .toEqual({ accountId: 'acc', jurisdiction: 'eu' });
+        expect(s3TemplateParams({ accountId: 'acc' })).toEqual({ accountId: 'acc' });
+        expect(s3TemplateParams({})).toBeUndefined();
+        expect(s3TemplateParams(undefined)).toBeUndefined();
+    });
+
+    it('recovers account id and jurisdiction from an endpoint saved without them', () => {
+        // A profile saved before a field existed carries the endpoint and not the
+        // field. This is the path that fills the form back in, and the defect it
+        // guards against is concrete: building the regex by substituting one
+        // placeholder leaves the other one in the pattern as a literal, so the
+        // host matches nothing and the account id of every old R2 profile is
+        // silently lost.
+        expect(parseS3EndpointParams('cloudflare-r2', 'https://a1b2c3.r2.cloudflarestorage.com'))
+            .toEqual({ accountId: 'a1b2c3' });
+        expect(parseS3EndpointParams('cloudflare-r2', 'https://a1b2c3.eu.r2.cloudflarestorage.com'))
+            .toEqual({ accountId: 'a1b2c3', jurisdiction: 'eu' });
+        expect(parseS3EndpointParams('cloudflare-r2', 'a1b2c3.us.r2.cloudflarestorage.com/bucket'))
+            .toEqual({ accountId: 'a1b2c3', jurisdiction: 'us' });
+    });
+
+    it('recovers nothing from a host that is not this provider', () => {
+        expect(parseS3EndpointParams('cloudflare-r2', 'https://s3.wasabisys.com')).toEqual({});
+        expect(parseS3EndpointParams('cloudflare-r2', '')).toEqual({});
+        expect(parseS3EndpointParams(undefined, 'https://a.r2.cloudflarestorage.com')).toEqual({});
+        // A segment R2 does not publish is not a jurisdiction, and the account id
+        // must not silently absorb it either.
+        expect(parseS3EndpointParams('cloudflare-r2', 'https://a1b2c3.zz.r2.cloudflarestorage.com'))
+            .toEqual({});
+    });
+
+    it('round-trips: what resolve builds, parse reads back', () => {
+        for (const j of R2_JURISDICTIONS) {
+            const endpoint = resolveS3Endpoint('cloudflare-r2', 'auto', s3TemplateParams({
+                accountId: 'a1b2c3',
+                jurisdiction: j.value,
+            }));
+            expect(endpoint).toBe(`a1b2c3${j.segment}.r2.cloudflarestorage.com`);
+            const parsed = parseS3EndpointParams('cloudflare-r2', endpoint!);
+            expect(parsed.accountId).toBe('a1b2c3');
+            expect(parsed.jurisdiction ?? '').toBe(j.value);
+        }
+    });
+
+    it('leaves presets without a jurisdiction placeholder untouched', () => {
+        expect(resolveS3Endpoint('wasabi', 'eu-central-1'))
+            .toBe('https://s3.eu-central-1.wasabisys.com');
+    });
+});

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -14,6 +14,112 @@
 import { ProviderConfig, ProviderCategory, BaseProtocol, ProviderRegistry } from './types';
 
 // ============================================================================
+// Cloudflare R2 jurisdictions
+// ============================================================================
+
+/**
+ * The R2 jurisdictions, as the label the user picks and the segment that goes
+ * into the endpoint host. A bucket created in a jurisdiction answers ONLY on
+ * that host: `<account>.eu.r2.cloudflarestorage.com` for a bucket created with
+ * jurisdiction `eu`, and the plain `<account>.r2.cloudflarestorage.com` for one
+ * created without. The jurisdiction is fixed when the bucket is created and
+ * cannot be changed afterwards, so this is a property of the bucket the user
+ * reports, never something to guess.
+ *
+ * The empty value is the default and MUST stay first: it is what every profile
+ * saved before this field existed resolves to.
+ */
+export const R2_JURISDICTIONS: ReadonlyArray<{ value: string; label: string; segment: string }> = [
+    { value: '', label: 'Default (no jurisdiction)', segment: '' },
+    { value: 'eu', label: 'European Union (eu)', segment: '.eu' },
+    { value: 'us', label: 'United States (us)', segment: '.us' },
+];
+
+/**
+ * Endpoint host segment for a jurisdiction value. Anything unknown, empty or
+ * absent resolves to the default (no segment) rather than to an error: a
+ * profile that never carried the field must keep reaching the endpoint it
+ * reached before.
+ */
+export const jurisdictionSegment = (value?: string | null): string =>
+    R2_JURISDICTIONS.find(j => j.value === (value || '').trim().toLowerCase())?.segment ?? '';
+
+/**
+ * Read back, from an endpoint host, the template parameters that produced it.
+ *
+ * The inverse of `resolveS3Endpoint` for the parameters a saved profile may be
+ * missing: a profile written before a parameter existed carries the endpoint
+ * but not the field, and the form needs the field to show the right thing and
+ * to recompute the host later.
+ *
+ * Built by splitting the template on its placeholders rather than by string
+ * substitution into a regex, because a substituted `{accountId}` leaves any
+ * OTHER placeholder in place as a literal, which then matches nothing. That is
+ * exactly what happened when the R2 template gained `{jurisdiction}`: the
+ * previous one-line regex looked for the characters `{jurisdiction}` inside the
+ * host and silently stopped recovering the account id of every R2 profile
+ * saved in the old format.
+ */
+export const parseS3EndpointParams = (
+    providerId: string | undefined,
+    endpoint: string | undefined,
+): { accountId?: string; jurisdiction?: string } => {
+    if (!providerId || !endpoint) return {};
+    const template = providerRegistry.getById(providerId)?.defaults?.endpointTemplate;
+    if (!template) return {};
+
+    const host = endpoint.replace(/^https?:\/\//i, '').replace(/[/?#].*$/, '');
+    const escape = (v: string) => v.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const segments = R2_JURISDICTIONS.map(j => j.segment).filter(Boolean);
+
+    const captures: string[] = [];
+    const pattern = template
+        .split(/(\{accountId\}|\{jurisdiction\})/)
+        .map(part => {
+            if (part === '{accountId}') {
+                captures.push('accountId');
+                return '([^.]+)';
+            }
+            if (part === '{jurisdiction}') {
+                captures.push('jurisdiction');
+                return `(${segments.map(escape).join('|')})?`;
+            }
+            return escape(part);
+        })
+        .join('');
+
+    const match = host.match(new RegExp(`^${pattern}$`, 'i'));
+    if (!match) return {};
+
+    const out: { accountId?: string; jurisdiction?: string } = {};
+    captures.forEach((name, i) => {
+        const value = match[i + 1];
+        if (!value) return;
+        if (name === 'accountId') out.accountId = value;
+        if (name === 'jurisdiction') {
+            const code = R2_JURISDICTIONS.find(j => j.segment.toLowerCase() === value.toLowerCase())?.value;
+            if (code) out.jurisdiction = code;
+        }
+    });
+    return out;
+};
+
+/**
+ * Collect, from a saved profile's options, the parameters an S3 endpoint
+ * template can name. One place builds this set, because every caller that
+ * recomputes an endpoint has to pass ALL of them: a caller that passes only the
+ * parameter it knows about produces a host missing the others.
+ */
+export const s3TemplateParams = (
+    options?: { accountId?: unknown; jurisdiction?: unknown } | null,
+): Record<string, string> | undefined => {
+    const params: Record<string, string> = {};
+    if (options?.accountId) params.accountId = String(options.accountId);
+    if (options?.jurisdiction) params.jurisdiction = String(options.jurisdiction);
+    return Object.keys(params).length ? params : undefined;
+};
+
+// ============================================================================
 // Common Field Definitions (reusable)
 // ============================================================================
 
@@ -551,11 +657,21 @@ export const PROVIDERS: ProviderConfig[] = [
                 helpText: 'Cloudflare Dashboard → R2 → Overview → Account ID',
                 group: 'server',
             },
+            {
+                key: 'jurisdiction',
+                label: 'Jurisdiction',
+                type: 'select',
+                required: false,
+                defaultValue: '',
+                options: R2_JURISDICTIONS.map(j => ({ value: j.value, label: j.label })),
+                helpText: 'A bucket created in a jurisdiction is reachable only through that endpoint, and the choice is fixed at bucket creation',
+                group: 'server',
+            },
         ],
         defaults: {
             pathStyle: true,
             region: 'auto',
-            endpointTemplate: '{accountId}.r2.cloudflarestorage.com',
+            endpointTemplate: '{accountId}{jurisdiction}.r2.cloudflarestorage.com',
         },
         features: {
             shareLink: true,
@@ -2115,6 +2231,12 @@ export const resolveS3Endpoint = (providerId: string | undefined, region?: strin
 
     let result = template;
     if (region) result = result.replace('{region}', region);
+    // Jurisdiction before the generic pass: the stored value is the bare code
+    // (`eu`), the host wants the segment (`.eu`), and an absent value is the
+    // default rather than an unresolved placeholder.
+    if (result.includes('{jurisdiction}')) {
+        result = result.replace('{jurisdiction}', jurisdictionSegment(extraParams?.jurisdiction));
+    }
     if (extraParams) {
         for (const [key, value] of Object.entries(extraParams)) {
             result = result.replace(`{${key}}`, value);

--- a/src/types.ts
+++ b/src/types.ts
@@ -336,6 +336,7 @@ export interface ProviderOptions {
   region?: string;
   endpoint?: string; // For S3-compatible (MinIO, etc.)
   accountId?: string; // Cloudflare R2 account ID (used to compute endpoint)
+  jurisdiction?: string; // Cloudflare R2 jurisdiction ("", "eu", "us"): part of the endpoint host, fixed at bucket creation
   pathStyle?: boolean;
   storage_class?: string; // S3 default storage class for uploads
   sse_mode?: string; // S3 server-side encryption (AES256, aws:kms)

--- a/src/utils/speedTest.ts
+++ b/src/utils/speedTest.ts
@@ -1,6 +1,6 @@
 import { invoke } from '@tauri-apps/api/core';
 import { ServerProfile } from '../types';
-import { resolveS3Endpoint } from '../providers/registry';
+import { resolveS3Endpoint, s3TemplateParams } from '../providers/registry';
 import {
     SPEEDTEST_SUPPORTED_PROTOCOLS,
     SpeedTestProviderConnectionParams,
@@ -94,7 +94,7 @@ export async function buildSpeedTestConnection(server: ServerProfile): Promise<S
     const options = server.options || {};
     const region = options.region || (server.providerId === 'filelu-s3' ? 'global' : 'us-east-1');
     const endpoint = options.endpoint
-        || resolveS3Endpoint(server.providerId, region as string, options.accountId ? { accountId: options.accountId } : undefined)
+        || resolveS3Endpoint(server.providerId, region as string, s3TemplateParams(options))
         || (protocol === 's3' && server.host && !server.host.includes('amazonaws.com') ? server.host : null);
 
     return {


### PR DESCRIPTION
Two items from the triage of the 2026-09-04 provider and competitor digests, the two that were actionable. The rest of the triage closed items rather than opening work: the Nextcloud 35 RC3 fixes do not touch the path we use, GCS hierarchical namespace does not exist on the S3-compatible endpoint we speak, the S3 403 policy ARN item belongs to the structured-errors track, and the WinSCP 6.6.3 RC was filed as a security-parity priority when this tree already carries OpenSSL 3.6.3 against the 3.5.8 in that release, with the listed CVEs being PuTTY's own C code.

## 1. Backblaze: measure the digest before the service starts encrypting

From **2026-09-14** Backblaze encrypts new uploads and server-side copies with SSE-B2 by default. Nothing changes on the wire from our side, so the only observable is the digest the service reports for an object, which is what `sync`, `dedupe` and `verify` read instead of downloading the bytes.

The existing B2 suite could not have observed it. Its upload tests compare a SHA-256 computed locally before the upload with one computed locally after the download: that proves the bytes survive and says nothing about what the server publishes about them, so a digest that stopped being reported would leave every one of them green while sync silently degraded to size and mtime.

This adds the assertions that can fail:

- single-part upload: `contentSha1` must equal the content SHA-1;
- large file: no digest, which is the documented `B2_UNVERIFIED` behaviour, and if one ever appears it must be the real digest and not an opaque value that passes the 40-hex shape check;
- rename: a server-side copy must preserve it, since the destination bytes are written by the service rather than uploaded with a client-computed SHA-1;
- new `integration_b2_s3_compat`: the S3-compatible endpoint is a **second code path** with no live coverage, and a different exposure, because it reads the S3 ETag and `etag_to_md5` accepts only 32 hex characters, so an opaque ETag makes the digest disappear quietly. AWS keeps the ETag equal to the MD5 under SSE-S3 and only breaks it under SSE-KMS and SSE-C.

### Measured, and the answer is that nothing changes

The wait was avoidable: a bucket can be created with SSE-B2 as its default today, which is the same state Backblaze will switch everyone into. Two throw-away buckets were created, one with default encryption off and one with it on, and the suite was run against both.

| case | encryption off | encryption on |
|---|---|---|
| native, single-part | `sha1=ecfc8e86...23be` | `sha1=ecfc8e86...23be` |
| native, server-side copy | `sha1=bcb72176...4fea` | `sha1=bcb72176...4fea` |
| native, 250 MB multipart | none, as documented | none |
| S3-compat, single-part ETag | `md5=c35cc7d8...f372` | `md5=c35cc7d8...f372` |
| S3-compat, server-side copy | `md5=1910b453...bb77` | `md5=1910b453...bb77` |

SSE-B2 leaves both digests untouched, on both code paths, which is the AWS behaviour for SSE-S3 and not something that could be assumed for B2. So 2026-09-14 needs no client change. The tests stay: they are what makes that a measurement rather than a belief, and what will fail if the service changes its mind later.

Declared limit: the 250 MB multipart case was measured only on the encrypted bucket, to stay inside the free tier's 1 GB daily download cap. It leans away from the conclusion rather than toward it: an unencrypted bucket reporting a digest there would have made the encrypted "none" a regression, and both the checksum matrix and the provider code say a B2 large file never carries a usable `contentSha1`. One transient upload failure was seen on the first multipart run and did not reproduce; its message was lost to an output filter, so it is recorded here rather than explained.

Both files also print what the server actually reported, on a `[b2-digest-baseline]` line, because the comparison that settles this is between a run from **before** 2026-09-14 and one from after, and objects written before the change cannot be created after it. The new lane is registered in `scripts/smoke.mjs` so it is part of the matrix rather than a file nobody runs.

Everything here is `#[ignore]` and credential-gated: without a throw-away bucket these skip and pass, and measure nothing.

## 2. Cloudflare R2: the jurisdictions were unreachable

An R2 bucket created in a jurisdiction answers only on its own host. The preset composed `{accountId}.r2.cloudflarestorage.com` with no way to say otherwise, and a search across the tree found no `.eu.r2` or `.us.r2` anywhere: **`eu` was missing too**, not only the `us` announced on 2026-08-17. The two ways to reach such a bucket today are typing the segment into the Account ID field or unlocking the suffix and writing the endpoint by hand, which is a workaround, not support.

The suffix beside the Account ID becomes a picker showing the host each choice produces. The code is stored bare (`eu`) and mapped to a host segment in one place per side, both **total**: absent or unknown means the default placement, never a failure to resolve. That is what keeps profiles saved before this option existed working, since an unresolved placeholder makes the resolvers return nothing at all.

It reaches the surfaces without a form, as a connection option has to: the profile loader (CLI, MCP pool, schedulers), the CLI mode scrub, and the bridge's endpoint-to-preset mapping, which keeps recognising the longer host as R2 instead of falling through to `custom-s3`.

**One defect was introduced and closed inside this change.** The form recovers an Account ID from an endpoint saved before that field existed by building a regex from the template, substituting the one placeholder. With a second placeholder present, that regex looked for the literal characters `{jurisdiction}` in the host and matched nothing, which would have silently stopped recovering the account id of every R2 profile in the old format. `parseS3EndpointParams` now builds the pattern by splitting the template on its placeholders, handles any number of them, and recovers the jurisdiction as well.

## Gate

`cargo fmt --all`, `cargo clippy --all-targets -- -D warnings` (the CI command verbatim) green, `cargo test` green, `npx tsc --noEmit` clean, `npm run i18n:validate` at 0 placeholders (no new i18n keys: provider preset labels are plain text in the registry, like every other field there), 10 new frontend tests, 3 new backend tests in the profile loader, 2 jurisdiction hosts added to the bridge mapping test.

A compile error in the new S3-compat test was hidden by a `grep` in a build pipeline that returned 0 regardless; it was caught by rebuilding without the filter, which is why the lane is verified to compile and to register both of its tests rather than assumed to.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Cloudflare R2 jurisdiction support, including jurisdiction-specific endpoint selection for EU and US regions.
  - Added jurisdiction selection to S3-compatible connection profiles.
  - Existing profiles now preserve and recover jurisdiction settings when edited.
  - Speed tests and connection setup use the selected jurisdiction automatically.
  - Added jurisdiction configuration support to the CLI.

- **Bug Fixes**
  - Improved recognition of jurisdiction-specific Cloudflare R2 endpoints.
  - Preserved endpoint behavior for custom and non-R2 S3 providers.

- **Tests**
  - Expanded Backblaze B2 testing to verify server-reported digests, large-file renames, and S3-compatible connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->