### PR TITLE
docs(ci): say the apt cleanup removes three repos, not one

### DIFF
--- a/.github/workflows/aerorsync-protocol.yml
+++ b/.github/workflows/aerorsync-protocol.yml
@@ -75,9 +75,9 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install Linux system deps
         run: |
-          # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
-          # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
-          # Packages.gz), and nothing here installs from any of them.
+          # Runner-image extras: the preinstalled microsoft*, azure-cli* and google-chrome*
+          # apt repos fail often enough to redden a run (403 on InRelease, Hash Sum
+          # mismatch on Packages.gz), and nothing here installs from any of them.
           sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
@@ -137,9 +137,9 @@ jobs:
           df -h /
       - name: Install Linux system deps
         run: |
-          # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
-          # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
-          # Packages.gz), and nothing here installs from any of them.
+          # Runner-image extras: the preinstalled microsoft*, azure-cli* and google-chrome*
+          # apt repos fail often enough to redden a run (403 on InRelease, Hash Sum
+          # mismatch on Packages.gz), and nothing here installs from any of them.
           sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
@@ -199,9 +199,9 @@ jobs:
           echo "After:"; df -h /
       - name: Install Linux system deps
         run: |
-          # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
-          # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
-          # Packages.gz), and nothing here installs from any of them.
+          # Runner-image extras: the preinstalled microsoft*, azure-cli* and google-chrome*
+          # apt repos fail often enough to redden a run (403 on InRelease, Hash Sum
+          # mismatch on Packages.gz), and nothing here installs from any of them.
           sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \

--- a/.github/workflows/aerorsync-protocol.yml
+++ b/.github/workflows/aerorsync-protocol.yml
@@ -75,8 +75,9 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install Linux system deps
         run: |
-          # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
-          # enough to redden a run, and nothing here installs from them.
+          # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
+          # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
+          # Packages.gz), and nothing here installs from any of them.
           sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
@@ -136,8 +137,9 @@ jobs:
           df -h /
       - name: Install Linux system deps
         run: |
-          # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
-          # enough to redden a run, and nothing here installs from them.
+          # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
+          # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
+          # Packages.gz), and nothing here installs from any of them.
           sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
@@ -197,8 +199,9 @@ jobs:
           echo "After:"; df -h /
       - name: Install Linux system deps
         run: |
-          # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
-          # enough to redden a run, and nothing here installs from them.
+          # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
+          # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
+          # Packages.gz), and nothing here installs from any of them.
           sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \

--- a/.github/workflows/aerorsync-standalone.yml
+++ b/.github/workflows/aerorsync-standalone.yml
@@ -71,8 +71,9 @@ jobs:
       - name: Install system dependencies
         if: runner.os == 'Linux'
         run: |
-          # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
-          # enough to redden a run, and nothing here installs from them.
+          # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
+          # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
+          # Packages.gz), and nothing here installs from any of them.
           sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           # `libacl1-dev` is not optional here: `acl-sys` declares

--- a/.github/workflows/aerorsync-standalone.yml
+++ b/.github/workflows/aerorsync-standalone.yml
@@ -71,9 +71,9 @@ jobs:
       - name: Install system dependencies
         if: runner.os == 'Linux'
         run: |
-          # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
-          # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
-          # Packages.gz), and nothing here installs from any of them.
+          # Runner-image extras: the preinstalled microsoft*, azure-cli* and google-chrome*
+          # apt repos fail often enough to redden a run (403 on InRelease, Hash Sum
+          # mismatch on Packages.gz), and nothing here installs from any of them.
           sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           # `libacl1-dev` is not optional here: `acl-sys` declares

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,9 +77,9 @@ jobs:
 
       - name: Install Linux dependencies
         run: |
-          # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
-          # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
-          # Packages.gz), and nothing here installs from any of them.
+          # Runner-image extras: the preinstalled microsoft*, azure-cli* and google-chrome*
+          # apt repos fail often enough to redden a run (403 on InRelease, Hash Sum
+          # mismatch on Packages.gz), and nothing here installs from any of them.
           sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           # `dbus` is here for `cargo test` / portal_chooser (#510), not for
@@ -252,9 +252,9 @@ jobs:
       - name: Install Linux dependencies
         if: matrix.target == 'linux'
         run: |
-          # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
-          # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
-          # Packages.gz), and nothing here installs from any of them.
+          # Runner-image extras: the preinstalled microsoft*, azure-cli* and google-chrome*
+          # apt repos fail often enough to redden a run (403 on InRelease, Hash Sum
+          # mismatch on Packages.gz), and nothing here installs from any of them.
           sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           # `dbus` lives on `linux-validate` with `cargo test` / portal_chooser
@@ -847,9 +847,9 @@ jobs:
         env:
           SNAP_FILE: ${{ steps.snap-check.outputs.snap }}
         run: |
-          # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
-          # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
-          # Packages.gz), and nothing here installs from any of them.
+          # Runner-image extras: the preinstalled microsoft*, azure-cli* and google-chrome*
+          # apt repos fail often enough to redden a run (403 on InRelease, Hash Sum
+          # mismatch on Packages.gz), and nothing here installs from any of them.
           sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends squashfs-tools binutils file
@@ -909,9 +909,9 @@ jobs:
           SNAP_GUI_SCREENSHOT: ${{ runner.temp }}/snap-gui-screenshot.png
         run: |
           set -euo pipefail
-          # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
-          # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
-          # Packages.gz), and nothing here installs from any of them.
+          # Runner-image extras: the preinstalled microsoft*, azure-cli* and google-chrome*
+          # apt repos fail often enough to redden a run (403 on InRelease, Hash Sum
+          # mismatch on Packages.gz), and nothing here installs from any of them.
           sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends xvfb x11-apps imagemagick

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,8 +77,9 @@ jobs:
 
       - name: Install Linux dependencies
         run: |
-          # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
-          # enough to redden a run, and nothing here installs from them.
+          # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
+          # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
+          # Packages.gz), and nothing here installs from any of them.
           sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           # `dbus` is here for `cargo test` / portal_chooser (#510), not for
@@ -251,8 +252,9 @@ jobs:
       - name: Install Linux dependencies
         if: matrix.target == 'linux'
         run: |
-          # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
-          # enough to redden a run, and nothing here installs from them.
+          # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
+          # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
+          # Packages.gz), and nothing here installs from any of them.
           sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           # `dbus` lives on `linux-validate` with `cargo test` / portal_chooser
@@ -845,8 +847,9 @@ jobs:
         env:
           SNAP_FILE: ${{ steps.snap-check.outputs.snap }}
         run: |
-          # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
-          # enough to redden a run, and nothing here installs from them.
+          # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
+          # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
+          # Packages.gz), and nothing here installs from any of them.
           sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends squashfs-tools binutils file
@@ -906,8 +909,9 @@ jobs:
           SNAP_GUI_SCREENSHOT: ${{ runner.temp }}/snap-gui-screenshot.png
         run: |
           set -euo pipefail
-          # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
-          # enough to redden a run, and nothing here installs from them.
+          # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
+          # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
+          # Packages.gz), and nothing here installs from any of them.
           sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends xvfb x11-apps imagemagick

--- a/.github/workflows/cli-smoke.yml
+++ b/.github/workflows/cli-smoke.yml
@@ -109,9 +109,9 @@ jobs:
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
         run: |
-          # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
-          # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
-          # Packages.gz), and nothing here installs from any of them.
+          # Runner-image extras: the preinstalled microsoft*, azure-cli* and google-chrome*
+          # apt repos fail often enough to redden a run (403 on InRelease, Hash Sum
+          # mismatch on Packages.gz), and nothing here installs from any of them.
           sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
@@ -287,9 +287,9 @@ jobs:
 
       - name: Install Linux dependencies
         run: |
-          # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
-          # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
-          # Packages.gz), and nothing here installs from any of them.
+          # Runner-image extras: the preinstalled microsoft*, azure-cli* and google-chrome*
+          # apt repos fail often enough to redden a run (403 on InRelease, Hash Sum
+          # mismatch on Packages.gz), and nothing here installs from any of them.
           sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
@@ -360,9 +360,9 @@ jobs:
 
       - name: Install Linux dependencies
         run: |
-          # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
-          # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
-          # Packages.gz), and nothing here installs from any of them.
+          # Runner-image extras: the preinstalled microsoft*, azure-cli* and google-chrome*
+          # apt repos fail often enough to redden a run (403 on InRelease, Hash Sum
+          # mismatch on Packages.gz), and nothing here installs from any of them.
           sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \

--- a/.github/workflows/cli-smoke.yml
+++ b/.github/workflows/cli-smoke.yml
@@ -109,8 +109,9 @@ jobs:
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
         run: |
-          # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
-          # enough to redden a run, and nothing here installs from them.
+          # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
+          # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
+          # Packages.gz), and nothing here installs from any of them.
           sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
@@ -286,8 +287,9 @@ jobs:
 
       - name: Install Linux dependencies
         run: |
-          # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
-          # enough to redden a run, and nothing here installs from them.
+          # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
+          # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
+          # Packages.gz), and nothing here installs from any of them.
           sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
@@ -358,8 +360,9 @@ jobs:
 
       - name: Install Linux dependencies
         run: |
-          # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
-          # enough to redden a run, and nothing here installs from them.
+          # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
+          # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
+          # Packages.gz), and nothing here installs from any of them.
           sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \

--- a/.github/workflows/delta-sync-integration.yml
+++ b/.github/workflows/delta-sync-integration.yml
@@ -148,8 +148,9 @@ jobs:
             # next apt-get would refuse to run until it is told to finish.
             sudo dpkg --configure -a || true
             mkdir -p "$HOME/apt-archives/partial"
-            # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
-            # enough to redden a run, and nothing here installs from them.
+            # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
+            # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
+            # Packages.gz), and nothing here installs from any of them.
             sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
             sudo apt-get update
             # rsync + ssh client for the host side of the integration test.
@@ -349,8 +350,9 @@ jobs:
             set -euo pipefail
             sudo dpkg --configure -a || true
             mkdir -p "$HOME/apt-archives/partial"
-            # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
-            # enough to redden a run, and nothing here installs from them.
+            # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
+            # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
+            # Packages.gz), and nothing here installs from any of them.
             sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
             sudo apt-get update
             sudo apt-get install -y --no-install-recommends \

--- a/.github/workflows/delta-sync-integration.yml
+++ b/.github/workflows/delta-sync-integration.yml
@@ -148,9 +148,9 @@ jobs:
             # next apt-get would refuse to run until it is told to finish.
             sudo dpkg --configure -a || true
             mkdir -p "$HOME/apt-archives/partial"
-            # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
-            # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
-            # Packages.gz), and nothing here installs from any of them.
+            # Runner-image extras: the preinstalled microsoft*, azure-cli* and google-chrome*
+            # apt repos fail often enough to redden a run (403 on InRelease, Hash Sum
+            # mismatch on Packages.gz), and nothing here installs from any of them.
             sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
             sudo apt-get update
             # rsync + ssh client for the host side of the integration test.
@@ -350,9 +350,9 @@ jobs:
             set -euo pipefail
             sudo dpkg --configure -a || true
             mkdir -p "$HOME/apt-archives/partial"
-            # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
-            # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
-            # Packages.gz), and nothing here installs from any of them.
+            # Runner-image extras: the preinstalled microsoft*, azure-cli* and google-chrome*
+            # apt repos fail often enough to redden a run (403 on InRelease, Hash Sum
+            # mismatch on Packages.gz), and nothing here installs from any of them.
             sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
             sudo apt-get update
             sudo apt-get install -y --no-install-recommends \

--- a/.github/workflows/ftp-mlsd.yml
+++ b/.github/workflows/ftp-mlsd.yml
@@ -93,8 +93,9 @@ jobs:
             # next apt-get would refuse to run until it is told to finish.
             sudo dpkg --configure -a || true
             mkdir -p "$HOME/apt-archives/partial"
-            # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
-            # enough to redden a run, and nothing here installs from them.
+            # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
+            # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
+            # Packages.gz), and nothing here installs from any of them.
             sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
             sudo apt-get update
             sudo apt-get install -y --no-install-recommends \
@@ -239,8 +240,9 @@ jobs:
             set -euo pipefail
             sudo dpkg --configure -a || true
             mkdir -p "$HOME/apt-archives/partial"
-            # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
-            # enough to redden a run, and nothing here installs from them.
+            # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
+            # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
+            # Packages.gz), and nothing here installs from any of them.
             sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
             sudo apt-get update
             sudo apt-get install -y --no-install-recommends \

--- a/.github/workflows/ftp-mlsd.yml
+++ b/.github/workflows/ftp-mlsd.yml
@@ -93,9 +93,9 @@ jobs:
             # next apt-get would refuse to run until it is told to finish.
             sudo dpkg --configure -a || true
             mkdir -p "$HOME/apt-archives/partial"
-            # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
-            # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
-            # Packages.gz), and nothing here installs from any of them.
+            # Runner-image extras: the preinstalled microsoft*, azure-cli* and google-chrome*
+            # apt repos fail often enough to redden a run (403 on InRelease, Hash Sum
+            # mismatch on Packages.gz), and nothing here installs from any of them.
             sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
             sudo apt-get update
             sudo apt-get install -y --no-install-recommends \
@@ -240,9 +240,9 @@ jobs:
             set -euo pipefail
             sudo dpkg --configure -a || true
             mkdir -p "$HOME/apt-archives/partial"
-            # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
-            # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
-            # Packages.gz), and nothing here installs from any of them.
+            # Runner-image extras: the preinstalled microsoft*, azure-cli* and google-chrome*
+            # apt repos fail often enough to redden a run (403 on InRelease, Hash Sum
+            # mismatch on Packages.gz), and nothing here installs from any of them.
             sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
             sudo apt-get update
             sudo apt-get install -y --no-install-recommends \

--- a/.github/workflows/nightly-telemetry.yml
+++ b/.github/workflows/nightly-telemetry.yml
@@ -50,9 +50,9 @@ jobs:
       # system dev packages. Same set as cli-smoke.yml.
       - name: Install Linux dependencies
         run: |
-          # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
-          # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
-          # Packages.gz), and nothing here installs from any of them.
+          # Runner-image extras: the preinstalled microsoft*, azure-cli* and google-chrome*
+          # apt repos fail often enough to redden a run (403 on InRelease, Hash Sum
+          # mismatch on Packages.gz), and nothing here installs from any of them.
           sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \

--- a/.github/workflows/nightly-telemetry.yml
+++ b/.github/workflows/nightly-telemetry.yml
@@ -50,8 +50,9 @@ jobs:
       # system dev packages. Same set as cli-smoke.yml.
       - name: Install Linux dependencies
         run: |
-          # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
-          # enough to redden a run, and nothing here installs from them.
+          # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
+          # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
+          # Packages.gz), and nothing here installs from any of them.
           sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \

--- a/.github/workflows/portal-chooser.yml
+++ b/.github/workflows/portal-chooser.yml
@@ -73,9 +73,9 @@ jobs:
 
       - name: Install D-Bus
         run: |
-          # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
-          # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
-          # Packages.gz), and nothing here installs from any of them.
+          # Runner-image extras: the preinstalled microsoft*, azure-cli* and google-chrome*
+          # apt repos fail often enough to redden a run (403 on InRelease, Hash Sum
+          # mismatch on Packages.gz), and nothing here installs from any of them.
           sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends dbus
@@ -136,9 +136,9 @@ jobs:
       # windows, never to click.
       - name: Install the desktop and accessibility stack
         run: |
-          # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
-          # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
-          # Packages.gz), and nothing here installs from any of them.
+          # Runner-image extras: the preinstalled microsoft*, azure-cli* and google-chrome*
+          # apt repos fail often enough to redden a run (403 on InRelease, Hash Sum
+          # mismatch on Packages.gz), and nothing here installs from any of them.
           sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \

--- a/.github/workflows/portal-chooser.yml
+++ b/.github/workflows/portal-chooser.yml
@@ -73,8 +73,9 @@ jobs:
 
       - name: Install D-Bus
         run: |
-          # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
-          # enough to redden a run, and nothing here installs from them.
+          # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
+          # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
+          # Packages.gz), and nothing here installs from any of them.
           sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends dbus
@@ -135,8 +136,9 @@ jobs:
       # windows, never to click.
       - name: Install the desktop and accessibility stack
         run: |
-          # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
-          # enough to redden a run, and nothing here installs from them.
+          # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
+          # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
+          # Packages.gz), and nothing here installs from any of them.
           sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \

--- a/.github/workflows/snap-refresh.yml
+++ b/.github/workflows/snap-refresh.yml
@@ -129,8 +129,9 @@ jobs:
           node-version: '20'
 
       - name: Install audit tooling
-        # Runner-image extras: Microsoft's apt repos 403 on their InRelease
-        # often enough to redden a run, and nothing here installs from them.
+        # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
+        # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
+        # Packages.gz), and nothing here installs from any of them.
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update && sudo apt-get install -y --no-install-recommends squashfs-tools
@@ -176,8 +177,9 @@ jobs:
 
       - name: Install Linux build dependencies
         run: |
-          # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
-          # enough to redden a run, and nothing here installs from them.
+          # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
+          # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
+          # Packages.gz), and nothing here installs from any of them.
           sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y \
@@ -312,8 +314,9 @@ jobs:
         env:
           SNAP_FILE: ${{ steps.snap-check.outputs.snap }}
         run: |
-          # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
-          # enough to redden a run, and nothing here installs from them.
+          # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
+          # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
+          # Packages.gz), and nothing here installs from any of them.
           sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends squashfs-tools binutils file
@@ -361,8 +364,9 @@ jobs:
           SNAP_GUI_SCREENSHOT: ${{ runner.temp }}/snap-gui-screenshot.png
         run: |
           set -euo pipefail
-          # Runner-image extras: Microsoft's apt repos 403 on their InRelease often
-          # enough to redden a run, and nothing here installs from them.
+          # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
+          # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
+          # Packages.gz), and nothing here installs from any of them.
           sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends xvfb x11-apps imagemagick

--- a/.github/workflows/snap-refresh.yml
+++ b/.github/workflows/snap-refresh.yml
@@ -129,9 +129,9 @@ jobs:
           node-version: '20'
 
       - name: Install audit tooling
-        # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
-        # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
-        # Packages.gz), and nothing here installs from any of them.
+        # Runner-image extras: the preinstalled microsoft*, azure-cli* and google-chrome*
+        # apt repos fail often enough to redden a run (403 on InRelease, Hash Sum
+        # mismatch on Packages.gz), and nothing here installs from any of them.
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update && sudo apt-get install -y --no-install-recommends squashfs-tools
@@ -177,9 +177,9 @@ jobs:
 
       - name: Install Linux build dependencies
         run: |
-          # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
-          # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
-          # Packages.gz), and nothing here installs from any of them.
+          # Runner-image extras: the preinstalled microsoft*, azure-cli* and google-chrome*
+          # apt repos fail often enough to redden a run (403 on InRelease, Hash Sum
+          # mismatch on Packages.gz), and nothing here installs from any of them.
           sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y \
@@ -314,9 +314,9 @@ jobs:
         env:
           SNAP_FILE: ${{ steps.snap-check.outputs.snap }}
         run: |
-          # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
-          # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
-          # Packages.gz), and nothing here installs from any of them.
+          # Runner-image extras: the preinstalled microsoft*, azure-cli* and google-chrome*
+          # apt repos fail often enough to redden a run (403 on InRelease, Hash Sum
+          # mismatch on Packages.gz), and nothing here installs from any of them.
           sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends squashfs-tools binutils file
@@ -364,9 +364,9 @@ jobs:
           SNAP_GUI_SCREENSHOT: ${{ runner.temp }}/snap-gui-screenshot.png
         run: |
           set -euo pipefail
-          # Runner-image extras: the preinstalled Microsoft and Google apt repos fail
-          # often enough to redden a run (403 on InRelease, Hash Sum mismatch on
-          # Packages.gz), and nothing here installs from any of them.
+          # Runner-image extras: the preinstalled microsoft*, azure-cli* and google-chrome*
+          # apt repos fail often enough to redden a run (403 on InRelease, Hash Sum
+          # mismatch on Packages.gz), and nothing here installs from any of them.
           sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends xvfb x11-apps imagemagick


### PR DESCRIPTION
Follow-up to #766, comment text only.

The line that strips the runner image's preinstalled third-party apt sources removes `microsoft*`, `azure-cli*` and `google-chrome*` since #766 landed, but the comment above each of its 22 sites still named Microsoft alone and gave the 403 on InRelease as the only reason. That is the same shape of drift that made trap 16 cost a red: the remedy sat written down in the release skill's checklist while the code kept the older form, and someone reading either one alone could not tell they had diverged. A comment that describes less than its line does is worth the same suspicion.

Same 22 sites in the same 9 workflows. The change is mechanically verified as comment-only: every added and removed line in the diff starts with `#`, so no step, command or condition moves. The reason now covers both failure modes seen in practice, the 403 on `InRelease` and the Hash Sum mismatch on `Packages.gz`, and states the rule the checklist gives for why the glob covers all three repos rather than whichever failed last: nothing in CI installs from any preinstalled third-party apt source.

This touches `.github/workflows/**`, so it re-runs the path-gated lanes for a comment. That cost is the reason it rides on its own rather than being bundled into an unrelated change, and the reason it was not merged into #770, which had no workflow changes at all.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Linux workflow comments to identify the preinstalled `microsoft*`, `azure-cli*`, and `google-chrome*` APT repositories.
  * Documented possible HTTP 403 errors for `InRelease` files and package checksum mismatches.
  * Clarified that these repositories are removed before dependency installation.
  * Workflow behavior, configuration, and dependency installation remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->