### PR TITLE
feat(s3): size the delta grid so the worst case still fits

### DIFF
--- a/src-tauri/src/providers/s3.rs
+++ b/src-tauri/src/providers/s3.rs
@@ -7240,6 +7240,19 @@ mod tests {
     /// multipart copy. Validates the part-planning math without touching
     /// any HTTP path: the actual UploadPartCopy sequencing is verified
     /// in the owner-side MinIO smoke documented in the task plan.
+    /// The delta planner repeats the multipart threshold as its own floor so
+    /// it stays free of the provider (see `s3_delta_plan::DELTA_MIN_FILE_SIZE`
+    /// and the note there). A repeated constant is a drift risk, so the guard
+    /// is a test rather than a comment: this is the only place that can see
+    /// both values.
+    #[test]
+    fn delta_min_file_size_matches_the_multipart_threshold() {
+        assert_eq!(
+            crate::providers::s3_delta_plan::DELTA_MIN_FILE_SIZE,
+            S3Provider::MULTIPART_THRESHOLD as u64
+        );
+    }
+
     #[test]
     fn plan_copy_parts_returns_empty_for_zero_size_or_part_size() {
         assert!(plan_copy_parts(0, 100).is_empty());

--- a/src-tauri/src/providers/s3.rs
+++ b/src-tauri/src/providers/s3.rs
@@ -7236,23 +7236,30 @@ mod tests {
         assert_eq!(file.size, 1024);
     }
 
+    /// The delta planner repeats the multipart threshold as its own floor so it
+    /// stays free of the provider (see `s3_delta_plan::DELTA_MIN_FILE_SIZE` and
+    /// the note there). A repeated constant is a drift risk, so the guard is a
+    /// test rather than a comment: this is the only place that can see both
+    /// values.
+    ///
+    /// It pins the COMPARISON as well as the constant. `upload` goes multipart
+    /// only above the threshold, so a file of exactly that size takes the
+    /// single PUT path and the planner must refuse it: matching one and not the
+    /// other would leave a byte on which the two halves disagree.
+    #[test]
+    fn delta_min_file_size_matches_the_multipart_threshold() {
+        use crate::providers::s3_delta_plan::{delta_grid_size, DELTA_MIN_FILE_SIZE};
+        assert_eq!(DELTA_MIN_FILE_SIZE, S3Provider::MULTIPART_THRESHOLD as u64);
+        // At the threshold `upload` does not go multipart, and the planner
+        // agrees; one byte above, both change their minds together.
+        assert_eq!(delta_grid_size(DELTA_MIN_FILE_SIZE), None);
+        assert!(delta_grid_size(DELTA_MIN_FILE_SIZE + 1).is_some());
+    }
+
     /// T-DEBT-08: `plan_copy_parts` is the pure half of server-side
     /// multipart copy. Validates the part-planning math without touching
     /// any HTTP path: the actual UploadPartCopy sequencing is verified
     /// in the owner-side MinIO smoke documented in the task plan.
-    /// The delta planner repeats the multipart threshold as its own floor so
-    /// it stays free of the provider (see `s3_delta_plan::DELTA_MIN_FILE_SIZE`
-    /// and the note there). A repeated constant is a drift risk, so the guard
-    /// is a test rather than a comment: this is the only place that can see
-    /// both values.
-    #[test]
-    fn delta_min_file_size_matches_the_multipart_threshold() {
-        assert_eq!(
-            crate::providers::s3_delta_plan::DELTA_MIN_FILE_SIZE,
-            S3Provider::MULTIPART_THRESHOLD as u64
-        );
-    }
-
     #[test]
     fn plan_copy_parts_returns_empty_for_zero_size_or_part_size() {
         assert!(plan_copy_parts(0, 100).is_empty());

--- a/src-tauri/src/providers/s3_delta_plan.rs
+++ b/src-tauri/src/providers/s3_delta_plan.rs
@@ -118,11 +118,21 @@ pub fn delta_grid_size(file_len: u64) -> Option<u64> {
 /// has grown far enough that it no longer fits under the part cap on it, and
 /// then the honest answer is a full upload and a fresh set of digests.
 pub fn delta_grid_fits(grid: u64, file_len: u64) -> bool {
-    // The upper bound on `file_len` cannot be the clause that refuses: a grid
-    // at most DELTA_GRID_MAX and a cell count at most S3_MAX_PARTS already
-    // imply it. It is kept so the function reads as a complete statement of
-    // what it accepts rather than one that leans on arithmetic done elsewhere.
-    (S3_PART_MIN..=DELTA_GRID_MAX).contains(&grid)
+    // Everything the planner itself requires comes from the planner, not from
+    // a copy of its rules: that shared call is what stops this function from
+    // saying yes to a shape `plan_delta_parts` then refuses. A file that shrank
+    // below its stored cell is one such shape, and it was the third one found.
+    //
+    // Two of the clauses below can no longer be the one that refuses, and both
+    // are kept so the function reads as a complete statement of what it accepts
+    // rather than one leaning on arithmetic done elsewhere. The grid ceiling is
+    // implied by the shared call, since a floor above half the part ceiling
+    // fails `part_max < part_min * 2` there; the file ceiling is implied by
+    // that grid bound together with the cell count. Measured, not assumed: the
+    // mutation battery records both as knowingly equivalent, so an uncaught
+    // mutation there is the expected result and not an untested clause.
+    plan_preconditions_hold(file_len, grid, S3_PART_MAX, S3_MAX_PARTS)
+        && (S3_PART_MIN..=DELTA_GRID_MAX).contains(&grid)
         && file_len > DELTA_MIN_FILE_SIZE
         && file_len <= DELTA_MAX_FILE_SIZE
         && file_len.div_ceil(grid) <= u64::from(S3_MAX_PARTS)
@@ -243,6 +253,31 @@ pub fn plan_delta_parts(
 /// geometry would reuse: Azure's `Put Block From URL` has no 5 MiB floor, which
 /// is Tier 3 of the appendix and the reason the arithmetic is kept free of the
 /// S3 numbers.
+/// The shape a plan needs before any matching is looked at, in one place.
+///
+/// It is a function rather than three checks at the top of the planner because
+/// a second caller has to ask the same question: `delta_grid_fits` decides
+/// whether a grid recorded with an earlier upload can still be used, and the
+/// only honest meaning of "can" is "the planner will accept it". Restating the
+/// conditions there instead of sharing them is how that function came to
+/// disagree with this one three separate times, each in a different clause.
+fn plan_preconditions_hold(file_len: u64, part_min: u64, part_max: u64, max_parts: u32) -> bool {
+    if file_len == 0 || part_min == 0 || max_parts == 0 {
+        return false;
+    }
+    // A run longer than the ceiling is cut into equal pieces, and every piece
+    // has to clear the floor. Below a ceiling of two floors that is not
+    // always possible, so refuse rather than emit a plan the server rejects.
+    // The real S3 numbers are 5 MiB and 5 GiB, a factor of 1024.
+    if part_max < part_min.saturating_mul(2) {
+        return false;
+    }
+    // Under one full part there is nothing a multipart can win: a single PUT
+    // is both legal and cheaper. This is also the clause a stored grid fails
+    // when the file has shrunk below the cell it was uploaded on.
+    file_len >= part_min
+}
+
 fn plan_delta_parts_bounded(
     file_len: u64,
     matches: &[(u64, u64, u64)],
@@ -250,19 +285,7 @@ fn plan_delta_parts_bounded(
     part_max: u64,
     max_parts: u32,
 ) -> Option<Vec<DeltaPart>> {
-    if file_len == 0 || part_min == 0 || max_parts == 0 {
-        return None;
-    }
-    // A run longer than the ceiling is cut into equal pieces, and every piece
-    // has to clear the floor. Below a ceiling of two floors that is not
-    // always possible, so refuse rather than emit a plan the server rejects.
-    // The real S3 numbers are 5 MiB and 5 GiB, a factor of 1024.
-    if part_max < part_min.saturating_mul(2) {
-        return None;
-    }
-    // Under one full part there is nothing a multipart can win: a single PUT
-    // is both legal and cheaper.
-    if file_len < part_min {
+    if !plan_preconditions_hold(file_len, part_min, part_max, max_parts) {
         return None;
     }
 
@@ -1153,6 +1176,68 @@ mod tests {
         assert!(!delta_grid_fits(DELTA_PART_SIZE, DELTA_MIN_FILE_SIZE - 1));
         assert!(!delta_grid_fits(DELTA_PART_SIZE, DELTA_MIN_FILE_SIZE));
         assert!(delta_grid_fits(DELTA_PART_SIZE, DELTA_MIN_FILE_SIZE + 1));
+    }
+
+    #[test]
+    fn a_stored_grid_wider_than_the_file_is_rejected() {
+        // A file that shrank below the cell it was uploaded on. The grid is
+        // legal, the cell count is one, every bound this function states on its
+        // own is satisfied, and the planner refuses it because a file shorter
+        // than one part has nothing a multipart can win. Third disagreement
+        // between these two halves, and the reason they now share a function
+        // instead of each restating the rules.
+        assert!(!delta_grid_fits(DELTA_GRID_MAX, DELTA_MIN_FILE_SIZE + 1));
+        assert!(delta_grid_fits(DELTA_GRID_MAX, DELTA_GRID_MAX));
+        assert!(!delta_grid_fits(DELTA_GRID_MAX, DELTA_GRID_MAX - 1));
+    }
+
+    #[test]
+    fn what_the_grid_check_accepts_is_what_the_planner_accepts() {
+        // The cross-check the three disagreements would each have failed. It
+        // does not test either half against the specification: it tests them
+        // against each other, which is the only thing that can catch a rule
+        // restated in two places and then changed in one.
+        let mut rng = Lcg(0xc0ff_ee11);
+        let mut accepted = 0usize;
+        let rounds = 4000;
+        for _ in 0..rounds {
+            let grid = match rng.below(4) {
+                0 => DELTA_PART_SIZE,
+                1 => DELTA_GRID_MAX,
+                2 => S3_PART_MIN + rng.below(64 * MIB),
+                _ => DELTA_PART_SIZE * (1 + rng.below(400)),
+            };
+            // Sampled by scale rather than uniformly. A uniform draw over the
+            // whole range is almost always enormous next to a grid of at most
+            // a few GiB, so the region where the two halves can disagree, a
+            // file comparable to or smaller than its own cell, would come up
+            // about twice in four thousand rounds. The first version of this
+            // test drew uniformly and did NOT catch the disagreement it was
+            // written for; a generator that never visits the boundary is a
+            // green light pointed away from the road.
+            let file_len = match rng.below(4) {
+                0 => DELTA_MIN_FILE_SIZE + rng.below(4 * GIB),
+                1 => grid.saturating_sub(rng.below(2 * grid)),
+                2 => rng.below(100 * GIB),
+                _ => rng.below(DELTA_MAX_FILE_SIZE / 4),
+            };
+            if !delta_grid_fits(grid, file_len) {
+                continue;
+            }
+            accepted += 1;
+            // A grid the check accepts must produce a plan for the shape the
+            // matcher emits on it: whole cells, worst case all of them changed
+            // except the first.
+            let matches = [(0, 0, grid.min(file_len))];
+            assert!(
+                plan_delta_parts(file_len, &matches, grid, S3_MAX_PARTS).is_some(),
+                "delta_grid_fits accepted grid {grid} for {file_len} bytes and the planner refused it"
+            );
+        }
+        assert!(
+            accepted > 200,
+            "only {accepted} of {rounds} pairs were accepted: the cross-check barely ran"
+        );
     }
 
     #[test]

--- a/src-tauri/src/providers/s3_delta_plan.rs
+++ b/src-tauri/src/providers/s3_delta_plan.rs
@@ -30,12 +30,18 @@ pub const S3_MAX_PARTS: u32 = 10_000;
 /// an upload run by the repair.
 pub const DELTA_PART_SIZE: u64 = 8 * 1024 * 1024;
 
-/// Below this a delta is not attempted at all.
+/// A delta is attempted only strictly ABOVE this.
 ///
-/// Mirrors the provider's `MULTIPART_THRESHOLD`: under it `upload` sends a
-/// single PUT, and a multipart made of one part saves nothing. The value is
-/// repeated here rather than imported, so this module stays free of the
-/// provider, and `s3.rs` carries a test that fails if the two ever drift.
+/// Mirrors the provider's `MULTIPART_THRESHOLD`, and mirrors its comparison
+/// too: `upload` goes multipart when `total_size > MULTIPART_THRESHOLD`, so a
+/// file of exactly that size takes the single PUT path and has nothing for a
+/// delta to attach to. Matching the constant and not the comparison would
+/// leave one byte on which the two halves disagree, which is the seam this
+/// module has already been bitten by twice.
+///
+/// The value is repeated here rather than imported, so this module stays free
+/// of the provider, and `s3.rs` carries a test that fails if either the
+/// constants or the comparisons drift apart.
 pub const DELTA_MIN_FILE_SIZE: u64 = 200 * 1024 * 1024;
 
 /// Largest grid this module will ever use or accept, which is NOT the largest
@@ -52,13 +58,16 @@ pub const DELTA_MIN_FILE_SIZE: u64 = 200 * 1024 * 1024;
 /// `the_planner_accepts_exactly_this_grid_as_a_floor` pins the derivation.
 pub const DELTA_GRID_MAX: u64 = S3_PART_MAX / 2;
 
-/// Largest file an S3 delta can cover at all.
+/// Largest file this PLANNER can cover, which is well above what the backends
+/// allow an object to be: AWS, MinIO, R2 and Wasabi cap an object at 5 TiB and
+/// B2 at 10 TB, so in practice the object limit is what a user meets first.
 ///
-/// The protocol arithmetic alone would say `S3_MAX_PARTS * S3_PART_MAX`, 48.8
-/// TiB, and that number is wrong for this planner: past `S3_MAX_PARTS *
-/// DELTA_GRID_MAX`, 24.4 TiB, the grid the rule would choose is one the planner
-/// refuses on every plan. The two halves have to be sized against each other
-/// rather than each against the protocol.
+/// It is stated anyway because it is the planner's own bound and the rule that
+/// chooses a grid has to stop somewhere. The protocol arithmetic alone would
+/// say `S3_MAX_PARTS * S3_PART_MAX`, 48.8 TiB, and that is wrong here: past
+/// `S3_MAX_PARTS * DELTA_GRID_MAX`, 24.4 TiB, the grid the rule would choose is
+/// one the planner refuses on every plan. The two halves have to be sized
+/// against each other rather than each against the protocol.
 pub const DELTA_MAX_FILE_SIZE: u64 = S3_MAX_PARTS as u64 * DELTA_GRID_MAX;
 
 /// Choose the grid a file of `file_len` bytes is compared and cut on, or refuse
@@ -83,7 +92,7 @@ pub const DELTA_MAX_FILE_SIZE: u64 = S3_MAX_PARTS as u64 * DELTA_GRID_MAX;
 /// Returns `None` for a file too small for a delta to be worth anything and for
 /// a file past [`DELTA_MAX_FILE_SIZE`], where no legal grid exists.
 pub fn delta_grid_size(file_len: u64) -> Option<u64> {
-    if !(DELTA_MIN_FILE_SIZE..=DELTA_MAX_FILE_SIZE).contains(&file_len) {
+    if file_len <= DELTA_MIN_FILE_SIZE || file_len > DELTA_MAX_FILE_SIZE {
         return None;
     }
     let needed = file_len.div_ceil(u64::from(S3_MAX_PARTS));
@@ -109,8 +118,13 @@ pub fn delta_grid_size(file_len: u64) -> Option<u64> {
 /// has grown far enough that it no longer fits under the part cap on it, and
 /// then the honest answer is a full upload and a fresh set of digests.
 pub fn delta_grid_fits(grid: u64, file_len: u64) -> bool {
+    // The upper bound on `file_len` cannot be the clause that refuses: a grid
+    // at most DELTA_GRID_MAX and a cell count at most S3_MAX_PARTS already
+    // imply it. It is kept so the function reads as a complete statement of
+    // what it accepts rather than one that leans on arithmetic done elsewhere.
     (S3_PART_MIN..=DELTA_GRID_MAX).contains(&grid)
-        && (DELTA_MIN_FILE_SIZE..=DELTA_MAX_FILE_SIZE).contains(&file_len)
+        && file_len > DELTA_MIN_FILE_SIZE
+        && file_len <= DELTA_MAX_FILE_SIZE
         && file_len.div_ceil(grid) <= u64::from(S3_MAX_PARTS)
 }
 
@@ -1048,7 +1062,14 @@ mod tests {
     fn a_file_under_the_delta_floor_gets_no_grid() {
         assert_eq!(delta_grid_size(DELTA_MIN_FILE_SIZE - 1), None);
         assert_eq!(delta_grid_size(0), None);
-        assert_eq!(delta_grid_size(DELTA_MIN_FILE_SIZE), Some(DELTA_PART_SIZE));
+        // Exactly at the floor there is no delta, because `upload` sends a
+        // single PUT at exactly that size. Matching the constant without
+        // matching the comparison would leave one byte of disagreement.
+        assert_eq!(delta_grid_size(DELTA_MIN_FILE_SIZE), None);
+        assert_eq!(
+            delta_grid_size(DELTA_MIN_FILE_SIZE + 1),
+            Some(DELTA_PART_SIZE)
+        );
     }
 
     #[test]
@@ -1130,6 +1151,8 @@ mod tests {
         assert!(!delta_grid_fits(DELTA_GRID_MAX + 1, DELTA_MAX_FILE_SIZE));
         assert!(!delta_grid_fits(S3_PART_MAX, 2 * GIB));
         assert!(!delta_grid_fits(DELTA_PART_SIZE, DELTA_MIN_FILE_SIZE - 1));
+        assert!(!delta_grid_fits(DELTA_PART_SIZE, DELTA_MIN_FILE_SIZE));
+        assert!(delta_grid_fits(DELTA_PART_SIZE, DELTA_MIN_FILE_SIZE + 1));
     }
 
     #[test]
@@ -1165,7 +1188,7 @@ mod tests {
                     chosen += 1;
                 }
                 None => assert!(
-                    !(DELTA_MIN_FILE_SIZE..=DELTA_MAX_FILE_SIZE).contains(&file_len),
+                    file_len <= DELTA_MIN_FILE_SIZE || file_len > DELTA_MAX_FILE_SIZE,
                     "refused a file of {file_len} bytes that is inside the coverable range"
                 ),
             }
@@ -1205,7 +1228,7 @@ mod tests {
         // which handed the planner a floor above half its own ceiling and got
         // every plan refused. Found here, before review.
         for file_len in [
-            DELTA_MIN_FILE_SIZE,
+            DELTA_MIN_FILE_SIZE + 1,
             2 * GIB,
             79 * GIB,
             200 * GIB,

--- a/src-tauri/src/providers/s3_delta_plan.rs
+++ b/src-tauri/src/providers/s3_delta_plan.rs
@@ -38,17 +38,28 @@ pub const DELTA_PART_SIZE: u64 = 8 * 1024 * 1024;
 /// provider, and `s3.rs` carries a test that fails if the two ever drift.
 pub const DELTA_MIN_FILE_SIZE: u64 = 200 * 1024 * 1024;
 
+/// Largest grid this module will ever use or accept, which is NOT the largest
+/// part S3 allows.
+///
+/// The grid is handed to [`plan_delta_parts`] as its `part_min`, and the
+/// planner refuses a floor above half its ceiling, because above that an
+/// over-long run cannot be split into equal pieces that all still clear the
+/// floor. So the usable grid stops at half the part maximum, and every place
+/// that bounds a grid reads it from here rather than restating the arithmetic:
+/// the first version of this module got the bound right in the function that
+/// chooses a grid and left the protocol value in the function that accepts one,
+/// which is the same defect twice with one of the two occurrences fixed.
+/// `the_planner_accepts_exactly_this_grid_as_a_floor` pins the derivation.
+pub const DELTA_GRID_MAX: u64 = S3_PART_MAX / 2;
+
 /// Largest file an S3 delta can cover at all.
 ///
 /// The protocol arithmetic alone would say `S3_MAX_PARTS * S3_PART_MAX`, 48.8
-/// TiB, and that number is wrong for this planner. The grid is handed to
-/// [`plan_delta_parts`] as its `part_min`, and the planner refuses a floor
-/// above half the ceiling, because above that an over-long run cannot be split
-/// into equal pieces that all still clear the floor. So the real bound is the
-/// part cap times half the part ceiling, 24.4 TiB, and a grid past it would be
-/// a grid the planner then refuses on every file: the two halves have to be
-/// sized against each other rather than each against the protocol.
-pub const DELTA_MAX_FILE_SIZE: u64 = S3_MAX_PARTS as u64 * (S3_PART_MAX / 2);
+/// TiB, and that number is wrong for this planner: past `S3_MAX_PARTS *
+/// DELTA_GRID_MAX`, 24.4 TiB, the grid the rule would choose is one the planner
+/// refuses on every plan. The two halves have to be sized against each other
+/// rather than each against the protocol.
+pub const DELTA_MAX_FILE_SIZE: u64 = S3_MAX_PARTS as u64 * DELTA_GRID_MAX;
 
 /// Choose the grid a file of `file_len` bytes is compared and cut on, or refuse
 /// the file.
@@ -80,9 +91,9 @@ pub fn delta_grid_size(file_len: u64) -> Option<u64> {
         .max(needed)
         .div_ceil(DELTA_PART_SIZE)
         .saturating_mul(DELTA_PART_SIZE);
-    // `needed` is at most half the part ceiling at the maximum file size, and
-    // 2.5 GiB is a whole number of 8 MiB cells, so the rounding never lifts the
-    // grid past what the planner accepts as a floor. Asserted by
+    // `needed` is at most DELTA_GRID_MAX at the maximum file size, and 2.5 GiB
+    // is a whole number of 8 MiB cells, so the rounding never lifts the grid
+    // past what the planner accepts as a floor. Asserted by
     // `the_grid_never_exceeds_what_the_planner_accepts` rather than left as a
     // claim in a comment.
     Some(grid)
@@ -98,7 +109,7 @@ pub fn delta_grid_size(file_len: u64) -> Option<u64> {
 /// has grown far enough that it no longer fits under the part cap on it, and
 /// then the honest answer is a full upload and a fresh set of digests.
 pub fn delta_grid_fits(grid: u64, file_len: u64) -> bool {
-    (S3_PART_MIN..=S3_PART_MAX).contains(&grid)
+    (S3_PART_MIN..=DELTA_GRID_MAX).contains(&grid)
         && (DELTA_MIN_FILE_SIZE..=DELTA_MAX_FILE_SIZE).contains(&file_len)
         && file_len.div_ceil(grid) <= u64::from(S3_MAX_PARTS)
 }
@@ -1072,8 +1083,8 @@ mod tests {
         // of 5 GiB is a whole number of 8 MiB cells, so the rounding does not
         // push it over; if either constant changes so that it is not, this
         // fails here rather than by refusing every plan at runtime.
-        assert_eq!(delta_grid_size(DELTA_MAX_FILE_SIZE), Some(S3_PART_MAX / 2));
-        assert_eq!((S3_PART_MAX / 2) % DELTA_PART_SIZE, 0);
+        assert_eq!(delta_grid_size(DELTA_MAX_FILE_SIZE), Some(DELTA_GRID_MAX));
+        assert_eq!(DELTA_GRID_MAX % DELTA_PART_SIZE, 0);
     }
 
     #[test]
@@ -1108,10 +1119,16 @@ mod tests {
         // not a plan the server would refuse.
         assert!(delta_grid_fits(DELTA_PART_SIZE, 2 * GIB));
         assert!(!delta_grid_fits(DELTA_PART_SIZE, 100 * GIB));
-        // A grid outside the protocol is never usable, whatever produced it.
+        // A grid outside what the planner takes is never usable, whatever
+        // produced it. The upper bound here is DELTA_GRID_MAX and not the
+        // protocol's 5 GiB: a grid between the two is legal for S3 and refused
+        // by the planner on every plan, and this function reads a grid from
+        // storage, so a value written by an older rule can arrive here.
         assert!(!delta_grid_fits(0, 2 * GIB));
         assert!(!delta_grid_fits(S3_PART_MIN - 1, 2 * GIB));
-        assert!(!delta_grid_fits(S3_PART_MAX + 1, 2 * GIB));
+        assert!(delta_grid_fits(DELTA_GRID_MAX, DELTA_MAX_FILE_SIZE));
+        assert!(!delta_grid_fits(DELTA_GRID_MAX + 1, DELTA_MAX_FILE_SIZE));
+        assert!(!delta_grid_fits(S3_PART_MAX, 2 * GIB));
         assert!(!delta_grid_fits(DELTA_PART_SIZE, DELTA_MIN_FILE_SIZE - 1));
     }
 
@@ -1133,7 +1150,7 @@ mod tests {
                         "grid is not a whole number of default cells at {file_len}"
                     );
                     assert!(
-                        (S3_PART_MIN..=S3_PART_MAX).contains(&grid),
+                        (S3_PART_MIN..=DELTA_GRID_MAX).contains(&grid),
                         "grid {grid} outside the protocol at {file_len}"
                     );
                     assert!(
@@ -1156,6 +1173,25 @@ mod tests {
         assert!(
             chosen > rounds / 4,
             "the generator produced only {chosen} grids out of {rounds}: the assertions above were barely exercised"
+        );
+    }
+
+    #[test]
+    fn the_planner_accepts_exactly_this_grid_as_a_floor() {
+        // DELTA_GRID_MAX is derived from a rule that lives in another function,
+        // so it is pinned against that function rather than restated. One byte
+        // more and the planner refuses every plan, which is what makes a grid
+        // above it useless rather than merely large.
+        let file_len = 2 * DELTA_GRID_MAX;
+        let matches = [(0, 0, DELTA_GRID_MAX)];
+        assert!(
+            plan_delta_parts(file_len, &matches, DELTA_GRID_MAX, S3_MAX_PARTS).is_some(),
+            "the planner must accept DELTA_GRID_MAX as a floor"
+        );
+        assert_eq!(
+            plan_delta_parts(file_len, &matches, DELTA_GRID_MAX + 1, S3_MAX_PARTS),
+            None,
+            "one byte over DELTA_GRID_MAX the planner refuses, which is where the constant comes from"
         );
     }
 

--- a/src-tauri/src/providers/s3_delta_plan.rs
+++ b/src-tauri/src/providers/s3_delta_plan.rs
@@ -24,6 +24,85 @@ pub const S3_PART_MAX: u64 = 5 * 1024 * 1024 * 1024;
 /// Most parts S3 accepts in one multipart upload.
 pub const S3_MAX_PARTS: u32 = 10_000;
 
+/// Default delta grid: the cell the matcher compares and the part the planner
+/// emits when nothing forces it wider. A small multiple of the floor, so a cell
+/// that matches is likely to become a whole part rather than be absorbed into
+/// an upload run by the repair.
+pub const DELTA_PART_SIZE: u64 = 8 * 1024 * 1024;
+
+/// Below this a delta is not attempted at all.
+///
+/// Mirrors the provider's `MULTIPART_THRESHOLD`: under it `upload` sends a
+/// single PUT, and a multipart made of one part saves nothing. The value is
+/// repeated here rather than imported, so this module stays free of the
+/// provider, and `s3.rs` carries a test that fails if the two ever drift.
+pub const DELTA_MIN_FILE_SIZE: u64 = 200 * 1024 * 1024;
+
+/// Largest file an S3 delta can cover at all.
+///
+/// The protocol arithmetic alone would say `S3_MAX_PARTS * S3_PART_MAX`, 48.8
+/// TiB, and that number is wrong for this planner. The grid is handed to
+/// [`plan_delta_parts`] as its `part_min`, and the planner refuses a floor
+/// above half the ceiling, because above that an over-long run cannot be split
+/// into equal pieces that all still clear the floor. So the real bound is the
+/// part cap times half the part ceiling, 24.4 TiB, and a grid past it would be
+/// a grid the planner then refuses on every file: the two halves have to be
+/// sized against each other rather than each against the protocol.
+pub const DELTA_MAX_FILE_SIZE: u64 = S3_MAX_PARTS as u64 * (S3_PART_MAX / 2);
+
+/// Choose the grid a file of `file_len` bytes is compared and cut on, or refuse
+/// the file.
+///
+/// The default grid is [`DELTA_PART_SIZE`], and it does not survive every size:
+/// a file large enough that `file_len / DELTA_PART_SIZE` exceeds the 10 000
+/// part cap cannot be planned on it, because the worst case for the planner is
+/// one part per cell (a file whose cells alternate between changed and
+/// unchanged produces no coalescing at all). So the grid scales up to at least
+/// `file_len / S3_MAX_PARTS`, which is what keeps that worst case legal rather
+/// than only the average case.
+///
+/// The scaled grid is rounded up to a whole number of default cells, and that
+/// rounding is the point rather than tidiness. The grid is stored next to the
+/// baseline digests and a later delta has to reuse the same one, so a grid that
+/// moved with every byte of length would throw the cache away on every upload.
+/// Rounded, it only moves when `file_len` crosses a multiple of
+/// `S3_MAX_PARTS * DELTA_PART_SIZE`, which is 78.125 GiB, so an append or an
+/// edit keeps the grid it had.
+///
+/// Returns `None` for a file too small for a delta to be worth anything and for
+/// a file past [`DELTA_MAX_FILE_SIZE`], where no legal grid exists.
+pub fn delta_grid_size(file_len: u64) -> Option<u64> {
+    if !(DELTA_MIN_FILE_SIZE..=DELTA_MAX_FILE_SIZE).contains(&file_len) {
+        return None;
+    }
+    let needed = file_len.div_ceil(u64::from(S3_MAX_PARTS));
+    let grid = DELTA_PART_SIZE
+        .max(needed)
+        .div_ceil(DELTA_PART_SIZE)
+        .saturating_mul(DELTA_PART_SIZE);
+    // `needed` is at most half the part ceiling at the maximum file size, and
+    // 2.5 GiB is a whole number of 8 MiB cells, so the rounding never lifts the
+    // grid past what the planner accepts as a floor. Asserted by
+    // `the_grid_never_exceeds_what_the_planner_accepts` rather than left as a
+    // claim in a comment.
+    Some(grid)
+}
+
+/// Whether a grid recorded with an earlier upload can still be used for a file
+/// of `file_len` bytes.
+///
+/// A delta must compare the new file against the baseline on the grid the
+/// baseline's digests were computed with, not on the grid the new length would
+/// choose, or the cells do not line up and nothing matches. The stored grid can
+/// still have gone out of range in the meantime, most obviously when the file
+/// has grown far enough that it no longer fits under the part cap on it, and
+/// then the honest answer is a full upload and a fresh set of digests.
+pub fn delta_grid_fits(grid: u64, file_len: u64) -> bool {
+    (S3_PART_MIN..=S3_PART_MAX).contains(&grid)
+        && (DELTA_MIN_FILE_SIZE..=DELTA_MAX_FILE_SIZE).contains(&file_len)
+        && file_len.div_ceil(grid) <= u64::from(S3_MAX_PARTS)
+}
+
 /// One part of a planned delta upload.
 ///
 /// Parts are emitted in ascending `part_number` and concatenated by S3 in
@@ -950,6 +1029,174 @@ mod tests {
         let parts = plan_delta_parts(file_len, &matches, 5 * MIB, 10_000).expect("plan");
         assert_eq!(parts.len(), 4000);
         assert_plan_is_legal(file_len, &matches, 5 * MIB, S3_PART_MAX, 10_000, &parts);
+    }
+
+    // ---- the grid and its scale-up rule -----------------------------------
+
+    #[test]
+    fn a_file_under_the_delta_floor_gets_no_grid() {
+        assert_eq!(delta_grid_size(DELTA_MIN_FILE_SIZE - 1), None);
+        assert_eq!(delta_grid_size(0), None);
+        assert_eq!(delta_grid_size(DELTA_MIN_FILE_SIZE), Some(DELTA_PART_SIZE));
+    }
+
+    #[test]
+    fn an_ordinary_large_file_uses_the_default_grid() {
+        // 2 GiB on an 8 MiB grid is 256 cells, nowhere near the cap.
+        assert_eq!(delta_grid_size(2 * GIB), Some(DELTA_PART_SIZE));
+    }
+
+    #[test]
+    fn the_default_grid_survives_up_to_the_part_cap_and_not_past_it() {
+        // The default grid covers exactly S3_MAX_PARTS cells, 78.125 GiB.
+        let last = u64::from(S3_MAX_PARTS) * DELTA_PART_SIZE;
+        assert_eq!(delta_grid_size(last), Some(DELTA_PART_SIZE));
+        assert_eq!(delta_grid_size(last + 1), Some(2 * DELTA_PART_SIZE));
+    }
+
+    #[test]
+    fn the_grid_scales_up_when_the_default_would_blow_the_part_cap() {
+        // 200 GiB on the default grid is 25 600 cells. The worst case for the
+        // planner is one part per cell, so the grid has to widen until that
+        // worst case is legal, not until the average case is.
+        let grid = delta_grid_size(200 * GIB).expect("grid");
+        assert_eq!(grid, 24 * MIB);
+        assert!((200 * GIB).div_ceil(grid) <= u64::from(S3_MAX_PARTS));
+        assert_eq!(grid % DELTA_PART_SIZE, 0);
+    }
+
+    #[test]
+    fn the_grid_never_exceeds_what_the_planner_accepts() {
+        // At the largest coverable file the grid lands exactly on half the part
+        // ceiling, which is the largest floor `plan_delta_parts` accepts. Half
+        // of 5 GiB is a whole number of 8 MiB cells, so the rounding does not
+        // push it over; if either constant changes so that it is not, this
+        // fails here rather than by refusing every plan at runtime.
+        assert_eq!(delta_grid_size(DELTA_MAX_FILE_SIZE), Some(S3_PART_MAX / 2));
+        assert_eq!((S3_PART_MAX / 2) % DELTA_PART_SIZE, 0);
+    }
+
+    #[test]
+    fn a_file_past_the_largest_coverable_size_gets_no_grid() {
+        assert_eq!(delta_grid_size(DELTA_MAX_FILE_SIZE + 1), None);
+        assert_eq!(delta_grid_size(u64::MAX), None);
+    }
+
+    #[test]
+    fn an_append_does_not_move_the_grid() {
+        // The grid is stored with the baseline digests and a later delta has to
+        // reuse it. A grid that moved with every byte would throw the cache
+        // away exactly in the case the feature exists for.
+        let before = delta_grid_size(2 * GIB).expect("grid");
+        let after = delta_grid_size(2 * GIB + 50 * MIB).expect("grid");
+        assert_eq!(before, after);
+        // Past the point where the default no longer covers the file, the raw
+        // ratio moves with every byte and only the rounding holds the grid
+        // still. 100 GiB and the same file with 50 MiB appended must land on
+        // the same grid, or the appended upload would have to rehash the whole
+        // baseline it was about to reuse.
+        let before = delta_grid_size(100 * GIB).expect("grid");
+        let after = delta_grid_size(100 * GIB + 50 * MIB).expect("grid");
+        assert_eq!(before, after);
+        assert_eq!(before, 2 * DELTA_PART_SIZE);
+    }
+
+    #[test]
+    fn a_stored_grid_that_no_longer_fits_is_rejected() {
+        // The file grew from 2 GiB to 100 GiB: 12 800 cells on the stored 8 MiB
+        // grid, over the cap. The answer is a full upload and fresh digests,
+        // not a plan the server would refuse.
+        assert!(delta_grid_fits(DELTA_PART_SIZE, 2 * GIB));
+        assert!(!delta_grid_fits(DELTA_PART_SIZE, 100 * GIB));
+        // A grid outside the protocol is never usable, whatever produced it.
+        assert!(!delta_grid_fits(0, 2 * GIB));
+        assert!(!delta_grid_fits(S3_PART_MIN - 1, 2 * GIB));
+        assert!(!delta_grid_fits(S3_PART_MAX + 1, 2 * GIB));
+        assert!(!delta_grid_fits(DELTA_PART_SIZE, DELTA_MIN_FILE_SIZE - 1));
+    }
+
+    #[test]
+    fn every_grid_the_rule_chooses_is_one_the_rule_accepts() {
+        // The two halves have to agree: a grid chosen for a length must still
+        // be judged usable for that same length, or an upload would store a
+        // grid its own delta then refuses.
+        let mut rng = Lcg(0xf00d_4242);
+        let mut chosen = 0usize;
+        let rounds = 3000;
+        for _ in 0..rounds {
+            let file_len = rng.below(DELTA_MAX_FILE_SIZE + DELTA_MAX_FILE_SIZE / 8);
+            match delta_grid_size(file_len) {
+                Some(grid) => {
+                    assert_eq!(
+                        grid % DELTA_PART_SIZE,
+                        0,
+                        "grid is not a whole number of default cells at {file_len}"
+                    );
+                    assert!(
+                        (S3_PART_MIN..=S3_PART_MAX).contains(&grid),
+                        "grid {grid} outside the protocol at {file_len}"
+                    );
+                    assert!(
+                        file_len.div_ceil(grid) <= u64::from(S3_MAX_PARTS),
+                        "grid {grid} leaves {} cells at {file_len}",
+                        file_len.div_ceil(grid)
+                    );
+                    assert!(
+                        delta_grid_fits(grid, file_len),
+                        "chosen grid {grid} rejected for {file_len}"
+                    );
+                    chosen += 1;
+                }
+                None => assert!(
+                    !(DELTA_MIN_FILE_SIZE..=DELTA_MAX_FILE_SIZE).contains(&file_len),
+                    "refused a file of {file_len} bytes that is inside the coverable range"
+                ),
+            }
+        }
+        assert!(
+            chosen > rounds / 4,
+            "the generator produced only {chosen} grids out of {rounds}: the assertions above were barely exercised"
+        );
+    }
+
+    #[test]
+    fn the_chosen_grid_survives_the_planner_s_worst_case() {
+        // The rule sizes the grid for the WORST case rather than the average
+        // one: a file whose cells alternate between changed and unchanged
+        // coalesces nothing and produces one part per cell. This is the seam
+        // between the two halves, and it is where the first version was wrong:
+        // the ceiling on the file size was computed from the protocol alone,
+        // which handed the planner a floor above half its own ceiling and got
+        // every plan refused. Found here, before review.
+        for file_len in [
+            DELTA_MIN_FILE_SIZE,
+            2 * GIB,
+            79 * GIB,
+            200 * GIB,
+            DELTA_MAX_FILE_SIZE,
+        ] {
+            let grid = delta_grid_size(file_len).expect("grid");
+            let cells = file_len.div_ceil(grid);
+            let matches: Vec<(u64, u64, u64)> = (0..cells)
+                .step_by(2)
+                .map(|cell| {
+                    let start = cell * grid;
+                    (start, start, grid.min(file_len - start))
+                })
+                .collect();
+            let parts = plan_delta_parts(file_len, &matches, grid, S3_MAX_PARTS)
+                .unwrap_or_else(|| panic!("no plan for {file_len} bytes on a {grid} byte grid"));
+            assert!(
+                parts.len() <= S3_MAX_PARTS as usize,
+                "{file_len} bytes on a {grid} byte grid needs {} parts",
+                parts.len()
+            );
+            assert_eq!(
+                parts.iter().map(DeltaPart::byte_len).sum::<u64>(),
+                file_len,
+                "the plan must still cover the file exactly"
+            );
+        }
     }
 
     // ---- generated inputs -------------------------------------------------


### PR DESCRIPTION
## What this is

Step 2 of `APPENDIX-S3-DELTA-UPLOAD`: the delta grid and the rule that sizes it. Second tranche after the part planner in #723, and still nothing user-visible: this is the arithmetic that decides how wide a cell is before anything is compared or uploaded.

The grid is two things at once. It is the cell the Tier 1 matcher compares (cell `i` of the new file against cell `i` of the baseline), and it is what the planner receives as its `part_min`. That double role is what makes the sizing rule worth its own tranche rather than a constant.

## The scale-up rule, and why the bound is on the worst case

`DELTA_PART_SIZE` is 8 MiB, a small multiple of the 5 MiB floor so a cell that matches is likely to become a whole part instead of being absorbed by the repair. It does not survive every file: at 78.125 GiB a file already has 10 000 cells, and past that the default grid cannot produce a legal plan at all.

The bound has to be taken on the worst case, not the average one. The planner coalesces adjacent matching cells, so a typical file produces far fewer parts than cells, and it would be easy to size the grid on that. But a file whose cells alternate between changed and unchanged coalesces nothing and produces exactly one part per cell, and that file is not exotic: it is what a diffusely edited database or a re-encoded video looks like. So the grid scales to at least `file_len / S3_MAX_PARTS`, which makes `parts <= cells <= 10 000` hold by construction rather than on average.

## The rounding is the point, not tidiness

The scaled grid is rounded up to a whole number of default cells. That is not cosmetic: the grid is stored next to the baseline digests, and a later delta has to compare on the grid those digests were computed with, not on the grid the new length would pick. A grid taken as a raw ratio would move with every byte of length, so appending 50 MiB to a 100 GiB file would change the grid and throw away the entire cached baseline, on the exact case this feature exists for. Rounded, the grid only moves when the file crosses a multiple of 78.125 GiB, and `an_append_does_not_move_the_grid` pins it at a size where the raw ratio would have moved.

`delta_grid_fits` is the other half of the same fact: a stored grid can go out of range on its own, most obviously when the file has grown past what that grid can cover under the part cap. The honest answer there is a full upload and a fresh set of digests, not a plan the server would refuse.

## The seam between the two halves, which is where this was wrong first

The first version computed the largest coverable file from the protocol alone: 10 000 parts times 5 GiB, 48.8 TiB. That number is right about S3 and wrong about this planner. The grid is handed to `plan_delta_parts` as its `part_min`, and the planner refuses a floor above half its ceiling, because above that an over-long run cannot be split into equal pieces that all still clear the floor. Sized from the protocol, every file past 24.4 TiB would have been handed a grid the planner then refuses on every single plan: a rule that looks correct on each side and fits nothing in the middle.

The real ceiling is the part cap times half the part ceiling, and the fix is one constant. What matters more is how it was found: by writing the test that crosses the seam, `the_chosen_grid_survives_the_planner_s_worst_case`, which builds the alternating match list for a chosen grid and asks the planner for a plan. Neither half's own tests could have caught it, because each half was internally consistent. This is the same shape as the finding review caught on #723, where two of three protocol limits were enforced at one door and the third was not, so this time it was looked for on purpose rather than waited for.

## The repeated constant is guarded by a test, not a comment

`DELTA_MIN_FILE_SIZE` is 200 MiB, the provider's `MULTIPART_THRESHOLD`. It is repeated rather than imported so the planning module stays free of the provider, which is what keeps it reusable for a backend with a different geometry (Azure `Put Block From URL`, Tier 3 of the appendix, has no 5 MiB floor). A repeated constant is a drift risk, so `s3.rs` carries `delta_min_file_size_matches_the_multipart_threshold`, which is the only place in the tree that can see both values. If either moves, that test fails.

## The same seam again, caught by review this time

The paragraph above was written after fixing the ceiling in `delta_grid_size`, the function that chooses a grid, and it claimed the class was closed. It was not: `delta_grid_fits`, the function that accepts a grid, still carried the protocol value, so a stored grid between 2.5 and 5 GiB was called usable and then refused by the planner on every plan. One of two occurrences fixed, in a pull request whose body explained the defect. Raised by CodeRabbit.

That is also the half where it matters more, not less, because `delta_grid_fits` reads a grid back from storage: a value written by an older rule arrives there by design, which is exactly the input the protocol bound waves through. And the test meant to guard it was checking the wrong half, asserting `S3_PART_MAX + 1`, the protocol ceiling, while the planner ceiling went unchecked. It passed.

The fix is a name rather than a number, because a number would have to be remembered in two places a third time. `DELTA_GRID_MAX` is the largest grid this module uses or accepts, `DELTA_MAX_FILE_SIZE` derives from it, and `delta_grid_fits` reads it. The constant is pinned against the function it is derived from rather than restated: `the_planner_accepts_exactly_this_grid_as_a_floor` asserts the planner takes `DELTA_GRID_MAX` and refuses one byte more.

## The third disagreement, and why it stopped being patched

Review then found a third one, in a third clause: `delta_grid_fits` called a grid wider than the file usable, and the planner refuses that because a file shorter than one part has nothing a multipart can win. The input is a file that shrank below the cell it was uploaded on, which is exactly what that function exists to judge.

Three instances in three clauses is the signal that the defect is in none of them. **The planner's preconditions are now one function that both halves call**, so the grid check inherits the rules instead of restating them and the two cannot drift apart again. Two clauses in `delta_grid_fits` became implied as a result, the grid ceiling and the file ceiling; both are kept so the function states its whole contract, and both are recorded in the battery as knowingly equivalent so an uncaught mutation there reads as the expected result rather than an untested clause.

`what_the_grid_check_accepts_is_what_the_planner_accepts` is the cross-check none of the three would have survived: it tests neither half against the specification, it tests them against each other, which is the only thing that catches a rule written twice and changed once. **Its first version did not catch the disagreement it was written for**, because it drew file lengths uniformly over a range where the file is almost always enormous next to its grid, so the region where the two can disagree came up about twice in four thousand rounds. A generator that never visits the boundary is a green light pointed away from the road. It samples by scale now.

## Fail-first evidence

Eight new mutations, each caught by a named test, and the battery for the whole module now stands at 23 mutations, 23 caught, none failing only at compile time:

| Mutation | Caught by |
|---|---|
| M17 never scale up, keep the default grid | `the_grid_scales_up_when_the_default_would_blow_the_part_cap` and 5 more |
| M18 skip the rounding to whole default cells | `an_append_does_not_move_the_grid`, `the_default_grid_survives_up_to_the_part_cap_and_not_past_it` and 2 more |
| M19 no ceiling on the file size | `a_file_past_the_largest_coverable_size_gets_no_grid`, generated |
| M20 do not re-check the part cap when reusing a stored grid | `a_stored_grid_that_no_longer_fits_is_rejected` |
| M21 no floor on the file size | `a_file_under_the_delta_floor_gets_no_grid` |
| M22 size the file ceiling from the protocol instead of from the planner | `the_chosen_grid_survives_the_planner_s_worst_case`, `the_grid_never_exceeds_what_the_planner_accepts` and 2 more |
| M23 accept a stored grid the planner would refuse | `a_stored_grid_that_no_longer_fits_is_rejected` |
| M24 move the derived grid ceiling by one byte | `the_planner_accepts_exactly_this_grid_as_a_floor` and 2 more |

M22, M23 and M24 are the seam and its two halves, kept as mutations so neither can be undone quietly. During the work the harness's own assertion, that a mutation's anchor must match exactly once, refused M23 because the same expression appeared in two places and it would otherwise have mutated the wrong one.

## Gate

The Tier 1 pre-push gate in full: `cargo fmt --all`, `npm run typecheck`, `npm run i18n:validate`, `npm run i18n:diacritics`, `npm run i18n:untranslated`, `npm run check:provider-inventory`, `npm run test:unit` with 876 tests over 100 files. Plus `cargo test --lib s3` with 164 tests passing, 41 of them in `providers::s3_delta_plan::tests`, and `cargo clippy --all-targets -- -D warnings`.

Battery on this head: **24 mutations measured, 23 caught, 1 knowingly equivalent, 0 unmeasured**. The last number is there because the battery silently stopped at the first stale anchor after the refactor and did not run the sixteen mutations behind it: it now reports a stale anchor and continues, and the summary carries three counts instead of two, since a total that adds only the first two makes silence look like success.

`cargo clippy --all-targets -- -D warnings` was run too, although Tier 1 no longer requires it, because the lib had to be compiled for the focused tests anyway and the marginal cost was near zero. It caught four `manual_range_contains`, which would otherwise have been a CI red and a full cycle to learn.

## Not in this PR

The third bullet of step 2 in the executive plan, the per-endpoint cache of "this backend rejected a ranged `UploadPartCopy`". It needs a provider surface and a real HTTP path to populate it, so it belongs with the executor rather than with the arithmetic.

## Four review follow-ups, all small and one of them mine to answer for

An adversarial review found four things, none blocking, and they are recorded rather than folded in silently.

**The floor matched the constant and not the comparison.** `upload` goes multipart only ABOVE `MULTIPART_THRESHOLD`, so a file of exactly that size takes the single PUT path, while `delta_grid_size` was returning a grid for it: one byte on which the two halves disagreed, which is the same seam this branch already fixed twice at a larger scale. The floor is exclusive now, and the drift test in `s3.rs` pins the comparison as well as the value.

**The test this branch added to `s3.rs` stole a doc comment.** It had inserted itself between the T-DEBT-08 block and the function that block documents, so rustdoc attached it to the new test and `plan_copy_parts_returns_empty_for_zero_size_or_part_size` lost its documentation. Moved above it.

**`DELTA_MAX_FILE_SIZE` overclaimed.** It said "the largest file an S3 delta can cover at all", and it is the largest this planner can cover: AWS, MinIO, R2 and Wasabi cap an object at 5 TiB and B2 at 10 TB, so the object limit is what a user meets first. Reworded to name which bound it is.

**One clause can never be the one that refuses.** The `file_len` upper bound in `delta_grid_fits` is implied by a grid at most `DELTA_GRID_MAX` together with the part-cap clause, confirmed by measurement. Kept and declared as implied, so the function states in full what it accepts instead of leaning on arithmetic done elsewhere.

This branch was also rebased onto `3de4f6456` after #729 landed, so the two changes to `s3.rs` are now verified together rather than only in principle.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * S3 delta uploads now select an appropriate planning grid based on file size.
  * Delta processing is skipped for files at or below the supported minimum and for files exceeding the supported maximum.
  * Previously recorded delta grids are checked for compatibility before reuse.

* **Tests**
  * Added coverage for grid selection, scaling rules, size boundaries, multipart upload limits, and consistency between new and previously recorded grids.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->