### PR TITLE
perf(ci): stop rebuilding cargo-audit from source on every Checks run

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -94,7 +94,40 @@ jobs:
       - name: Provider inventory is not stale
         run: npm run check:provider-inventory
 
+      # `cargo install cargo-audit --locked` compiled the tool from source on
+      # every run: measured at 2m58s, for an audit that then takes about five
+      # seconds, on the workflow that runs more often than any other here (42
+      # times on main in the last seven days).
+      #
+      # The Rust cache above does cache `~/.cargo/bin`, so the intuitive reading
+      # is that it should already have covered this. It does not, because of how
+      # that action saves: on an exact key hit it reports the cache up to date
+      # and skips the save entirely, so a binary installed later in the same job
+      # is never persisted. cargo-audit could only ever enter that cache on the
+      # rarer runs where the dependency key had already changed, which is why it
+      # was rebuilt again and again.
+      #
+      # Give the tool its own cache, keyed by month, so its update cycle is
+      # separate from the app's dependency cycle and neither can skip the other.
+      # Monthly rather than pinned so the tool still moves forward without being
+      # rebuilt forty times to get there, and it does not go stale in the
+      # meantime: `cargo audit` fetches the advisory database at run time rather
+      # than baking it into the binary. Uses the official cache action already
+      # pinned by SHA elsewhere in this repo rather than a binary-installer
+      # action, to add no supply-chain surface to a security step.
+      - name: Month stamp for the cargo-audit cache key
+        id: audit-key
+        run: echo "month=$(date -u +%Y-%m)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache the cargo-audit binary
+        id: cargo-audit-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ~/.cargo/bin/cargo-audit
+          key: cargo-audit-${{ runner.os }}-${{ steps.audit-key.outputs.month }}
+
       - name: Install cargo-audit
+        if: steps.cargo-audit-cache.outputs.cache-hit != 'true'
         run: cargo install cargo-audit --locked
 
       - name: Rust dependency audit (cargo audit)

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -119,9 +119,17 @@ jobs:
         id: audit-key
         run: echo "month=$(date -u +%Y-%m)" >> "$GITHUB_OUTPUT"
 
-      - name: Cache the cargo-audit binary
+      # Restore and save are split deliberately. The combined `actions/cache`
+      # saves from a post-job step declared `post-if: success()`, so a job that
+      # ends red never saves. On main the audit below is authoritative, so a
+      # real advisory would fail the job and throw away the binary that had just
+      # been built: every rerun while the advisory is being fixed would pay the
+      # install again, precisely when runs are most frequent. Saving here, right
+      # after a successful install and before anything that can fail, makes the
+      # binary outlive a failing audit.
+      - name: Restore the cargo-audit binary
         id: cargo-audit-cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.cargo/bin/cargo-audit
           key: cargo-audit-${{ runner.os }}-${{ steps.audit-key.outputs.month }}
@@ -129,6 +137,13 @@ jobs:
       - name: Install cargo-audit
         if: steps.cargo-audit-cache.outputs.cache-hit != 'true'
         run: cargo install cargo-audit --locked
+
+      - name: Save the cargo-audit binary
+        if: steps.cargo-audit-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ~/.cargo/bin/cargo-audit
+          key: ${{ steps.cargo-audit-cache.outputs.cache-primary-key }}
 
       - name: Rust dependency audit (cargo audit)
         working-directory: ./src-tauri


### PR DESCRIPTION
First step on the CI wall-clock work, the isolated and measurable one.

`cargo install cargo-audit --locked` compiled the tool from source on every run of `checks.yml`, which is the workflow that runs more often than any other here: 42 times on `main` in the last seven days. That install was measured at 2m58s, for a `cargo audit` that then takes about five seconds.

The intuitive reading is that the Rust cache three steps above should already have covered it. An earlier version of this PR claimed that action excludes `~/.cargo/bin`; that was wrong, and a review by Codex L1 caught it. Checked against the action's README at the pinned SHA, it caches `~/.cargo` including installed binaries. The reason it never helped is in how it saves: on an exact key hit it reports the cache up to date and skips the save entirely, so a binary installed later in the same job is never persisted. cargo-audit could only enter that cache on the rarer runs where the dependency key had already changed, which is why it kept being rebuilt.

The tool gets its own cache now and the install runs only on a miss, which also separates the tool's update cycle from the app's dependency cycle so neither can skip the other. The key rotates monthly rather than being pinned to a version, so the tool still moves forward without being rebuilt forty times to get there. That does not weaken the audit: `cargo audit` fetches the advisory database at run time rather than baking it into the binary, so a month-old tool still reports today's advisories.

It uses the official cache action, already pinned by SHA elsewhere in this repo, rather than one of the binary-installer actions. This is the dependency-audit step; it is not where to add supply-chain surface to save a download.

Measured before, from the run of the previous PR on this repo: `Checks` spent 13 minutes queued and 4 minutes computing. The compute half is what this touches.

The larger piece, merging cache keys across jobs, is deliberately not here. The Actions cache sits at 10.01 GB across 11 entries and `linux-validate` logged `No cache found.` before spending 49 minutes recompiling from cold, so the pressure is real. But the design I had drafted for it rested on several jobs sharing one key and converging to the union of their artifacts, and that is not what the action does: on an exact key hit the save is skipped, so the first successful save fixes the contents and later jobs recompile what is missing without ever enriching it. A shared key needs a deliberate producer chosen for what it builds, and families grouped by runner image, toolchain, profile, target and effective flags rather than by matching key hashes, which do not cover the flags of the cargo commands that run after the cache step. That work is being done properly rather than shipped on the strength of a hash comparison.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated security checks by caching the auditing tool between workflow runs.
  * Reduced repeated setup time when a suitable cached tool is available.
  * Updated cache handling to improve reliability when checks fail after installation.
  * The auditing tool is installed automatically when no suitable cached version is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->