### PR TITLE
ci: save rust-cache only from main so PRs cannot evict it

### DIFF
--- a/.github/workflows/aerorsync-protocol.yml
+++ b/.github/workflows/aerorsync-protocol.yml
@@ -71,6 +71,8 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: src-tauri
+          # PRs restore; only main saves (Actions cache quota is 10 GB).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install Linux system deps
         run: |
           # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
@@ -124,6 +126,8 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: src-tauri
+          # PRs restore; only main saves (Actions cache quota is 10 GB).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Free disk space
         run: |
           sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
@@ -179,6 +183,8 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: src-tauri
+          # PRs restore; only main saves (Actions cache quota is 10 GB).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       # Same reclaim step delta-sync-integration.yml, cli-smoke.yml and
       # build.yml already use: the lib in test profile plus the Docker
       # fixture do not fit in the runner's free disk on a cold cache.

--- a/.github/workflows/aerorsync-standalone.yml
+++ b/.github/workflows/aerorsync-standalone.yml
@@ -105,6 +105,8 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: target/aerorsync-standalone
+          # PRs restore; only main saves (Actions cache quota is 10 GB).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: The emission is reproducible
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,8 @@ jobs:
           # See "Drop stale whisper-rs-sys CMake artifacts" below for the
           # belt-and-suspenders runtime cleanup.
           prefix-key: 'v2-whisper-vs18'
+          # PRs restore; only main saves (Actions cache quota is 10 GB).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Add macOS Intel cross target
         if: matrix.target == 'macos' && matrix.arch == 'x64'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -44,6 +44,8 @@ jobs:
         uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
           workspaces: './src-tauri -> target'
+          # PRs restore; only main saves (Actions cache quota is 10 GB).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install npm dependencies
         run: npm ci

--- a/.github/workflows/cli-smoke.yml
+++ b/.github/workflows/cli-smoke.yml
@@ -66,6 +66,8 @@ jobs:
           # See "Drop stale whisper-rs-sys CMake artifacts" below for the
           # belt-and-suspenders runtime cleanup. Mirrored from build.yml.
           prefix-key: 'v2-whisper-vs18'
+          # PRs restore; only main saves (Actions cache quota is 10 GB).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # whisper-rs-sys vendors whisper.cpp and runs CMake at build time. The
       # generator picked by cmake-rs is whichever Visual Studio CMake finds
@@ -267,6 +269,8 @@ jobs:
         with:
           workspaces: './src-tauri -> target'
           prefix-key: 'v2-whisper-vs18'
+          # PRs restore; only main saves (Actions cache quota is 10 GB).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install Linux dependencies
         run: |
@@ -331,6 +335,8 @@ jobs:
           # in this workflow. Linux coverage does not hit the VS18 issue,
           # but a shared prefix avoids partial cache reuse confusion.
           prefix-key: 'v2-whisper-vs18'
+          # PRs restore; only main saves (Actions cache quota is 10 GB).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install Linux dependencies
         run: |

--- a/.github/workflows/delta-sync-integration.yml
+++ b/.github/workflows/delta-sync-integration.yml
@@ -103,6 +103,8 @@ jobs:
         uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
           workspaces: './src-tauri -> target'
+          # PRs restore; only main saves (Actions cache quota is 10 GB).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # The apt step below fetches 61.5 MB of .deb, and that download is the
       # entire observed failure mode. In run 30488867618 the Azure mirror
@@ -315,6 +317,8 @@ jobs:
         with:
           workspaces: './src-tauri -> target'
           shared-key: delta-sync-fallback
+          # PRs restore; only main saves (Actions cache quota is 10 GB).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # See the key-auth job for the measurements this is based on. Separate
       # cache key: this lane installs sshpass on top of the same set.
@@ -491,6 +495,8 @@ jobs:
           # also pinned above as belt-and-suspenders, but if the pin is
           # ever lifted we still want the cache invalidation in place.
           prefix-key: 'v2-whisper-vs18'
+          # PRs restore; only main saves (Actions cache quota is 10 GB).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # whisper-rs-sys vendors whisper.cpp and runs CMake at build time.
       # The generator picked by cmake-rs is whichever Visual Studio

--- a/.github/workflows/ftp-mlsd.yml
+++ b/.github/workflows/ftp-mlsd.yml
@@ -51,6 +51,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
+          # PRs restore; only main saves (Actions cache quota is 10 GB).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # The three packages are the right ones and were not the whole answer.
       # delta-sync-integration.yml caches these archives because that download
@@ -192,6 +194,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
+          # PRs restore; only main saves (Actions cache quota is 10 GB).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # The three steps below are copied from the `mlsd` job, deliberately and
       # in full. This job was added beside that one and inherits nothing from

--- a/.github/workflows/nightly-telemetry.yml
+++ b/.github/workflows/nightly-telemetry.yml
@@ -38,6 +38,8 @@ jobs:
         uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
           workspaces: './src-tauri -> target'
+          # PRs restore; only main saves (Actions cache quota is 10 GB).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Rust formatting (cargo fmt --check)
         working-directory: ./src-tauri

--- a/.github/workflows/portal-chooser.yml
+++ b/.github/workflows/portal-chooser.yml
@@ -68,6 +68,8 @@ jobs:
         uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
           workspaces: './tests/portal-chooser/fake-portal -> target'
+          # PRs restore; only main saves (Actions cache quota is 10 GB).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install D-Bus
         run: |
@@ -125,6 +127,8 @@ jobs:
         uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
           workspaces: './src-tauri -> target'
+          # PRs restore; only main saves (Actions cache quota is 10 GB).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # at-spi2-core + python3-pyatspi are what make the trigger name-based
       # instead of coordinate-based. xdotool is used only to count and describe

--- a/.github/workflows/snap-refresh.yml
+++ b/.github/workflows/snap-refresh.yml
@@ -171,6 +171,8 @@ jobs:
         with:
           workspaces: './src-tauri -> target'
           prefix-key: 'v2-whisper-vs18'
+          # PRs restore; only main saves (Actions cache quota is 10 GB).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install Linux build dependencies
         run: |


### PR DESCRIPTION
## Description

GitHub Actions cache quota is 10 GB. All 18 `swatinem/rust-cache` uses currently save on every ref (`save-if` defaults to true). PR merge-ref entries (~1–1.6 GB each; #724 alone held ~6.7 GB) evict the `refs/heads/main` Linux/Windows caches. The Linux packaging leg then reports `No cache found` and rebuilds from cold (~2 hours).

This sets `save-if: ${{ github.ref == 'refs/heads/main' }}` on every rust-cache step. PRs still **restore** from whatever main last wrote. Only a push to `main` **writes**. Tags and PRs do not save, so they cannot evict the shared caches.

Declared limit, accepted: a second push on the same PR no longer reuses that PR's own cache. Main staying warm helps every run more than one branch caching itself.

Existing PR caches are **not** bulk-deleted; they can age out.

Sibling of #727 (cancel stale `build.yml` runs). Kept as a separate PR so #727's in-flight matrix is not cancelled by a follow-up push.

## Type of Change
- [x] Bug fix (CI cache eviction, not product)

## Checklist
- [x] My code follows the project's code style
- [x] I have tested my changes (18/18 rust-cache uses, YAML load, `save-if` sits inside each `with:` block)
- [ ] I have updated the documentation (if needed)
- [x] My changes generate no new warnings
- [x] Every commit is signed off (`git commit -s`), see CONTRIBUTING.md