### PR TITLE
fix(pcloud): name the trash refusal as an API limit, not a broken login

### DIFF
--- a/src-tauri/src/providers/onedrive.rs
+++ b/src-tauri/src/providers/onedrive.rs
@@ -2586,7 +2586,20 @@ mod tests {
 
         let pc_id = find(&std::env::var("PCLOUD_TEST_PROFILE").unwrap_or("pCloud".into()));
         let (k, s) = crate::bridge_commands::resolve_oauth_client_config(&store, "pcloud");
-        let mut pc = PCloudProvider::new(PCloudConfig::new(&k, &s, "eu")).with_profile_id(&pc_id);
+        // pCloud is region-split and a token only validates against the host it
+        // was minted for. The region is not on the profile: AeroFTP keeps it as
+        // the vault singleton `oauth_pcloud_region`, and an absent value means
+        // US. Read it the way the app does, so the test connects to the same
+        // host the app would rather than to whichever one happens to be written
+        // here.
+        let region = store
+            .get("oauth_pcloud_region")
+            .ok()
+            .map(|r| r.trim().to_string())
+            .filter(|r| !r.is_empty())
+            .unwrap_or_else(|| "us".to_string());
+        let mut pc =
+            PCloudProvider::new(PCloudConfig::new(&k, &s, &region)).with_profile_id(&pc_id);
         match pc.connect().await {
             Ok(()) => {
                 let listed = pc.list("/").await.map(|v| v.len());

--- a/src-tauri/src/providers/onedrive.rs
+++ b/src-tauri/src/providers/onedrive.rs
@@ -2533,6 +2533,78 @@ impl StorageProvider for OneDriveProvider {
 
 #[cfg(test)]
 mod tests {
+
+    // Both trash refusals, OneDrive's and pCloud's, rest on recognising what a
+    // vendor answers: Graph's `invalidRequest` plus "special folder identifier"
+    // for one, pCloud's result 1000 for the other. A predicate that matches a
+    // vendor's wording has no gate of its own, and when the wording moves the
+    // user gets the raw error back with nobody the wiser. This is that gate: it
+    // asks both services what they answer today. Read only, it lists and writes
+    // nothing, so it is safe to run against any account.
+    //
+    //   cargo test --release --lib live_trash_refusals -- --ignored --nocapture --test-threads=1
+    //
+    // Release only: debug builds resolve their data under the `aeroftp-dev`
+    // leaf, so a debug run opens a different vault and fails for an unrelated
+    // reason. Env: ONEDRIVE_TEST_PROFILE, PCLOUD_TEST_PROFILE.
+    #[tokio::test]
+    #[ignore = "live test; run explicitly"]
+    async fn live_trash_refusals_still_match_their_predicates() {
+        use crate::providers::types::PCloudConfig;
+        use crate::providers::PCloudProvider;
+
+        crate::credential_store::CredentialStore::init().expect("vault init failed");
+        let store = crate::credential_store::CredentialStore::from_cache().expect("vault not open");
+        let profiles = crate::user_partitions::mcp_list_active_server_profiles(&store).unwrap();
+        let find = |want: &str| -> String {
+            profiles
+                .iter()
+                .find(|p| {
+                    p.get("name")
+                        .and_then(|v| v.as_str())
+                        .is_some_and(|n| n.eq_ignore_ascii_case(want))
+                })
+                .and_then(|p| p.get("id").and_then(|v| v.as_str()))
+                .unwrap_or_else(|| panic!("profile {want:?} not found"))
+                .to_string()
+        };
+
+        let od_id = find(&std::env::var("ONEDRIVE_TEST_PROFILE").unwrap_or("OneDrive".into()));
+        let (k, s) = crate::bridge_commands::resolve_oauth_client_config(&store, "onedrive");
+        let mut od = OneDriveProvider::new(OneDriveConfig::new(&k, &s)).with_profile_id(&od_id);
+        match od.connect().await {
+            Ok(()) => {
+                let out = od.list_trash().await;
+                assert!(
+                    matches!(&out, Err(ProviderError::NotSupported(m)) if m.contains("onedrive.live.com")),
+                    "OneDrive no longer classified as an API limit: {out:?}"
+                );
+                eprintln!("LIVE onedrive list_trash -> {out:?}");
+            }
+            Err(e) => panic!("onedrive connect failed: {e}"),
+        }
+
+        let pc_id = find(&std::env::var("PCLOUD_TEST_PROFILE").unwrap_or("pCloud".into()));
+        let (k, s) = crate::bridge_commands::resolve_oauth_client_config(&store, "pcloud");
+        let mut pc = PCloudProvider::new(PCloudConfig::new(&k, &s, "eu")).with_profile_id(&pc_id);
+        match pc.connect().await {
+            Ok(()) => {
+                let listed = pc.list("/").await.map(|v| v.len());
+                assert!(
+                    listed.is_ok(),
+                    "control call failed, the token is not valid right now: {listed:?}"
+                );
+                eprintln!("LIVE pcloud control list / -> {listed:?}");
+                let out = pc.list_trash().await;
+                assert!(
+                    matches!(&out, Err(ProviderError::NotSupported(m)) if m.contains("pcloud.com")),
+                    "pCloud trash refusal no longer named as an API limit: {out:?}"
+                );
+                eprintln!("LIVE pcloud list_trash -> {out:?}");
+            }
+            Err(e) => panic!("pcloud connect failed: {e}"),
+        }
+    }
     use super::*;
 
     fn test_provider() -> OneDriveProvider {

--- a/src-tauri/src/providers/pcloud.rs
+++ b/src-tauri/src/providers/pcloud.rs
@@ -48,6 +48,43 @@ const PCLOUD_RESULT_THROTTLE: u32 = 4006;
 /// caller, so there is no fallback and no permission to request.
 const PCLOUD_RESULT_LOGIN_REQUIRED: u32 = 1000;
 
+/// The one place a pCloud `result` code becomes a `ProviderError`.
+///
+/// Both `check_response` and the trash mutations go through it, so a code
+/// cannot mean one thing on a listing and another on a delete. They used to
+/// have two tables: the listing classified through `check_response` while the
+/// three mutation endpoints had a single `result != 0` branch that answered
+/// `Other`, so an invalid token was an authentication failure on one and a
+/// generic failure on the other three. Two tables for one vendor's codes is how
+/// they drift apart.
+fn classify_pcloud_result(result: u32, error: Option<&str>) -> Option<ProviderError> {
+    if result == 0 {
+        return None;
+    }
+    let raw_msg = error
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("Error code: {result}"));
+    let msg = sanitize_api_error(&raw_msg);
+    Some(match result {
+        // 1000: "Log in required", 2000: "Log in failed", 2094: "Invalid access_token"
+        1000 | 2000 | 2094 => ProviderError::AuthenticationFailed(msg),
+        // 2005: "Directory does not exist", 2009: "File not found or invalid
+        // file/folder id", 2010: "Invalid path". All three are absence
+        // conditions: mapping them to NotFound lets `exists()` return
+        // Ok(false) (not a propagated error) so a probe for a missing file
+        // in an existing folder is a clean negative. Without 2005 here, the
+        // AeroCrypt overlay bootstrap probe (`exists(.aeroftp-crypt.json)`)
+        // saw a ServerError and failed "could not be unlocked" on pCloud.
+        2005 | 2009 | 2010 => ProviderError::NotFound(msg),
+        2003 | 2028 => ProviderError::PermissionDenied(msg),
+        2004 => ProviderError::AlreadyExists(msg),
+        // 4006: "Throttle limit reached", often inside HTTP 200 JSON.
+        // Map through a stable rate-limit phrase so AIMD sees RateLimited.
+        PCLOUD_RESULT_THROTTLE => pcloud_throttle_error("API", Some(msg.as_str())),
+        _ => ProviderError::ServerError(msg),
+    })
+}
+
 /// The refusal above, said as what it is.
 ///
 /// `check_response` maps 1000 to `AuthenticationFailed`, which is right
@@ -510,32 +547,10 @@ impl PCloudProvider {
 
     /// Check pCloud API response for errors (PA-014: sanitized messages)
     fn check_response(resp: &PCloudResponse) -> Result<(), ProviderError> {
-        if resp.result != 0 {
-            let raw_msg = resp
-                .error
-                .clone()
-                .unwrap_or_else(|| format!("Error code: {}", resp.result));
-            let msg = sanitize_api_error(&raw_msg);
-            return Err(match resp.result {
-                // 1000: "Log in required", 2000: "Log in failed", 2094: "Invalid access_token"
-                1000 | 2000 | 2094 => ProviderError::AuthenticationFailed(msg),
-                // 2005: "Directory does not exist", 2009: "File not found or invalid
-                // file/folder id", 2010: "Invalid path". All three are absence
-                // conditions: mapping them to NotFound lets `exists()` return
-                // Ok(false) (not a propagated error) so a probe for a missing file
-                // in an existing folder is a clean negative. Without 2005 here, the
-                // AeroCrypt overlay bootstrap probe (`exists(.aeroftp-crypt.json)`)
-                // saw a ServerError and failed "could not be unlocked" on pCloud.
-                2005 | 2009 | 2010 => ProviderError::NotFound(msg),
-                2003 | 2028 => ProviderError::PermissionDenied(msg),
-                2004 => ProviderError::AlreadyExists(msg),
-                // 4006: "Throttle limit reached", often inside HTTP 200 JSON.
-                // Map through a stable rate-limit phrase so AIMD sees RateLimited.
-                PCLOUD_RESULT_THROTTLE => pcloud_throttle_error("API", Some(msg.as_str())),
-                _ => ProviderError::ServerError(msg),
-            });
+        match classify_pcloud_result(resp.result, resp.error.as_deref()) {
+            Some(e) => Err(e),
+            None => Ok(()),
         }
-        Ok(())
     }
 
     /// Look up the `folderid` of a directory by path, creating the directory
@@ -2211,12 +2226,13 @@ impl PCloudProvider {
         if resp.result == PCLOUD_RESULT_LOGIN_REQUIRED {
             return Err(trash_refused_to_oauth());
         }
-        if resp.result != 0 {
-            return Err(ProviderError::Other(sanitize_api_error(
-                &resp
-                    .error
-                    .unwrap_or_else(|| "Failed to restore from trash".to_string()),
-            )));
+        if let Some(e) = classify_pcloud_result(
+            resp.result,
+            resp.error
+                .as_deref()
+                .or(Some("Failed to restore from trash")),
+        ) {
+            return Err(e);
         }
         info!("pCloud: restored item {} from trash", id);
         Ok(())
@@ -2235,12 +2251,11 @@ impl PCloudProvider {
         if resp.result == PCLOUD_RESULT_LOGIN_REQUIRED {
             return Err(trash_refused_to_oauth());
         }
-        if resp.result != 0 {
-            return Err(ProviderError::Other(sanitize_api_error(
-                &resp
-                    .error
-                    .unwrap_or_else(|| "Failed to empty trash".to_string()),
-            )));
+        if let Some(e) = classify_pcloud_result(
+            resp.result,
+            resp.error.as_deref().or(Some("Failed to empty trash")),
+        ) {
+            return Err(e);
         }
         info!("pCloud: trash emptied");
         Ok(())
@@ -2265,12 +2280,13 @@ impl PCloudProvider {
         if resp.result == PCLOUD_RESULT_LOGIN_REQUIRED {
             return Err(trash_refused_to_oauth());
         }
-        if resp.result != 0 {
-            return Err(ProviderError::Other(sanitize_api_error(
-                &resp
-                    .error
-                    .unwrap_or_else(|| "Failed to permanently delete".to_string()),
-            )));
+        if let Some(e) = classify_pcloud_result(
+            resp.result,
+            resp.error
+                .as_deref()
+                .or(Some("Failed to permanently delete")),
+        ) {
+            return Err(e);
         }
         info!("pCloud: permanently deleted item {} from trash", id);
         Ok(())
@@ -2454,15 +2470,21 @@ mod tests {
         // 1000 on a trash endpoint is pCloud saying OAuth cannot use the trash
         // at all, not that the login is broken: the reporter on #397 read the
         // latter, because that is what the message said. 2094 must keep saying
-        // what it means, which is why only 1000 is reinterpreted and only here.
+        // what it means, which is why only 1000 is reinterpreted.
+        //
+        // All four endpoints are exercised, not just the listing. Three of them
+        // used to answer through their own `result != 0` branch, so the same
+        // code meant different things depending on which one you called, and a
+        // test on the listing alone would have passed over that.
         use axum::{routing::get, Json, Router};
         for (result, expect_not_supported) in [(1000u32, true), (2094u32, false)] {
-            let app = Router::new().route(
-                "/trash_list",
-                get(move || async move {
-                    Json(serde_json::json!({"result": result, "error": "Log in required."}))
-                }),
-            );
+            let body = move || async move {
+                Json(serde_json::json!({"result": result, "error": "Log in required."}))
+            };
+            let app = Router::new()
+                .route("/trash_list", get(body))
+                .route("/trash_restore", get(body))
+                .route("/trash_clear", get(body));
             let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
             let addr = listener.local_addr().unwrap();
             let server = tokio::spawn(async move {
@@ -2470,16 +2492,45 @@ mod tests {
             });
             let mut provider = fixture_connected();
             provider.api_base_override = Some(format!("http://{addr}"));
-            let err = provider
-                .list_trash()
-                .await
-                .expect_err("the fixture never returns a listing");
-            match (&err, expect_not_supported) {
-                (ProviderError::NotSupported(m), true) => {
-                    assert!(m.contains("pcloud.com"), "{m}");
+
+            let outcomes: Vec<(&str, ProviderError)> = vec![
+                (
+                    "list_trash",
+                    provider
+                        .list_trash()
+                        .await
+                        .expect_err("fixture never lists"),
+                ),
+                (
+                    "restore_from_trash",
+                    provider
+                        .restore_from_trash("1", false)
+                        .await
+                        .expect_err("fixture never restores"),
+                ),
+                (
+                    "empty_trash",
+                    provider
+                        .empty_trash()
+                        .await
+                        .expect_err("fixture never empties"),
+                ),
+                (
+                    "permanent_delete_from_trash",
+                    provider
+                        .permanent_delete_from_trash("1", false)
+                        .await
+                        .expect_err("fixture never purges"),
+                ),
+            ];
+            for (endpoint, err) in outcomes {
+                match (&err, expect_not_supported) {
+                    (ProviderError::NotSupported(m), true) => {
+                        assert!(m.contains("pcloud.com"), "{endpoint}: {m}");
+                    }
+                    (ProviderError::AuthenticationFailed(_), false) => {}
+                    _ => panic!("{endpoint} turned result {result} into {err:?}"),
                 }
-                (ProviderError::AuthenticationFailed(_), false) => {}
-                _ => panic!("result {result} produced {err:?}"),
             }
             server.abort();
         }

--- a/src-tauri/src/providers/pcloud.rs
+++ b/src-tauri/src/providers/pcloud.rs
@@ -40,6 +40,31 @@ const PCLOUD_MULTIPART_PART_SIZE: u64 = 4 * 1024 * 1024;
 /// pCloud JSON result code for throttle (often inside HTTP 200).
 const PCLOUD_RESULT_THROTTLE: u32 = 4006;
 
+/// pCloud answers `1000 "Log in required."` on its trash endpoints to any OAuth
+/// access token, while `listfolder` answers `0` for the same token in the same
+/// session. Measured live twice, on 2026-08-27 and again on 2026-09-10, each
+/// time with a control call between two refusals to prove the token was valid at
+/// that instant, and `userinfo?getauth=1` mints no session token for an OAuth
+/// caller, so there is no fallback and no permission to request.
+const PCLOUD_RESULT_LOGIN_REQUIRED: u32 = 1000;
+
+/// The refusal above, said as what it is.
+///
+/// `check_response` maps 1000 to `AuthenticationFailed`, which is right
+/// everywhere else and reads as a broken login here: that is exactly what the
+/// reporter saw on #397. The GUI stopped offering the trash button for pCloud,
+/// and that is a guard on one door while `pcloud_list_trash`,
+/// `pcloud_restore_from_trash` and `pcloud_empty_trash` stay registered and
+/// callable, so the truth belongs on the error itself. Only 1000 is
+/// reinterpreted: 2000 and 2094 stay authentication failures, because those are
+/// what a genuinely bad token returns.
+fn trash_refused_to_oauth() -> ProviderError {
+    ProviderError::NotSupported(
+        "pCloud does not allow its trash to be listed, restored or emptied through an OAuth login, so AeroFTP cannot show it here. Use the Trash on pcloud.com instead."
+            .to_string(),
+    )
+}
+
 /// Live DAG-P1-05C blocker: concurrent `upload_write` on one `uploadid`
 /// returns result `2068` ("Error writing to upload"). Serial multipart still
 /// works (with occasional retry). Promotion to `HttpClonePool` is therefore
@@ -2126,6 +2151,9 @@ impl PCloudProvider {
             .await
             .map_err(|e| ProviderError::ParseError(sanitize_api_error(&e.to_string())))?;
 
+        if resp.result == PCLOUD_RESULT_LOGIN_REQUIRED {
+            return Err(trash_refused_to_oauth());
+        }
         Self::check_response(&resp)?;
 
         let metadata = resp.metadata.ok_or_else(|| {
@@ -2180,6 +2208,9 @@ impl PCloudProvider {
             .await
             .map_err(|e| ProviderError::ParseError(sanitize_api_error(&e.to_string())))?;
 
+        if resp.result == PCLOUD_RESULT_LOGIN_REQUIRED {
+            return Err(trash_refused_to_oauth());
+        }
         if resp.result != 0 {
             return Err(ProviderError::Other(sanitize_api_error(
                 &resp
@@ -2201,6 +2232,9 @@ impl PCloudProvider {
             .await
             .map_err(|e| ProviderError::ParseError(sanitize_api_error(&e.to_string())))?;
 
+        if resp.result == PCLOUD_RESULT_LOGIN_REQUIRED {
+            return Err(trash_refused_to_oauth());
+        }
         if resp.result != 0 {
             return Err(ProviderError::Other(sanitize_api_error(
                 &resp
@@ -2228,6 +2262,9 @@ impl PCloudProvider {
             .await
             .map_err(|e| ProviderError::ParseError(sanitize_api_error(&e.to_string())))?;
 
+        if resp.result == PCLOUD_RESULT_LOGIN_REQUIRED {
+            return Err(trash_refused_to_oauth());
+        }
         if resp.result != 0 {
             return Err(ProviderError::Other(sanitize_api_error(
                 &resp
@@ -2410,6 +2447,42 @@ mod tests {
         let mut p = PCloudProvider::connected_for_test(demo_cfg());
         p.test_access_token = Some("fixture-token".to_string());
         p
+    }
+
+    #[tokio::test]
+    async fn a_trash_refusal_is_an_api_limit_and_a_bad_token_is_still_a_bad_token() {
+        // 1000 on a trash endpoint is pCloud saying OAuth cannot use the trash
+        // at all, not that the login is broken: the reporter on #397 read the
+        // latter, because that is what the message said. 2094 must keep saying
+        // what it means, which is why only 1000 is reinterpreted and only here.
+        use axum::{routing::get, Json, Router};
+        for (result, expect_not_supported) in [(1000u32, true), (2094u32, false)] {
+            let app = Router::new().route(
+                "/trash_list",
+                get(move || async move {
+                    Json(serde_json::json!({"result": result, "error": "Log in required."}))
+                }),
+            );
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let addr = listener.local_addr().unwrap();
+            let server = tokio::spawn(async move {
+                axum::serve(listener, app).await.unwrap();
+            });
+            let mut provider = fixture_connected();
+            provider.api_base_override = Some(format!("http://{addr}"));
+            let err = provider
+                .list_trash()
+                .await
+                .expect_err("the fixture never returns a listing");
+            match (&err, expect_not_supported) {
+                (ProviderError::NotSupported(m), true) => {
+                    assert!(m.contains("pcloud.com"), "{m}");
+                }
+                (ProviderError::AuthenticationFailed(_), false) => {}
+                _ => panic!("result {result} produced {err:?}"),
+            }
+            server.abort();
+        }
     }
 
     #[tokio::test]

--- a/src-tauri/src/providers/pcloud.rs
+++ b/src-tauri/src/providers/pcloud.rs
@@ -97,7 +97,7 @@ fn classify_pcloud_result(result: u32, error: Option<&str>) -> Option<ProviderEr
 /// what a genuinely bad token returns.
 fn trash_refused_to_oauth() -> ProviderError {
     ProviderError::NotSupported(
-        "pCloud does not allow its trash to be listed, restored or emptied through an OAuth login, so AeroFTP cannot show it here. Use the Trash on pcloud.com instead."
+        "pCloud does not allow its trash to be listed, restored, emptied or purged through an OAuth login, so AeroFTP cannot manage it here. Use the Trash on pcloud.com instead."
             .to_string(),
     )
 }


### PR DESCRIPTION
## Description

Two live probes against the OneDrive and pCloud trash, run because both fixes for #397 rest on recognising what a vendor answers and neither had a gate. One held. The other turned out to be guarded at the button rather than at the error.

### What the probes measured, today

**OneDrive** still classifies correctly. Microsoft Graph answers the documented 400 for a Personal account and it arrives as an API limit with the account kind named:

```
Err(NotSupported("This OneDrive Personal account does not expose its recycle bin through Microsoft Graph ... Use the Recycle bin on onedrive.live.com instead"))
```

**pCloud** still refuses, and the refusal still read as a broken login:

```
control list / -> Ok(12)
list_trash     -> Err(AuthenticationFailed("Log in required."))
```

The control call succeeds in the same session with the same token, so the token is good at that instant and the refusal is a property of pCloud's OAuth, exactly as measured on 2026-08-27.

### The change

`check_response` maps 1000 to `AuthenticationFailed`, which is right everywhere else and reads as a broken login here. That is the sentence the reporter of #397 saw, and it sends a user to look at their credentials for a limit of the API.

The August fix removed the `pcloud` entry from the trash-button dispatch map, so the GUI stops offering a control pCloud cannot honour. That is a guard on one door: `pcloud_list_trash`, `pcloud_restore_from_trash`, `pcloud_empty_trash` and `pcloud_permanently_delete_trash` stay registered and callable, and whoever arrives through any of them gets the misleading sentence back.

All four trash entry points now name the refusal for what it is and point at pcloud.com. **Only 1000 is reinterpreted, and only on those endpoints**: 2000 and 2094 stay authentication failures, because that is what a genuinely bad token returns, and swallowing them would trade one wrong sentence for another.

### The gate the predicates did not have

Both refusals rest on recognising a vendor's wording, Graph's `invalidRequest` plus "special folder identifier" for one and pCloud's result 1000 for the other. When the wording moves, the classification stops firing and the user gets the raw error with nobody the wiser.

- `a_trash_refusal_is_an_api_limit_and_a_bad_token_is_still_a_bad_token` serves both codes from a fixture and asserts they land in different variants. Runs in CI. Seen failing on the previous code with `result 1000 produced AuthenticationFailed("Log in required.")`.
- `live_trash_refusals_still_match_their_predicates` asks both services what they answer today. Opt-in, read only, release only, since a debug build resolves its data under the `aeroftp-dev` leaf and would fail for an unrelated reason.

### Verification

`cargo fmt --all -- --check`, `git diff --check`, the unit gate green and seen red on the pre-fix code, and the live test green against real OneDrive and pCloud accounts:

```
LIVE onedrive list_trash -> Err(NotSupported("This OneDrive Personal account ..."))
LIVE pcloud control list / -> Ok(12)
LIVE pcloud list_trash -> Err(NotSupported("pCloud does not allow its trash ... Use the Trash on pcloud.com instead."))
```

## Type of Change

- [x] Bug fix
- [x] Test coverage

## Checklist

- [x] My code follows the project's code style
- [x] I have tested my changes
- [x] Every commit is signed off (`git commit -s`)

## Related Issues

Refs #397 and #628. It does not close either: #397 still holds the Dropbox tier work tracked separately, and this is one refusal made honest, not a capability gained.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pCloud recycle-bin error handling so unsupported trash operations clearly report that the feature isn’t available, instead of displaying an authentication failure.
  - Updated viewing, restoring, emptying, and permanently deleting items from the pCloud recycle bin to provide more accurate error messages.
  - Correctly identify authentication-related pCloud errors across supported operations, helping users distinguish sign-in issues from unavailable features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->