### PR TITLE
ci(dco): match a GitHub App by name, it cannot pick either address

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -33,11 +33,30 @@ jobs:
           for sha in $(git rev-list --no-merges "$BASE".."$HEAD"); do
             author_name=$(git show -s --format='%an' "$sha")
             author_mail=$(git show -s --format='%ae' "$sha")
-            expected="Signed-off-by: ${author_name} <${author_mail}>"
+            case "$author_mail" in
+              *'[bot]@users.noreply.github.com')
+                # A GitHub App picks neither of its two addresses. It authors
+                # with the NNN+name[bot]@users.noreply.github.com that GitHub
+                # issues for the app, and signs off with the app's own contact
+                # address: Dependabot authors as
+                # 49699333+dependabot[bot]@users.noreply.github.com and writes
+                # Signed-off-by: dependabot[bot] <support@github.com>. Requiring
+                # the two to match leaves every bot pull request permanently red
+                # over a difference nobody can amend. Match the app by name and
+                # take the address it signs with; the sign-off is still
+                # required, only its address is not compared.
+                expected="Signed-off-by: ${author_name} <"
+                shown="Signed-off-by: ${author_name} <the address the app signs with>"
+                ;;
+              *)
+                expected="Signed-off-by: ${author_name} <${author_mail}>"
+                shown="$expected"
+                ;;
+            esac
             if git show -s --format='%B' "$sha" | grep -qiF "$expected"; then
               continue
             fi
-            echo "::error::commit $sha is missing '$expected'"
+            echo "::error::commit $sha is missing '$shown'"
             git show -s --format='  %h %s' "$sha"
             missing=1
           done
@@ -47,7 +66,8 @@ jobs:
             echo "  git commit --amend -s --no-edit"
             echo "  git rebase --signoff $BASE"
             echo ""
-            echo "The sign-off must match the commit author exactly. It certifies"
+            echo "The sign-off must match the commit author; a GitHub App is matched"
+            echo "by name, since it cannot pick either of its two addresses. It certifies"
             echo "the Developer Certificate of Origin, see the DCO file in the repo root."
             exit 1
           fi


### PR DESCRIPTION
Every Dependabot pull request has been red since the sign-off check landed, and none of them could have been fixed by the thing the error suggested. Dependabot does sign off. It authors as `dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>`, the address GitHub issues for the app, and writes `Signed-off-by: dependabot[bot] <support@github.com>`, the app's own contact address. Neither is settable per repository, so demanding that the two match is a condition no amend can satisfy: eleven open pull requests carrying a red check that says nothing about the change in them, which is the cost of a guard that cannot be passed.

An author address of the form `NNN+name[bot]@users.noreply.github.com` is issued by GitHub to a GitHub App and to nothing else. On that path the sign-off is matched by author name and its address is not compared. The certification is still required, and the human path is untouched.

Verified case by case against the extracted step, on real commits and on crafted ones, with the number of inspected commits printed so an empty range cannot read as a pass: the head of #748 and #754 pass, three signed commits on main pass, and five stay red, a bot with no sign-off at all, a bot signed in another bot's name, a human with no sign-off, a human whose sign-off carries a different address, and an author calling itself `someone[bot]` from an ordinary address, which takes the human path and is compared on both halves.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated contribution sign-off validation to correctly handle commits authored by GitHub App bots.
  * Improved sign-off error messages and guidance for bot-authored commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->