### PR TITLE
test(dropbox): close the live 409 retest declared open on #738

### DIFF
--- a/src-tauri/src/providers/dropbox.rs
+++ b/src-tauri/src/providers/dropbox.rs
@@ -3088,16 +3088,20 @@ mod tests {
             .expect("delete file");
         p.delete(&format!("{root}/sub")).await.expect("delete sub");
         let deleted = p.list_deleted(&root).await.expect("list_deleted");
+        // A row that is not in the listing at all and a row whose kind was not
+        // established both have to survive until after the cleanup, and they
+        // have to stay distinguishable: Dropbox's trash listing is eventually
+        // consistent, so a missing row means "ask again", while an empty kind
+        // means the probe answered and could not name it. Collapsing them into
+        // one empty string would report the first as the second.
+        let row = |name: &str| deleted.iter().find(|e| e.name == name);
         let kind = |name: &str| -> String {
-            deleted
-                .iter()
-                .find(|e| e.name == name)
-                .unwrap_or_else(|| panic!("{name} missing from the trash listing: {deleted:#?}"))
-                .metadata
-                .get("trash_kind")
-                .cloned()
+            row(name)
+                .and_then(|e| e.metadata.get("trash_kind").cloned())
                 .unwrap_or_default()
         };
+        let folder_listed = row("sub").is_some();
+        let file_listed = row("file.txt").is_some();
         // Observations are collected now and asserted after the cleanup below.
         // A live test that fails before it cleans up leaves debris on somebody's
         // real account and the next run starts from a dirty state, which is not
@@ -3137,6 +3141,10 @@ mod tests {
 
         // The two halves of the report: the folder must not read as a file, and
         // the file must carry a revision the restore can actually use.
+        assert!(
+            folder_listed && file_listed,
+            "the trash listing did not carry both rows back: {deleted:#?}"
+        );
         assert_eq!(
             folder_kind, "folder",
             "trashed folder read as {folder_kind:?}"

--- a/src-tauri/src/providers/dropbox.rs
+++ b/src-tauri/src/providers/dropbox.rs
@@ -3066,34 +3066,88 @@ mod tests {
             .as_secs();
         let root = format!("/aeroftp-397-live-{stamp}");
         let body = format!("aeroftp 397 live retest\nstamp {stamp}\n");
-        let local = std::env::temp_dir().join(format!("dbx-397-{stamp}.txt"));
-        tokio::fs::write(&local, body.as_bytes()).await.unwrap();
-
-        p.mkdir(&root).await.expect("mkdir root");
-        p.mkdir(&format!("{root}/sub")).await.expect("mkdir sub");
-        p.upload(local.to_str().unwrap(), &format!("{root}/file.txt"), None)
+        // The local fixture lives in a directory the OS creates for this run,
+        // not under a predictable name in the shared temp dir: a path another
+        // local user could create first, as a symlink for instance, would turn
+        // this write into an overwrite of whatever the link points at.
+        let scratch = tempfile::tempdir().expect("private scratch dir");
+        let local = scratch.path().join("upload.txt");
+        let back = scratch.path().join("restored.txt");
+        tokio::fs::write(&local, body.as_bytes())
             .await
-            .expect("upload file");
-        p.upload(
-            local.to_str().unwrap(),
-            &format!("{root}/sub/nested.txt"),
-            None,
-        )
-        .await
-        .expect("upload nested");
+            .expect("write local fixture");
 
-        // Trash both kinds, then read the trash back.
-        p.delete(&format!("{root}/file.txt"))
+        // Every remote step runs inside this block and reports instead of
+        // panicking. Once the first mkdir succeeds, a panic anywhere skips the
+        // cleanup below and leaves the tree on a real account, and the setup
+        // steps fail as easily as the listing does: they were the exits the
+        // previous version still left open. What the checks need is captured
+        // here and asserted only after the cleanup has run.
+        let observed: Result<(_, _, _, _), String> = async {
+            p.mkdir(&root)
+                .await
+                .map_err(|e| format!("mkdir root: {e}"))?;
+            p.mkdir(&format!("{root}/sub"))
+                .await
+                .map_err(|e| format!("mkdir sub: {e}"))?;
+            p.upload(local.to_str().unwrap(), &format!("{root}/file.txt"), None)
+                .await
+                .map_err(|e| format!("upload file: {e}"))?;
+            p.upload(
+                local.to_str().unwrap(),
+                &format!("{root}/sub/nested.txt"),
+                None,
+            )
             .await
-            .expect("delete file");
-        p.delete(&format!("{root}/sub")).await.expect("delete sub");
-        let deleted = p.list_deleted(&root).await.expect("list_deleted");
+            .map_err(|e| format!("upload nested: {e}"))?;
+
+            // Trash both kinds, then read the trash back.
+            p.delete(&format!("{root}/file.txt"))
+                .await
+                .map_err(|e| format!("delete file: {e}"))?;
+            p.delete(&format!("{root}/sub"))
+                .await
+                .map_err(|e| format!("delete sub: {e}"))?;
+            let deleted = p
+                .list_deleted(&root)
+                .await
+                .map_err(|e| format!("list_deleted: {e}"))?;
+
+            // The file must come back byte for byte. The stale rev is passed on
+            // purpose: passing means the tombstone was revalidated rather than
+            // trusted.
+            let restore_outcome = p
+                .restore_file(&format!("{root}/file.txt"), "stale-rev")
+                .await;
+            let restored_bytes = if restore_outcome.is_ok() {
+                p.download(&format!("{root}/file.txt"), back.to_str().unwrap(), None)
+                    .await
+                    .ok();
+                tokio::fs::read(&back).await.ok()
+            } else {
+                None
+            };
+            let folder_restore = p.restore_file(&format!("{root}/sub"), "").await;
+            Ok((deleted, restore_outcome, restored_bytes, folder_restore))
+        }
+        .await;
+
+        // Clean up first, whatever happened above, so a failure cannot litter
+        // the account. The local fixture goes with `scratch` when it drops.
+        p.delete(&format!("{root}/file.txt")).await.ok();
+        let cleanup = p.delete(&root).await;
+        let still_there = p.exists(&root).await.unwrap_or(false);
+
+        let (deleted, restore_outcome, restored_bytes, folder_restore) =
+            observed.unwrap_or_else(|e| {
+                panic!("live #397 retest failed before its checks (cleanup already ran): {e}")
+            });
+
         // A row that is not in the listing at all and a row whose kind was not
-        // established both have to survive until after the cleanup, and they
-        // have to stay distinguishable: Dropbox's trash listing is eventually
-        // consistent, so a missing row means "ask again", while an empty kind
-        // means the probe answered and could not name it. Collapsing them into
-        // one empty string would report the first as the second.
+        // established have to stay distinguishable: Dropbox's trash listing is
+        // eventually consistent, so a missing row means "ask again", while an
+        // empty kind means the probe answered and could not name it. Collapsing
+        // them into one empty string would report the first as the second.
         let row = |name: &str| deleted.iter().find(|e| e.name == name);
         let kind = |name: &str| -> String {
             row(name)
@@ -3102,42 +3156,12 @@ mod tests {
         };
         let folder_listed = row("sub").is_some();
         let file_listed = row("file.txt").is_some();
-        // Observations are collected now and asserted after the cleanup below.
-        // A live test that fails before it cleans up leaves debris on somebody's
-        // real account and the next run starts from a dirty state, which is not
-        // hypothetical: it is what the red run of this very test did.
         let folder_kind = kind("sub");
         let file_kind = kind("file.txt");
-        let file_rev = deleted
-            .iter()
-            .find(|e| e.name == "file.txt")
+        let file_rev = row("file.txt")
             .and_then(|e| e.metadata.get("rev"))
             .cloned()
             .unwrap_or_default();
-
-        // The file must come back byte for byte. The stale rev is passed on
-        // purpose: passing means the tombstone was revalidated rather than
-        // trusted. Outcomes are captured, not asserted, until after cleanup.
-        let restore_outcome = p
-            .restore_file(&format!("{root}/file.txt"), "stale-rev")
-            .await;
-        let back = std::env::temp_dir().join(format!("dbx-397-back-{stamp}.txt"));
-        let restored_bytes = if restore_outcome.is_ok() {
-            p.download(&format!("{root}/file.txt"), back.to_str().unwrap(), None)
-                .await
-                .ok();
-            tokio::fs::read(&back).await.ok()
-        } else {
-            None
-        };
-        let folder_restore = p.restore_file(&format!("{root}/sub"), "").await;
-
-        // Clean up first, so a failed assertion cannot litter the account.
-        p.delete(&format!("{root}/file.txt")).await.ok();
-        let cleanup = p.delete(&root).await;
-        let still_there = p.exists(&root).await.unwrap_or(false);
-        let _ = tokio::fs::remove_file(&local).await;
-        let _ = tokio::fs::remove_file(&back).await;
 
         // The two halves of the report: the folder must not read as a file, and
         // the file must carry a revision the restore can actually use.

--- a/src-tauri/src/providers/dropbox.rs
+++ b/src-tauri/src/providers/dropbox.rs
@@ -3001,6 +3001,162 @@ mod tests {
         server.abort();
     }
 
+    // Live retest for #397: the reporter saw a 409 restoring from the Dropbox
+    // trash, and folders rendered with the file icon. Both come from the same
+    // place: a Dropbox tombstone does not carry the entry kind, so the listing
+    // was guessing it and the restore used the latest revision even when it was
+    // not restorable.
+    //
+    // This is the red/green proof on a live account. On a pre-#738 build the
+    // listing labels the trashed folder as a file and the restore of an expired
+    // revision answers 409; with the revision probe it passes.
+    //
+    // Run explicitly (never in CI):
+    //   cargo test --release --lib live_trash_identifies_kinds_and_restores -- --ignored --nocapture
+    // Env: DROPBOX_TEST_PROFILE (default "My Dropbox").
+    //
+    // The test builds its own uniquely named tree, trashes a file and a folder,
+    // reads the trash, restores the file and byte-compares it, checks that the
+    // folder restore is refused with the explanation rather than a raw 409, and
+    // removes what it created. It never empties the trash: that is the whole
+    // account's, not this test's.
+    #[tokio::test]
+    #[ignore = "live Dropbox test; run explicitly"]
+    async fn live_trash_identifies_kinds_and_restores_a_file() {
+        let profile_query =
+            std::env::var("DROPBOX_TEST_PROFILE").unwrap_or_else(|_| "My Dropbox".to_string());
+        let status = crate::credential_store::CredentialStore::init().expect("vault init failed");
+        if status == "MASTER_PASSWORD_REQUIRED" {
+            let password = zeroize::Zeroizing::new(
+                std::env::var("AEROFTP_MASTER_PASSWORD")
+                    .expect("set AEROFTP_MASTER_PASSWORD for this master-mode test vault"),
+            );
+            crate::credential_store::CredentialStore::unlock_with_master(&password, None)
+                .expect("test vault unlock failed");
+        }
+        let store = crate::credential_store::CredentialStore::from_cache().expect("vault not open");
+        let profiles = crate::user_partitions::mcp_list_active_server_profiles(&store)
+            .expect("profile listing failed");
+        let matched = profiles
+            .iter()
+            .find(|p| {
+                p.get("name")
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|n| n.eq_ignore_ascii_case(&profile_query))
+            })
+            .cloned()
+            .unwrap_or_else(|| panic!("test profile {profile_query:?} not found"));
+        let profile_id = matched
+            .get("id")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        // Same two steps the CLI takes for an OAuth profile: the app keys come
+        // from the vault's oauth client config, the refresh chain is bound by
+        // profile id, and connect() resolves the access token from it.
+        let (app_key, app_secret) =
+            crate::bridge_commands::resolve_oauth_client_config(&store, "dropbox");
+        let mut p = DropboxProvider::new(DropboxConfig::new(&app_key, &app_secret))
+            .with_profile_id(&profile_id);
+        p.connect().await.expect("connect failed");
+
+        let stamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let root = format!("/aeroftp-397-live-{stamp}");
+        let body = format!("aeroftp 397 live retest\nstamp {stamp}\n");
+        let local = std::env::temp_dir().join(format!("dbx-397-{stamp}.txt"));
+        tokio::fs::write(&local, body.as_bytes()).await.unwrap();
+
+        p.mkdir(&root).await.expect("mkdir root");
+        p.mkdir(&format!("{root}/sub")).await.expect("mkdir sub");
+        p.upload(local.to_str().unwrap(), &format!("{root}/file.txt"), None)
+            .await
+            .expect("upload file");
+        p.upload(
+            local.to_str().unwrap(),
+            &format!("{root}/sub/nested.txt"),
+            None,
+        )
+        .await
+        .expect("upload nested");
+
+        // Trash both kinds, then read the trash back.
+        p.delete(&format!("{root}/file.txt"))
+            .await
+            .expect("delete file");
+        p.delete(&format!("{root}/sub")).await.expect("delete sub");
+        let deleted = p.list_deleted(&root).await.expect("list_deleted");
+        let kind = |name: &str| -> String {
+            deleted
+                .iter()
+                .find(|e| e.name == name)
+                .unwrap_or_else(|| panic!("{name} missing from the trash listing: {deleted:#?}"))
+                .metadata
+                .get("trash_kind")
+                .cloned()
+                .unwrap_or_default()
+        };
+        // The two halves of the report: the folder must not read as a file, and
+        // the file must carry a revision that the restore can actually use.
+        assert_eq!(
+            kind("sub"),
+            "folder",
+            "trashed folder read as {:?}",
+            kind("sub")
+        );
+        assert_eq!(kind("file.txt"), "file");
+        assert!(
+            deleted
+                .iter()
+                .find(|e| e.name == "file.txt")
+                .and_then(|e| e.metadata.get("rev"))
+                .is_some_and(|r| !r.is_empty()),
+            "no usable revision on the trashed file"
+        );
+
+        // The file comes back, byte for byte. The stale rev is passed on purpose:
+        // restore_file revalidates the tombstone and picks a restorable revision.
+        p.restore_file(&format!("{root}/file.txt"), "stale-rev")
+            .await
+            .expect("restore file");
+        let back = std::env::temp_dir().join(format!("dbx-397-back-{stamp}.txt"));
+        p.download(&format!("{root}/file.txt"), back.to_str().unwrap(), None)
+            .await
+            .expect("download restored file");
+        assert_eq!(
+            tokio::fs::read(&back).await.unwrap(),
+            body.as_bytes(),
+            "restored file differs from what was uploaded"
+        );
+
+        // The folder is refused, and refused in words. Dropbox restores file
+        // revisions and has no folder equivalent, so the 409 the reporter saw is
+        // the API being asked something it cannot do: the value here is that the
+        // message says so instead of surfacing the status code.
+        let err = p
+            .restore_file(&format!("{root}/sub"), "")
+            .await
+            .expect_err("a folder restore cannot succeed on Dropbox")
+            .to_string();
+        assert!(
+            err.contains("dropbox.com") && !err.contains("409"),
+            "folder restore should explain itself, got: {err}"
+        );
+
+        // Clean up what this test created, and prove it is gone.
+        p.delete(&format!("{root}/file.txt")).await.ok();
+        p.delete(&root).await.expect("cleanup root");
+        assert!(
+            !p.exists(&root).await.unwrap_or(false),
+            "test tree still present at {root}"
+        );
+        let _ = tokio::fs::remove_file(&local).await;
+        let _ = tokio::fs::remove_file(&back).await;
+        eprintln!("live #397 retest passed against profile {profile_query:?}, tree {root} removed");
+    }
+
     #[test]
     fn clone_for_transfer_requires_connection() {
         let p = DropboxProvider::new(demo_cfg());

--- a/src-tauri/src/providers/dropbox.rs
+++ b/src-tauri/src/providers/dropbox.rs
@@ -3098,62 +3098,72 @@ mod tests {
                 .cloned()
                 .unwrap_or_default()
         };
+        // Observations are collected now and asserted after the cleanup below.
+        // A live test that fails before it cleans up leaves debris on somebody's
+        // real account and the next run starts from a dirty state, which is not
+        // hypothetical: it is what the red run of this very test did.
+        let folder_kind = kind("sub");
+        let file_kind = kind("file.txt");
+        let file_rev = deleted
+            .iter()
+            .find(|e| e.name == "file.txt")
+            .and_then(|e| e.metadata.get("rev"))
+            .cloned()
+            .unwrap_or_default();
+
+        // The file must come back byte for byte. The stale rev is passed on
+        // purpose: passing means the tombstone was revalidated rather than
+        // trusted. Outcomes are captured, not asserted, until after cleanup.
+        let restore_outcome = p
+            .restore_file(&format!("{root}/file.txt"), "stale-rev")
+            .await;
+        let back = std::env::temp_dir().join(format!("dbx-397-back-{stamp}.txt"));
+        let restored_bytes = if restore_outcome.is_ok() {
+            p.download(&format!("{root}/file.txt"), back.to_str().unwrap(), None)
+                .await
+                .ok();
+            tokio::fs::read(&back).await.ok()
+        } else {
+            None
+        };
+        let folder_restore = p.restore_file(&format!("{root}/sub"), "").await;
+
+        // Clean up first, so a failed assertion cannot litter the account.
+        p.delete(&format!("{root}/file.txt")).await.ok();
+        let cleanup = p.delete(&root).await;
+        let still_there = p.exists(&root).await.unwrap_or(false);
+        let _ = tokio::fs::remove_file(&local).await;
+        let _ = tokio::fs::remove_file(&back).await;
+
         // The two halves of the report: the folder must not read as a file, and
-        // the file must carry a revision that the restore can actually use.
+        // the file must carry a revision the restore can actually use.
         assert_eq!(
-            kind("sub"),
-            "folder",
-            "trashed folder read as {:?}",
-            kind("sub")
+            folder_kind, "folder",
+            "trashed folder read as {folder_kind:?}"
         );
-        assert_eq!(kind("file.txt"), "file");
+        assert_eq!(file_kind, "file");
         assert!(
-            deleted
-                .iter()
-                .find(|e| e.name == "file.txt")
-                .and_then(|e| e.metadata.get("rev"))
-                .is_some_and(|r| !r.is_empty()),
+            !file_rev.is_empty(),
             "no usable revision on the trashed file"
         );
-
-        // The file comes back, byte for byte. The stale rev is passed on purpose:
-        // restore_file revalidates the tombstone and picks a restorable revision.
-        p.restore_file(&format!("{root}/file.txt"), "stale-rev")
-            .await
-            .expect("restore file");
-        let back = std::env::temp_dir().join(format!("dbx-397-back-{stamp}.txt"));
-        p.download(&format!("{root}/file.txt"), back.to_str().unwrap(), None)
-            .await
-            .expect("download restored file");
+        restore_outcome.expect("restore file");
         assert_eq!(
-            tokio::fs::read(&back).await.unwrap(),
-            body.as_bytes(),
+            restored_bytes.as_deref(),
+            Some(body.as_bytes()),
             "restored file differs from what was uploaded"
         );
-
-        // The folder is refused, and refused in words. Dropbox restores file
-        // revisions and has no folder equivalent, so the 409 the reporter saw is
-        // the API being asked something it cannot do: the value here is that the
-        // message says so instead of surfacing the status code.
-        let err = p
-            .restore_file(&format!("{root}/sub"), "")
-            .await
+        // Dropbox restores file revisions and has no folder equivalent, so the
+        // 409 the reporter saw is the API being asked something it cannot do.
+        // What matters is that the message says so instead of the status code.
+        let err = folder_restore
             .expect_err("a folder restore cannot succeed on Dropbox")
             .to_string();
         assert!(
             err.contains("dropbox.com") && !err.contains("409"),
             "folder restore should explain itself, got: {err}"
         );
-
-        // Clean up what this test created, and prove it is gone.
-        p.delete(&format!("{root}/file.txt")).await.ok();
-        p.delete(&root).await.expect("cleanup root");
-        assert!(
-            !p.exists(&root).await.unwrap_or(false),
-            "test tree still present at {root}"
-        );
-        let _ = tokio::fs::remove_file(&local).await;
-        let _ = tokio::fs::remove_file(&back).await;
+        cleanup.expect("cleanup root");
+        assert!(!still_there, "test tree still present at {root}");
         eprintln!("live #397 retest passed against profile {profile_query:?}, tree {root} removed");
     }
 


### PR DESCRIPTION
## Description

#738 fixed the Dropbox trash findings from #397 and shipped them covered by HTTP fixtures shaped like the Dropbox API, with the live 409 explicitly declared as not retested against a real account. This closes that declaration with a live test rather than with another sentence.

### What it adds

`live_trash_identifies_kinds_and_restores_a_file` in the Dropbox provider, opt-in and never run in CI:

```
cargo test --release --lib live_trash_identifies_kinds_and_restores -- --ignored --nocapture --test-threads=1
```

It builds its own uniquely named tree, trashes a file and a folder, reads the trash back, restores the file, compares the restored bytes with what it uploaded, checks that the folder restore is refused with an explanation, and removes what it created. It never empties the trash: that belongs to the account, not to a test.

### Red and green, on a live account

Pre-fix build, both reported symptoms reproduce:

```
listing: name=file.txt is_dir=false metadata={}
listing: name=sub      is_dir=false metadata={}
restore file (stale rev) -> 409 Conflict {"error":{".tag":"invalid_revision"}}
restore folder           -> 409 Conflict {"error":{"path":{".tag":"not_file"}}}
```

The trashed folder carries `is_dir=false` and no metadata, which is the file icon in the report, and the restore answers 409 for two different reasons. On the current build the same test passes in about 12 seconds.

### Three things the run itself taught

**Release only, and not as a preference.** Debug builds resolve their data under the `aeroftp-dev` leaf, so a debug run opens a different vault and would fail for a reason that has nothing to do with the trash.

**Live tests against one account have to be serialised.** Running two of them in parallel made Dropbox answer `too_many_write_operations`, which is the same throttle the trash listing now surfaces instead of labelling an entry `unknown`.

**A live test cleans up before it asserts.** The first failing run left its tree on the account, so the outcomes are collected, the tree is removed, and only then are the assertions made. A live test that litters when it fails poisons the next run.

## Type of Change

- [x] Test coverage

## Checklist

- [x] My code follows the project's code style
- [x] I have tested my changes
- [x] Every commit is signed off (`git commit -s`)

## Related Issues

Refs #397 and #738. It does not close #397: the OneDrive and pCloud OAuth parts of that issue are separate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an optional live Dropbox integration test covering identification of deleted files and folders.
  * Verified restoring a deleted file, including handling an outdated revision.
  * Confirmed folder restoration is rejected with a clear error message.
  * Added checks that temporary files and test data are cleaned up after testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->