### PR TITLE
fix(s3): derive the delta upload's mtime instead of asking for it

### DIFF
--- a/src-tauri/src/providers/s3.rs
+++ b/src-tauri/src/providers/s3.rs
@@ -2585,9 +2585,43 @@ impl S3Provider {
         grid: u64,
         baseline_etag: &str,
         content_type: Option<&str>,
-        source_mtime: Option<String>,
         on_progress: Option<Box<dyn Fn(u64, u64) + Send>>,
     ) -> Result<Option<u64>, ProviderError> {
+        // Derived here and not taken as a parameter, the way
+        // `upload_multipart_streaming` does it. The function already has
+        // `local_path`, so a parameter only creates a way for a caller to pass
+        // `None` and silently drop the mtime the original object carried, and
+        // an object rebuilt by the delta that lost its mtime is one that every
+        // later sync compares by timestamp and never finds equal. The caller
+        // that would have had to remember does not exist yet: the adapter arm
+        // is the next tranche, which is exactly when this would have been
+        // discovered the expensive way.
+        // Two limits from the appendix's constraint sheet are deliberately not
+        // checked here, and both are written down rather than left to be
+        // rediscovered as defects.
+        //
+        // A ranged copy is only allowed when the SOURCE object is larger than
+        // 5 MB. Nothing enforces it because nothing can reach it: a baseline
+        // under 5 MB cannot produce a match as wide as the grid, which is at
+        // least 8 MiB, so the planner demotes every copy run and refuses the
+        // plan before a single UploadPartCopy is built. The argument is the
+        // reason there is no check, not an excuse for its absence.
+        //
+        // The appendix also asks for the result to be verified, by creating the
+        // multipart with a checksum algorithm and comparing a full-object
+        // digest against the local file. That is not done, and it is not a
+        // small omission to bolt on: for a multipart the object-level checksum
+        // is COMPOSITE, a hash of the part hashes with an `-N` suffix, which is
+        // the same shape the appendix already documents for the multipart ETag
+        // and is not comparable to a digest computed over the local file. A
+        // whole-object digest needs the full-object checksum type, which S3
+        // offers for the CRC families and not for SHA256, with uneven support
+        // across S3-compatible backends. Measured alongside this: on MinIO and
+        // R2 a multipart object is not hash-verifiable by a third-party client
+        // today at all. So the guardrail needs restating on what is actually
+        // obtainable before it can be implemented, and it is tracked in the
+        // appendix rather than silently dropped here.
+        let source_mtime = Self::source_mtime_metadata(local_path);
         use tokio::io::AsyncReadExt;
 
         // The door: plan BEFORE any request. A refused shape costs nothing
@@ -7892,6 +7926,10 @@ mod tests {
     #[derive(Default)]
     struct DeltaMockState {
         creates: usize,
+        /// `x-amz-meta-mtime` as it arrived on each CreateMultipartUpload.
+        /// `None` means the header was absent, which is how the rebuilt object
+        /// would silently lose the mtime the original carried.
+        create_mtimes: Vec<Option<String>>,
         /// (part_number, x-amz-copy-source-range, x-amz-copy-source-if-match)
         copies: Vec<(u32, String, Option<String>)>,
         /// (part_number, body)
@@ -7940,7 +7978,15 @@ mod tests {
                     let is_upload_id_query = query.contains("uploadId=");
 
                     if method == axum::http::Method::POST && query.starts_with("uploads") {
-                        seen.lock().unwrap().creates += 1;
+                        let mut guard = seen.lock().unwrap();
+                        guard.creates += 1;
+                        guard.create_mtimes.push(
+                            headers
+                                .get("x-amz-meta-mtime")
+                                .and_then(|v| v.to_str().ok())
+                                .map(str::to_string),
+                        );
+                        drop(guard);
                         return axum::response::Response::new(axum::body::Body::from(
                             "<InitiateMultipartUploadResult><UploadId>u1</UploadId></InitiateMultipartUploadResult>",
                         ));
@@ -8080,7 +8126,6 @@ mod tests {
                     "baseline-v1",
                     Some("application/octet-stream"),
                     None,
-                    None,
                 )
                 .await
                 .expect("a refused plan is Ok(None), not an error");
@@ -8118,7 +8163,6 @@ mod tests {
                 crate::providers::s3_delta_plan::S3_PART_MIN,
                 "baseline-v1",
                 Some("application/octet-stream"),
-                None,
                 Some(Box::new(move |done, total| {
                     progress_seen.lock().unwrap().push((done, total));
                 })),
@@ -8169,6 +8213,45 @@ mod tests {
         );
     }
 
+    /// The object a delta rebuilds must carry the same `x-amz-meta-mtime` an
+    /// ordinary upload writes. Every later sync compares by timestamp, so an
+    /// object that lost it is one that never compares equal again and is
+    /// re-uploaded whole, which is the opposite of what this feature is for.
+    ///
+    /// This is on the door and not on the guard: it asserts the header arrived
+    /// on the wire, not that a helper can compute one. The executor used to
+    /// take the value as a parameter, so it was the caller's job to remember,
+    /// and the caller that would have had to remember is the adapter arm of
+    /// the next tranche, which is when the loss would have been found.
+    #[tokio::test]
+    async fn a_delta_upload_carries_the_source_mtime_like_an_ordinary_one() {
+        let (provider, state, dir) = delta_mock_server(false, false).await;
+        let (path, bytes) = delta_fixture_file(dir.path());
+        let grid = crate::providers::s3_delta_plan::S3_PART_MIN;
+        let matches = vec![(0, 0, grid)];
+        provider
+            .upload_delta_multipart(
+                "big.bin",
+                &path,
+                bytes.len() as u64,
+                &matches,
+                grid,
+                "baseline-v1",
+                Some("application/octet-stream"),
+                None,
+            )
+            .await
+            .expect("the delta runs");
+
+        let seen = state.lock().unwrap();
+        assert_eq!(seen.creates, 1, "one CreateMultipartUpload");
+        let sent = seen.create_mtimes[0]
+            .as_deref()
+            .expect("the create must carry x-amz-meta-mtime");
+        let expected = S3Provider::source_mtime_metadata(&path).expect("the fixture has an mtime");
+        assert_eq!(sent, expected, "and it must be the source file's own");
+    }
+
     #[tokio::test]
     async fn delta_412_from_the_guard_aborts_and_never_completes() {
         // A concurrent overwrite of the baseline turns the if-match guard
@@ -8187,7 +8270,6 @@ mod tests {
                 &matches,
                 crate::providers::s3_delta_plan::S3_PART_MIN,
                 "baseline-v1",
-                None,
                 None,
                 None,
             )
@@ -8227,7 +8309,6 @@ mod tests {
                 &matches,
                 crate::providers::s3_delta_plan::S3_PART_MIN,
                 "baseline-v1",
-                None,
                 None,
                 None,
             )
@@ -8419,7 +8500,6 @@ mod tests {
                 grid,
                 &baseline_etag,
                 Some("application/octet-stream"),
-                None,
                 None,
             )
             .await


### PR DESCRIPTION
## The defect

`upload_delta_multipart` took `source_mtime` as a parameter. `upload_multipart_streaming`, one screen away in the same file, derives it from the local path with `Self::source_mtime_metadata(local_path)`.

The executor already holds `local_path`, since that is where it reads the PUT parts from, so the parameter existed only as a way to forget. A caller passing `None` leaves the rebuilt object without the `x-amz-meta-mtime` the original carried, silently. From then on every sync that compares timestamps never finds that object equal and re-uploads the whole file, which is the exact outcome a delta upload exists to avoid.

**The caller that would have had to remember does not exist yet.** The adapter arm is the next tranche, which is when this would have been found: on a real transfer, by a user whose sync stopped converging.

It came from the G Lane, while they were checking whether their own S3 work collided with #755. Nothing in that pull request's sixteen green checks could have shown it. The code compiles with the parameter, `create_multipart_upload` accepts `None` by design, and no test asked what reached the wire.

## The test asks what reached the wire

`a_delta_upload_carries_the_source_mtime_like_an_ordinary_one` asserts that `x-amz-meta-mtime` arrived on the `CreateMultipartUpload`, carrying the source file's own value. Not that a helper can compute one, which is the version that would have passed either way.

The mock backend now records the header on each create, so the absence is observable rather than inferred. Seen failing on a version where the executor passes `None`, which is precisely the shape the parameter allowed:

```
a_delta_upload_carries_the_source_mtime_like_an_ordinary_one ... FAILED
the create must carry x-amz-meta-mtime
```

## Two limits, written down instead of left silent

Both come from the appendix's constraint sheet, and neither is enforced in code. That is now stated in the executor with its reasoning, so the next reader does not have to decide whether it is an oversight.

**A ranged copy needs a source object above 5 MB.** There is no check because there is no way to reach the case: a baseline under 5 MB cannot produce a match as wide as the grid, which is at least 8 MiB, so the planner demotes every copy run and refuses the plan before a single `UploadPartCopy` is built. The argument is the reason for the absence, not an excuse for it.

**"Verify the result, do not assume it" is a guardrail to restate, not an omission to fill.** The appendix asks for the multipart to be created with a checksum algorithm so S3 returns a full-object digest comparable against the local file. For a multipart the object-level checksum is COMPOSITE: a hash of the part hashes with an `-N` suffix, which is the same shape the appendix itself already documents for the multipart ETag in `04(b)`, and it is not comparable to a digest computed over the local file. A whole-object digest needs the full-object checksum type, which S3 offers for the CRC families and not for SHA256, with uneven support across S3-compatible backends.

Measured alongside this, by the test station's rclone comparison bench on 300 MiB server-side copies:

```
copy-300m-minio  aeroftp integrity  CHECK=ok :: size match (no remote sha)
copy-300m-r2     aeroftp integrity  CHECK=ok :: size match (no remote sha)
```

with their own caveat attached: the bench asks for sha256 and rclone's S3 backend normally exposes the ETag, so that is partly a limit of the reading side. It is not proof that `x-amz-checksum-algorithm` fails; it is evidence that a multipart object is not hash-verifiable by a third-party client today on either backend, which is why deferring closes nothing that currently works.

## On the yardstick, since the numbers will be quoted

The delta's saving should be cited against **our own rsync path**, not against rclone. rclone has no delta on S3 and resends the whole object, so "16 MiB against 1 GiB" measures that the other tool does not play, not how well this one does. The informative comparison is the wire ratio our native rsync achieves on the same file and the same edit, because that is what prices the aligned grid: near parity on an append, roughly 60 percent more wire on a middle edit that straddles two cells, and everything against nothing on an insertion at offset zero, which is Tier 1's declared blind spot. That gap is the field data the deferred Tier 2 decision rests on.

## Gate

`cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --lib s3` with 180 tests passing and 3 ignored (the env-gated live lane), run on the branch merged over `main` at `bf15c887c`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of delta multipart uploads by preserving source modification-time metadata.
  * Added safeguards for conditional-copy failures and truncated-file cleanup.
  * Improved consistency across live upload and download round trips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->