### PR TITLE
ci(build): skip the four-platform bundle for changes that touch only documentation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,23 @@ on:
     branches: [main]
     tags:
       - 'v*'
+    # A change that touches only documentation cannot change the bundles:
+    # skip the four-platform build (about 80 minutes) for it. The filter
+    # applies only when EVERY changed file matches, so a PR that edits code
+    # and docs together still builds. The main ruleset declares no required
+    # status contexts, so a skipped workflow blocks nothing.
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'LICENSE*'
+      - '.github/ISSUE_TEMPLATE/**'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'LICENSE*'
+      - '.github/ISSUE_TEMPLATE/**'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Third step of the CI wall-clock work. A pull request that edits only docs, the changelog or a README ran the full Tauri build on four platforms (about 80 minutes on the last runs) for bundles that cannot differ.

`build.yml`'s `push` and `pull_request` triggers now carry `paths-ignore` for `docs/**`, every `*.md`, the licence files and the issue templates. GitHub applies the filter only when every changed file matches, so a change that edits code and docs together still builds; tags and `workflow_dispatch` are untouched. `checks.yml` (format, unit, i18n, audit) still runs on every PR, and the `main` ruleset declares no required status contexts, so a skipped build blocks nothing.

Verified: YAML parsed. This PR itself changes a workflow file, so it builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Documentation-only changes no longer trigger automated build workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->