### PR TITLE
ci(aerorsync): run the standalone lane when only the lockfile changes

### DIFF
--- a/.github/workflows/aerorsync-standalone.yml
+++ b/.github/workflows/aerorsync-standalone.yml
@@ -17,6 +17,7 @@ on:
     paths:
       - 'src-tauri/src/aerorsync/**'
       - 'src-tauri/Cargo.toml'
+      - 'src-tauri/Cargo.lock'
       - 'src-tauri/.cargo/config.toml'
       - 'scripts/aerorsync-emit.sh'
       - 'scripts/aerorsync-emit-guard-tests.sh'
@@ -25,6 +26,7 @@ on:
     paths:
       - 'src-tauri/src/aerorsync/**'
       - 'src-tauri/Cargo.toml'
+      - 'src-tauri/Cargo.lock'
       - 'src-tauri/.cargo/config.toml'
       - 'scripts/aerorsync-emit.sh'
       - 'scripts/aerorsync-emit-guard-tests.sh'


### PR DESCRIPTION
## Description

The emitter copies the application's `Cargo.lock` into the emitted crate, so the standalone crate compiles the versions the product pins rather than whatever the registry resolves that day. That was added because the two had already drifted: the emitted crate was building `russh 0.63.2` against the `0.63.1` the product ships, on the very crate this repository keeps pinned for its history.

The lane's path triggers were not updated with it. A change to the lockfile alone, which is exactly what `cargo update -p <crate>` produces and what a Dependabot batch can produce, changes what the emitted crate compiles and did not start the workflow that checks it. The gate did not fire on a change it exists to judge.

Verified before fixing: `src-tauri/Cargo.lock` was absent from both trigger lists, the `push` one and the `pull_request` one. It is now in both.

Raised in the plan review of the standalone-crate track, alongside the observation that the emitted manifest is a bootstrap for verification and not the distributable manifest that phase E1 will need. That second half is a phase E item and is recorded there, not here.

## Type of Change
- [x] CI reliability, no production code
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standalone compilation checks now run when the Rust lockfile changes, helping validate dependency updates automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->