### PR TITLE
docs: keep AGENTS.md as the CLI guide, put push gates in CONTRIBUTING

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,8 @@ snapcraft.login
 # Internal development docs and config (not for public GitHub)
 docs/dev/
 CLAUDE.md
+GROK.md
+CODEX.md
 
 # Native rsync protocol sources live in tree now. Only the
 # multi-hundred-MB capture harness stays out of git (Docker images,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,28 +1,10 @@
 # AeroFTP CLI - Agent Integration Guide
 
-> _Last updated: 2026-06-28_
+> _Last updated: 2026-09-04_
 
 > This file is for AI coding agents (Claude Code, Cursor, Codex, Devin, OpenClaw).
 > It describes how to use AeroFTP CLI for remote operations without credentials.
-
-## Mandatory Pre-Push Gate
-
-Before any agent pushes a code commit, run:
-
-```bash
-npm run ci:pre-push
-```
-
-This is not optional even when targeted task tests already passed. It mirrors
-the blocking local Linux gates from `checks.yml` and `build.yml`: Rust format,
-security regression, manifest-version consistency, frontend
-tests/typecheck/i18n, strict Clippy, the complete Rust test suite, and RustSec
-audit. Task-specific tests remain additional gates, not substitutes.
-
-Do not push while the command is red. If a required gate cannot run locally,
-stop and report the exact environmental blocker before pushing. Platform-native
-packaging remains CI-owned; changes in a platform-specific area also require
-the corresponding local/cross-platform gate documented by that subsystem.
+> Development and pre-push gates live in CONTRIBUTING.md, not here.
 
 ## Quick Start
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to AeroFTP
 
-> _Last updated: 2026-06-22_
+> _Last updated: 2026-09-04_
 
 First off, thank you for considering contributing to AeroFTP!
 
@@ -28,10 +28,47 @@ Be respectful, inclusive, and professional. We're here to build great software t
 1. Fork the repo
 2. Create a feature branch (`git checkout -b feature/amazing-feature`)
 3. Make your changes
-4. Run tests (`cd src-tauri && cargo test`)
+4. Run the local checks in [Development and Pre-Push Gates](#development-and-pre-push-gates)
 5. Commit **with a sign-off** (`git commit -s -m 'Add amazing feature'`), see [Sign-off](#sign-off-developer-certificate-of-origin)
 6. Push (`git push origin feature/amazing-feature`)
 7. Open a Pull Request
+
+## Development and Pre-Push Gates
+
+Owner, 2026-09-04. For a feature/fix PR, GitHub Actions is the green. Do not
+also run a full local `npm run ci:pre-push` (~45 minutes of Clippy + the
+complete Rust suite) on a PR branch: that duplicates CI.
+
+`checks.yml` is not the full PR green. Clippy, Rust tests, `tsc`,
+`i18n:validate`, and the security-regression suite live in `build.yml` on
+Linux. Merge only when those jobs are actually green, not when Checks and
+DCO alone are green.
+
+How to drive the product from an agent (profiles, `ls` / `get` / `put`, no
+credentials) is `AGENTS.md`. That file is not this gate.
+
+### PR branches
+
+Locally, before push, run the short set for what you touched:
+
+- `cargo fmt --all -- --check` in `src-tauri`
+- `npx tsc --noEmit` if TypeScript changed
+- `npm run i18n:validate` if locales changed
+- focused vitest / `cargo test --lib <filter>` for the files you touched
+
+That is about 40 seconds. Do not start a second full Cargo/Tauri compile while
+another worktree is already compiling.
+
+### Direct `main`, release, pre-tag
+
+Full `npm run ci:pre-push` remains required for:
+
+- a push or merge directly to `main`
+- a release or pre-tag
+- CI cannot run, or the change is in a platform-specific area CI does not cover
+
+Do not push while that command is red. If a required gate cannot run, stop and
+report the blocker.
 
 ## Development Setup
 


### PR DESCRIPTION
## Description

Root `AGENTS.md` is the agent integration guide for **using** AeroFTP (profiles, `ls` / `get` / `put`, no credentials). It is not the development-gate doc.

It currently opened with a "Mandatory Pre-Push Gate" that still required a full local `npm run ci:pre-push` on every push. That is the retired absolute rule (owner 2026-09-04), and it was in the wrong file.

This PR:

- removes that gate from `AGENTS.md` (Quick Start is the first section again)
- records the two-tier rule in `CONTRIBUTING.md`, which is where contributors look for how to open a PR

Station-local `CLAUDE.md` / skills stay per-agent. They are gitignored and do not reach a fresh worktree; `CONTRIBUTING.md` does.

## Type of Change
- [x] Documentation update

## Checklist
- [x] My code follows the project's code style
- [x] I have tested my changes
- [x] I have updated the documentation (if needed)
- [x] My changes generate no new warnings
- [x] Every commit is signed off (`git commit -s`), see CONTRIBUTING.md