### PR TITLE
fix(s3): keep a same-named file on recursive delete, and export the rclone marker setting

### DIFF
--- a/docs/PROTOCOL-FEATURES.md
+++ b/docs/PROTOCOL-FEATURES.md
@@ -182,7 +182,8 @@ option does not establish that the folder was removed. See
 AeroFTP recursive deletion removes the folder's marker and children. An object
 with the same name **without** the trailing slash is a distinct file and is
 preserved unless HEAD identifies it as a zero-byte directory marker used by a
-gateway. Errors from individual DELETE requests are reported even when the
+gateway. A denied or unsupported HEAD preserves that separate key and does
+not block deletion inside the folder's prefix. Errors from individual DELETE requests are reported even when the
 server does not support batch deletion.
 A fresh listing after recursive deletion also reports an error if objects
 remain, including children a gateway only exposes after a conflicting object

--- a/docs/PROTOCOL-FEATURES.md
+++ b/docs/PROTOCOL-FEATURES.md
@@ -155,6 +155,44 @@ open still fails, re-toggle File Transfer on the phone and retry.
 **Azure rename = copy+delete
 ***kDrive rename = move to same parent with new name
 
+### S3 empty folders and rclone interoperability
+
+AeroFTP preserves empty folders with a zero-byte object whose key ends in `/`,
+tagged `application/x-directory`. This follows the
+[AWS folder convention](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-folders.html).
+Markers remain when a folder gains children, preserving the explicitly created
+folder if its children are later removed.
+
+S3 profiles exported to rclone enable `directory_markers = true`. For older
+exports or independently configured remotes, enable that setting in the S3
+backend section or pass `--s3-directory-markers`:
+
+```sh
+rclone purge "remote:bucket/scratch-folder" --s3-directory-markers
+```
+
+This command deletes the specified folder and its contents. With rclone 1.74.0
+and the option disabled, purging a folder with its own marker constructs a key
+ending in `//`: MinIO returns an error, while Cloudflare R2 returns success for
+that absent key and leaves the actual marker behind. Both were verified live;
+the option removes the marker correctly on both. A successful exit without the
+option does not establish that the folder was removed. See
+[rclone's S3 directory marker setting](https://rclone.org/s3/#s3-directory-markers).
+
+AeroFTP recursive deletion removes the folder's marker and children. An object
+with the same name **without** the trailing slash is a distinct file and is
+preserved unless HEAD identifies it as a zero-byte directory marker used by a
+gateway. Errors from individual DELETE requests are reported even when the
+server does not support batch deletion.
+A fresh listing after recursive deletion also reports an error if objects
+remain, including children a gateway only exposes after a conflicting object
+has been deleted.
+
+Backblaze S3 exports use rclone's `provider = Other` with the B2 S3 endpoint;
+`Backblaze` is not a supported S3 provider name in rclone 1.74.0. Native B2 is
+a separate backend. For existing buckets with credentials that cannot create
+buckets, rclone uploads or mkdir may also need `--s3-no-check-bucket`.
+
 ### Advanced Operations (v1.4.0)
 
 | Operation | FTP | FTPS | SFTP | WebDAV | S3 | GDrive | Dropbox | OneDrive | MEGA | Box | pCloud | Azure | 4shared | Filen | Zoho WD | Internxt | kDrive | FileLu | Yandex | OpenDrive |

--- a/docs/PROTOCOL-FEATURES.md
+++ b/docs/PROTOCOL-FEATURES.md
@@ -173,9 +173,9 @@ rclone purge "remote:bucket/scratch-folder" --s3-directory-markers
 
 This command deletes the specified folder and its contents. With rclone 1.74.0
 and the option disabled, purging a folder with its own marker constructs a key
-ending in `//`: MinIO returns an error, while Cloudflare R2 returns success for
-that absent key and leaves the actual marker behind. Both were verified live;
-the option removes the marker correctly on both. A successful exit without the
+ending in `//`: MinIO returns an error, while AWS S3 and Cloudflare R2 return
+success for that absent key and leave the actual marker behind. All three were
+verified live; the option removes the marker correctly on each. A successful exit without the
 option does not establish that the folder was removed. See
 [rclone's S3 directory marker setting](https://rclone.org/s3/#s3-directory-markers).
 

--- a/src-tauri/src/providers/s3.rs
+++ b/src-tauri/src/providers/s3.rs
@@ -3985,10 +3985,36 @@ impl StorageProvider for S3Provider {
         if !keys.contains(&prefix) {
             keys.push(prefix.clone());
         }
-        // Also try without trailing slash (some providers use both)
+        // A slashless key is a distinct object on S3. Only include it when
+        // HEAD positively identifies a gateway's directory marker; otherwise
+        // deleting `reports/` would also erase the unrelated file `reports`.
         let no_slash = path.trim_matches('/').to_string();
-        if !keys.contains(&no_slash) {
-            keys.push(no_slash);
+        let response = self.s3_request(Method::HEAD, &no_slash, None, None).await?;
+        match response.status() {
+            StatusCode::OK => {
+                let content_type = response
+                    .headers()
+                    .get(reqwest::header::CONTENT_TYPE)
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or("");
+                if is_s3_directory_content_type(content_type)
+                    && response
+                        .headers()
+                        .get(reqwest::header::CONTENT_LENGTH)
+                        .and_then(|v| v.to_str().ok())
+                        == Some("0")
+                    && !keys.contains(&no_slash)
+                {
+                    keys.push(no_slash);
+                }
+            }
+            StatusCode::NOT_FOUND => {}
+            status => {
+                return Err(ProviderError::ServerError(format!(
+                    "Directory marker HEAD failed with status: {}",
+                    status
+                )))
+            }
         }
 
         tracing::info!(
@@ -4000,7 +4026,16 @@ impl StorageProvider for S3Provider {
         // DELETE-01: Use S3 batch delete (POST /?delete) for up to 1000 keys per
         // request. Delete the current version of each key (no version id).
         let objects: Vec<(String, Option<String>)> = keys.into_iter().map(|k| (k, None)).collect();
-        self.batch_delete_objects(&objects).await
+        self.batch_delete_objects(&objects).await?;
+        // A gateway can expose previously hidden children after deletion of
+        // a conflicting object. Never report a complete purge with leftovers.
+        if !self.list_keys_with_prefix(&prefix).await?.is_empty() {
+            return Err(ProviderError::TransferFailed(format!(
+                "Directory '{}' still contains objects after recursive deletion",
+                path
+            )));
+        }
+        Ok(())
     }
 
     async fn rename(&mut self, from: &str, to: &str) -> Result<(), ProviderError> {
@@ -5489,11 +5524,18 @@ impl S3Provider {
                 );
                 for (key, version_id) in chunk {
                     let params = version_id.as_ref().map(|v| vec![("versionId", v.as_str())]);
-                    if let Err(e) = self
+                    match self
                         .s3_request(Method::DELETE, key, params.as_deref(), None)
                         .await
                     {
-                        failures.push((key.clone(), e.to_string()));
+                        Ok(response)
+                            if response.status().is_success()
+                                || response.status() == StatusCode::NOT_FOUND => {}
+                        Ok(response) => failures.push((
+                            key.clone(),
+                            format!("DELETE returned {}", response.status()),
+                        )),
+                        Err(e) => failures.push((key.clone(), e.to_string())),
                     }
                 }
             }
@@ -7255,6 +7297,246 @@ mod tests {
         .expect("Failed to create S3Provider")
     }
 
+    #[tokio::test]
+    async fn recursive_delete_preserves_slashless_files_and_checks_gateway_markers() {
+        use std::sync::{Arc, Mutex};
+        // Real files (including zero-byte files) survive; only a confirmed
+        // zero-byte directory marker may be removed outside the prefix.
+        for (status, content_type, length, include_bare, head_ok, leftovers) in [
+            (200, "text/plain", "17", false, true, false),
+            (200, "application/octet-stream", "0", false, true, false),
+            (200, "application/x-directory", "17", false, true, false),
+            (200, "application/x-directory", "0", true, true, false),
+            (200, "httpd/unix-directory", "0", true, true, false),
+            (404, "", "0", false, true, false),
+            (403, "", "0", false, false, false),
+            (404, "", "0", false, true, true),
+        ] {
+            let bodies = Arc::new(Mutex::new(Vec::new()));
+            let captured = Arc::clone(&bodies);
+            let app = axum::Router::new().fallback(axum::routing::any(
+                move |req: axum::extract::Request| {
+                    let captured = Arc::clone(&captured);
+                    async move {
+                        match *req.method() {
+                            Method::HEAD => axum::http::Response::builder()
+                                .status(status)
+                                .header("content-type", content_type)
+                                .header("content-length", length)
+                                .body(axum::body::Body::empty()).unwrap(),
+                            Method::GET => {
+                                let xml = if !leftovers && !captured.lock().unwrap().is_empty() {
+                                    "<ListBucketResult/>"
+                                } else {
+                                    "<ListBucketResult><Contents><Key>folder/</Key></Contents><Contents><Key>folder/child</Key></Contents></ListBucketResult>"
+                                };
+                                axum::http::Response::new(axum::body::Body::from(xml))
+                            }
+                            Method::POST => {
+                                let bytes = axum::body::to_bytes(req.into_body(), 8192).await.unwrap();
+                                captured.lock().unwrap().push(String::from_utf8(bytes.to_vec()).unwrap());
+                                axum::http::Response::new(axum::body::Body::from("<DeleteResult/>"))
+                            }
+                            _ => panic!("unexpected request"),
+                        }
+                    }
+                },
+            ));
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let addr = listener.local_addr().unwrap();
+            let server = tokio::spawn(async move {
+                axum::serve(listener, app).await.unwrap();
+            });
+            let mut provider = make_provider(Some(&format!("http://{addr}")));
+            provider.connected = true;
+            assert_eq!(
+                provider.rmdir_recursive("/folder/").await.is_ok(),
+                head_ok && !leftovers
+            );
+            let bodies = bodies.lock().unwrap();
+            if head_ok {
+                assert_eq!(bodies.len(), 1);
+                assert!(bodies[0].contains("<Key>folder/</Key>"));
+                assert!(bodies[0].contains("<Key>folder/child</Key>"));
+                assert_eq!(bodies[0].contains("<Key>folder</Key>"), include_bare);
+            } else {
+                assert!(bodies.is_empty(), "HEAD failure must prevent deletion");
+            }
+            server.abort();
+        }
+    }
+
+    #[tokio::test]
+    async fn batch_delete_fallback_reports_http_failures() {
+        use std::sync::{Arc, Mutex};
+        let deleted = Arc::new(Mutex::new(Vec::new()));
+        let captured = Arc::clone(&deleted);
+        let app =
+            axum::Router::new().fallback(axum::routing::any(move |req: axum::extract::Request| {
+                let captured = Arc::clone(&captured);
+                async move {
+                    if req.method() == Method::POST {
+                        return axum::http::StatusCode::METHOD_NOT_ALLOWED;
+                    }
+                    assert_eq!(req.method(), Method::DELETE);
+                    captured.lock().unwrap().push(req.uri().path().to_string());
+                    match req.uri().path() {
+                        "/test-bucket/denied" => axum::http::StatusCode::FORBIDDEN,
+                        "/test-bucket/missing" => axum::http::StatusCode::NOT_FOUND,
+                        _ => axum::http::StatusCode::NO_CONTENT,
+                    }
+                }
+            }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        let provider = make_provider(Some(&format!("http://{addr}")));
+        let error = provider
+            .batch_delete_objects(&[
+                ("denied".into(), None),
+                ("missing".into(), None),
+                ("ok".into(), None),
+            ])
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("1 of 3"), "{error}");
+        assert!(error.contains("denied") && error.contains("403"), "{error}");
+        assert_eq!(deleted.lock().unwrap().len(), 3, "continue after a failure");
+        provider
+            .batch_delete_objects(&[("missing".into(), None), ("ok".into(), None)])
+            .await
+            .unwrap();
+        server.abort();
+    }
+
+    /// Opt-in live check. Supply a disposable bucket's saved-profile export
+    /// through AEROFTP_MARKER_LIVE_* environment variables. Only a unique
+    /// scratch prefix is mutated; no bucket creation or bucket-root deletion.
+    #[tokio::test]
+    #[ignore = "requires an explicitly authorized live S3 profile and rclone"]
+    async fn s3_marker_live_export_and_delete_regression() {
+        let env = |name: &str| {
+            std::env::var(format!("AEROFTP_MARKER_LIVE_{name}"))
+                .unwrap_or_else(|_| panic!("missing AEROFTP_MARKER_LIVE_{name}"))
+        };
+        let endpoint = env("ENDPOINT");
+        let bucket = env("BUCKET");
+        let access_key = env("ACCESS_KEY");
+        let secret = env("SECRET_KEY");
+        let region = env("REGION");
+        let mut provider = make_provider(Some(&endpoint));
+        provider.config.bucket = bucket.clone();
+        provider.config.access_key_id = access_key.clone();
+        provider.config.secret_access_key = secrecy::SecretString::from(secret.clone());
+        provider.config.region = region.clone();
+        provider.connected = true;
+        let root = format!("codex-s3-patched-{}", uuid::Uuid::new_v4());
+        assert!(provider
+            .list_keys_with_prefix(&root)
+            .await
+            .unwrap()
+            .is_empty());
+        let result: Result<(), String> = async {
+            provider.mkdir(&root).await.map_err(|e| e.to_string())?;
+            provider
+                .mkdir(&format!("{root}/child"))
+                .await
+                .map_err(|e| e.to_string())?;
+            let keys = provider
+                .list_keys_with_prefix(&format!("{root}/"))
+                .await
+                .map_err(|e| e.to_string())?;
+            assert!(keys.contains(&format!("{root}/")));
+            assert!(keys.contains(&format!("{root}/child/")));
+            let temp = tempfile::tempdir().unwrap();
+            let config_path = temp.path().join("rclone.conf");
+            let servers = vec![crate::rclone_import::RcloneExportServer {
+                name: "marker-live".into(),
+                host: endpoint.clone(),
+                port: 443,
+                username: access_key,
+                protocol: Some("s3".into()),
+                provider_id: Some(env("PROVIDER")),
+                options: Some(
+                    serde_json::json!({"bucket": bucket, "endpoint": endpoint, "region": region}),
+                ),
+            }];
+            crate::rclone_import::export_rclone(
+                &servers,
+                &HashMap::from([("marker-live".into(), secret)]),
+                &config_path,
+            )
+            .map_err(|e| e.to_string())?;
+            // No --s3-directory-markers flag: this verifies the actual export.
+            let output = std::process::Command::new("rclone")
+                .arg("--config")
+                .arg(&config_path)
+                .arg("purge")
+                .arg(format!("marker-live-{bucket}:{root}"))
+                .args(["--retries", "1"])
+                .output()
+                .map_err(|e| e.to_string())?;
+            if !output.status.success() {
+                return Err(format!("rclone purge exited {}", output.status));
+            }
+            assert!(provider
+                .list_keys_with_prefix(&format!("{root}/"))
+                .await
+                .unwrap()
+                .is_empty());
+            // Empty directory + a separate nonempty slashless object.
+            // The latter must survive deletion byte-for-byte.
+            let folder = format!("{root}/same-name");
+            provider.mkdir(&folder).await.map_err(|e| e.to_string())?;
+            let payload = b"keep this distinct object".to_vec();
+            let put = provider
+                .s3_request_ext(
+                    Method::PUT,
+                    &folder,
+                    None,
+                    Some(payload.clone()),
+                    &[("content-type", "text/plain")],
+                )
+                .await
+                .unwrap();
+            assert!(put.status().is_success());
+            provider
+                .rmdir_recursive(&folder)
+                .await
+                .map_err(|e| e.to_string())?;
+            let get = provider
+                .s3_request(Method::GET, &folder, None, None)
+                .await
+                .unwrap();
+            assert!(get.status().is_success());
+            assert_eq!(get.bytes().await.unwrap().as_ref(), payload.as_slice());
+            assert!(provider
+                .list_keys_with_prefix(&format!("{folder}/"))
+                .await
+                .unwrap()
+                .is_empty());
+            provider.delete(&folder).await.map_err(|e| e.to_string())?;
+            Ok(())
+        }
+        .await;
+        // This root is unique to this test. Cleanup also runs on ordinary
+        // operation errors; assertions intentionally preserve failure evidence.
+        provider
+            .rmdir_recursive(&root)
+            .await
+            .expect("scratch cleanup");
+        assert!(provider
+            .list_keys_with_prefix(&format!("{root}/"))
+            .await
+            .unwrap()
+            .is_empty());
+        result.unwrap();
+        println!("PASS: exported-config purge, same-name file preserved, cleaned {root}");
+    }
+
     fn make_provider_with_token(session_token: Option<&str>) -> S3Provider {
         S3Provider::new(S3Config {
             endpoint: None,
@@ -7289,8 +7571,8 @@ mod tests {
     async fn bodyless_put_sends_explicit_content_length_zero() {
         use std::sync::{Arc, Mutex};
 
-        /// (method, Content-Length) of the request the provider actually sent.
-        type SeenRequest = Option<(String, Option<String>)>;
+        /// (method, Content-Length, path, Content-Type) on the wire.
+        type SeenRequest = Option<(String, Option<String>, String, Option<String>)>;
 
         let seen: Arc<Mutex<SeenRequest>> = Arc::new(Mutex::new(None));
         let captured = Arc::clone(&seen);
@@ -7304,7 +7586,13 @@ mod tests {
                         .get(reqwest::header::CONTENT_LENGTH)
                         .and_then(|v| v.to_str().ok())
                         .map(String::from);
-                    *captured.lock().unwrap() = Some((method, value));
+                    let path = req.uri().path().to_string();
+                    let content_type = req
+                        .headers()
+                        .get("content-type")
+                        .and_then(|v| v.to_str().ok())
+                        .map(String::from);
+                    *captured.lock().unwrap() = Some((method, value, path, content_type));
                     axum::http::StatusCode::OK
                 }
             }));
@@ -7321,12 +7609,14 @@ mod tests {
         provider.connected = true;
         provider.mkdir("/some/folder").await.expect("mkdir");
 
-        let (method, value) = seen
+        let (method, value, path, content_type) = seen
             .lock()
             .unwrap()
             .clone()
             .expect("no request reached the server");
         assert_eq!(method, "PUT", "mkdir must write the marker with a PUT");
+        assert_eq!(path, "/test-bucket/some/folder/");
+        assert_eq!(content_type.as_deref(), Some(S3_DIRECTORY_CONTENT_TYPE));
         assert_eq!(
             value.as_deref(),
             Some("0"),

--- a/src-tauri/src/providers/s3.rs
+++ b/src-tauri/src/providers/s3.rs
@@ -4010,10 +4010,14 @@ impl StorageProvider for S3Provider {
             }
             StatusCode::NOT_FOUND => {}
             status => {
-                return Err(ProviderError::ServerError(format!(
-                    "Directory marker HEAD failed with status: {}",
-                    status
-                )))
+                // GetObject/HEAD permission is independent of DeleteObject.
+                // An inconclusive probe cannot authorize deletion of the
+                // slashless key, but must not block deletion inside the prefix.
+                tracing::warn!(
+                    "Directory marker HEAD returned {} for '{}'; preserving the slashless key",
+                    status,
+                    no_slash
+                );
             }
         }
 
@@ -7302,15 +7306,20 @@ mod tests {
         use std::sync::{Arc, Mutex};
         // Real files (including zero-byte files) survive; only a confirmed
         // zero-byte directory marker may be removed outside the prefix.
-        for (status, content_type, length, include_bare, head_ok, leftovers) in [
-            (200, "text/plain", "17", false, true, false),
-            (200, "application/octet-stream", "0", false, true, false),
-            (200, "application/x-directory", "17", false, true, false),
-            (200, "application/x-directory", "0", true, true, false),
-            (200, "httpd/unix-directory", "0", true, true, false),
-            (404, "", "0", false, true, false),
-            (403, "", "0", false, false, false),
-            (404, "", "0", false, true, true),
+        for (status, content_type, length, include_bare, leftovers) in [
+            (200, "text/plain", "17", false, false),
+            (200, "application/octet-stream", "0", false, false),
+            (200, "application/x-directory", "17", false, false),
+            (200, "application/x-directory", "0", true, false),
+            (200, "httpd/unix-directory", "0", true, false),
+            (404, "", "0", false, false),
+            // Denied/unsupported HEAD must not require read permission for
+            // prefix deletion, even if error headers resemble a marker.
+            (403, "application/x-directory", "0", false, false),
+            (401, "", "0", false, false),
+            (405, "", "0", false, false),
+            (404, "", "0", false, true),
+            (403, "", "0", false, true),
         ] {
             let bodies = Arc::new(Mutex::new(Vec::new()));
             let captured = Arc::clone(&bodies);
@@ -7351,17 +7360,13 @@ mod tests {
             provider.connected = true;
             assert_eq!(
                 provider.rmdir_recursive("/folder/").await.is_ok(),
-                head_ok && !leftovers
+                !leftovers
             );
             let bodies = bodies.lock().unwrap();
-            if head_ok {
-                assert_eq!(bodies.len(), 1);
-                assert!(bodies[0].contains("<Key>folder/</Key>"));
-                assert!(bodies[0].contains("<Key>folder/child</Key>"));
-                assert_eq!(bodies[0].contains("<Key>folder</Key>"), include_bare);
-            } else {
-                assert!(bodies.is_empty(), "HEAD failure must prevent deletion");
-            }
+            assert_eq!(bodies.len(), 1);
+            assert!(bodies[0].contains("<Key>folder/</Key>"));
+            assert!(bodies[0].contains("<Key>folder/child</Key>"));
+            assert_eq!(bodies[0].contains("<Key>folder</Key>"), include_bare);
             server.abort();
         }
     }

--- a/src-tauri/src/rclone_import.rs
+++ b/src-tauri/src/rclone_import.rs
@@ -1813,6 +1813,10 @@ pub fn export_rclone(
             }
             "s3" => {
                 body.push_str("type = s3\n");
+                // AeroFTP persists empty directories as `<key>/` objects.
+                // rclone must recognize them, including the purge root's own
+                // marker, instead of constructing a DELETE for `<key>//`.
+                body.push_str("directory_markers = true\n");
                 let provider_id = server.provider_id.as_deref().unwrap_or("custom-s3");
                 // rclone S3 backend providers: see `rclone help backend s3`.
                 // Names are case-sensitive; "Other" forces the generic
@@ -1823,7 +1827,9 @@ pub fn export_rclone(
                     "cloudflare-r2" => "Cloudflare",
                     "digitalocean-spaces" => "DigitalOcean",
                     "wasabi" => "Wasabi",
-                    "backblaze" | "backblaze-b2" => "Backblaze",
+                    // B2's S3 API uses the generic backend. "Backblaze" is
+                    // not a valid rclone S3 provider (native B2 is type=b2).
+                    "backblaze" | "backblaze-b2" => "Other",
                     "linode-object-storage" => "Linode",
                     "scaleway" => "Scaleway",
                     "storj" => "Storj",
@@ -3370,6 +3376,10 @@ user = t
 
         // No inert bucket key in the s3 backend section.
         assert!(
+            conf.contains("type = s3\ndirectory_markers = true\n"),
+            "the S3 backend must recognize AeroFTP empty-directory markers"
+        );
+        assert!(
             !conf.contains("\nbucket = "),
             "must not emit the ignored s3 `bucket =` key:\n{conf}"
         );
@@ -4342,6 +4352,29 @@ token = {\"access_token\":\"acc\",\"token_type\":\"Zoho-oauthtoken\",\"refresh_t
             !conf.contains("/remote.php/"),
             "must not inject a Nextcloud DAV path on generic WebDAV:\n{conf}"
         );
+    }
+
+    #[test]
+    fn test_export_backblaze_s3_uses_supported_rclone_provider() {
+        let dir = tempfile::tempdir().unwrap();
+        for provider_id in ["backblaze", "backblaze-b2"] {
+            let servers = vec![RcloneExportServer {
+                name: "b2-s3".into(),
+                host: "s3.eu-central-003.backblazeb2.com".into(),
+                port: 443,
+                username: "test-key".into(),
+                protocol: Some("s3".into()),
+                options: Some(serde_json::json!({"bucket": "test-bucket"})),
+                provider_id: Some(provider_id.into()),
+            }];
+            let path = dir.path().join("rclone.conf");
+            export_rclone(&servers, &HashMap::new(), &path).unwrap();
+            let config = std::fs::read_to_string(path).unwrap();
+            assert!(config.contains("provider = Other\n"));
+            assert!(!config.contains("provider = Backblaze"));
+            assert!(config.contains("directory_markers = true\n"));
+            assert!(config.contains("s3.eu-central-003.backblazeb2.com"));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What this fixes

Three defects on the S3 deletion and export path, one of which loses data.

1. Data loss. `rmdir_recursive` deleted both `folder/` and the slashless key `folder`. On S3 those are two distinct objects, so deleting the folder `reports/` also erased an unrelated file named `reports`. Reproduced live on Cloudflare R2. The slashless key is now deleted only when a HEAD positively identifies it as a gateway's directory marker (zero length plus `application/x-directory` or `httpd/unix-directory`), and anything else is preserved.

2. A denied HEAD must not block the delete. An IAM policy can grant `s3:DeleteObject` and refuse the HEAD. An inconclusive probe cannot authorize deleting the slashless key, but it also must not stop deletion inside the prefix: the probe warns, and the prefix delete proceeds.

3. Silent partial deletes. The sequential fallback used when a server refuses batch delete recorded transport errors only, so a 403 on an individual DELETE still returned `Ok(())`. It now records the HTTP status. A fresh listing after the batch also reports an error when objects remain, which covers a gateway that exposes children only after a conflicting object is gone.

## rclone interoperability

AeroFTP keeps an empty folder as a zero-byte `key/` object. rclone with `directory_markers` off builds a DELETE for `key//` when it purges a folder that carries its own marker: MinIO answers 400, AWS and R2 answer success for that absent key and leave the real marker behind. A successful `rclone purge` exit therefore does not establish that the folder was removed. Exports now write `directory_markers = true`, and `docs/PROTOCOL-FEATURES.md` documents the flag for configurations exported earlier.

Backblaze S3 profiles exported `provider = Backblaze`, which rclone 1.74.0 does not have (native B2 is a separate backend). They now export `provider = Other`.

## Verification

An HTTP matrix over eleven HEAD outcomes proves that a real file survives, that a confirmed marker is removed, and that 401, 403 and 405 do not block the prefix delete. A fallback test proves a refused individual DELETE surfaces instead of passing.

Live runs on MinIO, Cloudflare R2 and AWS S3, with raw ListObjectsV2 key counts before and after, on scratch prefixes only, all cleaned up afterwards. An opt-in `#[ignore]` live regression test is included: it takes its profile from `AEROFTP_MARKER_LIVE_*` and touches only a UUID scratch prefix.

## Known limitation

The post-delete listing assumes a read-after-delete consistent listing. That holds on AWS today and on every gateway tested here. On a gateway whose listing lags, the symptom is a false failure ("still contains objects after recursive deletion") that does not reproduce on the next run, never a wrong deletion.

Refs #266, #347.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved interoperability with rclone by recognizing empty S3 folders and preserving directory markers.
  - Added support for exporting compatible rclone profiles for Backblaze S3.

- **Bug Fixes**
  - Recursive deletion now preserves regular files with similar names while removing empty-folder markers correctly.
  - Deletion failures are reported more reliably, including when objects remain after deletion.
  - Improved compatibility with MinIO, AWS S3, Cloudflare R2, and Backblaze S3 workflows.

- **Documentation**
  - Added guidance on S3 empty folders, directory markers, rclone purge behavior, and provider-specific settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->