### PR TITLE
fix(s3): refuse to sign for a cleartext endpoint without consent

### DIFF
--- a/src-tauri/src/providers/s3.rs
+++ b/src-tauri/src/providers/s3.rs
@@ -325,6 +325,12 @@ pub struct S3Provider {
     /// Serializes STS refreshes so concurrent multipart parts re-assume the
     /// role once instead of stampeding the STS endpoint near expiry.
     sts_refresh_lock: Arc<tokio::sync::Mutex<()>>,
+    /// One cleartext warning per provider, not one per signed request.
+    /// The confidentiality check runs at every signing path now, and its
+    /// consent branch used to log unconditionally, so an N part upload logged
+    /// N identical warnings. Shared across clones on purpose: a clone is the
+    /// same profile talking to the same endpoint.
+    cleartext_warned: Arc<std::sync::atomic::AtomicBool>,
 }
 
 /// Owned snapshot of the credentials a single signing pass uses, taken under
@@ -403,6 +409,7 @@ impl S3Provider {
             storage_class_override: None,
             temp_credentials: Arc::new(std::sync::RwLock::new(None)),
             sts_refresh_lock: Arc::new(tokio::sync::Mutex::new(())),
+            cleartext_warned: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         })
     }
 
@@ -563,6 +570,16 @@ impl S3Provider {
         if !self.temp_credentials_need_refresh() {
             return Ok(());
         }
+
+        // Second choke point, and it is not the same as the one in
+        // `sign_request`. An AssumeRole is a signed request of its own, made
+        // before anything is signed for S3, so on a door that does not go
+        // through `connect()` a role profile would burn an exchange (and a
+        // one-time MFA code) against an endpoint the user never consented to,
+        // then fail with an STS error instead of the confidentiality one.
+        // Placed after the two early returns above, so a profile without a
+        // role or with fresh credentials pays nothing for it.
+        self.validate_endpoint_confidentiality()?;
 
         let _guard = self.sts_refresh_lock.lock().await;
         // Another task may have refreshed while we waited for the lock.
@@ -777,18 +794,34 @@ impl S3Provider {
             )));
         }
 
-        if self.config.role_arn.is_some() {
-            warn!(
-                "[S3] endpoint {} is CLEARTEXT HTTP and carries an STS session token:                  token and payload are unencrypted (opted in on this profile)",
-                host
-            );
-        } else {
-            warn!(
-                "[S3] endpoint {} is CLEARTEXT HTTP: credentials and payload are                  unencrypted (opted in on this profile)",
-                host
-            );
+        // Once per provider. This runs at every signing path, so an
+        // unconditional log here would put one identical warning per part of a
+        // multipart upload into the user's log and drown the rest of it.
+        if self.take_cleartext_warning_slot() {
+            if self.config.role_arn.is_some() {
+                warn!(
+                    "[S3] endpoint {} is CLEARTEXT HTTP and carries an STS session token:                  token and payload are unencrypted (opted in on this profile)",
+                    host
+                );
+            } else {
+                warn!(
+                    "[S3] endpoint {} is CLEARTEXT HTTP: credentials and payload are                  unencrypted (opted in on this profile)",
+                    host
+                );
+            }
         }
         Ok(())
+    }
+
+    /// True the first time it is called on a provider and false afterwards.
+    ///
+    /// Split out so the once-ness is testable without a tracing subscriber:
+    /// asserting on the slot is asserting on exactly the decision the log line
+    /// depends on.
+    fn take_cleartext_warning_slot(&self) -> bool {
+        !self
+            .cleartext_warned
+            .swap(true, std::sync::atomic::Ordering::Relaxed)
     }
 
     /// Detect MEGA S4 Object Storage endpoints.
@@ -3846,6 +3879,14 @@ impl StorageProvider for S3Provider {
         path: &str,
         options: ShareLinkOptions,
     ) -> Result<ShareLinkResult, ProviderError> {
+        // The eleventh signer, and the only one that does not go through
+        // `sign_request`: this builds a SigV4 QUERY signature instead of an
+        // Authorization header, so it inherits nothing from the choke point
+        // below. A presigned URL for a cleartext endpoint is worse than a
+        // single request, because it is a bearer credential that travels in
+        // the clear every time anyone opens it.
+        self.validate_endpoint_confidentiality()?;
+
         // Generate a presigned URL
         use hmac::{Hmac, Mac};
         use sha2::{Digest, Sha256};
@@ -6089,6 +6130,115 @@ mod tests {
             matches!(err, ProviderError::NetworkError(_)),
             "with consent the failure must come from the network, got {err:?}"
         );
+    }
+
+    /// A role profile reaches the STS exchange before anything is signed for
+    /// S3, so the choke point in `sign_request` is too late for it: the base
+    /// key goes to `sts.<region>.amazonaws.com`, an AssumeRole is burnt on
+    /// every Quick Connect click, a one-time MFA code with it, and what the
+    /// user sees is an STS error instead of the reason the call was refused.
+    /// Not a cleartext exposure, since STS is https, but the wrong behaviour
+    /// and the wrong message.
+    #[tokio::test]
+    async fn a_role_profile_is_refused_before_the_sts_exchange() {
+        let provider = cleartext_test_provider(
+            "http://s3.invalid:9000",
+            false,
+            Some("arn:aws:iam::123456789012:role/review"),
+        );
+        let err = provider
+            .discover_buckets()
+            .await
+            .expect_err("discovery must refuse before assuming a role");
+        assert!(
+            matches!(err, ProviderError::ConnectionFailed(_)),
+            "the refusal must be the confidentiality one, not an STS failure: {err:?}"
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("plain HTTP"), "names the reason: {msg}");
+        assert!(
+            !msg.contains("AssumeRole"),
+            "an AssumeRole error means the exchange was attempted: {msg}"
+        );
+    }
+
+    /// Counts WARN events so the assertion is on the log line itself.
+    ///
+    /// An earlier draft of this test asserted the once-slot instead, which is
+    /// the guard and not the door: removing the `if` around the warning would
+    /// have restored one line per signed request and left that test green.
+    struct WarnCounter(std::sync::Arc<std::sync::atomic::AtomicUsize>);
+
+    impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for WarnCounter {
+        fn on_event(
+            &self,
+            event: &tracing::Event<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            if *event.metadata().level() == tracing::Level::WARN {
+                self.0.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            }
+        }
+    }
+
+    #[test]
+    fn the_cleartext_warning_is_logged_once_per_provider() {
+        use tracing_subscriber::layer::SubscriberExt;
+
+        // The consent branch used to log unconditionally, and it now runs at
+        // every signing path: an upload of N parts would put N identical
+        // warnings into the user's log and drown everything else in it.
+        let warnings = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let subscriber =
+            tracing_subscriber::registry().with(WarnCounter(std::sync::Arc::clone(&warnings)));
+        tracing::subscriber::with_default(subscriber, || {
+            let provider = cleartext_test_provider("http://minio.example.com:9000", true, None);
+            for _ in 0..5 {
+                provider
+                    .validate_endpoint_confidentiality()
+                    .expect("consent given");
+            }
+        });
+        assert_eq!(
+            warnings.load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "five signatures on a consenting profile must warn once, not five times"
+        );
+
+        // A different provider is a different session and warns again.
+        let warnings = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let subscriber =
+            tracing_subscriber::registry().with(WarnCounter(std::sync::Arc::clone(&warnings)));
+        tracing::subscriber::with_default(subscriber, || {
+            for _ in 0..2 {
+                cleartext_test_provider("http://minio.example.com:9000", true, None)
+                    .validate_endpoint_confidentiality()
+                    .expect("consent given");
+            }
+        });
+        assert_eq!(
+            warnings.load(std::sync::atomic::Ordering::Relaxed),
+            2,
+            "the warning is once per provider, not once per process"
+        );
+    }
+
+    /// The third door, and the only signer that builds a query signature
+    /// instead of a header one. A presigned URL for a cleartext endpoint is
+    /// worse than one request: it is a bearer credential that travels in the
+    /// clear every time anyone opens it.
+    #[tokio::test]
+    async fn a_share_link_is_refused_for_a_cleartext_endpoint_without_consent() {
+        let mut provider = cleartext_test_provider("http://s3.invalid:9000", false, None);
+        let err = provider
+            .create_share_link("/file.bin", ShareLinkOptions::default())
+            .await
+            .expect_err("a presigned URL must not be minted for a cleartext endpoint");
+        assert!(
+            matches!(err, ProviderError::ConnectionFailed(_)),
+            "the refusal must be the confidentiality one: {err:?}"
+        );
+        assert!(err.to_string().contains("plain HTTP"), "{err}");
     }
 
     /// The choke point itself, one level below the door: signing is where the

--- a/src-tauri/src/providers/s3.rs
+++ b/src-tauri/src/providers/s3.rs
@@ -950,6 +950,23 @@ impl S3Provider {
 
         type HmacSha256 = Hmac<Sha256>;
 
+        // The confidentiality check belongs here and not only in `connect()`.
+        // A signature authenticates a request without encrypting it, so the
+        // Authorization header this function is about to build is exactly the
+        // secret that must not cross a cleartext link. `connect()` guarded the
+        // sessions that go through it and left every entry point that does not:
+        // `discover_buckets` is `pub`, is called by Quick Connect without a
+        // connect, and signed a ListBuckets against whatever endpoint the user
+        // had just typed. Guarding each door in turn is how that door was
+        // missed, so the guard sits where all ten signing paths meet, and a
+        // future eleventh inherits it without anyone remembering to ask.
+        //
+        // `connect()` keeps its own call: refusing there is what stops the STS
+        // exchange, which signs through `sts.rs` and never reaches this
+        // function, and it fails the session before any work is done rather
+        // than at the first request.
+        self.validate_endpoint_confidentiality()?;
+
         // Single consistent snapshot of the effective credentials for this
         // signing pass (temporary STS creds when a role is assumed, else base).
         let creds = self.effective_credentials();
@@ -6025,6 +6042,70 @@ mod tests {
             "names the key: {msg}"
         );
         assert!(msg.contains("connection form"), "names the form: {msg}");
+    }
+
+    /// The guard's own tests assert that it refuses a cleartext endpoint, and
+    /// eight of them passed while `discover_buckets` signed and sent anyway.
+    /// This one is on the DOOR instead: it asserts that no request leaves.
+    ///
+    /// The endpoint host is in `.invalid`, which is reserved and never
+    /// resolves, so the two outcomes are distinguishable rather than merely
+    /// different in wording. If the refusal happens before any I/O the error is
+    /// the confidentiality one; if a request were attempted the DNS failure
+    /// would surface as a `NetworkError` naming ListBuckets. Asserting the
+    /// first and denying the second is what makes this a test of the door.
+    #[tokio::test]
+    async fn bucket_discovery_sends_nothing_to_a_cleartext_endpoint_without_consent() {
+        let provider = cleartext_test_provider("http://s3.invalid:9000", false, None);
+        let err = provider
+            .discover_buckets()
+            .await
+            .expect_err("discovery must refuse before signing anything");
+        let msg = err.to_string();
+        assert!(
+            matches!(err, ProviderError::ConnectionFailed(_)),
+            "the refusal must be the confidentiality one, got {err:?}"
+        );
+        assert!(msg.contains("s3.invalid"), "names the host: {msg}");
+        assert!(msg.contains("plain HTTP"), "names the reason: {msg}");
+        assert!(
+            !msg.contains("ListBuckets"),
+            "a ListBuckets error means the request was attempted: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn bucket_discovery_proceeds_once_the_profile_consents() {
+        // With consent the guard steps aside and the call reaches the network,
+        // where the unresolvable host produces the transport error. Without
+        // this half the test above would also pass on a `discover_buckets` that
+        // refuses everything unconditionally.
+        let provider = cleartext_test_provider("http://s3.invalid:9000", true, None);
+        let err = provider
+            .discover_buckets()
+            .await
+            .expect_err("the host does not resolve");
+        assert!(
+            matches!(err, ProviderError::NetworkError(_)),
+            "with consent the failure must come from the network, got {err:?}"
+        );
+    }
+
+    /// The choke point itself, one level below the door: signing is where the
+    /// Authorization header is built, so it is where the check cannot be
+    /// forgotten by a caller that did not exist when the guard was written.
+    #[test]
+    fn signing_refuses_a_cleartext_endpoint_without_consent() {
+        let provider = cleartext_test_provider("http://minio.example.com:9000", false, None);
+        let mut headers = std::collections::HashMap::new();
+        let err = provider
+            .sign_request("GET", "http://minio.example.com:9000/", &mut headers, "")
+            .expect_err("signing must refuse a cleartext endpoint without consent");
+        assert!(err.to_string().contains("plain HTTP"), "{err}");
+        assert!(
+            !headers.contains_key("Authorization"),
+            "nothing may be handed back to a caller that was refused"
+        );
     }
 
     #[test]

--- a/src-tauri/src/providers/s3.rs
+++ b/src-tauri/src/providers/s3.rs
@@ -6241,6 +6241,69 @@ mod tests {
         assert!(err.to_string().contains("plain HTTP"), "{err}");
     }
 
+    /// The once-slot is an `Arc`, so it is shared with every clone. Both the
+    /// transfer pool and the list pool clone the provider, and a clone is the
+    /// same profile talking to the same endpoint, so it must not warn again.
+    ///
+    /// This was a sentence in a comment and in the pull request body before it
+    /// was a test: true by how `clone_for_transfer` happens to be written, and
+    /// nothing would have failed if it had been given a `Clone` that rebuilt
+    /// the field. A claim with a green test beside it that does not test the
+    /// claim is the shape this whole change is about.
+    #[tokio::test]
+    async fn a_clone_of_the_provider_does_not_warn_again() {
+        use tracing_subscriber::layer::SubscriberExt;
+
+        let warnings = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let subscriber =
+            tracing_subscriber::registry().with(WarnCounter(std::sync::Arc::clone(&warnings)));
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let provider = cleartext_test_provider("http://minio.example.com:9000", true, None);
+        provider
+            .validate_endpoint_confidentiality()
+            .expect("consent given");
+        let mut pooled = provider.clone_for_transfer().expect("clone for transfer");
+        // Goes through the trait, on the clone, and reaches the guard again.
+        let _ = pooled
+            .create_share_link("/file.bin", ShareLinkOptions::default())
+            .await;
+        let mut listing = provider.clone_for_list().expect("clone for list");
+        let _ = listing
+            .create_share_link("/file.bin", ShareLinkOptions::default())
+            .await;
+
+        assert_eq!(
+            warnings.load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "the pool clones are the same profile and must not warn again"
+        );
+    }
+
+    /// The presigned URL path refuses a role profile before the STS exchange
+    /// too, for the same reason discovery does: an AssumeRole burns a one-time
+    /// MFA code and puts the wrong error on screen.
+    #[tokio::test]
+    async fn a_share_link_on_a_role_profile_is_refused_before_the_sts_exchange() {
+        let mut provider = cleartext_test_provider(
+            "http://s3.invalid:9000",
+            false,
+            Some("arn:aws:iam::123456789012:role/review"),
+        );
+        let err = provider
+            .create_share_link("/file.bin", ShareLinkOptions::default())
+            .await
+            .expect_err("a presigned URL must not be minted for a cleartext endpoint");
+        assert!(
+            matches!(err, ProviderError::ConnectionFailed(_)),
+            "the refusal must be the confidentiality one: {err:?}"
+        );
+        assert!(
+            !err.to_string().contains("AssumeRole"),
+            "an AssumeRole error means the exchange was attempted: {err}"
+        );
+    }
+
     /// The choke point itself, one level below the door: signing is where the
     /// Authorization header is built, so it is where the check cannot be
     /// forgotten by a caller that did not exist when the guard was written.


### PR DESCRIPTION
## The gap

The cleartext consent gate added in #729 lives in `connect()`. `discover_buckets()` does not go through `connect()`: it is `pub`, Quick Connect reaches it directly from `provider_discover_targets` (`provider_commands.rs:1414`), and it ran `ensure_fresh_credentials()` and then `sign_request()` against whatever endpoint the user had just typed.

So on a plain `http://` endpoint that is not on this machine, pressing the button that lists buckets sent a signed request with the `Authorization` header readable on the wire, and the consent the profile is supposed to require was never asked for. That is precisely the exposure #729 was written to close, reached through a door it did not cover.

Verified against `origin/main` before anything was written:

```
validate_endpoint_confidentiality   1 production call site (s3.rs, inside connect)
                                    8 call sites in tests
provider_commands.rs:1411-1415      S3Provider::new(cfg).discover_buckets()   <- no connect()
discover_buckets                    ensure_fresh_credentials -> sign_request("GET") -> send
```

## The fix is at the choke point, not at the door

The obvious repair is a call at the top of `discover_buckets`. This puts it in `sign_request()` instead, and that difference is the point: guarding one door at a time is exactly how this door came to be missed.

A signature authenticates a request without encrypting it, so the `Authorization` header `sign_request` is about to build is itself the secret at risk. Ten of the eleven signing paths in `s3.rs` pass through it, and a twelfth written six months from now inherits the check without anyone having to remember it exists. The eleventh is the query signer described below, which needed its own call.

`connect()` keeps its own call, so a session fails before any work rather than at its first request.

There are two other places the check has to be, and review found both. **The STS exchange runs before anything is signed for S3**, so on a door that does not go through `connect()` a role profile burnt an AssumeRole, and a one-time MFA code with it, then failed with an STS error instead of the reason it was refused. Not a cleartext exposure, since STS always dials `sts.<region>.amazonaws.com` over https, but the wrong work and the wrong message. The guard is now in `ensure_fresh_credentials` too, after the role and freshness early returns, so a profile without a role pays nothing for it. The first version of this body claimed that refusing in `connect()` is what stops the STS exchange: true for `connect()`, false for this door.

**And there is an eleventh signer that does not go through `sign_request` at all**: `create_share_link` builds a SigV4 query signature rather than an Authorization header. A presigned URL for a cleartext endpoint is worse than a single request, because it is a bearer credential that travels readable every time anyone opens it. Guarded at the top of that method.

## The sibling doors were checked, not assumed

Closing one door and leaving its twin would be the same defect applied to its own remedy, so `provider_discover_targets` was read in full. It has three branches:

| Branch | Exposure | Why |
|---|---|---|
| S3 | yes, fixed here | `S3Config` carries a user-supplied `endpoint` |
| Backblaze | none | `B2Config` has four fields and no endpoint at all, so discovery talks to Backblaze's fixed HTTPS API |
| kDrive | none | pinned to `https://api.infomaniak.com` by a constant |

Swift has a cleartext guard of its own (`allow_cleartext_storage_endpoint`) and no discovery branch here, so it is untouched.

## The tests are on the door, not on the guard

Eight tests already assert that `validate_endpoint_confidentiality` refuses a cleartext endpoint. All eight passed while discovery signed and sent anyway, so a ninth of the same kind would have proved nothing. The difference between testing the guard and testing the door is this entire finding.

- `bucket_discovery_sends_nothing_to_a_cleartext_endpoint_without_consent` asserts that no request leaves. The endpoint host is in `.invalid`, which is reserved and never resolves, so the two outcomes are distinguishable rather than merely worded differently: with the guard the error is the confidentiality refusal, without it the DNS failure surfaces as a `NetworkError` naming ListBuckets, which is the request already in flight.
- `bucket_discovery_proceeds_once_the_profile_consents` is the control. Without it the first test would also pass on a `discover_buckets` that refused everything unconditionally.
- `signing_refuses_a_cleartext_endpoint_without_consent` pins the choke point itself and asserts that no `Authorization` header is handed back to a caller that was refused.
- `a_role_profile_is_refused_before_the_sts_exchange` asserts a role profile gets the confidentiality refusal and not an `AssumeRole` failure, which is what proves the exchange did not happen.
- `a_share_link_is_refused_for_a_cleartext_endpoint_without_consent` covers the query signer.
- `the_cleartext_warning_is_logged_once_per_provider` counts WARN events through a tracing layer. The consent branch logs, and moving the check into `sign_request` turned one line per session into one per signature. **An earlier draft of this test asserted the once-slot instead, which is the guard and not the door**: removing the condition around the warning would have restored one line per signature and left it green, which is the same mistake this pull request exists to fix, made half an hour after writing it down.

**Fail-first, and it is worth quoting.** Run against the unfixed code, the door test fails with:

```
the refusal must be the confidentiality one, got
NetworkError("ListBuckets failed: error sending request for url (http://s3.invalid:9000/)")
```

That message is the vulnerability demonstrated rather than argued: the signed request was already on the wire. The control test passed in that same run, as designed.

## Gate

The Tier 1 pre-push gate in full: `cargo fmt --all --check`, `npm run typecheck`, `npm run i18n:validate`, `npm run i18n:diacritics`, `npm run i18n:untranslated`, `npm run check:provider-inventory`, `npm run test:unit`. Plus `cargo clippy --all-targets -- -D warnings` and `cargo test --lib s3` with 156 tests.

Fail-first covers every remedy and not only the first: four mutations, one per guard, each caught by its named test. One first reported as NOT CAUGHT, and that was the harness rather than the code, since the filter it ran did not match the test's name. A mutation runner that cannot tell "the test did not fail" from "the test did not run" is the same blind guard the rest of this pull request is about.

## Provenance

Reported by CodeRabbit as an out-of-diff comment while reviewing #732, which is an unrelated change to the delta grid. It was verified against `origin/main` line by line before being acted on, and deliberately kept out of #732: a security fix folded into a pull request about part sizing would make both stories unreadable, and would make this one invisible to anyone later asking when it was closed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Cleartext storage endpoints are now blocked consistently during request signing unless explicit profile consent is provided.
  - Bucket discovery validates endpoint security before making network requests.
  - Presigned share links now apply the same cleartext endpoint protection.
  - Cleartext warnings are shown only once per provider connection, reducing duplicate alerts.
  - Requests to approved endpoints continue to work normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->