### PR TITLE
ci(cli-smoke): run coverage and cargo-install-smoke on main only, and cancel superseded runs

### DIFF
--- a/.github/workflows/cli-smoke.yml
+++ b/.github/workflows/cli-smoke.yml
@@ -20,6 +20,12 @@ on:
 permissions:
   contents: read
 
+# A new SHA on a PR supersedes the previous one: cancel the smoke matrix that
+# was still building for it, like checks.yml and build.yml already do.
+concurrency:
+  group: cli-smoke-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref_type != 'tag' }}
+
 jobs:
   smoke:
     runs-on: ${{ matrix.os }}
@@ -252,6 +258,12 @@ jobs:
   # path is what differs; the cross-OS smoke job above already covers the
   # multi-platform behavior of the binary itself.
   cargo-install-smoke:
+    # Proves that `cargo install` works from the crate as published, which is
+    # packaging, not the code of a pull request: it costs a third release
+    # build of the CLI per PR (about 25 minutes) and cannot change with the
+    # PR's diff in a way the smoke matrix above does not already exercise.
+    # Runs on main and on demand.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
 
     steps:
@@ -302,8 +314,14 @@ jobs:
           fi
 
   coverage:
+    # The same ~5000 tests already run uninstrumented in build.yml on every
+    # pull request; under llvm-cov instrumentation they took 41 minutes and,
+    # queued behind the smoke matrix, made this workflow the longest lane of
+    # every PR. Coverage is a report, not a gate (the floor below is far under
+    # the baseline), so it runs on main and on demand, and no longer waits
+    # for the smoke binaries it never used.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
-    needs: smoke
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

Per pull request, the CLI Smoke workflow had become the longest lane (77 to 110 minutes on the last full runs, against 53 to 80 for the Tauri build) for two reasons that have nothing to do with the PR's diff:

| job | minutes | what it did on a PR |
|---|---|---|
| coverage | 41 | the whole ~5000-test suite a second time, instrumented with llvm-cov, queued behind the smoke matrix (`needs: smoke`) whose binaries it never used |
| cargo-install-smoke | 25 | a third release build of the CLI, to prove `cargo install` works from the crate |
| smoke x3 OS | 25 to 35 | build the CLI and smoke it on Linux, macOS and Windows |

`build.yml` already runs the same tests uninstrumented on every PR, and coverage is a report, not a gate (`--fail-under-lines 10` against a baseline well above it). `cargo install` from the crate is packaging, not the diff. Both jobs now run on push to main and on `workflow_dispatch`; the smoke matrix stays on every PR, it is the cross-platform door of the binary. The workflow also gets the `concurrency` group `checks.yml` and `build.yml` already have, so a new SHA on a PR cancels the matrix still building for the previous one.

Expected per PR: CLI Smoke from 77 to 110 minutes down to the smoke matrix alone, 25 to 35, with every test still run once. The ruleset on `main` declares no required status contexts, so a skipped job blocks nothing.

Not in this PR, measured separately: the slow tail of the suite (27 of the 41 test minutes are spent in a few dozen tests that wait on real time) and a path filter for docs-only PRs on `build.yml`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved automated validation workflows by reducing redundant runs.
  - Updated smoke and coverage checks to run under the appropriate event conditions.
  - Improved handling of concurrent validation runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->