### PR TITLE
ci: run Linux lint and tests off the packaging critical path

### DIFF
--- a/.github/workflows/aerorsync-protocol.yml
+++ b/.github/workflows/aerorsync-protocol.yml
@@ -71,6 +71,8 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: src-tauri
+          # PRs restore; only main saves (Actions cache quota is 10 GB).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install Linux system deps
         run: |
           # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
@@ -124,6 +126,8 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: src-tauri
+          # PRs restore; only main saves (Actions cache quota is 10 GB).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Free disk space
         run: |
           sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
@@ -179,6 +183,8 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: src-tauri
+          # PRs restore; only main saves (Actions cache quota is 10 GB).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       # Same reclaim step delta-sync-integration.yml, cli-smoke.yml and
       # build.yml already use: the lib in test profile plus the Docker
       # fixture do not fit in the runner's free disk on a cold cache.

--- a/.github/workflows/aerorsync-standalone.yml
+++ b/.github/workflows/aerorsync-standalone.yml
@@ -105,6 +105,8 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: target/aerorsync-standalone
+          # PRs restore; only main saves (Actions cache quota is 10 GB).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: The emission is reproducible
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,8 @@ jobs:
           # See "Drop stale whisper-rs-sys CMake artifacts" below for the
           # belt-and-suspenders runtime cleanup.
           prefix-key: 'v2-whisper-vs18'
+          # PRs restore; only main saves (Actions cache quota is 10 GB).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Add macOS Intel cross target
         if: matrix.target == 'macos' && matrix.arch == 'x64'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -530,12 +530,12 @@ jobs:
           Write-Host "Contents:"
           Get-ChildItem $stage | ForEach-Object { Write-Host "  $($_.Name) ($($_.Length) bytes)" }
 
-      # On-demand artifact upload (NOT release builds). Lets us download
-      # platform-native installers from the Actions run page without cutting
-      # a public release. Tag-driven runs skip these steps because the
-      # Sigstore-signed artifacts are already attached to the GitHub Release.
+      # Always upload platform installers as workflow artifacts. Tag runs used
+      # to skip this and publish straight from the runner; that raced
+      # linux-validate after C2. Tags now publish from these artifacts in
+      # `publish-github-release`, which needs linux-validate first.
       - name: Upload Linux installers
-        if: ${{ !startsWith(github.ref, 'refs/tags/') && matrix.target == 'linux' }}
+        if: matrix.target == 'linux'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: aeroftp-linux-${{ github.sha }}
@@ -547,7 +547,7 @@ jobs:
           retention-days: 1
 
       - name: Upload Windows installers
-        if: ${{ !startsWith(github.ref, 'refs/tags/') && matrix.target == 'windows' }}
+        if: matrix.target == 'windows'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: aeroftp-windows-${{ github.sha }}
@@ -559,7 +559,7 @@ jobs:
           retention-days: 1
 
       - name: Upload macOS installers
-        if: ${{ !startsWith(github.ref, 'refs/tags/') && matrix.target == 'macos' }}
+        if: matrix.target == 'macos'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: aeroftp-macos-${{ matrix.arch }}-${{ github.sha }}
@@ -567,38 +567,65 @@ jobs:
           if-no-files-found: warn
           retention-days: 1
 
-      # Sigstore keyless signing: supply chain transparency for all release artifacts.
-      # Uses GitHub OIDC identity (zero secrets). Produces .sigstore.json verification bundles.
+  # Tag publication is a separate job so a v* tag cannot sign/upload while
+  # linux-validate is still red. Packaging stays parallel with validation.
+  # `!cancelled()` plus an explicit linux-validate success check matches
+  # build-snap: a flaky Windows/macOS matrix leg must not block Linux assets,
+  # but a failed test/clippy job must.
+  publish-github-release:
+    if: ${{ !cancelled() && startsWith(github.ref, 'refs/tags/') && needs.linux-validate.result == 'success' }}
+    needs: [linux-validate, build-and-release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Download Linux installers
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: aeroftp-linux-${{ github.sha }}
+          path: release-assets
+
+      - name: Download Windows installers
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: aeroftp-windows-${{ github.sha }}
+          path: release-assets
+
+      - name: Download macOS aarch64 installer
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: aeroftp-macos-aarch64-${{ github.sha }}
+          path: release-assets
+
+      - name: Download macOS x64 installer
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: aeroftp-macos-x64-${{ github.sha }}
+          path: release-assets
+
       - name: Install Cosign
-        if: startsWith(github.ref, 'refs/tags/')
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign release artifacts with Sigstore
-        if: startsWith(github.ref, 'refs/tags/')
         shell: bash
         run: |
+          set -euo pipefail
           shopt -s nullglob
-          ARTIFACTS=()
-
-          case "${{ matrix.target }}" in
-            linux)
-              ARTIFACTS+=(src-tauri/target/release/bundle/deb/*.deb)
-              ARTIFACTS+=(src-tauri/target/release/bundle/rpm/*.rpm)
-              ARTIFACTS+=(src-tauri/target/release/bundle/appimage/*.AppImage)
-              # .snap is signed in the dedicated build-snap job (issue #164)
-              ;;
-            windows)
-              ARTIFACTS+=(src-tauri/target/release/bundle/msi/*.msi)
-              ARTIFACTS+=(src-tauri/target/release/bundle/nsis/*.exe)
-              ARTIFACTS+=(src-tauri/target/release/bundle/AeroFTP-*-portable-*.zip)
-              ;;
-            macos)
-              ARTIFACTS+=(src-tauri/target/release/bundle/dmg/*.dmg)
-              ;;
-          esac
-
+          mkdir -p release-assets
+          mapfile -t ARTIFACTS < <(find release-assets -type f ! -name '*.sigstore.json' | sort)
           echo "Found ${#ARTIFACTS[@]} artifacts to sign"
-
+          if [ "${#ARTIFACTS[@]}" -eq 0 ]; then
+            echo "::error::no packaging artifacts to sign; linux-validate passed but the matrix uploaded nothing"
+            exit 1
+          fi
           for artifact in "${ARTIFACTS[@]}"; do
             echo "Signing: $(basename "$artifact")"
             cosign sign-blob \
@@ -609,16 +636,11 @@ jobs:
             echo "Signed: $(basename "$artifact").sigstore.json"
           done
 
-      # Upload directly to GitHub Release (only on tags)
-      # Each platform uploads its own binaries - no intermediate artifacts needed
       - name: Extract changelog for release
-        if: startsWith(github.ref, 'refs/tags/') && matrix.target == 'linux'
         id: changelog
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          # Extract the section between this version header and the next version header
           NOTES=$(sed -n "/^## \[${VERSION}\]/,/^## \[/p" CHANGELOG.md | head -n -1)
-          # Append download instructions
           NOTES="${NOTES}
 
           **Downloads:**
@@ -629,8 +651,7 @@ jobs:
           echo "$NOTES" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-      - name: Upload Linux binaries to Release
-        if: startsWith(github.ref, 'refs/tags/') && matrix.target == 'linux'
+      - name: Upload binaries to GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           name: 'AeroFTP ${{ github.ref_name }}'
@@ -647,43 +668,10 @@ jobs:
           # delete, not a side effect.
           overwrite_files: false
           files: |
-            src-tauri/target/release/bundle/deb/*.deb
-            src-tauri/target/release/bundle/deb/*.deb.sigstore.json
-            src-tauri/target/release/bundle/rpm/*.rpm
-            src-tauri/target/release/bundle/rpm/*.rpm.sigstore.json
-            src-tauri/target/release/bundle/appimage/*.AppImage
-            src-tauri/target/release/bundle/appimage/*.AppImage.sigstore.json
+            release-assets/**
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # .snap upload is handled in the dedicated build-snap job (issue #164)
-
-      - name: Upload Windows binaries to Release
-        if: startsWith(github.ref, 'refs/tags/') && matrix.target == 'windows'
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-        with:
-          # See the Linux upload step: published assets are immutable.
-          overwrite_files: false
-          files: |
-            src-tauri/target/release/bundle/msi/*.msi
-            src-tauri/target/release/bundle/msi/*.msi.sigstore.json
-            src-tauri/target/release/bundle/nsis/*.exe
-            src-tauri/target/release/bundle/nsis/*.exe.sigstore.json
-            src-tauri/target/release/bundle/AeroFTP-*-portable-*.zip
-            src-tauri/target/release/bundle/AeroFTP-*-portable-*.zip.sigstore.json
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload macOS binaries to Release
-        if: startsWith(github.ref, 'refs/tags/') && matrix.target == 'macos'
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-        with:
-          # See the Linux upload step: published assets are immutable.
-          overwrite_files: false
-          files: |
-            src-tauri/target/release/bundle/dmg/*.dmg
-            src-tauri/target/release/bundle/dmg/*.dmg.sigstore.json
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Build the Snap package on a dedicated runner. Issue #164 background:
   # the original inline step was silent-OOM-ing during LXD setup on the
@@ -723,8 +711,8 @@ jobs:
     # depends on the ubuntu-22.04 leg's payload, so a flaky macOS or Windows leg
     # must not block it. If the Linux leg is the one that failed, the payload
     # artifact is missing and this job fails on the download - which is right.
-    if: ${{ !cancelled() && (startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch') }}
-    needs: build-and-release
+    if: ${{ !cancelled() && needs.linux-validate.result == 'success' && (startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch') }}
+    needs: [linux-validate, build-and-release]
     runs-on: ubuntu-24.04
     permissions:
       contents: write   # required for softprops/action-gh-release
@@ -734,8 +722,8 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       # Guard the snap version BEFORE packaging. Kept even though this job now
-      # runs behind `needs: build-and-release` (whose R10 gate covers the same
-      # ground): it costs a second, and it is what caught v4.0.9 shipping a
+      # runs behind `needs: [linux-validate, build-and-release]` (R10 lives on
+      # linux-validate): it costs a second, and it is what caught v4.0.9 shipping a
       # Sigstore-signed 4.0.8 snap as an asset of the 4.0.9 release. The
       # snap-refresh rebuild path carries its own copy of this guard. Parsed
       # with grep/sed because there is no node in this job any more.
@@ -975,8 +963,8 @@ jobs:
 
   # Publish to Windows Package Manager (winget) on tag pushes
   publish-winget:
-    needs: build-and-release
-    if: startsWith(github.ref, 'refs/tags/')
+    needs: [linux-validate, build-and-release]
+    if: ${{ startsWith(github.ref, 'refs/tags/') && needs.linux-validate.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Publish to WinGet

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,114 @@ permissions:
   contents: read
 
 jobs:
+  # C2: Linux lint+test used to sit on the packaging critical path
+  # (clippy ~8m + cargo test ~42m + bundle ~61m serial). This job runs
+  # them on their own ubuntu-22.04 runner so the 4-leg matrix can bundle
+  # in parallel. Coverage unchanged; wall clock ~max(50, 61).
+  linux-validate:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Free disk space (Linux)
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/share/swift
+          sudo apt-get clean
+          df -h /
+
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+          components: clippy
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        with:
+          workspaces: './src-tauri -> target'
+          # Same prefix as packaging so a warm main cache is a valid restore
+          # key shape, but no shared-key: this job id gets its own cache
+          # after main is warm. That is intended (C1 + C2).
+          prefix-key: 'v2-whisper-vs18'
+          # PRs restore; only main saves (Actions cache quota is 10 GB).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Install Linux dependencies
+        run: |
+          # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
+          # enough to redden a run, and nothing here installs from them.
+          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
+          sudo apt-get update
+          # `dbus` is here for `cargo test` / portal_chooser (#510), not for
+          # packaging. `portal_chooser`'s three cases stand up a throwaway
+          # session bus with `dbus-daemon` to prove that a portal-less host
+          # reads as portal-less. Without the daemon those tests skipped, and
+          # a skip is invisible in the log because a passing test's stderr is
+          # captured: the pin would have reported success while proving
+          # nothing. Bundle tools (patchelf, rpm, squashfs-tools, libfuse3-dev)
+          # stay on the packaging Linux leg.
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev dbus libacl1-dev libacl1
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      # R10 (APPENDIX-CLI-DISPATCH): the three sources of truth for the
+      # AeroFTP version must stay in lockstep. If they drift, an update
+      # ships a CLI that claims one version while the GUI manifest claims
+      # another, the AUR pkgver bump targets the wrong tag, and the
+      # in-app update check compares against the wrong baseline. Cheap
+      # to run (no build, just text parsing). Moved off the packaging
+      # Linux leg so it no longer blocks the Tauri bundle.
+      - name: R10 manifest version match (Cargo.toml, package.json, tauri.conf.json, snapcraft.yaml, and the tag on tag builds)
+        shell: bash
+        run: |
+          CARGO=$(grep -m1 '^version' src-tauri/Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
+          PKG=$(node -p "require('./package.json').version")
+          TAURI=$(node -p "require('./src-tauri/tauri.conf.json').version")
+          SNAP=$(grep -m1 '^version:' snap/snapcraft.yaml | sed "s/.*['\"]\(.*\)['\"].*/\1/")
+          echo "Cargo.toml:        $CARGO"
+          echo "package.json:      $PKG"
+          echo "tauri.conf.json:   $TAURI"
+          echo "snapcraft.yaml:    $SNAP"
+          if [ "$CARGO" != "$PKG" ] || [ "$CARGO" != "$TAURI" ] || [ "$CARGO" != "$SNAP" ]; then
+            echo "::error::R10 version drift: cargo=$CARGO package.json=$PKG tauri.conf.json=$TAURI snapcraft.yaml=$SNAP"
+            exit 1
+          fi
+          # On a tag build the four manifests must also equal the tag itself. R10
+          # previously compared them only to each other, so a release tagged vX.Y.Z
+          # with every manifest left at the prior version passed in silence and
+          # shipped artifacts labelled with the wrong version. The manifests are
+          # already proven equal above, so comparing one of them to the tag suffices.
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            TAG="${GITHUB_REF_NAME#v}"
+            echo "tag:               $TAG"
+            if [ "$CARGO" != "$TAG" ]; then
+              echo "::error::R10 tag drift: manifests=$CARGO but tag=$TAG"
+              exit 1
+            fi
+          fi
+
+      - name: TypeScript type check
+        run: npx tsc --noEmit
+
+      - name: i18n validation
+        run: npm run i18n:validate
+
+      - name: Rust linting (clippy)
+        working-directory: src-tauri
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Rust tests
+        working-directory: src-tauri
+        run: cargo test
+
   build-and-release:
     # Required for creating releases and Sigstore keyless signing via GitHub OIDC.
     permissions:
@@ -124,14 +232,9 @@ jobs:
           # enough to redden a run, and nothing here installs from them.
           sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
           sudo apt-get update
-          # `dbus` is here for the `Rust tests` step below, not for the build.
-          # `portal_chooser`'s three cases stand up a throwaway session bus with
-          # `dbus-daemon` to prove that a portal-less host reads as portal-less,
-          # and this is the only job that runs `cargo test` on Linux. Without the
-          # daemon those tests skipped, and a skip is invisible in the log because
-          # a passing test's stderr is captured: the pin would have reported
-          # success while proving nothing. See #510.
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libfuse3-dev dbus libacl1-dev libacl1 binutils rpm squashfs-tools
+          # `dbus` lives on `linux-validate` with `cargo test` / portal_chooser
+          # (#510). This leg only needs the Tauri/bundle toolchain.
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libfuse3-dev libacl1-dev libacl1 binutils rpm squashfs-tools
           # No snapcraft here any more: this leg stopped building the snap when
           # PR #172 moved it to its own job, and snapcore/action-build brings
           # its own snapcraft. The leftover install (5 retries, 60 s apart on a
@@ -143,72 +246,6 @@ jobs:
       - name: Run security regression suite (MVP)
         run: npm run security:regression
 
-      # R10 (APPENDIX-CLI-DISPATCH): the three sources of truth for the
-      # AeroFTP version must stay in lockstep. If they drift, an update
-      # ships a CLI that claims one version while the GUI manifest claims
-      # another, the AUR pkgver bump targets the wrong tag, and the
-      # in-app update check compares against the wrong baseline. Cheap
-      # to run (no build, just text parsing). Linux-only because the
-      # source files are identical across the matrix; one check covers
-      # the whole release.
-      - name: R10 manifest version match (Cargo.toml, package.json, tauri.conf.json, snapcraft.yaml, and the tag on tag builds)
-        if: matrix.target == 'linux'
-        shell: bash
-        run: |
-          CARGO=$(grep -m1 '^version' src-tauri/Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
-          PKG=$(node -p "require('./package.json').version")
-          TAURI=$(node -p "require('./src-tauri/tauri.conf.json').version")
-          SNAP=$(grep -m1 '^version:' snap/snapcraft.yaml | sed "s/.*['\"]\(.*\)['\"].*/\1/")
-          echo "Cargo.toml:        $CARGO"
-          echo "package.json:      $PKG"
-          echo "tauri.conf.json:   $TAURI"
-          echo "snapcraft.yaml:    $SNAP"
-          if [ "$CARGO" != "$PKG" ] || [ "$CARGO" != "$TAURI" ] || [ "$CARGO" != "$SNAP" ]; then
-            echo "::error::R10 version drift: cargo=$CARGO package.json=$PKG tauri.conf.json=$TAURI snapcraft.yaml=$SNAP"
-            exit 1
-          fi
-          # On a tag build the four manifests must also equal the tag itself. R10
-          # previously compared them only to each other, so a release tagged vX.Y.Z
-          # with every manifest left at the prior version passed in silence and
-          # shipped artifacts labelled with the wrong version. The manifests are
-          # already proven equal above, so comparing one of them to the tag suffices.
-          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-            TAG="${GITHUB_REF_NAME#v}"
-            echo "tag:               $TAG"
-            if [ "$CARGO" != "$TAG" ]; then
-              echo "::error::R10 tag drift: manifests=$CARGO but tag=$TAG"
-              exit 1
-            fi
-          fi
-
-      # Quality gates: run on Linux only to avoid duplicating work across platforms
-      - name: TypeScript type check
-        if: matrix.target == 'linux'
-        run: npx tsc --noEmit
-
-      - name: i18n validation
-        if: matrix.target == 'linux'
-        run: npm run i18n:validate
-
-      - name: Rust linting (clippy)
-        if: matrix.target == 'linux'
-        working-directory: src-tauri
-        run: cargo clippy --all-targets -- -D warnings
-
-      - name: Rust tests
-        if: matrix.target == 'linux'
-        working-directory: src-tauri
-        run: cargo test
-
-      # Native build: Linux, Windows, and the macOS arm64 leg (host arch, no
-      # --target). A real/native target dir keeps every package bin in
-      # target/release so the bundler finds them all.
-      #
-      # Linux AppImage packaging downloads AppRun/linuxdeploy helpers from
-      # GitHub during Tauri's bundling phase. GitHub-hosted runners can drop
-      # those connections after the Rust build is already complete, so retry
-      # only the Linux build step and clear partial helper downloads between
-      # attempts.
       - name: Build Tauri app (Linux with AppImage download retry)
         if: matrix.target == 'linux'
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
   # in parallel. Coverage unchanged; wall clock ~max(50, 61).
   linux-validate:
     runs-on: ubuntu-22.04
+    timeout-minutes: 90
     steps:
       - name: Free disk space (Linux)
         run: |
@@ -246,6 +247,15 @@ jobs:
       - name: Run security regression suite (MVP)
         run: npm run security:regression
 
+      # Native build: Linux, Windows, and the macOS arm64 leg (host arch, no
+      # --target). A real/native target dir keeps every package bin in
+      # target/release so the bundler finds them all.
+      #
+      # Linux AppImage packaging downloads AppRun/linuxdeploy helpers from
+      # GitHub during Tauri's bundling phase. GitHub-hosted runners can drop
+      # those connections after the Rust build is already complete, so retry
+      # only the Linux build step and clear partial helper downloads between
+      # attempts.
       - name: Build Tauri app (Linux with AppImage download retry)
         if: matrix.target == 'linux'
         shell: bash

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -44,6 +44,8 @@ jobs:
         uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
           workspaces: './src-tauri -> target'
+          # PRs restore; only main saves (Actions cache quota is 10 GB).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install npm dependencies
         run: npm ci

--- a/.github/workflows/cli-smoke.yml
+++ b/.github/workflows/cli-smoke.yml
@@ -66,6 +66,8 @@ jobs:
           # See "Drop stale whisper-rs-sys CMake artifacts" below for the
           # belt-and-suspenders runtime cleanup. Mirrored from build.yml.
           prefix-key: 'v2-whisper-vs18'
+          # PRs restore; only main saves (Actions cache quota is 10 GB).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # whisper-rs-sys vendors whisper.cpp and runs CMake at build time. The
       # generator picked by cmake-rs is whichever Visual Studio CMake finds
@@ -267,6 +269,8 @@ jobs:
         with:
           workspaces: './src-tauri -> target'
           prefix-key: 'v2-whisper-vs18'
+          # PRs restore; only main saves (Actions cache quota is 10 GB).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install Linux dependencies
         run: |
@@ -331,6 +335,8 @@ jobs:
           # in this workflow. Linux coverage does not hit the VS18 issue,
           # but a shared prefix avoids partial cache reuse confusion.
           prefix-key: 'v2-whisper-vs18'
+          # PRs restore; only main saves (Actions cache quota is 10 GB).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install Linux dependencies
         run: |

--- a/.github/workflows/delta-sync-integration.yml
+++ b/.github/workflows/delta-sync-integration.yml
@@ -103,6 +103,8 @@ jobs:
         uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
           workspaces: './src-tauri -> target'
+          # PRs restore; only main saves (Actions cache quota is 10 GB).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # The apt step below fetches 61.5 MB of .deb, and that download is the
       # entire observed failure mode. In run 30488867618 the Azure mirror
@@ -315,6 +317,8 @@ jobs:
         with:
           workspaces: './src-tauri -> target'
           shared-key: delta-sync-fallback
+          # PRs restore; only main saves (Actions cache quota is 10 GB).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # See the key-auth job for the measurements this is based on. Separate
       # cache key: this lane installs sshpass on top of the same set.
@@ -491,6 +495,8 @@ jobs:
           # also pinned above as belt-and-suspenders, but if the pin is
           # ever lifted we still want the cache invalidation in place.
           prefix-key: 'v2-whisper-vs18'
+          # PRs restore; only main saves (Actions cache quota is 10 GB).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # whisper-rs-sys vendors whisper.cpp and runs CMake at build time.
       # The generator picked by cmake-rs is whichever Visual Studio

--- a/.github/workflows/ftp-mlsd.yml
+++ b/.github/workflows/ftp-mlsd.yml
@@ -51,6 +51,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
+          # PRs restore; only main saves (Actions cache quota is 10 GB).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # The three packages are the right ones and were not the whole answer.
       # delta-sync-integration.yml caches these archives because that download
@@ -192,6 +194,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
+          # PRs restore; only main saves (Actions cache quota is 10 GB).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # The three steps below are copied from the `mlsd` job, deliberately and
       # in full. This job was added beside that one and inherits nothing from

--- a/.github/workflows/nightly-telemetry.yml
+++ b/.github/workflows/nightly-telemetry.yml
@@ -38,6 +38,8 @@ jobs:
         uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
           workspaces: './src-tauri -> target'
+          # PRs restore; only main saves (Actions cache quota is 10 GB).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Rust formatting (cargo fmt --check)
         working-directory: ./src-tauri

--- a/.github/workflows/portal-chooser.yml
+++ b/.github/workflows/portal-chooser.yml
@@ -68,6 +68,8 @@ jobs:
         uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
           workspaces: './tests/portal-chooser/fake-portal -> target'
+          # PRs restore; only main saves (Actions cache quota is 10 GB).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install D-Bus
         run: |
@@ -125,6 +127,8 @@ jobs:
         uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
           workspaces: './src-tauri -> target'
+          # PRs restore; only main saves (Actions cache quota is 10 GB).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # at-spi2-core + python3-pyatspi are what make the trigger name-based
       # instead of coordinate-based. xdotool is used only to count and describe

--- a/.github/workflows/snap-refresh.yml
+++ b/.github/workflows/snap-refresh.yml
@@ -171,6 +171,8 @@ jobs:
         with:
           workspaces: './src-tauri -> target'
           prefix-key: 'v2-whisper-vs18'
+          # PRs restore; only main saves (Actions cache quota is 10 GB).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install Linux build dependencies
         run: |


### PR DESCRIPTION
## Description

Stacked on #728 (C1). Linux packaging today is serial: clippy ~8m + `cargo test` ~42m + Tauri bundle ~61m (~1h56m). This adds a parallel `linux-validate` job on `ubuntu-22.04` and moves R10, `tsc`, `i18n:validate`, clippy, and `cargo test` onto it.

The packaging job id stays `build-and-release` so rust-cache keys for the 4-leg matrix do not change. `dbus` follows the tests (portal_chooser / #510). Bundle tools (`patchelf`, `rpm`, `squashfs-tools`, `libfuse3-dev`) stay on the Linux packaging leg. `security:regression` still runs on every packaging OS.

`linux-validate` has `timeout-minutes: 90` and the same C1 `save-if: ${{ github.ref == 'refs/heads/main' }}` (no `shared-key` with packaging).

Coverage unchanged. Wall clock should become about max(50, 61) instead of 8+42+61 serial.

## Type of Change
- [x] Bug fix (CI wall clock, not product)

## Checklist
- [x] My code follows the project's code style
- [x] I have tested my changes (YAML load; quality-gate steps gone from packaging; present on `linux-validate`)
- [ ] I have updated the documentation (if needed)
- [x] My changes generate no new warnings
- [x] Every commit is signed off (`git commit -s`), see CONTRIBUTING.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **CI/CD**
  - Rust build caches are now restored across workflows but saved only for runs on the `main` branch, reducing redundant cache entries from pull requests and other branches.
  - Linux quality checks now run in a dedicated validation job, including version checks, type checking, localization validation, linting, and tests.
  - Build and release packaging runs separately from Linux validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->