### PR TITLE
feat(s3): remember the bytes we uploaded, and match a delta against them

### DIFF
--- a/.github/workflows/aerorsync-protocol.yml
+++ b/.github/workflows/aerorsync-protocol.yml
@@ -77,7 +77,7 @@ jobs:
         run: |
           # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
           # enough to redden a run, and nothing here installs from them.
-          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
+          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev \
@@ -138,7 +138,7 @@ jobs:
         run: |
           # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
           # enough to redden a run, and nothing here installs from them.
-          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
+          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev \
@@ -199,7 +199,7 @@ jobs:
         run: |
           # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
           # enough to redden a run, and nothing here installs from them.
-          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
+          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev \

--- a/.github/workflows/aerorsync-standalone.yml
+++ b/.github/workflows/aerorsync-standalone.yml
@@ -73,7 +73,7 @@ jobs:
         run: |
           # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
           # enough to redden a run, and nothing here installs from them.
-          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
+          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           # `libacl1-dev` is not optional here: `acl-sys` declares
           # `#[link(name = "acl")]` on Linux, so the test binary does not link

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
           # enough to redden a run, and nothing here installs from them.
-          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
+          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           # `dbus` is here for `cargo test` / portal_chooser (#510), not for
           # packaging. `portal_chooser`'s three cases stand up a throwaway
@@ -238,7 +238,7 @@ jobs:
         run: |
           # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
           # enough to redden a run, and nothing here installs from them.
-          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
+          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           # `dbus` lives on `linux-validate` with `cargo test` / portal_chooser
           # (#510). This leg only needs the Tauri/bundle toolchain.
@@ -832,7 +832,7 @@ jobs:
         run: |
           # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
           # enough to redden a run, and nothing here installs from them.
-          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
+          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends squashfs-tools binutils file
           ./scripts/snap-abi-check.sh "$SNAP_FILE"
@@ -893,7 +893,7 @@ jobs:
           set -euo pipefail
           # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
           # enough to redden a run, and nothing here installs from them.
-          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
+          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends xvfb x11-apps imagemagick
           sudo snap install --dangerous "$SNAP_FILE"

--- a/.github/workflows/cli-smoke.yml
+++ b/.github/workflows/cli-smoke.yml
@@ -111,7 +111,7 @@ jobs:
         run: |
           # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
           # enough to redden a run, and nothing here installs from them.
-          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
+          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             libwebkit2gtk-4.1-dev \
@@ -288,7 +288,7 @@ jobs:
         run: |
           # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
           # enough to redden a run, and nothing here installs from them.
-          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
+          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             libwebkit2gtk-4.1-dev \
@@ -360,7 +360,7 @@ jobs:
         run: |
           # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
           # enough to redden a run, and nothing here installs from them.
-          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
+          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             libwebkit2gtk-4.1-dev \

--- a/.github/workflows/delta-sync-integration.yml
+++ b/.github/workflows/delta-sync-integration.yml
@@ -150,7 +150,7 @@ jobs:
             mkdir -p "$HOME/apt-archives/partial"
             # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
             # enough to redden a run, and nothing here installs from them.
-            sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
+            sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
             sudo apt-get update
             # rsync + ssh client for the host side of the integration test.
             # Webkit/GTK stack is needed because compiling the aeroftp
@@ -351,7 +351,7 @@ jobs:
             mkdir -p "$HOME/apt-archives/partial"
             # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
             # enough to redden a run, and nothing here installs from them.
-            sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
+            sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
             sudo apt-get update
             sudo apt-get install -y --no-install-recommends \
               -o Dir::Cache::archives="$HOME/apt-archives/" \

--- a/.github/workflows/ftp-mlsd.yml
+++ b/.github/workflows/ftp-mlsd.yml
@@ -95,7 +95,7 @@ jobs:
             mkdir -p "$HOME/apt-archives/partial"
             # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
             # enough to redden a run, and nothing here installs from them.
-            sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
+            sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
             sudo apt-get update
             sudo apt-get install -y --no-install-recommends \
               -o Dir::Cache::archives="$HOME/apt-archives/" \
@@ -241,7 +241,7 @@ jobs:
             mkdir -p "$HOME/apt-archives/partial"
             # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
             # enough to redden a run, and nothing here installs from them.
-            sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
+            sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
             sudo apt-get update
             sudo apt-get install -y --no-install-recommends \
               -o Dir::Cache::archives="$HOME/apt-archives/" \

--- a/.github/workflows/nightly-telemetry.yml
+++ b/.github/workflows/nightly-telemetry.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
           # enough to redden a run, and nothing here installs from them.
-          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
+          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             libwebkit2gtk-4.1-dev \

--- a/.github/workflows/portal-chooser.yml
+++ b/.github/workflows/portal-chooser.yml
@@ -75,7 +75,7 @@ jobs:
         run: |
           # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
           # enough to redden a run, and nothing here installs from them.
-          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
+          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends dbus
 
@@ -137,7 +137,7 @@ jobs:
         run: |
           # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
           # enough to redden a run, and nothing here installs from them.
-          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
+          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev \

--- a/.github/workflows/snap-refresh.yml
+++ b/.github/workflows/snap-refresh.yml
@@ -132,7 +132,7 @@ jobs:
         # Runner-image extras: Microsoft's apt repos 403 on their InRelease
         # often enough to redden a run, and nothing here installs from them.
         run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
+          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update && sudo apt-get install -y --no-install-recommends squashfs-tools
 
       - name: Audit published revision against the Ubuntu archive
@@ -178,7 +178,7 @@ jobs:
         run: |
           # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
           # enough to redden a run, and nothing here installs from them.
-          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
+          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev \
@@ -314,7 +314,7 @@ jobs:
         run: |
           # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
           # enough to redden a run, and nothing here installs from them.
-          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
+          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends squashfs-tools binutils file
           ./ci-tools/scripts/snap-abi-check.sh "$SNAP_FILE" snap/snapcraft.yaml
@@ -363,7 +363,7 @@ jobs:
           set -euo pipefail
           # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
           # enough to redden a run, and nothing here installs from them.
-          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli*
+          sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends xvfb x11-apps imagemagick
           sudo snap install --dangerous "$SNAP_FILE"

--- a/src-tauri/src/delta_sync_rsync.rs
+++ b/src-tauri/src/delta_sync_rsync.rs
@@ -558,9 +558,33 @@ pub async fn try_delta_transfer_with_progress(
     remote_path: &str,
     progress: Option<crate::delta_transport::DeltaProgressSink>,
 ) -> Option<DeltaSyncResult> {
-    // Only SFTP is delta-eligible in Fase 1. Downcasting via `as_any_mut()` keeps
-    // the generic trait intact: we don't need a new `delta_transport_context()`
-    // contract on every provider implementation.
+    // An encrypted overlay cannot compare plaintext grid digests to its
+    // ciphertext object. Do not unwrap it to reach an inner S3 provider.
+    if provider
+        .as_any_mut()
+        .is::<crate::crypt_overlay_provider::CryptOverlayProvider>()
+    {
+        return Some(DeltaSyncResult::fallback("encrypted_overlay"));
+    }
+    if let Some(s3) = provider
+        .as_any_mut()
+        .downcast_mut::<crate::providers::s3::S3Provider>()
+    {
+        if direction != SyncDirection::Upload {
+            return None;
+        }
+        let on_progress = progress.map(|sink| {
+            let sink = std::sync::Mutex::new(sink);
+            Box::new(move |sent, total| {
+                (sink.lock().unwrap_or_else(|e| e.into_inner()))(sent, total);
+            }) as Box<dyn Fn(u64, u64) + Send>
+        });
+        let outcome = s3
+            .try_delta_upload(local_path, remote_path, on_progress)
+            .await;
+        return Some(s3_delta_result(outcome));
+    }
+    // The SFTP transport/probe lifecycle remains independent of S3.
     let sftp = provider
         .as_any_mut()
         .downcast_mut::<crate::providers::sftp::SftpProvider>()?;
@@ -586,6 +610,46 @@ pub async fn try_delta_transfer_with_progress(
         progress,
     )
     .await
+}
+
+/// Preserve the existing result surface without reusing the native envelope
+/// classifier. A failed delta can retry as a plain upload except for explicit
+/// credential/permission refusals.
+fn s3_delta_result(
+    outcome: Result<
+        crate::providers::s3_delta::S3DeltaOutcome,
+        crate::providers::s3_delta::S3DeltaError,
+    >,
+) -> DeltaSyncResult {
+    use crate::providers::s3_delta::{
+        classify_delta_failure, DeltaFailureDecision, S3DeltaOutcome,
+    };
+    match outcome {
+        Ok(S3DeltaOutcome::Refused(reason)) => DeltaSyncResult::fallback(reason),
+        Ok(S3DeltaOutcome::Uploaded {
+            wire_bytes,
+            total_size,
+            copy_parts,
+            duration_ms,
+        }) => DeltaSyncResult::used(RsyncStats {
+            bytes_sent: wire_bytes,
+            bytes_received: 0,
+            total_size,
+            // All-copy is a real delta with zero payload. Saturate the ratio
+            // at a one-byte denominator so JSON/UI never receive infinity.
+            speedup: total_size as f64 / wire_bytes.max(1) as f64,
+            // Executor plan + wire time; excludes HEAD and matcher read.
+            duration_ms,
+            copy_blocks: copy_parts,
+            warnings: vec![],
+        }),
+        Err(error) => match classify_delta_failure(&error) {
+            DeltaFailureDecision::Hard => DeltaSyncResult::hard_error(sanitize_rsync_message(
+                &error.into_provider_error().to_string(),
+            )),
+            DeltaFailureDecision::Fallback(reason) => DeltaSyncResult::fallback(reason),
+        },
+    }
 }
 
 /// Probe the current provider session and report whether delta sync is

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -60,6 +60,8 @@ pub mod pcloud;
 pub mod peer;
 pub mod retry_after;
 pub mod s3;
+pub(crate) mod s3_delta;
+pub mod s3_delta_baseline;
 pub mod s3_delta_plan;
 pub mod sftp;
 pub mod sts;

--- a/src-tauri/src/providers/s3.rs
+++ b/src-tauri/src/providers/s3.rs
@@ -9293,7 +9293,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn delta_short_local_file_aborts_instead_of_completing() {
+    /// A source shorter than the size the caller declared is refused before a
+    /// single request goes out: the executor compares the file's length against
+    /// `total_size` at entry, so no multipart exists to abort and nothing needs
+    /// cleaning up. This used to cost a CreateMultipartUpload and then an abort,
+    /// which is why the assertion is now "no request at all" rather than "one
+    /// abort". The abort path stays covered by the PartError case of
+    /// `s3_baseline_failed_aborted_and_missing_etag_uploads_leave_no_row`.
+    async fn delta_short_local_file_is_refused_before_any_request() {
         // The plan is computed from the caller's total_size; a local file
         // shorter than that fails the put read. The executor aborts rather
         // than completing a shorter object over the old key.
@@ -9315,17 +9322,28 @@ mod tests {
                 None,
             )
             .await
-            .expect_err("a truncated local file must fail the put part");
+            .expect_err("a truncated local file must be refused");
 
         let seen = state.lock().unwrap();
         assert!(
             matches!(err, ProviderError::TransferFailed(_)),
             "a read failure is a transfer failure, got: {err}"
         );
-        assert_eq!(seen.aborts, 1, "the failed upload must be aborted");
+        assert!(
+            seen.create_mtimes.is_empty(),
+            "a source that cannot fill the plan must not create a multipart upload"
+        );
+        assert!(
+            seen.puts.is_empty() && seen.copies.is_empty(),
+            "no part may be sent for a source shorter than the declared size"
+        );
+        assert_eq!(
+            seen.aborts, 0,
+            "nothing was created, so there is nothing to abort"
+        );
         assert!(
             seen.completed.is_empty(),
-            "CompleteMultipartUpload must never run after a failed part"
+            "CompleteMultipartUpload must never run"
         );
     }
 

--- a/src-tauri/src/providers/s3.rs
+++ b/src-tauri/src/providers/s3.rs
@@ -178,11 +178,18 @@ impl MultipartAbortGuard {
         if !self.armed {
             return;
         }
-        self.armed = false;
+        // Disarm AFTER the await, never before. Marking first looks tidier and
+        // opens the hole this guard exists to close: a future dropped while
+        // this DELETE is in flight, which is precisely what GUI cancellation
+        // does, would find the guard already disarmed, and the request would
+        // die with the future without anyone resending it. Left armed, `Drop`
+        // spawns it. The worst case is one duplicate DELETE answered 404
+        // NoSuchUpload; the case avoided is an abort that never happens.
         let _ = self
             .provider
             .abort_multipart_upload_internal(&self.key, &self.upload_id)
             .await;
+        self.armed = false;
     }
 }
 

--- a/src-tauri/src/providers/s3.rs
+++ b/src-tauri/src/providers/s3.rs
@@ -135,6 +135,83 @@ fn is_s3_directory_content_type(content_type: &str) -> bool {
     ct == "application/x-directory" || ct == "httpd/unix-directory"
 }
 
+/// Owns the abort of a multipart upload the server has already opened.
+///
+/// Every early exit used to carry its own `abort_multipart_upload_internal`
+/// call. That covered the error branches and nothing else: dropping the future,
+/// which is exactly what GUI cancellation does, runs no branch at all, so the
+/// parts already uploaded stayed under the upload id until the bucket lifecycle
+/// rule removed them, if the bucket had one. Owning the upload id means an
+/// abort happens on every exit that is not a proven completion.
+///
+/// `Drop` is sync and cannot await, so it schedules the abort on the current
+/// runtime, the shape `crate::util::provider_guard::ProviderGuard` already uses
+/// for disconnect, and warns rather than panicking when no runtime is left.
+/// Known error paths call `abort_now` and await it instead, so their behaviour
+/// and the tests that count aborts stay deterministic; `Drop` is the net for
+/// cancellation and panics, which no explicit branch can reach.
+struct MultipartAbortGuard {
+    provider: S3Provider,
+    key: String,
+    upload_id: String,
+    armed: bool,
+}
+
+impl MultipartAbortGuard {
+    fn new(provider: &S3Provider, key: &str, upload_id: &str) -> Self {
+        Self {
+            provider: provider.clone(),
+            key: key.to_string(),
+            upload_id: upload_id.to_string(),
+            armed: true,
+        }
+    }
+
+    /// The upload completed. Nothing to clean up.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+
+    /// A known failure. Abort now and observe it, so the caller returns only
+    /// after the server has been told, and a test can assert the count.
+    async fn abort_now(&mut self) {
+        if !self.armed {
+            return;
+        }
+        self.armed = false;
+        let _ = self
+            .provider
+            .abort_multipart_upload_internal(&self.key, &self.upload_id)
+            .await;
+    }
+}
+
+impl Drop for MultipartAbortGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let provider = self.provider.clone();
+        let key = std::mem::take(&mut self.key);
+        let upload_id = std::mem::take(&mut self.upload_id);
+        match tokio::runtime::Handle::try_current() {
+            Ok(handle) => {
+                handle.spawn(async move {
+                    let _ = provider
+                        .abort_multipart_upload_internal(&key, &upload_id)
+                        .await;
+                });
+            }
+            Err(_) => tracing::warn!(
+                "multipart upload {} for {} was dropped without a Tokio runtime; \
+                 its parts stay until the bucket lifecycle rule removes them",
+                upload_id,
+                key
+            ),
+        }
+    }
+}
+
 fn etag_to_md5(raw: &str) -> Option<String> {
     let v = raw.trim().trim_matches('"').to_ascii_lowercase();
     if v.len() == 32 && v.bytes().all(|b| b.is_ascii_hexdigit()) {
@@ -2505,6 +2582,7 @@ impl S3Provider {
                 Self::source_mtime_metadata(local_path),
             )
             .await?;
+        let mut abort_guard = MultipartAbortGuard::new(self, key, &upload_id);
         let mut parts: Vec<(u32, String)> = Vec::new();
         let mut part_number = 1u32;
         let mut uploaded: u64 = 0;
@@ -2526,7 +2604,7 @@ impl S3Provider {
                     let n = match file.read(&mut buf[filled..]).await {
                         Ok(n) => n,
                         Err(e) => {
-                            let _ = self.abort_multipart_upload_internal(key, &upload_id).await;
+                            abort_guard.abort_now().await;
                             return Err(ProviderError::TransferFailed(format!("Read error: {e}")));
                         }
                     };
@@ -2582,13 +2660,13 @@ impl S3Provider {
                         // Drain aborted futures so JoinSet drops cleanly before
                         // we fire the S3 AbortMultipartUpload.
                         while joinset.join_next().await.is_some() {}
-                        let _ = self.abort_multipart_upload_internal(key, &upload_id).await;
+                        abort_guard.abort_now().await;
                         return Err(e);
                     }
                     Err(e) => {
                         joinset.abort_all();
                         while joinset.join_next().await.is_some() {}
-                        let _ = self.abort_multipart_upload_internal(key, &upload_id).await;
+                        abort_guard.abort_now().await;
                         return Err(ProviderError::TransferFailed(format!(
                             "Upload task panicked: {e}"
                         )));
@@ -2606,10 +2684,11 @@ impl S3Provider {
         {
             Ok(etag) => etag,
             Err(e) => {
-                let _ = self.abort_multipart_upload_internal(key, &upload_id).await;
+                abort_guard.abort_now().await;
                 return Err(e);
             }
         };
+        abort_guard.disarm();
         self.save_baseline(key, baseline, etag).await;
         Ok(())
     }
@@ -3024,6 +3103,7 @@ impl S3Provider {
                 .await;
         }
         let upload_id = initiated?;
+        let mut abort_guard = MultipartAbortGuard::new(self, key, &upload_id);
 
         let max_parallel = self.effective_upload_concurrency();
         let mut parts: Vec<(u32, String)> = Vec::with_capacity(plan.len());
@@ -3116,13 +3196,13 @@ impl S3Provider {
                     Ok(Err(e)) => {
                         joinset.abort_all();
                         while joinset.join_next().await.is_some() {}
-                        let _ = self.abort_multipart_upload_internal(key, &upload_id).await;
+                        abort_guard.abort_now().await;
                         return Err(e);
                     }
                     Err(e) => {
                         joinset.abort_all();
                         while joinset.join_next().await.is_some() {}
-                        let _ = self.abort_multipart_upload_internal(key, &upload_id).await;
+                        abort_guard.abort_now().await;
                         return Err(ProviderError::TransferFailed(format!(
                             "Delta upload task panicked: {e}"
                         ))
@@ -3139,7 +3219,7 @@ impl S3Provider {
             .map(|after| Self::same_delta_source(&source_before, &after))
             .unwrap_or(false);
         if !unchanged {
-            let _ = self.abort_multipart_upload_internal(key, &upload_id).await;
+            abort_guard.abort_now().await;
             return Err(S3DeltaError::SourceChanged);
         }
         let etag = match self
@@ -3148,10 +3228,11 @@ impl S3Provider {
         {
             Ok(etag) => etag,
             Err(e) => {
-                let _ = self.abort_multipart_upload_internal(key, &upload_id).await;
+                abort_guard.abort_now().await;
                 return Err(e);
             }
         };
+        abort_guard.disarm();
 
         info!(
             "Delta multipart uploaded {} ({} bytes over the wire, {} parts)",

--- a/src-tauri/src/providers/s3.rs
+++ b/src-tauri/src/providers/s3.rs
@@ -579,7 +579,7 @@ impl S3Provider {
                     duration_ms: done.duration_ms,
                 })
             }
-            Ok(None) => Ok(S3DeltaOutcome::Refused("no_match_found")),
+            Ok(None) => Ok(S3DeltaOutcome::Refused("plan_refused")),
             Err(error) => {
                 remember_range_rejection(identity, &error);
                 Err(error)

--- a/src-tauri/src/providers/s3.rs
+++ b/src-tauri/src/providers/s3.rs
@@ -2228,6 +2228,32 @@ impl S3Provider {
             .max(Self::MULTIPART_PART_MIN)
     }
 
+    /// The part size handed to the DAG, snapped up to a whole number of delta
+    /// grid cells.
+    ///
+    /// The DAG uploads parts on independent clones and hashes each one on its
+    /// own, so `MultipartBaseline::finish` can only concatenate those digests
+    /// when every part begins on a grid boundary. The default part size is a
+    /// multiple of the grid, but the CLI's upload buffer override accepts any
+    /// byte count, and an unaligned one made every DAG upload seed nothing at
+    /// all: no row, and the next delta answering `no_baseline` with nothing to
+    /// say why. Snapping the hint costs at most one cell of part size and
+    /// restores the seeding.
+    ///
+    /// Only the hint is snapped. The streaming path needs none of this, since
+    /// its hasher carries a partial cell across reads and is indifferent to
+    /// part boundaries (`s3_baseline_hasher_ignores_upload_chunk_boundaries`),
+    /// so the override is still honoured verbatim where it already worked.
+    ///
+    /// Above roughly 80 GB the grid grows past `DELTA_PART_SIZE` and the DAG
+    /// builder grows the chunk on its own to keep the part count legal, so
+    /// alignment there is not this function's to promise. That case is a
+    /// declared limit, not an oversight.
+    fn dag_aligned_part_size(&self) -> usize {
+        let grid = super::s3_delta_plan::DELTA_PART_SIZE as usize;
+        self.effective_part_size().div_ceil(grid) * grid
+    }
+
     /// Initiate a multipart upload, returns the UploadId.
     /// Optionally sets Content-Type for the resulting object (UPLOAD-01).
     async fn create_multipart_upload(
@@ -5416,7 +5442,7 @@ impl StorageProvider for S3Provider {
             } else {
                 u64::MAX
             },
-            multipart_part_size: self.effective_part_size() as u64,
+            multipart_part_size: self.dag_aligned_part_size() as u64,
             multipart_max_parallel: 4,
             supports_range_download: true,
             supports_resume_download: true,
@@ -10404,6 +10430,37 @@ mod tests {
             "an unknown size keeps the probe"
         );
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The hint the DAG chunks by must always be a whole number of grid cells,
+    /// or its per-part digests cannot be concatenated and the upload seeds no
+    /// baseline at all. The default is already aligned; the override is the
+    /// case that was not, and it is reachable from the CLI's upload buffer flag.
+    #[test]
+    fn dag_part_size_hint_is_always_a_whole_number_of_grid_cells() {
+        const MIB: u64 = 1024 * 1024;
+        let grid = super::super::s3_delta_plan::DELTA_PART_SIZE as usize;
+        let mut provider = make_provider(None);
+
+        // The default must be left exactly where it is.
+        assert_eq!(provider.effective_part_size() % grid, 0);
+        assert_eq!(
+            provider.dag_aligned_part_size(),
+            provider.effective_part_size(),
+            "an already aligned default must not be moved"
+        );
+
+        for mib in [1u64, 5, 10, 12, 17, 100] {
+            provider.set_chunk_sizes(Some(mib * MIB), None);
+            let raw = provider.effective_part_size();
+            let hint = provider.dag_aligned_part_size();
+            assert_eq!(hint % grid, 0, "{mib} MiB override left an unaligned hint");
+            assert!(hint >= raw, "the hint may only round up: {mib} MiB");
+            assert!(
+                hint - raw < grid,
+                "and by less than one cell: {mib} MiB gave {raw} -> {hint}"
+            );
+        }
     }
 }
 

--- a/src-tauri/src/providers/s3.rs
+++ b/src-tauri/src/providers/s3.rs
@@ -23,6 +23,8 @@ use std::sync::Arc;
 use tokio::io::{AsyncSeekExt, AsyncWriteExt};
 use tracing::{debug, info, warn};
 
+use super::s3_delta::{DeltaOperation, S3DeltaCompleted, S3DeltaError, S3DeltaOutcome};
+use super::s3_delta_baseline::{BaselineHasher, BaselineKey, BaselineStore};
 use super::sts;
 use super::{
     sanitize_api_error, FileVersion, MultipartHandle, ProviderError, ProviderTransferExecutorKind,
@@ -267,6 +269,12 @@ fn format_s3_error(
 /// S3 Storage Provider
 #[derive(Clone)]
 pub struct S3Provider {
+    /// Shared by the DAG's independent provider clones. Bounded signature-only
+    /// sessions, retired at completion/abort; no upload payload is retained.
+    multipart_baselines:
+        Arc<std::sync::Mutex<HashMap<String, super::s3_delta_baseline::MultipartBaseline>>>,
+    #[cfg(test)]
+    baseline_test_path: Option<PathBuf>,
     config: S3Config,
     client: Client,
     current_prefix: String,
@@ -398,6 +406,9 @@ impl S3Provider {
             client,
             current_prefix: String::new(),
             connected: false,
+            multipart_baselines: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            #[cfg(test)]
+            baseline_test_path: None,
             clock_offset_secs: 0,
             upload_chunk_override: None,
             multi_thread_streams: 1,
@@ -411,6 +422,250 @@ impl S3Provider {
             sts_refresh_lock: Arc::new(tokio::sync::Mutex::new(())),
             cleartext_warned: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         })
+    }
+
+    /// The S3 adapter door. All remote observations are HEAD metadata; the
+    /// baseline payload is never read over the network.
+    pub(crate) async fn try_delta_upload(
+        &mut self,
+        local_path: &std::path::Path,
+        remote_path: &str,
+        on_progress: Option<Box<dyn Fn(u64, u64) + Send>>,
+    ) -> Result<S3DeltaOutcome, S3DeltaError> {
+        use super::s3_delta::{range_copy_rejected, remember_range_rejection};
+        use super::s3_delta_baseline::{MatchOutcome, MatchRefusal};
+        use super::s3_delta_plan::{delta_grid_size, DELTA_MIN_FILE_SIZE};
+
+        if !self.connected {
+            return Err(ProviderError::NotConnected.into());
+        }
+        let before = tokio::fs::metadata(local_path)
+            .await
+            .map_err(ProviderError::IoError)?;
+        if !before.is_file() {
+            return Ok(S3DeltaOutcome::Refused("not_regular_file"));
+        }
+        let total_size = before.len();
+        if delta_grid_size(total_size).is_none() {
+            return Ok(S3DeltaOutcome::Refused(
+                if total_size <= DELTA_MIN_FILE_SIZE {
+                    "file_too_small"
+                } else {
+                    "file_too_large"
+                },
+            ));
+        }
+        if self.is_filen_s3_endpoint() {
+            return Ok(S3DeltaOutcome::Refused("multipart_unsupported"));
+        }
+        let identity = self.endpoint_identity();
+        if range_copy_rejected(&identity) {
+            return Ok(S3DeltaOutcome::Refused("backend_rejected_range_copy"));
+        }
+        let Some(store) = self.baseline_store() else {
+            return Ok(S3DeltaOutcome::Refused("baseline_cache_unavailable"));
+        };
+        let key = remote_path.trim_start_matches('/');
+        let cache_key = self.delta_baseline_key(key);
+        let response = self.s3_request(Method::HEAD, key, None, None).await?;
+        let status = response.status();
+        if status == StatusCode::NOT_FOUND {
+            let _ = store.invalidate(cache_key).await;
+            return Ok(S3DeltaOutcome::Refused("no_baseline"));
+        }
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(self.delta_response_error(DeltaOperation::Head, status, &body, None));
+        }
+        let archive = response
+            .headers()
+            .get("x-amz-storage-class")
+            .and_then(|v| v.to_str().ok());
+        if matches!(archive, Some("GLACIER" | "DEEP_ARCHIVE"))
+            || response.headers().contains_key("x-amz-archive-status")
+        {
+            return Ok(S3DeltaOutcome::Refused("baseline_archived"));
+        }
+        let Some(baseline_size) = response
+            .headers()
+            .get(reqwest::header::CONTENT_LENGTH)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse::<u64>().ok())
+        else {
+            return Ok(S3DeltaOutcome::Refused("baseline_metadata_invalid"));
+        };
+        let Some(etag) = response
+            .headers()
+            .get(reqwest::header::ETAG)
+            .and_then(|v| v.to_str().ok())
+            .filter(|v| !v.trim_matches('"').is_empty())
+            .map(str::to_owned)
+        else {
+            let _ = store.invalidate(cache_key).await;
+            return Ok(S3DeltaOutcome::Refused("no_baseline_etag"));
+        };
+        if baseline_size <= super::s3_delta_plan::S3_PART_MIN {
+            let _ = store.invalidate(cache_key).await;
+            return Ok(S3DeltaOutcome::Refused("baseline_too_small"));
+        }
+        let (outcome, fresh) = match store
+            .prepare_file(cache_key.clone(), etag.clone(), baseline_size, local_path)
+            .await
+        {
+            Ok(result) => result,
+            Err(_) => return Ok(S3DeltaOutcome::Refused("baseline_unavailable")),
+        };
+        let (grid, matches) = match outcome {
+            MatchOutcome::Refused(reason) => {
+                return Ok(S3DeltaOutcome::Refused(match reason {
+                    MatchRefusal::NoBaseline => "no_baseline",
+                    MatchRefusal::EtagMismatch => "etag_mismatch",
+                    MatchRefusal::SizeMismatch => "baseline_size_mismatch",
+                    MatchRefusal::GridMismatch => "baseline_grid_mismatch",
+                    MatchRefusal::InvalidRow => "baseline_invalid",
+                }))
+            }
+            MatchOutcome::Matches { grid, matches } => (grid, matches),
+        };
+        if matches.is_empty() {
+            return Ok(S3DeltaOutcome::Refused("no_match_found"));
+        }
+        let after_match = tokio::fs::metadata(local_path)
+            .await
+            .map_err(ProviderError::IoError)?;
+        if !Self::same_delta_source(&before, &after_match) {
+            return Ok(S3DeltaOutcome::Refused("source_changed"));
+        }
+        let Some(local_str) = local_path.to_str() else {
+            return Ok(S3DeltaOutcome::Refused("local_path_invalid"));
+        };
+        if store.invalidate(cache_key).await.is_err() {
+            return Ok(S3DeltaOutcome::Refused("baseline_cache_unavailable"));
+        }
+        let content_type = mime_guess::from_path(local_path)
+            .first_or_octet_stream()
+            .to_string();
+        let verification = fresh
+            .as_ref()
+            .and_then(BaselineHasher::verification)
+            .map(Arc::new);
+        let result = self
+            .execute_delta_multipart(
+                key,
+                local_str,
+                total_size,
+                &matches,
+                grid,
+                &etag,
+                Some(&content_type),
+                on_progress,
+                verification,
+            )
+            .await;
+        match result {
+            Ok(Some(done)) => {
+                let after = tokio::fs::metadata(local_path).await.ok();
+                if after
+                    .as_ref()
+                    .is_some_and(|after| Self::same_delta_source(&before, after))
+                {
+                    self.save_baseline(key, fresh.map(|hasher| (store, hasher)), done.etag)
+                        .await;
+                }
+                Ok(S3DeltaOutcome::Uploaded {
+                    wire_bytes: done.wire_bytes,
+                    total_size,
+                    copy_parts: done.copy_parts,
+                    duration_ms: done.duration_ms,
+                })
+            }
+            Ok(None) => Ok(S3DeltaOutcome::Refused("no_match_found")),
+            Err(error) => {
+                remember_range_rejection(identity, &error);
+                Err(error)
+            }
+        }
+    }
+
+    fn same_delta_source(before: &std::fs::Metadata, after: &std::fs::Metadata) -> bool {
+        let unchanged =
+            before.len() == after.len() && before.modified().ok() == after.modified().ok();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            unchanged
+                && before.dev() == after.dev()
+                && before.ino() == after.ino()
+                && before.ctime() == after.ctime()
+                && before.ctime_nsec() == after.ctime_nsec()
+        }
+        #[cfg(not(unix))]
+        {
+            unchanged
+        }
+    }
+
+    fn delta_response_error(
+        &self,
+        operation: DeltaOperation,
+        status: StatusCode,
+        body: &str,
+        retry_after: Option<&str>,
+    ) -> S3DeltaError {
+        S3DeltaError::Response {
+            status: status.as_u16(),
+            code: self.extract_xml_tag(body, "Code"),
+            operation,
+            message: format_s3_error(operation.name(), status, body, retry_after),
+        }
+    }
+
+    /// T5 uses this same key when looking up the current baseline.
+    pub fn delta_baseline_key(&self, key: &str) -> BaselineKey {
+        BaselineKey::new(
+            self.endpoint_identity(),
+            &self.config.bucket,
+            key.trim_start_matches('/'),
+        )
+    }
+
+    fn baseline_store(&self) -> Option<BaselineStore> {
+        #[cfg(test)]
+        let path = self.baseline_test_path.clone();
+        #[cfg(not(test))]
+        let path = BaselineStore::default_path();
+        path.map(BaselineStore::new)
+    }
+
+    async fn begin_baseline(
+        &self,
+        key: &str,
+        size: u64,
+    ) -> Option<(BaselineStore, BaselineHasher)> {
+        let store = self.baseline_store()?;
+        // Also invalidate when an eligible object is replaced with a small one.
+        if let Err(error) = store.invalidate(self.delta_baseline_key(key)).await {
+            warn!("S3 baseline cache unavailable: {error}");
+            return None;
+        }
+        Some((store, BaselineHasher::new(size)?))
+    }
+
+    async fn save_baseline(
+        &self,
+        key: &str,
+        pending: Option<(BaselineStore, BaselineHasher)>,
+        etag: Option<String>,
+    ) {
+        if let (Some((store, hasher)), Some(etag)) = (pending, etag) {
+            if let Err(error) = store
+                .record_completed(self.delta_baseline_key(key), hasher, etag)
+                .await
+            {
+                // Cache failure never turns a successful upload into a retry.
+                warn!("S3 baseline cache write failed: {error}");
+            }
+        }
     }
 
     /// Default parallelism for multipart upload parts.
@@ -1904,6 +2159,17 @@ impl S3Provider {
         content_type: Option<&str>,
         source_mtime: Option<String>,
     ) -> Result<String, ProviderError> {
+        self.create_multipart_upload_typed(key, content_type, source_mtime)
+            .await
+            .map_err(S3DeltaError::into_provider_error)
+    }
+
+    async fn create_multipart_upload_typed(
+        &self,
+        key: &str,
+        content_type: Option<&str>,
+        source_mtime: Option<String>,
+    ) -> Result<String, S3DeltaError> {
         self.ensure_fresh_credentials().await?;
         // For multipart, Content-Type must be set on initiation, not on individual parts.
         // We build a custom request to include the header.
@@ -1951,17 +2217,18 @@ impl S3Provider {
             .map(String::from);
         let body = response.text().await.unwrap_or_default();
 
-        if !status.is_success() {
-            return Err(ProviderError::TransferFailed(format_s3_error(
-                "CreateMultipartUpload failed",
+        if !status.is_success() || body.to_ascii_lowercase().contains("<error>") {
+            return Err(self.delta_response_error(
+                DeltaOperation::Create,
                 status,
                 &body,
                 retry_header.as_deref(),
-            )));
+            ));
         }
 
-        self.extract_xml_tag(&body, "UploadId")
-            .ok_or_else(|| ProviderError::ParseError("Missing UploadId in response".to_string()))
+        self.extract_xml_tag(&body, "UploadId").ok_or_else(|| {
+            ProviderError::ParseError("Missing UploadId in response".to_string()).into()
+        })
     }
 
     /// Upload a single part, returns the ETag.
@@ -1977,6 +2244,18 @@ impl S3Provider {
         part_number: u32,
         data: Vec<u8>,
     ) -> Result<String, ProviderError> {
+        self.upload_part_internal_typed(key, upload_id, part_number, data)
+            .await
+            .map_err(S3DeltaError::into_provider_error)
+    }
+
+    async fn upload_part_internal_typed(
+        &self,
+        key: &str,
+        upload_id: &str,
+        part_number: u32,
+        data: Vec<u8>,
+    ) -> Result<String, S3DeltaError> {
         let part_num_str = part_number.to_string();
         let params: &[(&str, &str)] = &[("partNumber", &part_num_str), ("uploadId", upload_id)];
 
@@ -1992,12 +2271,12 @@ impl S3Provider {
                 .and_then(|v| v.to_str().ok())
                 .map(String::from);
             let body = response.text().await.unwrap_or_default();
-            return Err(ProviderError::TransferFailed(format_s3_error(
-                &format!("UploadPart {} failed", part_number),
+            return Err(self.delta_response_error(
+                DeltaOperation::Put,
                 status,
                 &body,
                 retry_header.as_deref(),
-            )));
+            ));
         }
 
         // ETag is in the response headers
@@ -2046,6 +2325,30 @@ impl S3Provider {
         range_end_inclusive: u64,
         if_match: Option<&str>,
     ) -> Result<String, ProviderError> {
+        self.upload_part_copy_internal_typed(
+            dest_key,
+            upload_id,
+            part_number,
+            copy_source,
+            range_start,
+            range_end_inclusive,
+            if_match,
+        )
+        .await
+        .map_err(S3DeltaError::into_provider_error)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn upload_part_copy_internal_typed(
+        &self,
+        dest_key: &str,
+        upload_id: &str,
+        part_number: u32,
+        copy_source: &str,
+        range_start: u64,
+        range_end_inclusive: u64,
+        if_match: Option<&str>,
+    ) -> Result<String, S3DeltaError> {
         let part_num_str = part_number.to_string();
         let range_value = format!("bytes={}-{}", range_start, range_end_inclusive);
         let params: &[(&str, &str)] = &[("partNumber", &part_num_str), ("uploadId", upload_id)];
@@ -2075,36 +2378,32 @@ impl S3Provider {
             .map(String::from);
         let body = response.text().await.unwrap_or_default();
         if !status.is_success() {
-            return Err(ProviderError::TransferFailed(format_s3_error(
-                &format!("UploadPartCopy {} failed", part_number),
+            return Err(self.delta_response_error(
+                DeltaOperation::Copy,
                 status,
                 &body,
                 retry_header.as_deref(),
-            )));
+            ));
         }
         // S3-compatible servers (AWS + MinIO + Filen bridge) can return HTTP
         // 200 with an `<Error>` XML body when validation fails late on the
         // server side. Mirror the single-PUT copy path's 200-with-error
         // handling so the caller doesn't silently complete a broken upload.
         if body.to_ascii_lowercase().contains("<error>") {
-            let err_code = self
-                .extract_xml_tag(&body, "Code")
-                .unwrap_or_else(|| "CopyPartError".to_string());
-            let err_msg = self
-                .extract_xml_tag(&body, "Message")
-                .unwrap_or_else(|| "Server reported error during UploadPartCopy".to_string());
-            return Err(ProviderError::TransferFailed(format!(
-                "UploadPartCopy {} 200-with-error ({}): {}",
-                part_number,
-                sanitize_api_error(&err_code),
-                sanitize_api_error(&err_msg)
-            )));
+            return Err(self.delta_response_error(
+                DeltaOperation::Copy,
+                status,
+                &body,
+                retry_header.as_deref(),
+            ));
         }
+
         self.extract_xml_tag(&body, "ETag").ok_or_else(|| {
             ProviderError::ParseError(format!(
                 "Missing ETag in UploadPartCopy {} response",
                 part_number
             ))
+            .into()
         })
     }
 
@@ -2118,7 +2417,18 @@ impl S3Provider {
         key: &str,
         upload_id: &str,
         parts: &[(u32, String)],
-    ) -> Result<(), ProviderError> {
+    ) -> Result<Option<String>, ProviderError> {
+        self.complete_multipart_upload_internal_typed(key, upload_id, parts)
+            .await
+            .map_err(S3DeltaError::into_provider_error)
+    }
+
+    async fn complete_multipart_upload_internal_typed(
+        &self,
+        key: &str,
+        upload_id: &str,
+        parts: &[(u32, String)],
+    ) -> Result<Option<String>, S3DeltaError> {
         // Build XML body
         let mut xml = String::from("<CompleteMultipartUpload>");
         for (part_number, etag) in parts {
@@ -2147,27 +2457,25 @@ impl S3Provider {
         let body = response.text().await.unwrap_or_default();
 
         if !status.is_success() {
-            return Err(ProviderError::TransferFailed(format_s3_error(
-                "CompleteMultipartUpload failed",
+            return Err(self.delta_response_error(
+                DeltaOperation::Complete,
                 status,
                 &body,
                 retry_header.as_deref(),
-            )));
+            ));
         }
 
         // UPLOAD-07: AWS S3 can return HTTP 200 but include an <Error> in the XML body
-        if body.contains("<Error>") {
-            let error_msg = self
-                .extract_xml_tag(&body, "Message")
-                .or_else(|| self.extract_xml_tag(&body, "Code"))
-                .unwrap_or_else(|| "Unknown error in CompleteMultipartUpload response".to_string());
-            return Err(ProviderError::TransferFailed(format!(
-                "CompleteMultipartUpload 200-with-error: {}",
-                sanitize_api_error(&error_msg)
-            )));
+        if body.to_ascii_lowercase().contains("<error>") {
+            return Err(self.delta_response_error(
+                DeltaOperation::Complete,
+                status,
+                &body,
+                retry_header.as_deref(),
+            ));
         }
 
-        Ok(())
+        Ok(self.extract_xml_tag(&body, "ETag"))
     }
 
     /// Upload a file using S3 multipart upload with streaming (no full-file buffering).
@@ -2181,10 +2489,15 @@ impl S3Provider {
     ) -> Result<(), ProviderError> {
         use tokio::io::AsyncReadExt;
 
+        let mut baseline = self.begin_baseline(key, total_size).await;
+
         // UPLOAD-01: Detect MIME type from filename for multipart uploads
         let content_type = mime_guess::from_path(local_path)
             .first_or_octet_stream()
             .to_string();
+        let mut file = tokio::fs::File::open(local_path)
+            .await
+            .map_err(ProviderError::IoError)?;
         let upload_id = self
             .create_multipart_upload(
                 key,
@@ -2193,9 +2506,6 @@ impl S3Provider {
             )
             .await?;
         let mut parts: Vec<(u32, String)> = Vec::new();
-        let mut file = tokio::fs::File::open(local_path)
-            .await
-            .map_err(ProviderError::IoError)?;
         let mut part_number = 1u32;
         let mut uploaded: u64 = 0;
 
@@ -2213,10 +2523,13 @@ impl S3Provider {
                 let mut buf = vec![0u8; part_size];
                 let mut filled = 0;
                 while filled < part_size {
-                    let n = file
-                        .read(&mut buf[filled..])
-                        .await
-                        .map_err(|e| ProviderError::TransferFailed(format!("Read error: {e}")))?;
+                    let n = match file.read(&mut buf[filled..]).await {
+                        Ok(n) => n,
+                        Err(e) => {
+                            let _ = self.abort_multipart_upload_internal(key, &upload_id).await;
+                            return Err(ProviderError::TransferFailed(format!("Read error: {e}")));
+                        }
+                    };
                     if n == 0 {
                         break;
                     }
@@ -2226,6 +2539,9 @@ impl S3Provider {
                     break;
                 }
                 buf.truncate(filled);
+                if let Some((_, hasher)) = &mut baseline {
+                    hasher.update(&buf);
+                }
                 batch.push((part_number, buf));
                 part_number += 1;
             }
@@ -2284,8 +2600,18 @@ impl S3Provider {
             parts.sort_by_key(|(pn, _)| *pn);
         }
 
-        self.complete_multipart_upload_internal(key, &upload_id, &parts)
+        let etag = match self
+            .complete_multipart_upload_internal(key, &upload_id, &parts)
             .await
+        {
+            Ok(etag) => etag,
+            Err(e) => {
+                let _ = self.abort_multipart_upload_internal(key, &upload_id).await;
+                return Err(e);
+            }
+        };
+        self.save_baseline(key, baseline, etag).await;
+        Ok(())
     }
 
     /// Abort a multipart upload (internal inherent path).
@@ -2572,10 +2898,8 @@ impl S3Provider {
     ///
     /// Caller must have validated `self.connected`. `key` is the trimmed
     /// destination key and is also the copy source.
-    // dead_code: T3 has no production caller yet; the sync adapter arm (T4)
-    // is the consumer. Until then the mock and live lanes exercise it.
-    #[allow(dead_code)]
     #[allow(clippy::too_many_arguments)]
+    #[cfg(test)]
     async fn upload_delta_multipart(
         &self,
         key: &str,
@@ -2587,15 +2911,43 @@ impl S3Provider {
         content_type: Option<&str>,
         on_progress: Option<Box<dyn Fn(u64, u64) + Send>>,
     ) -> Result<Option<u64>, ProviderError> {
+        self.execute_delta_multipart(
+            key,
+            local_path,
+            total_size,
+            matches,
+            grid,
+            baseline_etag,
+            content_type,
+            on_progress,
+            None,
+        )
+        .await
+        .map(|result| result.map(|done| done.wire_bytes))
+        .map_err(S3DeltaError::into_provider_error)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn execute_delta_multipart(
+        &self,
+        key: &str,
+        local_path: &str,
+        total_size: u64,
+        matches: &[(u64, u64, u64)],
+        grid: u64,
+        baseline_etag: &str,
+        content_type: Option<&str>,
+        on_progress: Option<Box<dyn Fn(u64, u64) + Send>>,
+        verification: Option<Arc<super::s3_delta_baseline::PreparedDigests>>,
+    ) -> Result<Option<S3DeltaCompleted>, S3DeltaError> {
+        let started = std::time::Instant::now();
         // Derived here and not taken as a parameter, the way
         // `upload_multipart_streaming` does it. The function already has
         // `local_path`, so a parameter only creates a way for a caller to pass
         // `None` and silently drop the mtime the original object carried, and
         // an object rebuilt by the delta that lost its mtime is one that every
         // later sync compares by timestamp and never finds equal. The caller
-        // that would have had to remember does not exist yet: the adapter arm
-        // is the next tranche, which is exactly when this would have been
-        // discovered the expensive way.
+        // must never supply an optional timestamp that can be forgotten.
         // Two limits from the appendix's constraint sheet are deliberately not
         // checked here, and both are written down rather than left to be
         // rediscovered as defects.
@@ -2636,6 +2988,14 @@ impl S3Provider {
             return Ok(None);
         };
 
+        let source_before = tokio::fs::metadata(local_path)
+            .await
+            .map_err(ProviderError::IoError)?;
+        if source_before.len() != total_size {
+            return Err(S3DeltaError::SourceChanged);
+        }
+
+        let copy_parts = plan.iter().filter(|part| part.is_copy()).count() as u64;
         // Wire bytes are the PUT parts; COPY parts are requests, not bytes.
         // The denominator is the plan's, so progress reaches exactly 100%.
         let total_wire: u64 = plan
@@ -2653,11 +3013,14 @@ impl S3Provider {
         // One retry on a fresh connection is enough, and replaying a create
         // is safe: the failed attempt never reached the server.
         let mut initiated = self
-            .create_multipart_upload(key, content_type, source_mtime.clone())
+            .create_multipart_upload_typed(key, content_type, source_mtime.clone())
             .await;
-        if matches!(initiated, Err(ProviderError::NetworkError(_))) {
+        if matches!(
+            initiated,
+            Err(S3DeltaError::Provider(ProviderError::NetworkError(_)))
+        ) {
             initiated = self
-                .create_multipart_upload(key, content_type, source_mtime)
+                .create_multipart_upload_typed(key, content_type, source_mtime)
                 .await;
         }
         let upload_id = initiated?;
@@ -2679,6 +3042,7 @@ impl S3Provider {
                 let copy_source_owned = copy_source.clone();
                 let etag_owned = baseline_etag.to_string();
                 let local_path_owned = local_path.to_string();
+                let verification = verification.clone();
                 joinset.spawn(async move {
                     match part {
                         crate::providers::s3_delta_plan::DeltaPart::Copy {
@@ -2687,7 +3051,7 @@ impl S3Provider {
                             src_end_inclusive,
                         } => {
                             let etag = provider
-                                .upload_part_copy_internal(
+                                .upload_part_copy_internal_typed(
                                     &dest_key,
                                     &upload_id_owned,
                                     part_number,
@@ -2697,7 +3061,7 @@ impl S3Provider {
                                     Some(&etag_owned),
                                 )
                                 .await?;
-                            Ok::<(u32, String, u64), ProviderError>((part_number, etag, 0))
+                            Ok::<(u32, String, u64), S3DeltaError>((part_number, etag, 0))
                         }
                         crate::providers::s3_delta_plan::DeltaPart::Put {
                             part_number,
@@ -2716,10 +3080,21 @@ impl S3Provider {
                                     "Delta read of part {part_number} at {local_start}+{len}: {e}"
                                 ))
                             })?;
+                            if verification
+                                .as_ref()
+                                .is_some_and(|expected| !expected.verify_put(local_start, &buf))
+                            {
+                                return Err(S3DeltaError::SourceChanged);
+                            }
                             let etag = provider
-                                .upload_part_internal(&dest_key, &upload_id_owned, part_number, buf)
+                                .upload_part_internal_typed(
+                                    &dest_key,
+                                    &upload_id_owned,
+                                    part_number,
+                                    buf,
+                                )
                                 .await?;
-                            Ok::<(u32, String, u64), ProviderError>((part_number, etag, len))
+                            Ok::<(u32, String, u64), S3DeltaError>((part_number, etag, len))
                         }
                     }
                 });
@@ -2750,7 +3125,8 @@ impl S3Provider {
                         let _ = self.abort_multipart_upload_internal(key, &upload_id).await;
                         return Err(ProviderError::TransferFailed(format!(
                             "Delta upload task panicked: {e}"
-                        )));
+                        ))
+                        .into());
                     }
                 }
             }
@@ -2758,13 +3134,24 @@ impl S3Provider {
 
         parts.sort_by_key(|(pn, _)| *pn);
 
-        if let Err(e) = self
-            .complete_multipart_upload_internal(key, &upload_id, &parts)
+        let unchanged = tokio::fs::metadata(local_path)
+            .await
+            .map(|after| Self::same_delta_source(&source_before, &after))
+            .unwrap_or(false);
+        if !unchanged {
+            let _ = self.abort_multipart_upload_internal(key, &upload_id).await;
+            return Err(S3DeltaError::SourceChanged);
+        }
+        let etag = match self
+            .complete_multipart_upload_internal_typed(key, &upload_id, &parts)
             .await
         {
-            let _ = self.abort_multipart_upload_internal(key, &upload_id).await;
-            return Err(e);
-        }
+            Ok(etag) => etag,
+            Err(e) => {
+                let _ = self.abort_multipart_upload_internal(key, &upload_id).await;
+                return Err(e);
+            }
+        };
 
         info!(
             "Delta multipart uploaded {} ({} bytes over the wire, {} parts)",
@@ -2772,7 +3159,12 @@ impl S3Provider {
             uploaded_wire,
             parts.len()
         );
-        Ok(Some(uploaded_wire))
+        Ok(Some(S3DeltaCompleted {
+            wire_bytes: uploaded_wire,
+            etag,
+            copy_parts,
+            duration_ms: started.elapsed().as_millis().min(u128::from(u64::MAX)) as u64,
+        }))
     }
 
     /// Multi-thread chunk-parallel download for a single S3 object.
@@ -3130,6 +3522,21 @@ impl StorageProvider for S3Provider {
         } else {
             format!("s3://{} ({})", self.config.bucket, self.config.region)
         }
+    }
+
+    fn endpoint_identity(&self) -> crate::transfer_dag::EndpointIdentity {
+        use sha2::{Digest, Sha256};
+        // The trait default is only a display label for S3: different custom
+        // hosts and accounts can have that same label. Hash exact authority
+        // components so EndpointIdentity's case folding cannot merge them.
+        // Use stable configured credentials, not rotating STS session keys.
+        let account =
+            serde_json::json!([self.config.access_key_id, self.config.role_arn]).to_string();
+        crate::transfer_dag::EndpointIdentity::new(
+            "s3",
+            hex::encode(Sha256::digest(self.endpoint().as_bytes())),
+            hex::encode(Sha256::digest(account.as_bytes())),
+        )
     }
 
     async fn connect(&mut self) -> Result<(), ProviderError> {
@@ -3831,8 +4238,27 @@ impl StorageProvider for S3Provider {
         let file = tokio::fs::File::open(local_path)
             .await
             .map_err(ProviderError::IoError)?;
+        let pending = self.begin_baseline(key, total_size).await;
+        let (baseline_store, hasher) = match pending {
+            Some((store, hasher)) => (Some(store), Some(hasher)),
+            None => (None, None),
+        };
+        let hasher = Arc::new(std::sync::Mutex::new(hasher));
+        let stream_hasher = Arc::clone(&hasher);
+        let source = ReaderStream::new(file).map(move |chunk| {
+            if let Ok(bytes) = &chunk {
+                if let Some(hasher) = stream_hasher
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .as_mut()
+                {
+                    hasher.update(bytes);
+                }
+            }
+            chunk
+        });
         let stream = crate::transfer_dag::throttle::throttle_stream(
-            ReaderStream::new(file),
+            source,
             crate::transfer_dag::governor::TransferDirection::Upload,
         );
         let body = reqwest::Body::wrap_stream(stream);
@@ -3870,6 +4296,14 @@ impl StorageProvider for S3Provider {
 
         match response.status() {
             StatusCode::OK | StatusCode::CREATED | StatusCode::NO_CONTENT => {
+                let etag = response
+                    .headers()
+                    .get(reqwest::header::ETAG)
+                    .and_then(|value| value.to_str().ok())
+                    .map(str::to_owned);
+                let finished = hasher.lock().unwrap_or_else(|e| e.into_inner()).take();
+                self.save_baseline(key, baseline_store.zip(finished), etag)
+                    .await;
                 if let Some(progress) = on_progress {
                     progress(total_size, total_size);
                 }
@@ -4742,7 +5176,7 @@ impl StorageProvider for S3Provider {
     async fn begin_multipart_upload(
         &mut self,
         remote_path: &str,
-        _total_size: u64,
+        total_size: u64,
         content_type: Option<&str>,
         local_source_path: Option<&str>,
     ) -> Result<MultipartHandle, ProviderError> {
@@ -4759,6 +5193,7 @@ impl StorageProvider for S3Provider {
             ));
         }
         let key = remote_path.trim_start_matches('/');
+        let baseline = self.begin_baseline(key, total_size).await;
         let upload_id = self
             .create_multipart_upload(
                 key,
@@ -4766,6 +5201,33 @@ impl StorageProvider for S3Provider {
                 local_source_path.and_then(Self::source_mtime_metadata),
             )
             .await?;
+        if let Some((store, _)) = baseline {
+            let mut sessions = self
+                .multipart_baselines
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            sessions.retain(|_, session| {
+                session.touched.elapsed() < std::time::Duration::from_secs(3600)
+            });
+            if sessions.len() >= 128 {
+                if let Some(oldest) = sessions
+                    .iter()
+                    .min_by_key(|(_, session)| session.touched)
+                    .map(|(key, _)| key.clone())
+                {
+                    sessions.remove(&oldest);
+                }
+            }
+            sessions.insert(
+                upload_id.clone(),
+                super::s3_delta_baseline::MultipartBaseline {
+                    size: total_size,
+                    store,
+                    touched: std::time::Instant::now(),
+                    parts: std::collections::BTreeMap::new(),
+                },
+            );
+        }
         Ok(MultipartHandle {
             upload_id,
             remote_path: key.to_string(),
@@ -4781,10 +5243,39 @@ impl StorageProvider for S3Provider {
         if !self.connected {
             return Err(ProviderError::NotConnected);
         }
-        let etag = self
+        let size = self
+            .multipart_baselines
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(&handle.upload_id)
+            .map(|s| s.size);
+        let digests =
+            size.and_then(|size| super::s3_delta_baseline::hash_multipart_part(size, &data));
+        let result = self
             .upload_part_internal(&handle.remote_path, &handle.upload_id, part_number, data)
-            .await?;
-        Ok(UploadedPart { part_number, etag })
+            .await;
+        let mut sessions = self
+            .multipart_baselines
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        match result {
+            Ok(etag) => {
+                if let (Some(session), Some(digests)) =
+                    (sessions.get_mut(&handle.upload_id), digests)
+                {
+                    if !session.record(part_number, etag.clone(), digests) {
+                        sessions.remove(&handle.upload_id);
+                    }
+                } else {
+                    sessions.remove(&handle.upload_id);
+                }
+                Ok(UploadedPart { part_number, etag })
+            }
+            Err(error) => {
+                sessions.remove(&handle.upload_id);
+                Err(error)
+            }
+        }
     }
 
     async fn complete_multipart_upload(
@@ -4798,8 +5289,17 @@ impl StorageProvider for S3Provider {
         let mut numbered: Vec<(u32, String)> =
             parts.into_iter().map(|p| (p.part_number, p.etag)).collect();
         numbered.sort_by_key(|(pn, _)| *pn);
-        self.complete_multipart_upload_internal(&handle.remote_path, &handle.upload_id, &numbered)
-            .await
+        let session = self
+            .multipart_baselines
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(&handle.upload_id);
+        let pending = session.and_then(|session| session.finish(&numbered));
+        let etag = self
+            .complete_multipart_upload_internal(&handle.remote_path, &handle.upload_id, &numbered)
+            .await?;
+        self.save_baseline(&handle.remote_path, pending, etag).await;
+        Ok(())
     }
 
     async fn abort_multipart_upload(
@@ -4809,6 +5309,10 @@ impl StorageProvider for S3Provider {
         if !self.connected {
             return Err(ProviderError::NotConnected);
         }
+        self.multipart_baselines
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(&handle.upload_id);
         self.abort_multipart_upload_internal(&handle.remote_path, &handle.upload_id)
             .await
     }
@@ -6452,6 +6956,196 @@ mod tests {
     use super::*;
 
     #[test]
+    fn s3_baseline_endpoint_identity_separates_authorities_and_accounts() {
+        let provider = make_provider(Some("https://one.example/Case"));
+        let original = provider.endpoint_identity();
+        for endpoint in ["https://two.example/Case", "https://one.example/case"] {
+            assert_ne!(original, make_provider(Some(endpoint)).endpoint_identity());
+        }
+        let mut other = provider.clone();
+        other.config.access_key_id = "KEY".into();
+        assert_ne!(original, other.endpoint_identity());
+        other = provider.clone();
+        other.config.role_arn = Some("arn:aws:iam::123456789012:role/other".into());
+        assert_ne!(original, other.endpoint_identity());
+        other = provider.clone();
+        other.config.secret_access_key = secrecy::SecretString::from("rotated".to_owned());
+        assert_eq!(original, other.endpoint_identity());
+    }
+
+    #[derive(Clone, Copy)]
+    enum BaselineReply {
+        Success,
+        MissingEtag,
+        PartError,
+        CompleteError,
+        PutError,
+    }
+
+    struct BaselineMock {
+        provider: S3Provider,
+        dir: tempfile::TempDir,
+        wire: Arc<AtomicU64>,
+        aborts: Arc<AtomicU64>,
+        server: tokio::task::JoinHandle<()>,
+    }
+
+    // Drain request bodies in bounded chunks. No request counter from AeroFTP
+    // is used as the wire-byte oracle and no 200 MiB payload is kept in memory.
+    async fn baseline_mock(reply: BaselineReply, single: bool) -> BaselineMock {
+        let bytes = Arc::new(AtomicU64::new(0));
+        let aborts = Arc::new(AtomicU64::new(0));
+        let wire = Arc::clone(&bytes);
+        let aborted = Arc::clone(&aborts);
+        let app = axum::Router::new().fallback(axum::routing::any(move |req: axum::extract::Request| {
+            let wire = Arc::clone(&wire);
+            let aborted = Arc::clone(&aborted);
+            async move {
+                let method = req.method().clone();
+                let query = req.uri().query().unwrap_or_default().to_string();
+                let mut stream = req.into_body().into_data_stream();
+                while let Some(chunk) = stream.next().await {
+                    let chunk = chunk.unwrap();
+                    if method == axum::http::Method::PUT {
+                        wire.fetch_add(chunk.len() as u64, Ordering::SeqCst);
+                    }
+                }
+                let mut response = axum::response::Response::builder();
+                let body = if method == axum::http::Method::POST && query.starts_with("uploads") {
+                    "<InitiateMultipartUploadResult><UploadId>u1</UploadId></InitiateMultipartUploadResult>"
+                } else if method == axum::http::Method::DELETE {
+                    aborted.fetch_add(1, Ordering::SeqCst);
+                    ""
+                } else if method == axum::http::Method::PUT {
+                    if matches!(reply, BaselineReply::PartError | BaselineReply::PutError) {
+                        response = response.status(400);
+                        "<Error><Code>InvalidRequest</Code></Error>"
+                    } else {
+                        if !matches!(reply, BaselineReply::MissingEtag) || !single {
+                            response = response.header("etag", if single { "\"our-completion\"" } else { "\"part-etag\"" });
+                        }
+                        ""
+                    }
+                } else if method == axum::http::Method::POST {
+                    match reply {
+                        BaselineReply::CompleteError => "<Error><Code>InvalidPart</Code></Error>",
+                        BaselineReply::MissingEtag => "<CompleteMultipartUploadResult/>",
+                        _ => "<CompleteMultipartUploadResult><ETag>\"our-completion\"</ETag></CompleteMultipartUploadResult>",
+                    }
+                } else {
+                    // A later stat must never supply the certification ETag.
+                    response = response.status(400);
+                    "unexpected request"
+                };
+                response.body(axum::body::Body::from(body)).unwrap()
+            }
+        }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let mut provider =
+            make_provider(Some(&format!("http://{}", listener.local_addr().unwrap())));
+        provider.connected = true;
+        if single {
+            provider.config.region = "filen".into();
+        }
+        let dir = tempfile::tempdir().unwrap();
+        provider.baseline_test_path = Some(dir.path().join("baseline.db"));
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        BaselineMock {
+            provider,
+            dir,
+            wire: bytes,
+            aborts,
+            server,
+        }
+    }
+
+    #[tokio::test]
+    async fn s3_baseline_upload_doors_certify_only_successful_response_etags() {
+        use super::super::s3_delta_baseline::MatchOutcome;
+        use super::super::s3_delta_plan::DELTA_PART_SIZE;
+        // Eligible but non-grid-aligned; the upload grid remains 16 MiB.
+        let size = 201 * 1024 * 1024;
+        for single in [false, true] {
+            let BaselineMock {
+                mut provider,
+                dir,
+                wire,
+                aborts,
+                server,
+            } = baseline_mock(BaselineReply::Success, single).await;
+            // Prove digests survive unsigned request bodies as well as signing.
+            provider.disable_checksum = true;
+            let path = dir.path().join("source.bin");
+            std::fs::File::create(&path).unwrap().set_len(size).unwrap();
+            provider
+                .upload(path.to_str().unwrap(), "object", None)
+                .await
+                .unwrap();
+            assert_eq!(wire.load(Ordering::SeqCst), size);
+            assert_eq!(aborts.load(Ordering::SeqCst), 0);
+            let store = provider.baseline_store().unwrap();
+            assert_eq!(
+                store
+                    .match_file(
+                        provider.delta_baseline_key("object"),
+                        "our-completion".into(),
+                        size,
+                        &path
+                    )
+                    .await
+                    .unwrap(),
+                MatchOutcome::Matches {
+                    grid: DELTA_PART_SIZE,
+                    matches: vec![(0, 0, size)]
+                }
+            );
+            let conn =
+                rusqlite::Connection::open(provider.baseline_test_path.as_ref().unwrap()).unwrap();
+            let etag: String = conn
+                .query_row("SELECT etag FROM baselines", [], |r| r.get(0))
+                .unwrap();
+            assert_eq!(etag, "\"our-completion\"");
+            server.abort();
+        }
+    }
+
+    #[tokio::test]
+    async fn s3_baseline_failed_aborted_and_missing_etag_uploads_leave_no_row() {
+        let size = 201 * 1024 * 1024;
+        for (reply, single, failed, aborted) in [
+            (BaselineReply::PartError, false, true, true),
+            (BaselineReply::CompleteError, false, true, true),
+            (BaselineReply::MissingEtag, false, false, false),
+            (BaselineReply::PutError, true, true, false),
+            (BaselineReply::MissingEtag, true, false, false),
+        ] {
+            let BaselineMock {
+                mut provider,
+                dir,
+                aborts,
+                server,
+                ..
+            } = baseline_mock(reply, single).await;
+            let path = dir.path().join("source.bin");
+            std::fs::File::create(&path).unwrap().set_len(size).unwrap();
+            let result = provider
+                .upload(path.to_str().unwrap(), "object", None)
+                .await;
+            assert_eq!(result.is_err(), failed);
+            assert_eq!(aborts.load(Ordering::SeqCst) > 0, aborted);
+            let conn =
+                rusqlite::Connection::open(provider.baseline_test_path.as_ref().unwrap()).unwrap();
+            let rows: usize = conn
+                .query_row("SELECT COUNT(*) FROM baselines", [], |r| r.get(0))
+                .unwrap();
+            assert_eq!(rows, 0, "upload outcome must leave no optimistic row");
+            server.abort();
+        }
+    }
+
+    #[test]
     fn clock_skew_classifier_rejects_an_ordinary_timeout() {
         assert!(is_s3_clock_skew_error(
             "The difference between the request time and the server time is too large",
@@ -7276,7 +7970,7 @@ mod tests {
         assert_eq!(provider.multi_thread_cutoff, 250 * 1024 * 1024);
     }
 
-    fn make_provider(endpoint: Option<&str>) -> S3Provider {
+    pub(super) fn make_provider(endpoint: Option<&str>) -> S3Provider {
         S3Provider::new(S3Config {
             endpoint: endpoint.map(String::from),
             region: "us-east-1".to_string(),
@@ -9613,3 +10307,7 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 }
+
+#[cfg(test)]
+#[path = "s3_delta_tests.rs"]
+mod delta_adapter_tests;

--- a/src-tauri/src/providers/s3_delta.rs
+++ b/src-tauri/src/providers/s3_delta.rs
@@ -262,4 +262,63 @@ mod tests {
         );
         assert!(!range_copy_rejected(&identity));
     }
+
+    /// The converse nobody wrote. Every existing case proves that a ranged
+    /// copy refusal IS remembered; none proves that anything else is not. So
+    /// moving `operation: Copy` to another operation in both arms of
+    /// `remember_range_rejection` leaves the whole battery green, and the
+    /// cache would start refusing delta on endpoints whose HEAD or UploadPart
+    /// answered 501, which says nothing about ranged copy.
+    #[test]
+    fn s3_adapter_negative_memory_only_remembers_a_copy_refusal() {
+        for operation in [
+            DeltaOperation::Head,
+            DeltaOperation::Create,
+            DeltaOperation::Put,
+            DeltaOperation::Complete,
+        ] {
+            for (status, code) in [
+                (501, "NotImplemented"),
+                (400, "NotImplemented"),
+                (200, "XNotImplemented"),
+                (405, "NotSupported"),
+            ] {
+                let identity = crate::transfer_dag::EndpointIdentity::new(
+                    "s3",
+                    format!("converse-{}-{status}-{code}", operation.name()),
+                    "test",
+                );
+                remember_range_rejection(
+                    identity.clone(),
+                    &S3DeltaError::Response {
+                        status,
+                        code: Some(code.into()),
+                        operation,
+                        message: String::new(),
+                    },
+                );
+                assert!(
+                    !range_copy_rejected(&identity),
+                    "{} {status} {code} must not teach us anything about ranged copy",
+                    operation.name()
+                );
+            }
+        }
+        // The door: the same statuses and codes on a Copy are remembered, so
+        // the rejections above turn on the operation and on nothing else.
+        for (status, code) in [
+            (501, "NotImplemented"),
+            (400, "NotImplemented"),
+            (200, "XNotImplemented"),
+            (405, "NotSupported"),
+        ] {
+            let identity = crate::transfer_dag::EndpointIdentity::new(
+                "s3",
+                format!("converse-copy-door-{status}-{code}"),
+                "test",
+            );
+            remember_range_rejection(identity.clone(), &failure(status, code));
+            assert!(range_copy_rejected(&identity), "{status} {code}");
+        }
+    }
 }

--- a/src-tauri/src/providers/s3_delta.rs
+++ b/src-tauri/src/providers/s3_delta.rs
@@ -1,0 +1,265 @@
+//! Typed S3 delta outcomes. These never enter the native rsync string classifier.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+use super::ProviderError;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DeltaOperation {
+    Head,
+    Create,
+    Put,
+    Copy,
+    Complete,
+}
+impl DeltaOperation {
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Head => "HeadObject",
+            Self::Create => "CreateMultipartUpload",
+            Self::Put => "UploadPart",
+            Self::Copy => "UploadPartCopy",
+            Self::Complete => "CompleteMultipartUpload",
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum S3DeltaError {
+    SourceChanged,
+    Provider(ProviderError),
+    Response {
+        status: u16,
+        code: Option<String>,
+        operation: DeltaOperation,
+        message: String,
+    },
+}
+
+impl From<ProviderError> for S3DeltaError {
+    fn from(error: ProviderError) -> Self {
+        Self::Provider(error)
+    }
+}
+
+impl S3DeltaError {
+    pub(crate) fn into_provider_error(self) -> ProviderError {
+        match self {
+            Self::SourceChanged => ProviderError::TransferFailed("source_changed".into()),
+            Self::Provider(error) => error,
+            Self::Response { message, .. } => ProviderError::TransferFailed(message),
+        }
+    }
+
+    /// Exact typed variants/status/XML Code values, never rendered-text needles.
+    pub(crate) fn is_hard(&self) -> bool {
+        match self {
+            Self::Provider(
+                ProviderError::AuthenticationFailed(_) | ProviderError::PermissionDenied(_),
+            ) => true,
+            Self::Response { status, code, .. } => {
+                matches!(status, 401 | 403)
+                    || matches!(
+                        code.as_deref(),
+                        Some(
+                            "AccessDenied"
+                                | "InvalidAccessKeyId"
+                                | "SignatureDoesNotMatch"
+                                | "ExpiredToken"
+                                | "InvalidToken"
+                                | "TokenRefreshRequired"
+                        )
+                    )
+            }
+            _ => false,
+        }
+    }
+
+    pub(crate) fn fallback_reason(&self) -> &'static str {
+        match self {
+            Self::SourceChanged => "source_changed",
+            Self::Response { status: 412, .. } => "etag_mismatch",
+            Self::Response {
+                code: Some(code), ..
+            } if code == "PreconditionFailed" => "etag_mismatch",
+            Self::Response {
+                status: 501,
+                operation: DeltaOperation::Copy,
+                ..
+            } => "backend_rejected_range_copy",
+            Self::Response {
+                code: Some(code),
+                operation: DeltaOperation::Copy,
+                ..
+            } if matches!(
+                code.as_str(),
+                "NotImplemented" | "XNotImplemented" | "NotSupported" | "InvalidRange"
+            ) =>
+            {
+                "backend_rejected_range_copy"
+            }
+            Self::Provider(ProviderError::NotConnected) => "not_connected",
+            Self::Provider(ProviderError::IoError(_)) => "local_read_failed",
+            _ => "s3_delta_failed",
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct S3DeltaCompleted {
+    pub wire_bytes: u64,
+    pub etag: Option<String>,
+    pub copy_parts: u64,
+    pub duration_ms: u64,
+}
+
+#[derive(Debug)]
+pub(crate) enum S3DeltaOutcome {
+    Refused(&'static str),
+    Uploaded {
+        wire_bytes: u64,
+        total_size: u64,
+        copy_parts: u64,
+        duration_ms: u64,
+    },
+}
+
+// Negative capability memory is small, expiring and account/endpoint-scoped.
+// Only explicit copy-operation unsupported responses enter it.
+static RANGE_REJECTIONS: std::sync::LazyLock<
+    std::sync::Mutex<
+        std::collections::HashMap<crate::transfer_dag::EndpointIdentity, std::time::Instant>,
+    >,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+const RANGE_REJECTION_TTL: std::time::Duration = std::time::Duration::from_secs(300);
+const RANGE_REJECTION_LIMIT: usize = 128;
+
+pub(crate) fn range_copy_rejected(identity: &crate::transfer_dag::EndpointIdentity) -> bool {
+    let mut cache = RANGE_REJECTIONS.lock().unwrap_or_else(|e| e.into_inner());
+    cache.retain(|_, at| at.elapsed() < RANGE_REJECTION_TTL);
+    cache.contains_key(identity)
+}
+
+pub(crate) fn remember_range_rejection(
+    identity: crate::transfer_dag::EndpointIdentity,
+    error: &S3DeltaError,
+) {
+    let unsupported = match error {
+        S3DeltaError::Response {
+            status: 501,
+            operation: DeltaOperation::Copy,
+            ..
+        } => true,
+        S3DeltaError::Response {
+            status,
+            code: Some(code),
+            operation: DeltaOperation::Copy,
+            ..
+        } if (*status == 200 || (400..500).contains(status)) && !matches!(*status, 412 | 429) => {
+            matches!(
+                code.as_str(),
+                "NotImplemented" | "XNotImplemented" | "NotSupported"
+            )
+        }
+        _ => false,
+    };
+    if !unsupported || error.is_hard() {
+        return;
+    }
+    let mut cache = RANGE_REJECTIONS.lock().unwrap_or_else(|e| e.into_inner());
+    cache.retain(|_, at| at.elapsed() < RANGE_REJECTION_TTL);
+    if cache.len() >= RANGE_REJECTION_LIMIT {
+        if let Some(oldest) = cache
+            .iter()
+            .min_by_key(|(_, at)| **at)
+            .map(|(key, _)| key.clone())
+        {
+            cache.remove(&oldest);
+        }
+    }
+    cache.insert(identity, std::time::Instant::now());
+}
+
+pub(crate) enum DeltaFailureDecision {
+    Hard,
+    Fallback(&'static str),
+}
+
+/// Single pure policy entry point, shared by adapter and capability memory.
+pub(crate) fn classify_delta_failure(error: &S3DeltaError) -> DeltaFailureDecision {
+    if error.is_hard() {
+        DeltaFailureDecision::Hard
+    } else {
+        DeltaFailureDecision::Fallback(error.fallback_reason())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn failure(status: u16, code: &str) -> S3DeltaError {
+        S3DeltaError::Response {
+            status,
+            code: Some(code.into()),
+            operation: DeltaOperation::Copy,
+            message: "native fallback (TransportFailure): internal misleading prose".into(),
+        }
+    }
+    #[test]
+    fn s3_adapter_classifier_uses_status_and_xml_code_not_prose() {
+        for (status, code, hard, reason) in [
+            (401, "", true, ""),
+            (403, "", true, ""),
+            (200, "AccessDenied", true, ""),
+            (200, "ExpiredToken", true, ""),
+            (200, "InvalidAccessKeyId", true, ""),
+            (200, "SignatureDoesNotMatch", true, ""),
+            (200, "TokenRefreshRequired", true, ""),
+            (412, "PreconditionFailed", false, "etag_mismatch"),
+            (200, "PreconditionFailed", false, "etag_mismatch"),
+            (500, "InternalError", false, "s3_delta_failed"),
+            (200, "InternalError", false, "s3_delta_failed"),
+            (503, "SlowDown", false, "s3_delta_failed"),
+            (400, "XNotImplemented", false, "backend_rejected_range_copy"),
+        ] {
+            match classify_delta_failure(&failure(status, code)) {
+                DeltaFailureDecision::Hard => assert!(hard, "{status} {code}"),
+                DeltaFailureDecision::Fallback(got) => {
+                    assert!(!hard, "{status} {code}");
+                    assert_eq!(got, reason);
+                }
+            }
+        }
+        assert!(matches!(
+            classify_delta_failure(&ProviderError::Timeout.into()),
+            DeltaFailureDecision::Fallback(_)
+        ));
+    }
+    #[test]
+    fn s3_adapter_negative_memory_does_not_cache_preconditions_or_transient_errors() {
+        for (status, code) in [
+            (412, "NotImplemented"),
+            (429, "NotImplemented"),
+            (500, "NotImplemented"),
+            (503, "SlowDown"),
+            (403, "NotImplemented"),
+        ] {
+            let identity = crate::transfer_dag::EndpointIdentity::new(
+                "s3",
+                format!("negative-test-{status}"),
+                "test",
+            );
+            remember_range_rejection(identity.clone(), &failure(status, code));
+            assert!(!range_copy_rejected(&identity));
+        }
+        let identity =
+            crate::transfer_dag::EndpointIdentity::new("s3", "negative-test-supported", "test");
+        remember_range_rejection(identity.clone(), &failure(400, "XNotImplemented"));
+        assert!(range_copy_rejected(&identity));
+        RANGE_REJECTIONS.lock().unwrap().insert(
+            identity.clone(),
+            std::time::Instant::now() - RANGE_REJECTION_TTL,
+        );
+        assert!(!range_copy_rejected(&identity));
+    }
+}

--- a/src-tauri/src/providers/s3_delta_baseline.rs
+++ b/src-tauri/src/providers/s3_delta_baseline.rs
@@ -424,6 +424,124 @@ fn evict(conn: &Connection, cap: usize) -> Result<(), String> {
     Ok(())
 }
 
+/// Per-part signatures for the clone-pool DAG hook. No payload bytes are kept.
+/// Multipart completion establishes part order; only aligned boundaries can
+/// safely concatenate independently computed cell hashes.
+pub(crate) struct MultipartPartDigests {
+    len: u64,
+    digests: Vec<[u8; 32]>,
+}
+
+pub(crate) fn hash_multipart_part(total_size: u64, bytes: &[u8]) -> Option<MultipartPartDigests> {
+    let grid = delta_grid_size(total_size)?;
+    if bytes.len() as u64 > total_size {
+        return None;
+    }
+    let digests = bytes
+        .chunks(grid as usize)
+        .map(|cell| Sha256::digest(cell).into())
+        .collect();
+    Some(MultipartPartDigests {
+        len: bytes.len() as u64,
+        digests,
+    })
+}
+
+pub(crate) struct MultipartBaseline {
+    pub size: u64,
+    pub store: BaselineStore,
+    pub touched: std::time::Instant,
+    pub parts: std::collections::BTreeMap<u32, (String, MultipartPartDigests)>,
+}
+
+impl MultipartBaseline {
+    pub fn record(&mut self, number: u32, etag: String, part: MultipartPartDigests) -> bool {
+        let existing: usize = self
+            .parts
+            .iter()
+            .filter(|(n, _)| **n != number)
+            .map(|(_, (_, p))| p.digests.len())
+            .sum();
+        if number == 0
+            || number > S3_MAX_PARTS
+            || existing.saturating_add(part.digests.len()) > DIGEST_LIMIT
+        {
+            return false;
+        }
+        self.parts.insert(number, (etag, part));
+        self.touched = std::time::Instant::now();
+        true
+    }
+
+    pub fn finish(
+        mut self,
+        completed: &[(u32, String)],
+    ) -> Option<(BaselineStore, BaselineHasher)> {
+        let grid = delta_grid_size(self.size)?;
+        if completed.len() > DIGEST_LIMIT || completed.len() != self.parts.len() {
+            return None;
+        }
+        let mut seen = 0u64;
+        let mut digests = Vec::new();
+        for (index, (number, etag)) in completed.iter().enumerate() {
+            if *number != index as u32 + 1 || seen % grid != 0 {
+                return None;
+            }
+            let (sent_etag, part) = self.parts.remove(number)?;
+            if sent_etag != *etag || part.len == 0 {
+                return None;
+            }
+            seen = seen.checked_add(part.len)?;
+            digests.extend(part.digests);
+            if digests.len() > DIGEST_LIMIT {
+                return None;
+            }
+        }
+        if seen != self.size {
+            return None;
+        }
+        Some((
+            self.store,
+            BaselineHasher {
+                size: self.size,
+                grid,
+                seen,
+                cell_len: 0,
+                hash: Sha256::new(),
+                digests,
+            },
+        ))
+    }
+}
+
+pub(crate) struct PreparedDigests {
+    size: u64,
+    grid: u64,
+    digests: Vec<[u8; 32]>,
+}
+
+impl PreparedDigests {
+    /// Confirm complete cells from the very PUT buffer handed to the request.
+    /// Cells split by repaired part boundaries retain the metadata guard.
+    pub fn verify_put(&self, offset: u64, bytes: &[u8]) -> bool {
+        let end = offset.saturating_add(bytes.len() as u64);
+        for index in offset.div_ceil(self.grid)..end.div_ceil(self.grid) {
+            let start = index * self.grid;
+            let cell_end = (start + self.grid).min(self.size);
+            if cell_end > end || cell_end <= start {
+                continue;
+            }
+            let digest: [u8; 32] =
+                Sha256::digest(&bytes[(start - offset) as usize..(cell_end - offset) as usize])
+                    .into();
+            if self.digests.get(index as usize) != Some(&digest) {
+                return false;
+            }
+        }
+        true
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::s3_delta_plan::{plan_delta_parts, DeltaPart, DELTA_PART_SIZE};
@@ -754,122 +872,165 @@ mod tests {
         }
         assert_eq!(count(&store), 1);
     }
-}
 
-/// Per-part signatures for the clone-pool DAG hook. No payload bytes are kept.
-/// Multipart completion establishes part order; only aligned boundaries can
-/// safely concatenate independently computed cell hashes.
-pub(crate) struct MultipartPartDigests {
-    len: u64,
-    digests: Vec<[u8; 32]>,
-}
-
-pub(crate) fn hash_multipart_part(total_size: u64, bytes: &[u8]) -> Option<MultipartPartDigests> {
-    let grid = delta_grid_size(total_size)?;
-    if bytes.len() as u64 > total_size {
-        return None;
+    fn multipart_part(len: u64, cells: usize) -> MultipartPartDigests {
+        MultipartPartDigests {
+            len,
+            digests: vec![[0u8; 32]; cells],
+        }
     }
-    let digests = bytes
-        .chunks(grid as usize)
-        .map(|cell| Sha256::digest(cell).into())
-        .collect();
-    Some(MultipartPartDigests {
-        len: bytes.len() as u64,
-        digests,
-    })
-}
 
-pub(crate) struct MultipartBaseline {
-    pub size: u64,
-    pub store: BaselineStore,
-    pub touched: std::time::Instant,
-    pub parts: std::collections::BTreeMap<u32, (String, MultipartPartDigests)>,
-}
+    fn multipart(size: u64, store: BaselineStore) -> MultipartBaseline {
+        MultipartBaseline {
+            size,
+            store,
+            touched: std::time::Instant::now(),
+            parts: std::collections::BTreeMap::new(),
+        }
+    }
 
-impl MultipartBaseline {
-    pub fn record(&mut self, number: u32, etag: String, part: MultipartPartDigests) -> bool {
-        let existing: usize = self
-            .parts
+    fn finish_case(
+        size: u64,
+        recorded: &[(u32, &str, u64, usize)],
+        completed: &[(u32, &str)],
+    ) -> bool {
+        let (_dir, store) = store();
+        let mut baseline = multipart(size, store);
+        for (number, etag, len, cells) in recorded {
+            assert!(
+                baseline.record(*number, (*etag).to_string(), multipart_part(*len, *cells)),
+                "record refused part {number}, which this case needs accepted"
+            );
+        }
+        let completed: Vec<(u32, String)> = completed
             .iter()
-            .filter(|(n, _)| **n != number)
-            .map(|(_, (_, p))| p.digests.len())
-            .sum();
-        if number == 0
-            || number > S3_MAX_PARTS
-            || existing.saturating_add(part.digests.len()) > DIGEST_LIMIT
-        {
-            return false;
-        }
-        self.parts.insert(number, (etag, part));
-        self.touched = std::time::Instant::now();
-        true
+            .map(|(number, etag)| (*number, (*etag).to_string()))
+            .collect();
+        baseline.finish(&completed).is_some()
     }
 
-    pub fn finish(
-        mut self,
-        completed: &[(u32, String)],
-    ) -> Option<(BaselineStore, BaselineHasher)> {
-        let grid = delta_grid_size(self.size)?;
-        if completed.len() > DIGEST_LIMIT || completed.len() != self.parts.len() {
-            return None;
-        }
-        let mut seen = 0u64;
-        let mut digests = Vec::new();
-        for (index, (number, etag)) in completed.iter().enumerate() {
-            if *number != index as u32 + 1 || seen % grid != 0 {
-                return None;
-            }
-            let (sent_etag, part) = self.parts.remove(number)?;
-            if sent_etag != *etag || part.len == 0 {
-                return None;
-            }
-            seen = seen.checked_add(part.len)?;
-            digests.extend(part.digests);
-            if digests.len() > DIGEST_LIMIT {
-                return None;
-            }
-        }
-        if seen != self.size {
-            return None;
-        }
-        Some((
-            self.store,
-            BaselineHasher {
-                size: self.size,
-                grid,
-                seen,
-                cell_len: 0,
-                hash: Sha256::new(),
-                digests,
-            },
-        ))
+    #[test]
+    fn s3_baseline_multipart_record_rejects_part_numbers_outside_the_s3_domain() {
+        const MIB: u64 = 1024 * 1024;
+        let (_dir, store) = store();
+        let mut baseline = multipart(208 * MIB, store);
+        assert!(
+            !baseline.record(0, "\"p\"".into(), multipart_part(96 * MIB, 12)),
+            "S3 numbers parts from 1; part 0 does not exist"
+        );
+        assert!(
+            !baseline.record(
+                S3_MAX_PARTS + 1,
+                "\"p\"".into(),
+                multipart_part(96 * MIB, 12)
+            ),
+            "past the last legal part number"
+        );
+        assert!(
+            !baseline.record(
+                1,
+                "\"p\"".into(),
+                multipart_part(96 * MIB, DIGEST_LIMIT + 1)
+            ),
+            "more cells than one baseline row may hold"
+        );
+        assert!(
+            baseline.parts.is_empty(),
+            "a refused record must leave no state behind"
+        );
+        // The door. Without it, a `record` that refused everything would
+        // satisfy all three rejections above.
+        assert!(baseline.record(1, "\"p\"".into(), multipart_part(96 * MIB, 12)));
+        assert_eq!(baseline.parts.len(), 1);
     }
-}
 
-pub(crate) struct PreparedDigests {
-    size: u64,
-    grid: u64,
-    digests: Vec<[u8; 32]>,
-}
+    #[test]
+    fn s3_baseline_multipart_finish_rejects_every_completion_it_cannot_certify() {
+        const MIB: u64 = 1024 * 1024;
+        // Strictly above DELTA_MIN_FILE_SIZE, which is 200 MiB exactly and is
+        // excluded, and a whole number of grid cells so the aligned control is
+        // genuinely aligned. Compared as an Option: an ineligible size must
+        // say so here rather than surface as an unwrap panic on a later line.
+        let size = 208 * MIB;
+        assert_eq!(
+            delta_grid_size(size),
+            Some(8 * MIB),
+            "the aligned parts below are written for this size and grid"
+        );
+        let aligned: &[(u32, &str, u64, usize)] = &[
+            (1, "\"p1\"", 96 * MIB, 12),
+            (2, "\"p2\"", 96 * MIB, 12),
+            (3, "\"p3\"", 16 * MIB, 2),
+        ];
+        let all: &[(u32, &str)] = &[(1, "\"p1\""), (2, "\"p2\""), (3, "\"p3\"")];
 
-impl PreparedDigests {
-    /// Confirm complete cells from the very PUT buffer handed to the request.
-    /// Cells split by repaired part boundaries retain the metadata guard.
-    pub fn verify_put(&self, offset: u64, bytes: &[u8]) -> bool {
-        let end = offset.saturating_add(bytes.len() as u64);
-        for index in offset.div_ceil(self.grid)..end.div_ceil(self.grid) {
-            let start = index * self.grid;
-            let cell_end = (start + self.grid).min(self.size);
-            if cell_end > end || cell_end <= start {
-                continue;
-            }
-            let digest: [u8; 32] =
-                Sha256::digest(&bytes[(start - offset) as usize..(cell_end - offset) as usize])
-                    .into();
-            if self.digests.get(index as usize) != Some(&digest) {
-                return false;
-            }
-        }
-        true
+        // The door first: an aligned, consecutive, fully covering completion
+        // must produce a baseline. Every rejection below is measured against
+        // it, so a `finish` that always returned None cannot pass this test.
+        assert!(
+            finish_case(size, aligned, all),
+            "the aligned control must succeed"
+        );
+
+        // A part that does not begin on a grid boundary. Independently
+        // computed cell hashes cannot be concatenated across it, so no row is
+        // written. This is reachable in shipped configurations (an upload
+        // chunk override, or a file large enough that the DAG builder grows
+        // the chunk past a grid multiple), and it fails silently, which is
+        // why it is pinned here rather than left to the default-sized paths.
+        assert!(
+            !finish_case(
+                size,
+                &[(1, "\"p1\"", 100 * MIB, 13), (2, "\"p2\"", 108 * MIB, 14)],
+                &[(1, "\"p1\""), (2, "\"p2\"")]
+            ),
+            "a part starting off the grid cannot concatenate"
+        );
+
+        // Parts that do not cover the object.
+        assert!(
+            !finish_case(
+                size,
+                &[(1, "\"p1\"", 96 * MIB, 12), (2, "\"p2\"", 96 * MIB, 12)],
+                &[(1, "\"p1\""), (2, "\"p2\"")]
+            ),
+            "192 MiB of parts cannot certify a 200 MiB object"
+        );
+
+        // A gap in the part numbers.
+        assert!(
+            !finish_case(
+                size,
+                &[(1, "\"p1\"", 96 * MIB, 12), (3, "\"p3\"", 112 * MIB, 14)],
+                &[(1, "\"p1\""), (3, "\"p3\"")]
+            ),
+            "part numbers must be consecutive from 1"
+        );
+
+        // The ETag the server completed with is not the one we sent.
+        assert!(
+            !finish_case(
+                size,
+                aligned,
+                &[(1, "\"other\""), (2, "\"p2\""), (3, "\"p3\"")]
+            ),
+            "a part completed under a different ETag is not the part we hashed"
+        );
+
+        // An empty part certifies nothing.
+        assert!(
+            !finish_case(
+                size,
+                &[(1, "\"p1\"", 0, 0), (2, "\"p2\"", 208 * MIB, 26)],
+                &[(1, "\"p1\""), (2, "\"p2\"")]
+            ),
+            "a zero length part cannot be part of a baseline"
+        );
+
+        // A completion listing more parts than were recorded.
+        assert!(
+            !finish_case(size, aligned, &[(1, "\"p1\""), (2, "\"p2\"")]),
+            "the completion must account for every recorded part"
+        );
     }
 }

--- a/src-tauri/src/providers/s3_delta_baseline.rs
+++ b/src-tauri/src/providers/s3_delta_baseline.rs
@@ -1,0 +1,875 @@
+//! Local memory of bytes uploaded by this client. No baseline network reads.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+use super::s3_delta_plan::{delta_grid_fits, delta_grid_size, S3_MAX_PARTS};
+use crate::transfer_dag::EndpointIdentity;
+use rusqlite::{params, Connection, OptionalExtension};
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+use tokio::io::AsyncReadExt;
+
+const ROW_LIMIT: usize = 10_000;
+const DIGEST_LIMIT: usize = S3_MAX_PARTS as usize;
+const ALGORITHM: &str = "sha256";
+const VERSION: u32 = 1;
+
+#[derive(Clone, Debug)]
+pub struct BaselineKey {
+    identity: String,
+    bucket: String,
+    key: String,
+}
+
+impl BaselineKey {
+    pub fn new(identity: EndpointIdentity, bucket: &str, key: &str) -> Self {
+        Self {
+            identity: serde_json::json!([identity.protocol, identity.host, identity.account])
+                .to_string(),
+            bucket: bucket.to_owned(),
+            key: key.to_owned(),
+        }
+    }
+}
+
+/// Hashes the object grid independently of signing and upload part boundaries.
+/// Kept in memory until the upload has successfully returned its own ETag.
+#[derive(Clone)]
+pub struct BaselineHasher {
+    size: u64,
+    grid: u64,
+    seen: u64,
+    cell_len: u64,
+    hash: Sha256,
+    digests: Vec<[u8; 32]>,
+}
+
+impl BaselineHasher {
+    pub fn new(size: u64) -> Option<Self> {
+        Some(Self {
+            size,
+            grid: delta_grid_size(size)?,
+            seen: 0,
+            cell_len: 0,
+            hash: Sha256::new(),
+            digests: Vec::new(),
+        })
+    }
+
+    pub fn update(&mut self, mut bytes: &[u8]) {
+        self.seen = self.seen.saturating_add(bytes.len() as u64);
+        // A source that grows during upload must not allocate unbounded rows.
+        if self.seen > self.size {
+            return;
+        }
+        while !bytes.is_empty() {
+            let take = (self.grid - self.cell_len).min(bytes.len() as u64) as usize;
+            self.hash.update(&bytes[..take]);
+            self.cell_len += take as u64;
+            bytes = &bytes[take..];
+            if self.cell_len == self.grid {
+                self.digests.push(self.hash.finalize_reset().into());
+                self.cell_len = 0;
+            }
+        }
+    }
+
+    pub(crate) fn verification(&self) -> Option<PreparedDigests> {
+        let row = self.clone().finish("pending-verification")?;
+        Some(PreparedDigests {
+            size: row.size,
+            grid: row.grid,
+            digests: row.digests,
+        })
+    }
+
+    fn finish(mut self, etag: &str) -> Option<Baseline> {
+        if self.seen != self.size || normalize_etag(etag).is_empty() {
+            return None;
+        }
+        if self.cell_len != 0 {
+            self.digests.push(self.hash.finalize().into());
+        }
+        Some(Baseline {
+            etag: etag.to_owned(),
+            size: self.size,
+            grid: self.grid,
+            digests: self.digests,
+        })
+    }
+}
+
+struct Baseline {
+    etag: String,
+    size: u64,
+    grid: u64,
+    digests: Vec<[u8; 32]>,
+}
+
+fn normalize_etag(etag: &str) -> &str {
+    etag.trim().trim_matches('"')
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum MatchRefusal {
+    NoBaseline,
+    EtagMismatch,
+    SizeMismatch,
+    GridMismatch,
+    InvalidRow,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum MatchOutcome {
+    Refused(MatchRefusal),
+    Matches {
+        grid: u64,
+        matches: Vec<(u64, u64, u64)>,
+    },
+}
+
+/// Per-user SQLite cache. Open and transact on a blocking worker; never keep a
+/// connection locked while reading the source or performing an HTTP request.
+#[derive(Clone)]
+pub struct BaselineStore {
+    path: PathBuf,
+}
+
+impl BaselineStore {
+    pub fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+
+    pub fn default_path() -> Option<PathBuf> {
+        crate::portable::cli_app_config_dir().map(|p| p.join("s3_delta_baselines.db"))
+    }
+
+    fn open(&self) -> Result<Connection, String> {
+        let conn = Connection::open(&self.path).map_err(|e| e.to_string())?;
+        conn.busy_timeout(std::time::Duration::from_secs(2))
+            .map_err(|e| e.to_string())?;
+        conn.execute_batch(&format!(
+            "PRAGMA journal_mode=WAL;
+             PRAGMA synchronous=NORMAL;
+             CREATE TABLE IF NOT EXISTS baselines (
+               identity TEXT NOT NULL, bucket TEXT NOT NULL, object_key TEXT NOT NULL,
+               etag TEXT NOT NULL, size INTEGER NOT NULL, grid INTEGER NOT NULL,
+               algorithm TEXT NOT NULL, version INTEGER NOT NULL,
+               digests BLOB NOT NULL CHECK(length(digests) <= {}),
+               last_use INTEGER NOT NULL,
+               PRIMARY KEY(identity, bucket, object_key));
+             CREATE INDEX IF NOT EXISTS baseline_lru ON baselines(last_use);",
+            DIGEST_LIMIT * 32
+        ))
+        .map_err(|e| e.to_string())?;
+        Ok(conn)
+    }
+
+    /// Forget the previous row before attempting a replacement. A failed or
+    /// cancelled attempt cannot leave a row claiming to describe that attempt.
+    pub async fn invalidate(&self, key: BaselineKey) -> Result<(), String> {
+        let store = self.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = store.open()?;
+            delete(&conn, &key)
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
+    /// Call only after a successful PUT/completion, with its response ETag.
+    pub async fn record_completed(
+        &self,
+        key: BaselineKey,
+        hasher: BaselineHasher,
+        etag: String,
+    ) -> Result<(), String> {
+        let Some(row) = hasher.finish(&etag) else {
+            return Ok(());
+        };
+        let store = self.clone();
+        tokio::task::spawn_blocking(move || store.insert(&key, row))
+            .await
+            .map_err(|e| e.to_string())?
+    }
+
+    fn insert(&self, key: &BaselineKey, row: Baseline) -> Result<(), String> {
+        if row.digests.len() > DIGEST_LIMIT {
+            return Err("Too many baseline digests".into());
+        }
+        let mut conn = self.open()?;
+        let tx = conn
+            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+            .map_err(|e| e.to_string())?;
+        let blob: Vec<u8> = row.digests.into_iter().flatten().collect();
+        tx.execute(
+            "INSERT OR REPLACE INTO baselines VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,
+             (SELECT COALESCE(MAX(last_use),0)+1 FROM baselines))",
+            params![
+                key.identity,
+                key.bucket,
+                key.key,
+                row.etag,
+                row.size,
+                row.grid,
+                ALGORITHM,
+                VERSION,
+                blob
+            ],
+        )
+        .map_err(|e| e.to_string())?;
+        evict(&tx, ROW_LIMIT)?;
+        tx.commit().map_err(|e| e.to_string())
+    }
+
+    fn lookup(
+        &self,
+        key: &BaselineKey,
+        etag: &str,
+        size: u64,
+        local_len: u64,
+    ) -> Result<Result<Baseline, MatchRefusal>, String> {
+        let mut conn = self.open()?;
+        let tx = conn
+            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+            .map_err(|e| e.to_string())?;
+        // Do not materialize a malformed unbounded BLOB, even from an older or
+        // externally modified database without the CHECK constraint.
+        let row = tx
+            .query_row(
+                "SELECT etag,size,grid,algorithm,version,
+             CASE WHEN length(digests)<=?4 THEN digests ELSE X'' END
+             FROM baselines WHERE identity=?1 AND bucket=?2 AND object_key=?3",
+                params![key.identity, key.bucket, key.key, DIGEST_LIMIT * 32],
+                |r| {
+                    Ok((
+                        r.get::<_, String>(0)?,
+                        r.get::<_, u64>(1)?,
+                        r.get::<_, u64>(2)?,
+                        r.get::<_, String>(3)?,
+                        r.get::<_, u32>(4)?,
+                        r.get::<_, Vec<u8>>(5)?,
+                    ))
+                },
+            )
+            .optional();
+        let row = match row {
+            Ok(None) => return Ok(Err(MatchRefusal::NoBaseline)),
+            Ok(Some(row)) => row,
+            Err(
+                rusqlite::Error::FromSqlConversionFailure(..)
+                | rusqlite::Error::IntegralValueOutOfRange(..)
+                | rusqlite::Error::InvalidColumnType(..),
+            ) => {
+                delete(&tx, key)?;
+                tx.commit().map_err(|e| e.to_string())?;
+                return Ok(Err(MatchRefusal::InvalidRow));
+            }
+            Err(e) => return Err(e.to_string()),
+        };
+        let (stored_etag, stored_size, grid, algorithm, version, blob) = row;
+        let refusal = if normalize_etag(&stored_etag).is_empty()
+            || normalize_etag(&stored_etag) != normalize_etag(etag)
+        {
+            Some(MatchRefusal::EtagMismatch)
+        } else if stored_size != size {
+            Some(MatchRefusal::SizeMismatch)
+        } else if !delta_grid_fits(grid, local_len) || !delta_grid_fits(grid, stored_size) {
+            Some(MatchRefusal::GridMismatch)
+        } else if algorithm != ALGORITHM
+            || version != VERSION
+            || blob.len() != stored_size.div_ceil(grid) as usize * 32
+        {
+            Some(MatchRefusal::InvalidRow)
+        } else {
+            None
+        };
+        if let Some(reason) = refusal {
+            delete(&tx, key)?;
+            tx.commit().map_err(|e| e.to_string())?;
+            return Ok(Err(reason));
+        }
+        tx.execute(
+            "UPDATE baselines SET last_use=(SELECT COALESCE(MAX(last_use),0)+1 FROM baselines)
+                    WHERE identity=?1 AND bucket=?2 AND object_key=?3",
+            params![key.identity, key.bucket, key.key],
+        )
+        .map_err(|e| e.to_string())?;
+        tx.commit().map_err(|e| e.to_string())?;
+        Ok(Ok(Baseline {
+            etag: stored_etag,
+            size,
+            grid,
+            digests: blob
+                .chunks_exact(32)
+                .map(|c| c.try_into().expect("32 byte chunk"))
+                .collect(),
+        }))
+    }
+
+    /// Tier 1: only same-offset cells, fused into runs. The baseline's final
+    /// partial cell is compared over its original length even after an append.
+    /// Refusals delete stale rows before any source bytes are read.
+    pub async fn match_file(
+        &self,
+        key: BaselineKey,
+        current_etag: String,
+        current_size: u64,
+        local_path: &Path,
+    ) -> Result<MatchOutcome, String> {
+        self.prepare_file(key, current_etag, current_size, local_path)
+            .await
+            .map(|(outcome, _)| outcome)
+    }
+
+    /// Also prepares the new object's signature in the same local read. The
+    /// caller may certify it only with its own successful completion ETag.
+    pub async fn prepare_file(
+        &self,
+        key: BaselineKey,
+        current_etag: String,
+        current_size: u64,
+        local_path: &Path,
+    ) -> Result<(MatchOutcome, Option<BaselineHasher>), String> {
+        let mut file = tokio::fs::File::open(local_path)
+            .await
+            .map_err(|e| e.to_string())?;
+        let before = file.metadata().await.map_err(|e| e.to_string())?;
+        let local_len = before.len();
+        let store = self.clone();
+        let row = tokio::task::spawn_blocking(move || {
+            store.lookup(&key, &current_etag, current_size, local_len)
+        })
+        .await
+        .map_err(|e| e.to_string())??;
+        let row = match row {
+            Ok(row) => row,
+            Err(reason) => return Ok((MatchOutcome::Refused(reason), None)),
+        };
+        let mut fresh = BaselineHasher::new(local_len);
+        let mut read_bytes = 0u64;
+        let mut matches: Vec<(u64, u64, u64)> = Vec::new();
+        let mut buf = vec![0u8; 64 * 1024];
+        for (i, expected) in row.digests.iter().enumerate() {
+            let off = i as u64 * row.grid;
+            let len = row.grid.min(row.size - off);
+            if off + len > local_len {
+                break;
+            }
+            let mut hash = Sha256::new();
+            let mut remaining = len;
+            while remaining != 0 {
+                let take = remaining.min(buf.len() as u64) as usize;
+                file.read_exact(&mut buf[..take])
+                    .await
+                    .map_err(|e| e.to_string())?;
+                hash.update(&buf[..take]);
+                if let Some(fresh) = &mut fresh {
+                    fresh.update(&buf[..take]);
+                }
+                read_bytes += take as u64;
+                remaining -= take as u64;
+            }
+            let actual: [u8; 32] = hash.finalize().into();
+            if actual == *expected {
+                if let Some(last) = matches.last_mut().filter(|last| last.0 + last.2 == off) {
+                    last.2 += len;
+                } else {
+                    matches.push((off, off, len));
+                }
+            }
+        }
+        // The old row ends before an appended tail; include that tail in the
+        // next baseline without a second read of the source or a remote GET.
+        if !matches.is_empty() {
+            while read_bytes < local_len {
+                let take = (local_len - read_bytes).min(buf.len() as u64) as usize;
+                file.read_exact(&mut buf[..take])
+                    .await
+                    .map_err(|e| e.to_string())?;
+                if let Some(fresh) = &mut fresh {
+                    fresh.update(&buf[..take]);
+                }
+                read_bytes += take as u64;
+            }
+        } else {
+            fresh = None;
+        }
+        let after = file.metadata().await.map_err(|e| e.to_string())?;
+        if after.len() != local_len || before.modified().ok() != after.modified().ok() {
+            return Err("Local file changed while matching S3 baseline".into());
+        }
+        Ok((
+            MatchOutcome::Matches {
+                grid: row.grid,
+                matches,
+            },
+            fresh,
+        ))
+    }
+}
+
+fn delete(conn: &Connection, key: &BaselineKey) -> Result<(), String> {
+    conn.execute(
+        "DELETE FROM baselines WHERE identity=?1 AND bucket=?2 AND object_key=?3",
+        params![key.identity, key.bucket, key.key],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+fn evict(conn: &Connection, cap: usize) -> Result<(), String> {
+    conn.execute("DELETE FROM baselines WHERE rowid IN
+                  (SELECT rowid FROM baselines ORDER BY last_use DESC, rowid DESC LIMIT -1 OFFSET ?1)", [cap]).map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::s3_delta_plan::{plan_delta_parts, DeltaPart, DELTA_PART_SIZE};
+    use super::*;
+    use std::io::{Seek, SeekFrom, Write};
+
+    fn key(name: &str) -> BaselineKey {
+        BaselineKey::new(
+            EndpointIdentity::new("s3", "host", "account"),
+            "bucket",
+            name,
+        )
+    }
+
+    fn store() -> (tempfile::TempDir, BaselineStore) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = BaselineStore::new(dir.path().join("baseline.db"));
+        (dir, store)
+    }
+
+    // Independently construct a sparse zero baseline, without using the
+    // streaming hasher to generate the matcher's expected digest rows.
+    fn zero_row(size: u64) -> Baseline {
+        let grid = delta_grid_size(size).unwrap();
+        let full: [u8; 32] = Sha256::digest(vec![0; grid as usize]).into();
+        let tail = size % grid;
+        let mut digests = vec![full; (size / grid) as usize];
+        if tail != 0 {
+            digests.push(Sha256::digest(vec![0; tail as usize]).into());
+        }
+        Baseline {
+            etag: "\"ours\"".into(),
+            size,
+            grid,
+            digests,
+        }
+    }
+
+    fn sparse(path: &Path, size: u64) -> std::fs::File {
+        let file = std::fs::File::create(path).unwrap();
+        file.set_len(size).unwrap();
+        file
+    }
+
+    fn count(store: &BaselineStore) -> usize {
+        store
+            .open()
+            .unwrap()
+            .query_row("SELECT COUNT(*) FROM baselines", [], |r| r.get(0))
+            .unwrap()
+    }
+
+    #[test]
+    fn s3_baseline_hasher_ignores_upload_chunk_boundaries() {
+        // Small grid here isolates streaming arithmetic from protocol eligibility.
+        let bytes = b"abcdefghijklmno";
+        for chunk_size in [1, 3, 4, 7, 16] {
+            let mut hash = BaselineHasher {
+                size: 15,
+                grid: 4,
+                seen: 0,
+                cell_len: 0,
+                hash: Sha256::new(),
+                digests: vec![],
+            };
+            for chunk in bytes.chunks(chunk_size) {
+                hash.update(chunk);
+            }
+            let row = hash.finish("response-etag").unwrap();
+            let expected: Vec<[u8; 32]> = bytes
+                .chunks(4)
+                .map(|chunk| Sha256::digest(chunk).into())
+                .collect();
+            assert_eq!(row.digests, expected);
+        }
+    }
+
+    #[test]
+    fn s3_baseline_incomplete_or_growing_stream_cannot_certify_bytes() {
+        for consumed in [0, 14, 16] {
+            let mut hash = BaselineHasher {
+                size: 15,
+                grid: 4,
+                seen: 0,
+                cell_len: 0,
+                hash: Sha256::new(),
+                digests: vec![],
+            };
+            hash.update(&vec![0; consumed]);
+            assert!(hash.finish("ours").is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn s3_baseline_append_reuses_partial_prefix_and_uploads_exact_tail() {
+        let (dir, store) = store();
+        let old_size = 25 * DELTA_PART_SIZE + 1024 * 1024;
+        let tail = 9 * 1024 * 1024;
+        store.insert(&key("object"), zero_row(old_size)).unwrap();
+        let path = dir.path().join("append.bin");
+        let mut file = sparse(&path, old_size + tail);
+        file.seek(SeekFrom::Start(old_size)).unwrap();
+        file.write_all(&vec![0x7b; tail as usize]).unwrap();
+        let MatchOutcome::Matches { grid, matches } = store
+            .match_file(key("object"), "ours".into(), old_size, &path)
+            .await
+            .unwrap()
+        else {
+            panic!("refused append")
+        };
+        assert_eq!(matches, vec![(0, 0, old_size)]);
+        let plan = plan_delta_parts(old_size + tail, &matches, grid, S3_MAX_PARTS).unwrap();
+        let puts: Vec<_> = plan
+            .iter()
+            .filter_map(|p| match p {
+                DeltaPart::Put {
+                    local_start, len, ..
+                } => Some((*local_start, *len)),
+                _ => None,
+            })
+            .collect();
+        // Expected bytes come from the fixture edit, not from match counters.
+        assert_eq!(puts, vec![(old_size, tail)]);
+        assert_eq!(
+            std::fs::read(&path).unwrap()[old_size as usize..],
+            vec![0x7b; tail as usize]
+        );
+    }
+
+    #[tokio::test]
+    async fn s3_baseline_middle_edit_uploads_only_touched_grid_cell() {
+        let (dir, store) = store();
+        let size = 26 * DELTA_PART_SIZE;
+        store.insert(&key("object"), zero_row(size)).unwrap();
+        let path = dir.path().join("middle.bin");
+        let mut file = sparse(&path, size);
+        let changed_start = 12 * DELTA_PART_SIZE;
+        file.seek(SeekFrom::Start(changed_start + 123)).unwrap();
+        file.write_all(b"changed bytes").unwrap();
+        let MatchOutcome::Matches { grid, matches } = store
+            .match_file(key("object"), "\"ours\"".into(), size, &path)
+            .await
+            .unwrap()
+        else {
+            panic!("refused middle edit")
+        };
+        assert_eq!(
+            matches,
+            vec![
+                (0, 0, changed_start),
+                (
+                    changed_start + grid,
+                    changed_start + grid,
+                    size - changed_start - grid
+                )
+            ]
+        );
+        let plan = plan_delta_parts(size, &matches, grid, S3_MAX_PARTS).unwrap();
+        let puts: Vec<_> = plan
+            .iter()
+            .filter_map(|p| match p {
+                DeltaPart::Put {
+                    local_start, len, ..
+                } => Some((*local_start, *len)),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(puts, vec![(changed_start, DELTA_PART_SIZE)]);
+        // Independently replay the plan against baseline zero bytes and local
+        // payload, then compare actual output to the edited source.
+        let local = std::fs::read(path).unwrap();
+        let mut rebuilt = Vec::new();
+        for part in plan {
+            match part {
+                DeltaPart::Copy {
+                    src_start,
+                    src_end_inclusive,
+                    ..
+                } => rebuilt.resize(
+                    rebuilt.len() + (src_end_inclusive - src_start + 1) as usize,
+                    0,
+                ),
+                DeltaPart::Put {
+                    local_start, len, ..
+                } => rebuilt
+                    .extend_from_slice(&local[local_start as usize..(local_start + len) as usize]),
+            }
+        }
+        assert_eq!(rebuilt, local);
+    }
+
+    #[tokio::test]
+    async fn s3_baseline_stale_rows_are_deleted_at_matcher_door() {
+        let (dir, store) = store();
+        let size = 26 * DELTA_PART_SIZE;
+        let path = dir.path().join("local");
+        sparse(&path, size);
+        for (etag, remote_size, reason) in [
+            ("theirs", size, MatchRefusal::EtagMismatch),
+            ("ours", size + 1, MatchRefusal::SizeMismatch),
+        ] {
+            store.insert(&key("object"), zero_row(size)).unwrap();
+            assert_eq!(
+                store
+                    .match_file(key("object"), etag.into(), remote_size, &path)
+                    .await
+                    .unwrap(),
+                MatchOutcome::Refused(reason)
+            );
+            assert_eq!(count(&store), 0);
+            assert_eq!(
+                store
+                    .match_file(key("object"), "ours".into(), size, &path)
+                    .await
+                    .unwrap(),
+                MatchOutcome::Refused(MatchRefusal::NoBaseline)
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn s3_baseline_grid_overflow_is_refused_before_reading_sparse_file() {
+        let (dir, store) = store();
+        let size = 26 * DELTA_PART_SIZE;
+        store.insert(&key("object"), zero_row(size)).unwrap();
+        let path = dir.path().join("grew");
+        sparse(&path, DELTA_PART_SIZE * u64::from(S3_MAX_PARTS) + 1);
+        assert_eq!(
+            store
+                .match_file(key("object"), "ours".into(), size, &path)
+                .await
+                .unwrap(),
+            MatchOutcome::Refused(MatchRefusal::GridMismatch)
+        );
+        assert_eq!(count(&store), 0);
+    }
+
+    #[test]
+    fn s3_baseline_malformed_rows_are_discarded_not_repaired() {
+        let (_dir, store) = store();
+        let size = 26 * DELTA_PART_SIZE;
+        for mutation in [
+            "algorithm='md5'",
+            "version=2",
+            "digests=X'00'",
+            "grid=0",
+            "size=-1",
+        ] {
+            store.insert(&key("object"), zero_row(size)).unwrap();
+            store
+                .open()
+                .unwrap()
+                .execute(&format!("UPDATE baselines SET {mutation}"), [])
+                .unwrap();
+            assert!(store
+                .lookup(&key("object"), "ours", size, size)
+                .unwrap()
+                .is_err());
+            assert_eq!(count(&store), 0);
+        }
+        let conn = store.open().unwrap();
+        conn.execute_batch("PRAGMA ignore_check_constraints=ON")
+            .unwrap();
+        store.insert(&key("object"), zero_row(size)).unwrap();
+        conn.execute(
+            "UPDATE baselines SET digests=zeroblob(?1)",
+            [DIGEST_LIMIT * 32 + 1],
+        )
+        .unwrap();
+        assert!(store
+            .lookup(&key("object"), "ours", size, size)
+            .unwrap()
+            .is_err());
+        assert_eq!(count(&store), 0);
+    }
+
+    #[test]
+    fn s3_baseline_lru_uses_reads_and_enforces_production_cap() {
+        let (_dir, store) = store();
+        let size = 26 * DELTA_PART_SIZE;
+        store.insert(&key("hot"), zero_row(size)).unwrap();
+        store.insert(&key("cold"), zero_row(size)).unwrap();
+        store
+            .lookup(&key("hot"), "ours", size, size)
+            .unwrap()
+            .unwrap();
+        let conn = store.open().unwrap();
+        // Seed cheap SQL rows to exercise the actual 10,000 row cap without
+        // hashing 10,000 objects or doing 10,000 fsyncs.
+        conn.execute("WITH RECURSIVE n(x) AS (SELECT 1 UNION ALL SELECT x+1 FROM n WHERE x<?1)
+            INSERT INTO baselines SELECT 'other','bucket',CAST(x AS TEXT),'e',1,1,'sha256',1,X'',x+100 FROM n", [ROW_LIMIT - 2]).unwrap();
+        store.insert(&key("new"), zero_row(size)).unwrap();
+        assert_eq!(count(&store), ROW_LIMIT);
+        assert_eq!(
+            store
+                .lookup(&key("cold"), "ours", size, size)
+                .unwrap()
+                .err(),
+            Some(MatchRefusal::NoBaseline)
+        );
+        assert!(store
+            .lookup(&key("hot"), "ours", size, size)
+            .unwrap()
+            .is_ok());
+    }
+
+    #[test]
+    fn s3_baseline_key_keeps_bucket_object_case_and_account_separate() {
+        let (_dir, store) = store();
+        let size = 26 * DELTA_PART_SIZE;
+        store.insert(&key("Object"), zero_row(size)).unwrap();
+        let mut others = vec![key("object")];
+        others.push(BaselineKey::new(
+            EndpointIdentity::new("s3", "host", "other"),
+            "bucket",
+            "Object",
+        ));
+        others.push(BaselineKey::new(
+            EndpointIdentity::new("s3", "host", "account"),
+            "Bucket",
+            "Object",
+        ));
+        for other in others {
+            assert_eq!(
+                store.lookup(&other, "ours", size, size).unwrap().err(),
+                Some(MatchRefusal::NoBaseline)
+            );
+        }
+        assert_eq!(count(&store), 1);
+    }
+}
+
+/// Per-part signatures for the clone-pool DAG hook. No payload bytes are kept.
+/// Multipart completion establishes part order; only aligned boundaries can
+/// safely concatenate independently computed cell hashes.
+pub(crate) struct MultipartPartDigests {
+    len: u64,
+    digests: Vec<[u8; 32]>,
+}
+
+pub(crate) fn hash_multipart_part(total_size: u64, bytes: &[u8]) -> Option<MultipartPartDigests> {
+    let grid = delta_grid_size(total_size)?;
+    if bytes.len() as u64 > total_size {
+        return None;
+    }
+    let digests = bytes
+        .chunks(grid as usize)
+        .map(|cell| Sha256::digest(cell).into())
+        .collect();
+    Some(MultipartPartDigests {
+        len: bytes.len() as u64,
+        digests,
+    })
+}
+
+pub(crate) struct MultipartBaseline {
+    pub size: u64,
+    pub store: BaselineStore,
+    pub touched: std::time::Instant,
+    pub parts: std::collections::BTreeMap<u32, (String, MultipartPartDigests)>,
+}
+
+impl MultipartBaseline {
+    pub fn record(&mut self, number: u32, etag: String, part: MultipartPartDigests) -> bool {
+        let existing: usize = self
+            .parts
+            .iter()
+            .filter(|(n, _)| **n != number)
+            .map(|(_, (_, p))| p.digests.len())
+            .sum();
+        if number == 0
+            || number > S3_MAX_PARTS
+            || existing.saturating_add(part.digests.len()) > DIGEST_LIMIT
+        {
+            return false;
+        }
+        self.parts.insert(number, (etag, part));
+        self.touched = std::time::Instant::now();
+        true
+    }
+
+    pub fn finish(
+        mut self,
+        completed: &[(u32, String)],
+    ) -> Option<(BaselineStore, BaselineHasher)> {
+        let grid = delta_grid_size(self.size)?;
+        if completed.len() > DIGEST_LIMIT || completed.len() != self.parts.len() {
+            return None;
+        }
+        let mut seen = 0u64;
+        let mut digests = Vec::new();
+        for (index, (number, etag)) in completed.iter().enumerate() {
+            if *number != index as u32 + 1 || seen % grid != 0 {
+                return None;
+            }
+            let (sent_etag, part) = self.parts.remove(number)?;
+            if sent_etag != *etag || part.len == 0 {
+                return None;
+            }
+            seen = seen.checked_add(part.len)?;
+            digests.extend(part.digests);
+            if digests.len() > DIGEST_LIMIT {
+                return None;
+            }
+        }
+        if seen != self.size {
+            return None;
+        }
+        Some((
+            self.store,
+            BaselineHasher {
+                size: self.size,
+                grid,
+                seen,
+                cell_len: 0,
+                hash: Sha256::new(),
+                digests,
+            },
+        ))
+    }
+}
+
+pub(crate) struct PreparedDigests {
+    size: u64,
+    grid: u64,
+    digests: Vec<[u8; 32]>,
+}
+
+impl PreparedDigests {
+    /// Confirm complete cells from the very PUT buffer handed to the request.
+    /// Cells split by repaired part boundaries retain the metadata guard.
+    pub fn verify_put(&self, offset: u64, bytes: &[u8]) -> bool {
+        let end = offset.saturating_add(bytes.len() as u64);
+        for index in offset.div_ceil(self.grid)..end.div_ceil(self.grid) {
+            let start = index * self.grid;
+            let cell_end = (start + self.grid).min(self.size);
+            if cell_end > end || cell_end <= start {
+                continue;
+            }
+            let digest: [u8; 32] =
+                Sha256::digest(&bytes[(start - offset) as usize..(cell_end - offset) as usize])
+                    .into();
+            if self.digests.get(index as usize) != Some(&digest) {
+                return false;
+            }
+        }
+        true
+    }
+}

--- a/src-tauri/src/providers/s3_delta_baseline.rs
+++ b/src-tauri/src/providers/s3_delta_baseline.rs
@@ -1007,14 +1007,20 @@ mod tests {
             "part numbers must be consecutive from 1"
         );
 
-        // The ETag the server completed with is not the one we sent.
+        // An accounting invariant rather than a door. The completion list is
+        // built from the very ETags `record` stored, so in production the two
+        // cannot disagree, and this case feeds an input the caller cannot
+        // produce. What certifies the row is the object ETag the completion
+        // returns, which `save_baseline` requires before writing. Should that
+        // list ever come from the server's response instead, this check
+        // becomes a real door and earns its place.
         assert!(
             !finish_case(
                 size,
                 aligned,
                 &[(1, "\"other\""), (2, "\"p2\""), (3, "\"p3\"")]
             ),
-            "a part completed under a different ETag is not the part we hashed"
+            "a completion list that disagrees with the recorded parts is not certifiable"
         );
 
         // An empty part certifies nothing.

--- a/src-tauri/src/providers/s3_delta_tests.rs
+++ b/src-tauri/src/providers/s3_delta_tests.rs
@@ -14,6 +14,10 @@ struct Fault {
     complete_code: Option<&'static str>,
     stale: bool,
     archived: bool,
+    /// Append to the local file while the first plain PUT is in flight, so
+    /// the source changes after the plan was built and after the buffer the
+    /// client is sending was read.
+    mutate_local_on_first_put: bool,
 }
 #[derive(Default)]
 struct Seen {
@@ -102,6 +106,12 @@ async fn mock() -> Mock {
                 while let Some(chunk) = stream.next().await {
                     let chunk = chunk.unwrap(); out.write_all(&chunk).await.unwrap();
                     state.wire.fetch_add(chunk.len() as u64,Ordering::SeqCst);
+                }
+                let mutate = { let mut f = state.fault.lock().unwrap(); let m = f.mutate_local_on_first_put; f.mutate_local_on_first_put = false; m };
+                if mutate {
+                    let mut local = tokio::fs::OpenOptions::new().append(true).open(root.join("local.bin")).await.unwrap();
+                    local.write_all(&vec![9u8;1024*1024]).await.unwrap();
+                    local.flush().await.unwrap();
                 }
                 return axum::response::Response::builder().header("etag","\"put\"").body(axum::body::Body::empty()).unwrap();
             }
@@ -212,6 +222,12 @@ async fn s3_adapter_middle_append_and_successive_delta_have_independent_wire_rat
             for _ in 0..9 {
                 file.write_all(&vec![7u8; 1024 * 1024]).await.unwrap();
             }
+            // Land the append before the transfer plans over it. Without this
+            // the buffered handle stays open and the file is still growing,
+            // which the source guard correctly reports as source_changed: the
+            // middle edit above already drops its handle for the same reason.
+            file.flush().await.unwrap();
+            drop(file);
         }
         mock.seen.wire.store(0, Ordering::SeqCst);
         mock.seen.copy_headers.lock().unwrap().clear();
@@ -513,5 +529,103 @@ async fn s3_adapter_batch_dag_seeds_completion_etag_through_clone_pool_hooks() {
     assert_eq!(
         file_digest(&local).await,
         file_digest(&mock.dir.path().join("remote.bin")).await
+    );
+}
+
+/// The stored baseline, as the columns that must not move when an upload is
+/// abandoned. `seed` already planted a row, so the assertion is "unchanged",
+/// not "absent": a test asserting zero rows here would be measuring the wrong
+/// thing and would fail for a reason that has nothing to do with the guard.
+fn baseline_rows(mock: &Mock) -> Vec<(String, i64, i64, i64)> {
+    let conn =
+        rusqlite::Connection::open(mock.provider.baseline_test_path.as_ref().unwrap()).unwrap();
+    let mut stmt = conn
+        .prepare("SELECT etag, size, grid, length(digests) FROM baselines ORDER BY object_key")
+        .unwrap();
+    let rows = stmt
+        .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)))
+        .unwrap();
+    rows.map(|r| r.unwrap()).collect()
+}
+
+/// F3's door. Every layer that certifies "only bytes that travelled" is
+/// present in the source, but nothing exercised it: no test changed the file
+/// between the plan and the completion, so a mutation that removed the
+/// pre-Complete guard, or made `verify_put` always return true, stayed green
+/// by construction. This changes the source while the first plain PUT is in
+/// flight and pins what must happen: no completion, an abort, the object left
+/// byte for byte as it was, and a soft fallback rather than a hard error,
+/// because a plain upload is still the right next move.
+#[tokio::test]
+async fn s3_adapter_refuses_to_complete_when_the_source_changes_mid_upload() {
+    let mut mock = mock().await;
+    let local = seed(&mut mock).await;
+    // A middle edit, so the plan contains at least one plain PUT part.
+    let mut file = tokio::fs::OpenOptions::new()
+        .write(true)
+        .open(&local)
+        .await
+        .unwrap();
+    file.seek(std::io::SeekFrom::Start(10 * GRID + 123))
+        .await
+        .unwrap();
+    file.write_all(b"edit").await.unwrap();
+    drop(file);
+
+    let completes = mock.seen.completes.load(Ordering::SeqCst);
+    let aborts = mock.seen.aborts.load(Ordering::SeqCst);
+    let remote_before = file_digest(&mock.dir.path().join("remote.bin")).await;
+    let baseline_before = baseline_rows(&mock);
+    assert!(
+        !baseline_before.is_empty(),
+        "seed must have planted a baseline, or this test proves nothing"
+    );
+    mock.seen.fault.lock().unwrap().mutate_local_on_first_put = true;
+
+    let result = try_delta_transfer(&mut mock.provider, SyncDirection::Upload, &local, "object")
+        .await
+        .unwrap();
+
+    assert!(!result.used_delta, "{result:?}");
+    assert_eq!(
+        result.fallback_reason.as_deref(),
+        Some("source_changed"),
+        "{result:?}"
+    );
+    assert!(
+        result.hard_error.is_none(),
+        "a changed source must not suppress the plain upload path: {result:?}"
+    );
+    assert_eq!(
+        mock.seen.completes.load(Ordering::SeqCst),
+        completes,
+        "a delta built from bytes that no longer exist must never complete"
+    );
+    assert_eq!(
+        mock.seen.aborts.load(Ordering::SeqCst),
+        aborts + 1,
+        "the abandoned multipart upload must be aborted"
+    );
+    assert_eq!(
+        file_digest(&mock.dir.path().join("remote.bin")).await,
+        remote_before,
+        "the object must be left byte for byte as it was"
+    );
+    // The row is invalidated before the executor runs, so it is legitimately
+    // gone here and a fallback upload reseeds it. What must never happen is a
+    // row certifying the changed bytes, which completed nowhere.
+    let after = baseline_rows(&mock);
+    let mutated = std::fs::metadata(&local).unwrap().len() as i64;
+    assert!(
+        mutated > SIZE as i64,
+        "the injected fault must have grown the source, or this test proves nothing"
+    );
+    assert!(
+        !after.iter().any(|(_, size, _, _)| *size == mutated),
+        "no baseline may certify bytes that never completed: {after:?}"
+    );
+    assert!(
+        after.is_empty() || after == baseline_before,
+        "the row may be dropped, never rewritten: before {baseline_before:?}, after {after:?}"
     );
 }

--- a/src-tauri/src/providers/s3_delta_tests.rs
+++ b/src-tauri/src/providers/s3_delta_tests.rs
@@ -1,0 +1,517 @@
+//! Adapter/DAG doors exercised over a local HTTP server, never a live account.
+use super::*;
+use crate::delta_sync_rsync::{try_delta_transfer, SyncDirection};
+use tokio::io::AsyncReadExt;
+
+const SIZE: u64 = 201 * 1024 * 1024;
+const GRID: u64 = 8 * 1024 * 1024;
+
+#[derive(Clone, Default)]
+struct Fault {
+    head_status: Option<u16>,
+    copy_status: Option<u16>,
+    copy_code: Option<&'static str>,
+    complete_code: Option<&'static str>,
+    stale: bool,
+    archived: bool,
+}
+#[derive(Default)]
+struct Seen {
+    wire: AtomicU64,
+    creates: AtomicU64,
+    completes: AtomicU64,
+    aborts: AtomicU64,
+    heads: AtomicU64,
+    gets: AtomicU64,
+    copy_headers: std::sync::Mutex<Vec<String>>,
+    mtimes: std::sync::Mutex<Vec<String>>,
+    fault: std::sync::Mutex<Fault>,
+}
+struct Mock {
+    provider: S3Provider,
+    dir: tempfile::TempDir,
+    seen: Arc<Seen>,
+    task: tokio::task::JoinHandle<()>,
+}
+impl Drop for Mock {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+fn xml_error(status: u16, code: &str) -> axum::response::Response {
+    axum::response::Response::builder()
+        .status(status)
+        .header("retry-after", "0")
+        .body(axum::body::Body::from(format!(
+            "<Error><Code>{code}</Code><Message>mock failure</Message></Error>"
+        )))
+        .unwrap()
+}
+
+async fn mock() -> Mock {
+    let dir = tempfile::tempdir().unwrap();
+    let remote_dir = dir.path().to_path_buf();
+    let seen = Arc::new(Seen::default());
+    let state = seen.clone();
+    let app = axum::Router::new().fallback(axum::routing::any(move |req: axum::extract::Request| {
+        let root = remote_dir.clone(); let state = state.clone();
+        async move {
+            let method = req.method().clone();
+            let query = req.uri().query().unwrap_or("").to_string();
+            let headers = req.headers().clone();
+            let fault = state.fault.lock().unwrap().clone();
+            let param = |name:&str| query.split('&').find_map(|p|p.strip_prefix(&format!("{name}="))).unwrap_or("").to_owned();
+            let uid = param("uploadId");
+            let part = param("partNumber");
+            let remote = root.join("remote.bin");
+            let current_etag = format!("\"v{}\"",state.completes.load(Ordering::SeqCst));
+            if method == Method::HEAD {
+                state.heads.fetch_add(1,Ordering::SeqCst);
+                if let Some(status) = fault.head_status { return xml_error(status,"AccessDenied"); }
+                let Ok(meta) = tokio::fs::metadata(&remote).await else { return xml_error(404,"NoSuchKey"); };
+                let mut response = axum::response::Response::builder().header("content-length",meta.len()).header("etag",if fault.stale {"\"theirs\""} else {&current_etag});
+                if fault.archived { response = response.header("x-amz-storage-class","DEEP_ARCHIVE"); }
+                return response.body(axum::body::Body::empty()).unwrap();
+            }
+            if method == Method::GET { state.gets.fetch_add(1,Ordering::SeqCst); return xml_error(400,"ForbiddenBaselineRead"); }
+            if method == Method::POST && query.starts_with("uploads") {
+                let id = state.creates.fetch_add(1,Ordering::SeqCst)+1;
+                state.mtimes.lock().unwrap().push(headers.get("x-amz-meta-mtime").and_then(|h|h.to_str().ok()).unwrap_or("").to_owned());
+                return axum::response::Response::new(axum::body::Body::from(format!("<InitiateMultipartUploadResult><UploadId>u{id}</UploadId></InitiateMultipartUploadResult>")));
+            }
+            if method == Method::DELETE { state.aborts.fetch_add(1,Ordering::SeqCst); return axum::response::Response::new(axum::body::Body::empty()); }
+            let part_path = root.join(format!("{uid}-{part}.part"));
+            if method == Method::PUT && headers.contains_key("x-amz-copy-source") {
+                let guard = headers.get("x-amz-copy-source-if-match").and_then(|h|h.to_str().ok()).unwrap_or("").to_string();
+                state.copy_headers.lock().unwrap().push(guard.clone());
+                if let Some(status) = fault.copy_status { return xml_error(status,fault.copy_code.unwrap_or("InternalError")); }
+                if guard != current_etag { return xml_error(412,"PreconditionFailed"); }
+                let range = headers.get("x-amz-copy-source-range").unwrap().to_str().unwrap().trim_start_matches("bytes=");
+                let (start,end) = range.split_once('-').unwrap();
+                let start:u64 = start.parse().unwrap(); let end:u64 = end.parse().unwrap();
+                let mut source = tokio::fs::File::open(remote).await.unwrap();
+                source.seek(std::io::SeekFrom::Start(start)).await.unwrap();
+                let mut out = tokio::fs::File::create(part_path).await.unwrap();
+                tokio::io::copy(&mut source.take(end-start+1),&mut out).await.unwrap();
+                return axum::response::Response::new(axum::body::Body::from("<CopyPartResult><ETag>\"copy\"</ETag></CopyPartResult>"));
+            }
+            if method == Method::PUT {
+                let mut out = tokio::fs::File::create(part_path).await.unwrap();
+                let mut stream = req.into_body().into_data_stream();
+                while let Some(chunk) = stream.next().await {
+                    let chunk = chunk.unwrap(); out.write_all(&chunk).await.unwrap();
+                    state.wire.fetch_add(chunk.len() as u64,Ordering::SeqCst);
+                }
+                return axum::response::Response::builder().header("etag","\"put\"").body(axum::body::Body::empty()).unwrap();
+            }
+            if method == Method::POST {
+                if let Some(code) = fault.complete_code { return xml_error(200,code); }
+                let body = axum::body::to_bytes(req.into_body(),1024*1024).await.unwrap();
+                let text = String::from_utf8(body.to_vec()).unwrap();
+                let next = root.join("next.bin");
+                let mut out = tokio::fs::File::create(&next).await.unwrap();
+                for rest in text.split("<PartNumber>").skip(1) {
+                    let number = rest.split("</PartNumber>").next().unwrap();
+                    let mut source = tokio::fs::File::open(root.join(format!("{uid}-{number}.part"))).await.unwrap();
+                    tokio::io::copy(&mut source,&mut out).await.unwrap();
+                }
+                out.flush().await.unwrap(); drop(out);
+                tokio::fs::rename(next,remote).await.unwrap();
+                let version = state.completes.fetch_add(1,Ordering::SeqCst)+1;
+                return axum::response::Response::new(axum::body::Body::from(format!("<CompleteMultipartUploadResult><ETag>\"v{version}\"</ETag></CompleteMultipartUploadResult>")));
+            }
+            xml_error(400,"UnexpectedRequest")
+        }
+    }));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let mut provider =
+        super::tests::make_provider(Some(&format!("http://{}", listener.local_addr().unwrap())));
+    provider.connected = true;
+    provider.disable_checksum = true;
+    provider.baseline_test_path = Some(dir.path().join("baseline.db"));
+    let task = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    Mock {
+        provider,
+        dir,
+        seen,
+        task,
+    }
+}
+
+async fn file_digest(path: &std::path::Path) -> [u8; 32] {
+    use sha2::{Digest, Sha256};
+    let mut file = tokio::fs::File::open(path).await.unwrap();
+    let mut hash = Sha256::new();
+    let mut buf = vec![0u8; 64 * 1024];
+    loop {
+        let n = file.read(&mut buf).await.unwrap();
+        if n == 0 {
+            break;
+        }
+        hash.update(&buf[..n]);
+    }
+    hash.finalize().into()
+}
+
+async fn seed(mock: &mut Mock) -> PathBuf {
+    let local = mock.dir.path().join("local.bin");
+    std::fs::File::create(&local)
+        .unwrap()
+        .set_len(SIZE)
+        .unwrap();
+    mock.provider
+        .upload(local.to_str().unwrap(), "object", None)
+        .await
+        .unwrap();
+    mock.seen.wire.store(0, Ordering::SeqCst);
+    local
+}
+
+async fn seed_zero_signature(mock: &Mock) {
+    let mut hash = BaselineHasher::new(SIZE).unwrap();
+    let buf = vec![0u8; 1024 * 1024];
+    for _ in 0..201 {
+        hash.update(&buf);
+    }
+    mock.provider
+        .baseline_store()
+        .unwrap()
+        .record_completed(
+            mock.provider.delta_baseline_key("object"),
+            hash,
+            "\"v1\"".into(),
+        )
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn s3_adapter_middle_append_and_successive_delta_have_independent_wire_ratios() {
+    let mut mock = mock().await;
+    let local = seed(&mut mock).await;
+    let mut file = tokio::fs::OpenOptions::new()
+        .write(true)
+        .open(&local)
+        .await
+        .unwrap();
+    file.seek(std::io::SeekFrom::Start(10 * GRID + 123))
+        .await
+        .unwrap();
+    file.write_all(b"edit").await.unwrap();
+    drop(file);
+    for (index, expected_wire) in [GRID, 9 * 1024 * 1024, 0].into_iter().enumerate() {
+        if index == 1 {
+            let mut file = tokio::fs::OpenOptions::new()
+                .append(true)
+                .open(&local)
+                .await
+                .unwrap();
+            for _ in 0..9 {
+                file.write_all(&vec![7u8; 1024 * 1024]).await.unwrap();
+            }
+        }
+        mock.seen.wire.store(0, Ordering::SeqCst);
+        mock.seen.copy_headers.lock().unwrap().clear();
+        let result =
+            try_delta_transfer(&mut mock.provider, SyncDirection::Upload, &local, "object")
+                .await
+                .unwrap();
+        assert!(result.used_delta, "{result:?}");
+        let size = std::fs::metadata(&local).unwrap().len();
+        let received = mock.seen.wire.load(Ordering::SeqCst);
+        assert_eq!(received, expected_wire); // independent fixture oracle
+        let stats = result.stats.unwrap();
+        assert_eq!(stats.bytes_sent, received);
+        assert_eq!(stats.bytes_received, 0);
+        assert_eq!(stats.total_size, size);
+        assert!(stats.speedup.is_finite());
+        let copies = mock.seen.copy_headers.lock().unwrap().clone();
+        assert!(!copies.is_empty());
+        assert_eq!(stats.copy_blocks, copies.len() as u64);
+        assert!(copies.iter().all(|h| h == &format!("\"v{}\"", index + 1)));
+        assert_eq!(
+            file_digest(&local).await,
+            file_digest(&mock.dir.path().join("remote.bin")).await
+        );
+        assert!(mock
+            .seen
+            .mtimes
+            .lock()
+            .unwrap()
+            .iter()
+            .all(|s| !s.is_empty()));
+        println!(
+            "S3 adapter door {index}: received={received} local={size} wire_ratio={:.8}",
+            received as f64 / size as f64
+        );
+    }
+    assert_eq!(mock.seen.gets.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn s3_adapter_http_failures_fallback_except_auth_and_never_poison_412_capability() {
+    let mut mock = mock().await;
+    let local = seed(&mut mock).await;
+    let cases = [
+        (
+            Fault {
+                copy_status: Some(412),
+                copy_code: Some("PreconditionFailed"),
+                ..Fault::default()
+            },
+            false,
+            "etag_mismatch",
+        ),
+        (
+            Fault {
+                copy_status: Some(412),
+                copy_code: Some("PreconditionFailed"),
+                ..Fault::default()
+            },
+            false,
+            "etag_mismatch",
+        ),
+        (
+            Fault {
+                copy_status: Some(500),
+                copy_code: Some("InternalError"),
+                ..Fault::default()
+            },
+            false,
+            "s3_delta_failed",
+        ),
+        (
+            Fault {
+                copy_status: Some(403),
+                copy_code: Some("AccessDenied"),
+                ..Fault::default()
+            },
+            true,
+            "",
+        ),
+        (
+            Fault {
+                head_status: Some(403),
+                ..Fault::default()
+            },
+            true,
+            "",
+        ),
+        (
+            Fault {
+                complete_code: Some("InternalError"),
+                ..Fault::default()
+            },
+            false,
+            "s3_delta_failed",
+        ),
+        (
+            Fault {
+                complete_code: Some("AccessDenied"),
+                ..Fault::default()
+            },
+            true,
+            "",
+        ),
+        (
+            Fault {
+                copy_status: Some(400),
+                copy_code: Some("XNotImplemented"),
+                ..Fault::default()
+            },
+            false,
+            "backend_rejected_range_copy",
+        ),
+    ];
+    for (fault, hard, reason) in cases {
+        seed_zero_signature(&mock).await;
+        let head_failed = fault.head_status.is_some();
+        *mock.seen.fault.lock().unwrap() = fault;
+        let before = mock.seen.creates.load(Ordering::SeqCst);
+        let aborts = mock.seen.aborts.load(Ordering::SeqCst);
+        let result =
+            try_delta_transfer(&mut mock.provider, SyncDirection::Upload, &local, "object")
+                .await
+                .unwrap();
+        assert!(!result.used_delta);
+        assert_eq!(result.hard_error.is_some(), hard, "{result:?}");
+        if !hard {
+            assert_eq!(result.fallback_reason.as_deref(), Some(reason));
+        }
+        assert_eq!(
+            mock.seen.creates.load(Ordering::SeqCst),
+            before + u64::from(!head_failed)
+        );
+        assert_eq!(
+            mock.seen.aborts.load(Ordering::SeqCst),
+            aborts + u64::from(!head_failed)
+        );
+        assert_eq!(mock.seen.completes.load(Ordering::SeqCst), 1);
+    }
+    *mock.seen.fault.lock().unwrap() = Fault::default();
+    let heads = mock.seen.heads.load(Ordering::SeqCst);
+    let creates = mock.seen.creates.load(Ordering::SeqCst);
+    let result = try_delta_transfer(
+        &mut mock.provider,
+        SyncDirection::Upload,
+        &local,
+        "other-file",
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        result.fallback_reason.as_deref(),
+        Some("backend_rejected_range_copy")
+    );
+    assert_eq!(mock.seen.heads.load(Ordering::SeqCst), heads);
+    assert_eq!(mock.seen.creates.load(Ordering::SeqCst), creates);
+}
+
+#[tokio::test]
+async fn s3_adapter_refusal_doors_never_create_multipart() {
+    let mut mock = mock().await;
+    let local = seed(&mut mock).await;
+    for (fault, reason) in [
+        (
+            Fault {
+                stale: true,
+                ..Fault::default()
+            },
+            "etag_mismatch",
+        ),
+        (Fault::default(), "no_baseline"),
+        (
+            Fault {
+                archived: true,
+                ..Fault::default()
+            },
+            "baseline_archived",
+        ),
+    ] {
+        *mock.seen.fault.lock().unwrap() = fault;
+        let result =
+            try_delta_transfer(&mut mock.provider, SyncDirection::Upload, &local, "object")
+                .await
+                .unwrap();
+        assert_eq!(result.fallback_reason.as_deref(), Some(reason));
+        assert!(!result.used_delta);
+        assert!(result.hard_error.is_none());
+        assert_eq!(mock.seen.creates.load(Ordering::SeqCst), 1);
+    }
+    let heads = mock.seen.heads.load(Ordering::SeqCst);
+    assert!(try_delta_transfer(
+        &mut mock.provider,
+        SyncDirection::Download,
+        &local,
+        "object"
+    )
+    .await
+    .is_none());
+    std::fs::File::create(&local).unwrap().set_len(1).unwrap();
+    let result = try_delta_transfer(&mut mock.provider, SyncDirection::Upload, &local, "object")
+        .await
+        .unwrap();
+    assert_eq!(result.fallback_reason.as_deref(), Some("file_too_small"));
+    assert_eq!(mock.seen.heads.load(Ordering::SeqCst), heads);
+}
+
+#[tokio::test]
+async fn s3_adapter_batch_dag_seeds_completion_etag_through_clone_pool_hooks() {
+    use crate::provider_transfer_executor::{ProviderExecutorSessionModel, ProviderUploadExecutor};
+    use crate::transfer_dag::{Capability, TransferCapabilities};
+    use crate::transfer_domain::{TransferBatchConfig, TransferDirection, TransferEntry};
+    let mock = mock().await;
+    let local = mock.dir.path().join("dag.bin");
+    std::fs::File::create(&local)
+        .unwrap()
+        .set_len(SIZE)
+        .unwrap();
+    let shared = Arc::new(tokio::sync::Mutex::new(Some(
+        Box::new(mock.provider.clone()) as Box<dyn StorageProvider>,
+    )));
+    let sink: Arc<dyn crate::transfer_event_sink::TransferEventSink> =
+        Arc::new(crate::transfer_event_sink::NoopTransferSink);
+    let caps = TransferCapabilities {
+        multipart_upload: Capability::Supported,
+        preferred_chunk_size: Some(16 * 1024 * 1024),
+        multipart_threshold: 200 * 1024 * 1024,
+        max_chunk_slots: Some(4),
+        ..TransferCapabilities::default()
+    };
+    let settings = crate::transfer_settings::ResolvedTransferSettings {
+        requested_max_concurrent: 1,
+        max_concurrent: 1,
+        retry_count: 0,
+        timeout_seconds: 300,
+        download_segments: 1,
+        sftp_download_preset: None,
+    };
+    let executor = Arc::new(ProviderUploadExecutor::new(
+        sink.clone(),
+        shared,
+        settings,
+        None,
+        tokio_util::sync::CancellationToken::new(),
+        ProviderExecutorSessionModel::HttpClonePool {
+            provider_type: ProviderType::S3,
+            max_leases: 4,
+        },
+        caps,
+    ));
+    let batch = crate::transfer_orchestrator::TransferBatch {
+        id: "s3-baseline-dag".into(),
+        display_name: "S3 baseline DAG door".into(),
+        direction: TransferDirection::Upload,
+        config: TransferBatchConfig {
+            timeout_ms: 300_000,
+            ..TransferBatchConfig::default()
+        },
+        entries: vec![TransferEntry {
+            id: "object".into(),
+            display_name: "object".into(),
+            remote_path: "object".into(),
+            local_path: local.to_string_lossy().into_owned(),
+            size: SIZE,
+            modified: None,
+        }],
+    };
+    let result = crate::transfer_dag_batch::execute_batch_dag(
+        sink,
+        batch,
+        executor,
+        Arc::new(AtomicBool::new(false)),
+        None,
+    )
+    .await;
+    assert_eq!(result.completed, 1, "{result:?}");
+    assert_eq!(result.failed, 0);
+    assert_eq!(mock.seen.creates.load(Ordering::SeqCst), 1);
+    assert_eq!(mock.seen.completes.load(Ordering::SeqCst), 1);
+    assert_eq!(mock.seen.wire.load(Ordering::SeqCst), SIZE);
+    let outcome = mock
+        .provider
+        .baseline_store()
+        .unwrap()
+        .match_file(
+            mock.provider.delta_baseline_key("object"),
+            "\"v1\"".into(),
+            SIZE,
+            &local,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        outcome,
+        super::super::s3_delta_baseline::MatchOutcome::Matches {
+            grid: GRID,
+            matches: vec![(0, 0, SIZE)]
+        }
+    );
+    assert_eq!(
+        file_digest(&local).await,
+        file_digest(&mock.dir.path().join("remote.bin")).await
+    );
+}

--- a/src-tauri/src/providers/s3_delta_tests.rs
+++ b/src-tauri/src/providers/s3_delta_tests.rs
@@ -18,6 +18,9 @@ struct Fault {
     /// the source changes after the plan was built and after the buffer the
     /// client is sending was read.
     mutate_local_on_first_put: bool,
+    /// Park the first plain PUT and announce it, so a test can drop the whole
+    /// transfer future while a part is genuinely in flight.
+    hold_first_put: bool,
 }
 #[derive(Default)]
 struct Seen {
@@ -30,6 +33,8 @@ struct Seen {
     copy_headers: std::sync::Mutex<Vec<String>>,
     mtimes: std::sync::Mutex<Vec<String>>,
     fault: std::sync::Mutex<Fault>,
+    /// Signalled once the first parked PUT has reached the server.
+    put_started: tokio::sync::Notify,
 }
 struct Mock {
     provider: S3Provider,
@@ -106,6 +111,13 @@ async fn mock() -> Mock {
                 while let Some(chunk) = stream.next().await {
                     let chunk = chunk.unwrap(); out.write_all(&chunk).await.unwrap();
                     state.wire.fetch_add(chunk.len() as u64,Ordering::SeqCst);
+                }
+                let hold = { let mut f = state.fault.lock().unwrap(); let h = f.hold_first_put; f.hold_first_put = false; h };
+                if hold {
+                    // notify_one leaves a permit if nobody is waiting yet, so the
+                    // test cannot lose the race between registering and the PUT.
+                    state.put_started.notify_one();
+                    tokio::time::sleep(std::time::Duration::from_secs(30)).await;
                 }
                 let mutate = { let mut f = state.fault.lock().unwrap(); let m = f.mutate_local_on_first_put; f.mutate_local_on_first_put = false; m };
                 if mutate {
@@ -627,5 +639,92 @@ async fn s3_adapter_refuses_to_complete_when_the_source_changes_mid_upload() {
     assert!(
         after.is_empty() || after == baseline_before,
         "the row may be dropped, never rewritten: before {baseline_before:?}, after {after:?}"
+    );
+}
+
+/// The cancellation door. Cancelling from the GUI drops the transfer future
+/// (`provider_commands.rs` races it against the cancel token), and dropping a
+/// future runs no error branch at all, so every explicit abort in the executor
+/// was unreachable from the one path users actually take. The parts already
+/// uploaded then sat under the upload id until the bucket lifecycle rule
+/// removed them, if the bucket had one. This drops the future while a part is
+/// genuinely in flight and pins what must follow: the multipart is aborted, no
+/// completion happens, the object is untouched, and no baseline row appears.
+///
+/// The abort is scheduled by the guard's `Drop`, which is sync and cannot
+/// await, so it is polled for rather than read once.
+#[tokio::test]
+async fn s3_adapter_dropping_a_delta_upload_aborts_the_multipart() {
+    let mut mock = mock().await;
+    let local = seed(&mut mock).await;
+    // A middle edit, so the plan carries a plain PUT the mock can park on.
+    let mut file = tokio::fs::OpenOptions::new()
+        .write(true)
+        .open(&local)
+        .await
+        .unwrap();
+    file.seek(std::io::SeekFrom::Start(10 * GRID + 123))
+        .await
+        .unwrap();
+    file.write_all(b"edit").await.unwrap();
+    file.flush().await.unwrap();
+    drop(file);
+
+    let seen = Arc::clone(&mock.seen);
+    let completes = seen.completes.load(Ordering::SeqCst);
+    let aborts = seen.aborts.load(Ordering::SeqCst);
+    let creates_before = seen.creates.load(Ordering::SeqCst);
+    let remote_before = file_digest(&mock.dir.path().join("remote.bin")).await;
+    let baseline_before = baseline_rows(&mock);
+    seen.fault.lock().unwrap().hold_first_put = true;
+
+    {
+        let transfer =
+            try_delta_transfer(&mut mock.provider, SyncDirection::Upload, &local, "object");
+        tokio::pin!(transfer);
+        tokio::select! {
+            biased;
+            _ = seen.put_started.notified() => {}
+            _ = &mut transfer => panic!("the upload must still be in flight when it is dropped"),
+        }
+        // Leaving this scope drops `transfer`, which is exactly what the GUI
+        // cancel arm does. No error branch of the executor runs.
+    }
+
+    let mut aborted = false;
+    for _ in 0..200 {
+        if seen.aborts.load(Ordering::SeqCst) == aborts + 1 {
+            aborted = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+    assert!(
+        aborted,
+        "no AbortMultipartUpload arrived within 5 s (200 polls of 25 ms) after the \
+         transfer future was dropped: the parts stay until the bucket lifecycle rule"
+    );
+    assert!(
+        seen.creates.load(Ordering::SeqCst) > creates_before,
+        "the fixture must have opened a multipart upload, or this proves nothing"
+    );
+    assert_eq!(
+        seen.completes.load(Ordering::SeqCst),
+        completes,
+        "a cancelled upload must never complete"
+    );
+    assert_eq!(
+        file_digest(&mock.dir.path().join("remote.bin")).await,
+        remote_before,
+        "the object must be left exactly as it was"
+    );
+    // The row is invalidated before the executor runs, so a cancelled attempt
+    // legitimately leaves none and the next upload reseeds it. What must never
+    // appear is a row rewritten to certify a completion that never happened.
+    let after = baseline_rows(&mock);
+    assert!(
+        after.is_empty() || after == baseline_before,
+        "a cancelled upload may leave the row invalidated, never rewritten: \
+         before {baseline_before:?}, after {after:?}"
     );
 }

--- a/src-tauri/src/rsync_over_ssh.rs
+++ b/src-tauri/src/rsync_over_ssh.rs
@@ -215,6 +215,10 @@ pub struct RsyncStats {
     pub bytes_sent: u64,
     pub bytes_received: u64,
     pub total_size: u64,
+    /// `total_size` over `bytes_sent`, with a one byte floor on the
+    /// denominator. An all-copy delta sends no payload, so the floor keeps
+    /// the ratio finite instead of handing infinity to JSON and the UI.
+    /// This is a wire ratio, not a wall-clock speedup.
     pub speedup: f64,
     pub duration_ms: u64,
     /// Baseline blocks directly reused by the native delta stream.


### PR DESCRIPTION
Steps T4 and T5 of the S3 delta upload lane, after the pure planner (#723) and the multipart executor (#755).

## What the lane gains

A delta upload needs to know what the remote object already contains. Reading the baseline back would cost egress on every attempt, so this keeps a local memory of the bytes this client uploaded: a SQLite store of per-cell digests, capped at 10,000 rows with LRU eviction and a per-row digest cap, keyed by the corrected endpoint and account identity plus bucket and object. Ordinary streaming uploads, the single PUT path and the DAG trait multipart path all seed it, and only after the upload response ETag certifies what landed. A failed, aborted or ETag-less upload leaves no row.

The matcher then aligns local cells against that memory without a single remote read, and the adapter wires S3 into the existing delta entry point. S3 failures are classified from the HTTP status and the XML error code, never from prose, and never through the native rsync string classifier: an authentication or permission refusal stays hard, everything else falls back to a plain upload, so a `503 SlowDown` cannot kill a transfer that has the ordinary path beside it. A backend that refuses ranged copy is remembered for 300 seconds, capped at 128 endpoints, and only when a Copy operation is the one that refused.

## What I added on top of the implementation commit

I inherited this branch with the code written but never compiled, so the second commit is what running it for the first time produced, plus the doors a mutation battery cannot reach on its own.

`MultipartBaseline::finish` writes a row only when every part begins on a grid boundary, because the DAG uploads parts on independent clones and hashes each one on its own, so the digests only concatenate where the cuts line up. That holds for the defaults, which is why it held wherever anyone looked, and it did not hold when the CLI's upload buffer override set a part size the grid cannot divide: no DAG upload seeded the store at all, the next delta answered `no_baseline`, and nothing said why. Failing safe and failing silently at once is the shape that never gets found, so the part size handed to the DAG is now snapped up to a whole number of grid cells, at a cost of at most one cell. Only the hint is snapped: the streaming path carries a partial cell across reads and is indifferent to part boundaries, which `s3_baseline_hasher_ignores_upload_chunk_boundaries` already pins, so the override is still honoured verbatim where it always worked. Above roughly 80 GB the grid grows past `DELTA_PART_SIZE` and the DAG builder grows the chunk itself to keep the part count legal, so alignment there is a declared limit rather than a promise. The domain table pins the precondition regardless, along with part 0, a number past the last legal one, a completion over the digest cap, non-consecutive numbers, an ETag the server completed under that is not the one we sent, incomplete coverage and an empty part, with the aligned control asserted first so a `finish` that always returned `None` cannot pass.

Nothing changed the source between the plan and the completion, so removing the pre-Complete guard stayed green by construction. The mock now grows the local file while the first plain PUT is in flight, and the door pins no completion, an abort, the object left byte for byte as it was, a soft fallback rather than a hard error, and no baseline row certifying bytes that completed nowhere.

The negative ranged-copy memory only proved that a Copy refusal is remembered, never that anything else is not, so moving the operation match to any other operation left the whole battery green. The converse now pins that a HeadObject, CreateMultipartUpload, UploadPart or CompleteMultipartUpload answering 501 or NotImplemented teaches nothing about ranged copy.

Two smaller things. The adapter reported a planner refusal as `no_match_found`, the same reason it uses when the matcher found nothing, which would have made the wire-ratio report count the two together; it is now `plan_refused`. And `RsyncStats::speedup` is documented as a wire ratio with a one byte floor on the denominator, not a wall-clock speedup.

Running the battery for the first time also surfaced two defects in the branch itself: the in-loop append of the wire-ratio door was never flushed or dropped, so the file was still growing when the delta planned over it and the source guard correctly answered `source_changed`, and clippy refused the baseline file for items after a test module.

## Mutation battery

Four mutations, four caught, none unmeasured. Each was applied to production code only, scoped to the function under test, and reverted afterwards.

| # | Mutation | Test that went red |
|---|---|---|
| 1 | Neutralize the pre-Complete source guard in the typed executor | `s3_adapter_refuses_to_complete_when_the_source_changes_mid_upload` |
| 2 | Match `DeltaOperation::Head` instead of `Copy` in both arms of `remember_range_rejection` | `s3_adapter_negative_memory_only_remembers_a_copy_refusal` |
| 3 | Drop the grid-boundary check from `MultipartBaseline::finish` | `s3_baseline_multipart_finish_rejects_every_completion_it_cannot_certify` |
| 4 | Drop the part-number domain from `MultipartBaseline::record` | `s3_baseline_multipart_record_rejects_part_numbers_outside_the_s3_domain` |

Mutation 2 is worth a note on method: `operation: DeltaOperation::Copy` appears five times in that file, not twice, because the tests contain it too. Applying it file-wide would have mutated test code and returned a meaningless green. Scoping it to the function body is what makes the result mean anything.

## Declared gaps

The 128-entry cap of the negative memory has no test, deliberately. The map is a process-wide static shared by every test in the binary and tests run in parallel, so proving the cap means inserting 129 entries and evicting other tests' rows while they run. That trades a missing test for a flaky suite. It becomes testable if the cache is injectable rather than static, or if the test is serialized.

The write-side digest cap is unreachable from either hasher by construction, so it is two guards with no door; testing it needs a baseline built by hand at the boundary and one past it. The adapter's `file_too_large` refusal is not reachable through the door either: it would need a 25 TiB sparse file, past what ext4 addresses, so it is testable only if that triage becomes a pure function of the size.

The baseline row is invalidated before the executor runs, so a planner refusal or a transient error leaves no row and the fallback upload reseeds it. That is fail safe and the door asserts the outcome that matters (no row may certify bytes that never completed) rather than assuming the row survives.

No live S3 account was exercised for this branch. The doors run against a local HTTP mock, and the live lane stays for the step that turns the executor on by default.

## Verification

`s3_baseline_` 14 passed, `s3_adapter_` 8 passed, `s3_delta_plan` 41 passed, plus #764's own `recursive_delete_preserves` and `batch_delete_fallback` tests re-run after the rebase since both commits touch `s3.rs`. `cargo clippy --all-targets -- -D warnings` and `cargo fmt --all --check` clean, on the rebased tree.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added S3 delta uploads that reuse unchanged portions of previously uploaded files to reduce data transfer.
  * Added local, account- and endpoint-aware baselines for faster repeat and appended-file uploads.
  * Added progress reporting and transfer statistics for S3 delta uploads.

* **Bug Fixes**
  * Improved fallback handling when delta uploads are unsupported or unavailable.
  * Added safeguards to detect files changing during transfer and prevent incomplete uploads.
  * Ensured interrupted or cancelled multipart uploads are properly aborted.
  * Improved validation of upload data and completion results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
## Cancellation safety (T5.1)

Cancelling a transfer from the GUI drops the transfer future: `provider_commands.rs` races it against the cancel token and the cancel arm wins by dropping it. Dropping a future runs no error branch at all, so every explicit `AbortMultipartUpload` in the executor was unreachable from the one path users actually take, and the parts already uploaded stayed under the upload id until the bucket lifecycle rule removed them, if the bucket had one. The object stayed atomic and intact; what leaked was remote storage, which S3 bills for.

`MultipartAbortGuard` owns the upload id from the moment the server returns it until a completion is proven. It has three entries, and the split is deliberate. Known failures call `abort_now` and await it, so the abort has happened before the caller sees the error and a test can assert the count. A proven completion calls `disarm`. `Drop` covers what no branch can reach, cancellation and panic, and since `Drop` is sync it schedules the abort on the current runtime, the shape `ProviderGuard` already uses for disconnect. The alternative, a single always-spawned owner, was measured against the tree and rejected: it would have made `s3_baseline_failed_aborted_and_missing_etag_uploads_leave_no_row` and `delta_412_from_the_guard_aborts_and_never_completes` racy, and it would have extended the guard's own warn-and-leak fallback, which fires when no runtime is left, to paths that do not need it.

The guard is armed on both multipart paths, the delta executor and `upload_multipart_streaming`. On the classic path it covers cancellation and nothing else: that function's explicit branches already aborted correctly, so the pre-existing exposure there was the drop case alone, not a forgotten branch.

Door test: the mock parks the first plain PUT, the test drops the transfer future while that part is genuinely in flight, then pins an abort, no completion, the object byte for byte as it was, and no baseline row. The abort is scheduled by `Drop` rather than awaited, so the test polls for it within an explicit five second bound and says so when it fails.

### Deferred, with the reason

Dropping the future *during* `CompleteMultipartUpload` is left as it is, and the outcome is bounded rather than unknown. The spawned DELETE races the in-flight completion and both orders are consistent: if the DELETE lands first the completion fails with NoSuchUpload, the parts are removed and the baseline object is untouched; if it lands second the completion won, the object is replaced and the DELETE gets a 404. Never a torn state, never an orphan part, never lost data. What is lost in the second order is the baseline row, which was already invalidated so the next delta simply uploads in full, and the accuracy of the GUI message, which says cancelled while the object is committed. That is accounting and cosmetics, not safety, and it does not justify widening this change. It is recorded as a T6 item with its own door test (drop during the completion: the object is committed and the row is written), alongside draining pending aborts on `disconnect`, which is the production justification that would also make the door test above stop polling.

## Mutation battery

Twelve mutations applied to production code on this exact tree, each scoped to the function under test, each reverted and the revert verified against a byte-for-byte backup rather than against HEAD, which would have been the wrong instrument while this work was uncommitted.

| # | Mutation | Test that went red |
|---|---|---|
| M1 | Route the S3 arm through the native rsync classifier | `s3_adapter_http_failures_fallback_except_auth_and_never_poison_412_capability` |
| M2 | Demote auth: drop `401 \| 403` and the credential code list together | `s3_adapter_classifier_uses_status_and_xml_code_not_prose` |
| M3 | Lose wire accounting on PUT parts | `s3_adapter_middle_append_and_successive_delta_have_independent_wire_ratios` |
| M3b | Count ranged copies as wire bytes | same |
| M4 | Do not certify the row with the completion ETag | same (`no_baseline` at door 1) |
| M4b | Seed the row from the pre-delta HEAD ETag | same (`etag_mismatch`) |
| M4c | Completion returns no ETag | `s3_baseline_upload_doors_certify_only_successful_response_etags` |
| M5 | Drop `x-amz-copy-source-if-match` from ranged copies | wire-ratio door (`etag_mismatch`) |
| M6 | Cache 412 and 429 in the negative capability memory | `s3_adapter_negative_memory_does_not_cache_preconditions_or_transient_errors` |
| MG | Neutralise the abort guard's `Drop` | `s3_adapter_dropping_a_delta_upload_aborts_the_multipart` |
| MH | Remove the snap that aligns the DAG part size hint | `dag_part_size_hint_is_always_a_whole_number_of_grid_cells` |
| MS | Neutralise the pre-completion source guard | `s3_adapter_refuses_to_complete_when_the_source_changes_mid_upload` |

Measured 12, caught 12, not measured 1. The one not measured is "pass a full upload off as a delta": the planner absorbs it, since empty matches return `None` and the attempt is refused before any request, so there is no mutation of the executor that reaches it. It is reported as not measured with that reason rather than forced into a shape that would prove nothing.

M2 carries a method note worth keeping: the status edit alone leaves the door green, because the mock's 403 also carries an `AccessDenied` code, so both halves belong in one edit. An earlier attempt at M6's sibling was stopped by an assertion when the string to mutate turned out to appear five times in the file rather than twice, the extra three being in tests: mutating test code would have returned a meaningless green.

