### PR TITLE
ci: cancel stale Tauri builds when a PR SHA is superseded

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,13 @@ on:
 permissions:
   contents: read
 
+# Same idea as checks.yml: a new SHA on a PR or on main should cancel the
+# previous 4-leg Tauri matrix, not let it keep burning. Do not cancel a tag
+# run: a release build must finish even if something else is dispatched.
+concurrency:
+  group: build-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref_type != 'tag' }}
+
 jobs:
   build-and-release:
     # Required for creating releases and Sigstore keyless signing via GitHub OIDC.


### PR DESCRIPTION
## Description

`checks.yml` already uses `concurrency` with `cancel-in-progress`. The packaging workflow did not, so every review-fix push on a PR started a new 4-leg Tauri matrix (linux, windows, two macOS) while the previous one kept running. #724 paid that three times in one day.

This adds the same cancel-on-new-SHA behaviour to `build.yml`, keyed on the workflow and the git ref. Tag runs are not cancelled, so a release build cannot be aborted by a later dispatch.

Standing rule 0604: GitHub CI is the PR green. This change only makes that CI cheaper when the SHA moves.

## Type of Change
- [x] Bug fix (CI waste, not product)

## Checklist
- [x] My code follows the project's code style
- [x] I have tested my changes
- [ ] I have updated the documentation (if needed)
- [x] My changes generate no new warnings
- [x] Every commit is signed off (`git commit -s`), see CONTRIBUTING.md