### PR TITLE
fix(cli): expose the crypt-overlay binding in the agent-facing JSON

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,10 +60,24 @@ The `profiles --json` output:
     "host": "prod.example.com",
     "port": 22,
     "username": "deploy",
-    "initialPath": "/var/www"
+    "initialPath": "/var/www",
+    "cryptOverlay": null,
+    "protocolClass": "SFTP"
   }
 ]
 ```
+
+`protocol` is always the transport you connect over. `cryptOverlay` is the
+encrypted-overlay binding: `null` when there is none, otherwise `"aerocrypt"`
+(native) or `"rclone-crypt"` (interop). `protocolClass` is the class the GUI
+table shows for the same profile, so a profile with an enabled overlay reads
+`"protocol": "ftp"` and `"protocolClass": "Crypt"` together.
+
+Read `cryptOverlay` before writing to a path: on a bound profile the CLI
+decrypts names and contents transparently, so what you upload lands encrypted
+on the remote. The same two fields appear in `agent-info --json` and in the
+agent's `server_list_saved`, and they survive `--redact-identifiers`, which
+hides who the account is (host, username) and not how the connection is shaped.
 
 ## Common Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,14 +69,16 @@ The `profiles --json` output:
 
 `protocol` is always the transport you connect over. `cryptOverlay` is the
 encrypted-overlay binding: `null` when there is none, otherwise `"aerocrypt"`
-(native) or `"rclone-crypt"` (interop). `protocolClass` is the class the GUI
+(native, which is also what a binding that names no kind means) or
+`"rclone-crypt"` (interop). `protocolClass` is the class the GUI
 table shows for the same profile, so a profile with an enabled overlay reads
 `"protocol": "ftp"` and `"protocolClass": "Crypt"` together.
 
 Read `cryptOverlay` before writing to a path: on a bound profile the CLI
 decrypts names and contents transparently, so what you upload lands encrypted
-on the remote. The same two fields appear in `agent-info --json` and in the
-agent's `server_list_saved`, and they survive `--redact-identifiers`, which
+on the remote. The same two fields appear in `agent-bootstrap --json`,
+`agent-info --json` and the agent's `server_list_saved`, and they survive
+`agent-info --redact-identifiers`, which
 hides who the account is (host, username) and not how the connection is shaped.
 
 ## Common Commands

--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -13332,20 +13332,31 @@ fn profile_has_crypt_overlay(profile: &serde_json::Value) -> bool {
 
 /// The crypt-overlay kind when the binding is enabled, `None` otherwise.
 ///
-/// Mirrors `getServerCryptOverlay` in `src/types.ts`, which returns the kind or
-/// null rather than a boolean, and for the same reason: `aerocrypt` (native) and
-/// `rclone-crypt` (interop) are different lanes, so a bare `true` would tell a
-/// reader that something is encrypted while hiding which one it is looking at.
+/// The kind rather than a boolean, for the reason `getServerCryptOverlay` in
+/// `src/types.ts` returns one: `aerocrypt` (native) and `rclone-crypt` (interop)
+/// are different lanes, so a bare `true` would tell a reader that something is
+/// encrypted while hiding which one it is looking at.
+///
+/// Both halves are borrowed rather than restated. The gate is
+/// `profile_has_crypt_overlay`, the same predicate that makes
+/// `profile_protocol_class` answer `Crypt`; the kind comes from the library's
+/// `overlay_kind`, the rule the overlay resolver applies when it opens the
+/// binding. So this can never report "no overlay" for a profile the table
+/// calls `Crypt`.
+///
+/// It agrees with the TypeScript helper on every binding the GUI writes, since
+/// the GUI always writes `kind`. It departs from it on purpose for a binding
+/// that lacks one (hand-edited, imported, older schema): the helper returns
+/// `undefined` there, while this reports `aerocrypt`, the lane the CLI will
+/// actually encrypt with. Any other answer would describe a rule no code path
+/// follows.
 fn profile_crypt_overlay_kind(profile: &serde_json::Value) -> Option<&str> {
-    let overlay = profile.get("aeroCryptOverlay")?;
-    if !overlay
-        .get("enabled")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false)
-    {
+    if !profile_has_crypt_overlay(profile) {
         return None;
     }
-    overlay.get("kind").and_then(|v| v.as_str())
+    profile
+        .get("aeroCryptOverlay")
+        .map(ftp_client_gui_lib::crypt_overlay_provider::overlay_kind)
 }
 
 /// Resolve the leading URL and encrypted-directory positionals of a `crypt`
@@ -24597,6 +24608,21 @@ fn safe_vault_profiles(cli: &Cli) -> Result<Vec<serde_json::Value>, String> {
         Err(_) => return Ok(vec![]),
     };
 
+    Ok(safe_profile_records(&store, &profiles))
+}
+
+/// Build the agent-facing records for a list of saved profiles, listing the vault
+/// keys once for all of them.
+///
+/// The single path for every agent surface that lists saved servers:
+/// `agent-bootstrap` and `agent-info` reach it through `safe_vault_profiles`, and
+/// the agent's `server_list_saved` tool through `safe_vault_profiles_for_agent`.
+/// That last one used to assemble its own eight-field record, so a field added to
+/// the shared shape never reached the tool agents call most.
+fn safe_profile_records(
+    store: &ftp_client_gui_lib::credential_store::CredentialStore,
+    profiles: &[serde_json::Value],
+) -> Vec<serde_json::Value> {
     // List vault keys ONCE; per-profile auth-state derivation then checks
     // existence in this set instead of issuing N decryptions.
     let accounts: std::collections::HashSet<String> = store
@@ -24604,26 +24630,24 @@ fn safe_vault_profiles(cli: &Cli) -> Result<Vec<serde_json::Value>, String> {
         .unwrap_or_default()
         .into_iter()
         .collect();
-
-    Ok(profiles
+    profiles
         .iter()
         .map(|p| {
             let id = p.get("id").and_then(|v| v.as_str()).unwrap_or("");
             let proto = p.get("protocol").and_then(|v| v.as_str()).unwrap_or("");
             let auth_state = ftp_client_gui_lib::profile_auth_state::derive_profile_auth_state(
-                &store, &accounts, id, proto,
+                store, &accounts, id, proto,
             );
             safe_profile_record(p, auth_state)
         })
-        .collect())
+        .collect()
 }
 
 /// Build the agent-facing record for one saved profile.
 ///
-/// Extracted from `safe_vault_profiles` so the emitted shape can be unit-tested
-/// without opening a vault: this is the surface `agent-bootstrap` inlines and
-/// the agent's `server_list_saved` reads, so a field missing here is a field an
-/// agent cannot see at all.
+/// Extracted so the emitted shape can be unit-tested without opening a vault.
+/// Every agent listing goes through `safe_profile_records`, so a field missing
+/// here is a field no agent can see.
 fn safe_profile_record(p: &serde_json::Value, auth_state: &str) -> serde_json::Value {
     serde_json::json!({
         "id": p.get("id").and_then(|v| v.as_str()).unwrap_or(""),
@@ -24665,21 +24689,7 @@ fn safe_vault_profiles_for_agent() -> Result<Vec<serde_json::Value>, String> {
             }
         };
 
-    Ok(profiles
-        .iter()
-        .map(|p| {
-            serde_json::json!({
-                "id": p.get("id").and_then(|v| v.as_str()).unwrap_or(""),
-                "name": p.get("name").and_then(|v| v.as_str()).unwrap_or("unnamed"),
-                "protocol": p.get("protocol").and_then(|v| v.as_str()).unwrap_or(""),
-                "host": p.get("host").and_then(|v| v.as_str()).unwrap_or(""),
-                "port": p.get("port").and_then(|v| v.as_u64()).unwrap_or(0),
-                "username": p.get("username").and_then(|v| v.as_str()).unwrap_or(""),
-                "initialPath": p.get("initialPath").and_then(|v| v.as_str()).unwrap_or("/"),
-                "providerId": p.get("providerId").and_then(|v| v.as_str()).unwrap_or(""),
-            })
-        })
-        .collect())
+    Ok(safe_profile_records(&store, &profiles))
 }
 
 /// Create a provider connection from a server profile name (for agent tool context).
@@ -27047,11 +27057,7 @@ async fn cli_apply_crypt_overlay(
         .get("aeroCryptOverlay")
         .cloned()
         .unwrap_or(serde_json::Value::Null);
-    let kind = overlay
-        .get("kind")
-        .and_then(|v| v.as_str())
-        .unwrap_or("aerocrypt")
-        .to_string();
+    let kind = ftp_client_gui_lib::crypt_overlay_provider::overlay_kind(&overlay).to_string();
     let id = profile.get("id").and_then(|v| v.as_str()).unwrap_or("");
     // The bound plaintext anchor: "" / unset = whole-remote crypt. Unlike the
     // compare path (which targets a specific remote path) the chokepoint wraps
@@ -55755,11 +55761,7 @@ async fn cli_unlock_crypt_compare_keys(
         .get("aeroCryptOverlay")
         .cloned()
         .unwrap_or(serde_json::Value::Null);
-    let kind = overlay
-        .get("kind")
-        .and_then(|v| v.as_str())
-        .unwrap_or("aerocrypt")
-        .to_string();
+    let kind = ftp_client_gui_lib::crypt_overlay_provider::overlay_kind(&overlay).to_string();
     let id = profile.get("id").and_then(|v| v.as_str()).unwrap_or("");
     let remote_scope = overlay
         .get("remoteScope")
@@ -72451,6 +72453,65 @@ mod tests {
             obj.get("protocolClass").and_then(|v| v.as_str()),
             Some("SFTP"),
             "with no overlay the class falls back to the transport"
+        );
+    }
+
+    /// An enabled binding with no explicit `kind` must still be reported as a
+    /// bound profile. Every backend path that actually opens the overlay reads a
+    /// missing kind as `aerocrypt`; the agent-facing record has to give the same
+    /// answer, or it prints `"cryptOverlay": null` next to
+    /// `"protocolClass": "Crypt"`, which is the ambiguity these fields exist to
+    /// remove.
+    #[test]
+    fn safe_profile_record_reads_missing_kind_as_aerocrypt() {
+        let bound_without_kind = json!({
+            "id": "srv_no_kind",
+            "name": "binding without kind",
+            "protocol": "sftp",
+            "host": "h",
+            "port": 22,
+            "username": "u",
+            "aeroCryptOverlay": { "enabled": true }
+        });
+        let record = safe_profile_record(&bound_without_kind, "valid");
+        let obj = record.as_object().expect("record is an object");
+
+        assert_eq!(
+            obj.get("protocolClass").and_then(|v| v.as_str()),
+            Some("Crypt"),
+            "an enabled overlay classifies the profile as Crypt"
+        );
+        assert_eq!(
+            obj.get("cryptOverlay").and_then(|v| v.as_str()),
+            Some("aerocrypt"),
+            "cryptOverlay must agree with protocolClass: an enabled binding with no \
+             kind is the native lane, which is how the overlay resolver reads it"
+        );
+    }
+
+    /// A disabled binding keeps its `kind` on disk but binds nothing. Guards the
+    /// gate: the kind may only be read once the overlay is known to be enabled.
+    #[test]
+    fn safe_profile_record_ignores_the_kind_of_a_disabled_overlay() {
+        let disabled = json!({
+            "id": "srv_disabled",
+            "name": "disabled binding",
+            "protocol": "ftp",
+            "host": "h",
+            "port": 21,
+            "username": "u",
+            "aeroCryptOverlay": { "enabled": false, "kind": "rclone-crypt" }
+        });
+        let record = safe_profile_record(&disabled, "valid");
+        let obj = record.as_object().expect("record is an object");
+
+        assert!(
+            obj.contains_key("cryptOverlay") && obj["cryptOverlay"].is_null(),
+            "a disabled overlay reports no binding, whatever kind it still stores"
+        );
+        assert_eq!(
+            obj.get("protocolClass").and_then(|v| v.as_str()),
+            Some("FTP")
         );
     }
 

--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -13330,6 +13330,24 @@ fn profile_has_crypt_overlay(profile: &serde_json::Value) -> bool {
         .unwrap_or(false)
 }
 
+/// The crypt-overlay kind when the binding is enabled, `None` otherwise.
+///
+/// Mirrors `getServerCryptOverlay` in `src/types.ts`, which returns the kind or
+/// null rather than a boolean, and for the same reason: `aerocrypt` (native) and
+/// `rclone-crypt` (interop) are different lanes, so a bare `true` would tell a
+/// reader that something is encrypted while hiding which one it is looking at.
+fn profile_crypt_overlay_kind(profile: &serde_json::Value) -> Option<&str> {
+    let overlay = profile.get("aeroCryptOverlay")?;
+    if !overlay
+        .get("enabled")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
+        return None;
+    }
+    overlay.get("kind").and_then(|v| v.as_str())
+}
+
 /// Resolve the leading URL and encrypted-directory positionals of a `crypt`
 /// subcommand when it runs against a saved `--profile`.
 ///
@@ -14916,6 +14934,13 @@ fn list_vault_profiles(cli: &Cli, format: OutputFormat, overrides: ProfilesViewO
                     },
                     "lastCompression": p.get("lastCompression").cloned()
                         .unwrap_or(serde_json::Value::Null),
+                    // `protocol` above stays the transport. These two carry what
+                    // the table already shows a human: an enabled crypt overlay
+                    // makes the profile a `Crypt` one. Emitted always, null when
+                    // unbound, so a reader never has to tell "absent" apart from
+                    // "no overlay".
+                    "cryptOverlay": profile_crypt_overlay_kind(p),
+                    "protocolClass": profile_protocol_class(p),
                 })
             })
             .collect();
@@ -24588,19 +24613,37 @@ fn safe_vault_profiles(cli: &Cli) -> Result<Vec<serde_json::Value>, String> {
             let auth_state = ftp_client_gui_lib::profile_auth_state::derive_profile_auth_state(
                 &store, &accounts, id, proto,
             );
-            serde_json::json!({
-                "id": id,
-                "name": p.get("name").and_then(|v| v.as_str()).unwrap_or("unnamed"),
-                "protocol": proto,
-                "host": p.get("host").and_then(|v| v.as_str()).unwrap_or(""),
-                "port": p.get("port").and_then(|v| v.as_u64()).unwrap_or(0),
-                "username": p.get("username").and_then(|v| v.as_str()).unwrap_or(""),
-                "initialPath": p.get("initialPath").and_then(|v| v.as_str()).unwrap_or("/"),
-                "providerId": p.get("providerId").and_then(|v| v.as_str()).unwrap_or(""),
-                "auth_state": auth_state,
-            })
+            safe_profile_record(p, auth_state)
         })
         .collect())
+}
+
+/// Build the agent-facing record for one saved profile.
+///
+/// Extracted from `safe_vault_profiles` so the emitted shape can be unit-tested
+/// without opening a vault: this is the surface `agent-bootstrap` inlines and
+/// the agent's `server_list_saved` reads, so a field missing here is a field an
+/// agent cannot see at all.
+fn safe_profile_record(p: &serde_json::Value, auth_state: &str) -> serde_json::Value {
+    serde_json::json!({
+        "id": p.get("id").and_then(|v| v.as_str()).unwrap_or(""),
+        "name": p.get("name").and_then(|v| v.as_str()).unwrap_or("unnamed"),
+        "protocol": p.get("protocol").and_then(|v| v.as_str()).unwrap_or(""),
+        "host": p.get("host").and_then(|v| v.as_str()).unwrap_or(""),
+        "port": p.get("port").and_then(|v| v.as_u64()).unwrap_or(0),
+        "username": p.get("username").and_then(|v| v.as_str()).unwrap_or(""),
+        "initialPath": p.get("initialPath").and_then(|v| v.as_str()).unwrap_or("/"),
+        "providerId": p.get("providerId").and_then(|v| v.as_str()).unwrap_or(""),
+        "auth_state": auth_state,
+        // The transport above answers "how do I reach it"; these two answer
+        // "what am I looking at". Without them an agent cannot see a crypt
+        // binding at all, while the table shows it as a `Crypt` profile: the
+        // same divergence CLI-JSON-01 already rules out for `providerId`.
+        // Always emitted, null when unbound, so "absent" never has to be
+        // guessed apart from "no overlay".
+        "cryptOverlay": profile_crypt_overlay_kind(p),
+        "protocolClass": profile_protocol_class(p),
+    })
 }
 
 /// Variant of safe_vault_profiles that works without a Cli reference (for agent tool context).
@@ -24901,6 +24944,18 @@ fn cmd_agent_info(cli: &Cli, redact_identifiers: bool) -> i32 {
                 // CLI-JSON-01: emit null (not "") for a missing providerId so the
                 // shape matches `profiles --json`; agents need not special-case both.
                 "providerId": p.get("providerId").and_then(|v| v.as_str()).filter(|s| !s.is_empty()),
+                // Propagated, never recomputed: both were derived once in
+                // `safe_profile_record`, and `p` here is already that record.
+                // Deriving them a second time is how two surfaces begin to
+                // disagree about the same profile.
+                //
+                // These survive PRIV-01 redaction on purpose: redaction hides
+                // WHO the account is (host, username), while these describe HOW
+                // the connection is shaped. They identify nobody, and dropping
+                // them would reopen the blind spot exactly where agents look
+                // first.
+                "cryptOverlay": p.get("cryptOverlay").and_then(|v| v.as_str()),
+                "protocolClass": p.get("protocolClass").and_then(|v| v.as_str()),
                 "transfer_capabilities": ftp_client_gui_lib::agent_session::transfer_capabilities_block(
                     protocol,
                     None,
@@ -72324,6 +72379,79 @@ mod tests {
             "aeroCryptOverlay": { "enabled": true, "kind": "aerocrypt", "remoteScope": "/enc" }
         });
         assert!(profile_has_crypt_overlay(&enabled));
+    }
+
+    /// The agent-facing record must SAY that a profile is crypt-bound.
+    ///
+    /// Asserting on the value alone would not guard anything: a key that is
+    /// absent deserialises as null for a permissive reader, so
+    /// `cryptOverlay == null` passes happily against a record that never emits
+    /// the field. What this test pins is the key being present at all.
+    #[test]
+    fn safe_profile_record_exposes_the_crypt_binding() {
+        let bound = json!({
+            "id": "srv_bound",
+            "name": "lab ftp",
+            "protocol": "ftp",
+            "host": "ftp.example.com",
+            "port": 21,
+            "username": "u",
+            "aeroCryptOverlay": { "enabled": true, "kind": "rclone-crypt", "remoteScope": "/enc" }
+        });
+        let record = safe_profile_record(&bound, "valid");
+        let obj = record.as_object().expect("record is an object");
+
+        assert!(
+            obj.contains_key("cryptOverlay"),
+            "record omits cryptOverlay entirely: an agent reading this surface cannot \
+             tell a crypt-bound profile from a plain one"
+        );
+        assert!(
+            obj.contains_key("protocolClass"),
+            "record omits protocolClass entirely"
+        );
+        assert_eq!(
+            obj.get("cryptOverlay").and_then(|v| v.as_str()),
+            Some("rclone-crypt"),
+            "the kind is the useful answer: a bare true cannot distinguish the interop \
+             lane from the native one"
+        );
+        assert_eq!(
+            obj.get("protocolClass").and_then(|v| v.as_str()),
+            Some("Crypt")
+        );
+        // The transport must stay untouched: consumers read `protocol` for it,
+        // and rewriting it to look like the table would break every one of them.
+        assert_eq!(obj.get("protocol").and_then(|v| v.as_str()), Some("ftp"));
+    }
+
+    /// Without an overlay the key must still be there, holding null. A field
+    /// that appears only on bound profiles would force every reader to treat
+    /// "absent" and "no overlay" as the same thing, which is the ambiguity this
+    /// change exists to remove.
+    #[test]
+    fn safe_profile_record_reports_absent_overlay_as_null_not_missing() {
+        let plain = json!({
+            "id": "srv_plain",
+            "name": "plain",
+            "protocol": "sftp",
+            "host": "h",
+            "port": 22,
+            "username": "u"
+        });
+        let record = safe_profile_record(&plain, "valid");
+        let obj = record.as_object().expect("record is an object");
+
+        assert!(
+            obj.contains_key("cryptOverlay"),
+            "the key must exist even when there is no overlay"
+        );
+        assert!(obj["cryptOverlay"].is_null());
+        assert_eq!(
+            obj.get("protocolClass").and_then(|v| v.as_str()),
+            Some("SFTP"),
+            "with no overlay the class falls back to the transport"
+        );
     }
 
     #[test]

--- a/src-tauri/src/crypt_overlay_provider.rs
+++ b/src-tauri/src/crypt_overlay_provider.rs
@@ -1949,6 +1949,30 @@ pub(crate) fn select_profile_by_name<'a>(
         .find(|p| p.get("name").and_then(|v| v.as_str()) == Some(name))
 }
 
+/// The kind an enabled binding takes when it does not name one: the native lane.
+pub const DEFAULT_OVERLAY_KIND: &str = "aerocrypt";
+
+/// The overlay kind a binding stands for, reading a missing `kind` as
+/// [`DEFAULT_OVERLAY_KIND`].
+///
+/// This is the one place that rule lives. It used to be restated wherever a
+/// binding is read (this resolver, `mcp::pool`, two CLI chokepoints), and the
+/// agent-facing JSON grew a fifth copy that answered differently: an enabled
+/// binding with no `kind` printed `"cryptOverlay": null` beside
+/// `"protocolClass": "Crypt"`. The copies existed because
+/// [`overlay_binding_from_profile`] is `pub(crate)` and the CLI binary cannot
+/// reach it, which is why this one is `pub`.
+///
+/// Takes the `aeroCryptOverlay` object rather than the profile: every caller has
+/// already established that the binding is enabled, and a function that checked
+/// again would hand each of them an impossible `None` to handle.
+pub fn overlay_kind(overlay: &serde_json::Value) -> &str {
+    overlay
+        .get("kind")
+        .and_then(|v| v.as_str())
+        .unwrap_or(DEFAULT_OVERLAY_KIND)
+}
+
 /// Extract the [`OverlayUnlockParams`] binding from a saved profile's
 /// `aeroCryptOverlay` JSON, or `None` when the profile carries no enabled
 /// overlay. Pure (no vault access): the secret lookup is the caller's job. The
@@ -1967,11 +1991,7 @@ pub(crate) fn overlay_binding_from_profile(
         return None;
     }
     Some(OverlayUnlockParams {
-        kind: overlay
-            .get("kind")
-            .and_then(|v| v.as_str())
-            .unwrap_or("aerocrypt")
-            .to_string(),
+        kind: overlay_kind(overlay).to_string(),
         remote_scope: overlay
             .get("remoteScope")
             .and_then(|v| v.as_str())
@@ -4410,6 +4430,25 @@ mod tests {
         assert_eq!(params.remote_scope, "");
         assert_eq!(params.filename_encryption, "standard");
         assert!(params.directory_name_encryption);
+    }
+
+    #[test]
+    fn overlay_kind_reads_a_missing_kind_as_the_native_lane() {
+        // The one rule every binding reader shares: an explicit kind is kept, and
+        // a missing or non-string one falls back to the native lane.
+        assert_eq!(
+            overlay_kind(&serde_json::json!({ "enabled": true, "kind": "rclone-crypt" })),
+            "rclone-crypt"
+        );
+        assert_eq!(
+            overlay_kind(&serde_json::json!({ "enabled": true })),
+            DEFAULT_OVERLAY_KIND
+        );
+        assert_eq!(
+            overlay_kind(&serde_json::json!({ "enabled": true, "kind": 7 })),
+            DEFAULT_OVERLAY_KIND
+        );
+        assert_eq!(DEFAULT_OVERLAY_KIND, "aerocrypt");
     }
 
     #[test]

--- a/src-tauri/src/mcp/pool.rs
+++ b/src-tauri/src/mcp/pool.rs
@@ -422,11 +422,7 @@ pub fn resolve_overlay_secrets(
         .cloned()
         .unwrap_or(serde_json::Value::Null);
     let id = profile.get("id").and_then(|v| v.as_str()).unwrap_or("");
-    let kind = overlay
-        .get("kind")
-        .and_then(|v| v.as_str())
-        .unwrap_or("aerocrypt")
-        .to_string();
+    let kind = crate::crypt_overlay_provider::overlay_kind(&overlay).to_string();
     let remote_scope = overlay
         .get("remoteScope")
         .and_then(|v| v.as_str())


### PR DESCRIPTION
## Description

`profiles --json`, `agent-bootstrap --json`, `agent-info --json` and the agent's `server_list_saved` tool all described a crypt-bound profile as a plain one: `protocol` carried the transport and nothing carried the overlay, while the My Servers table has shown these as `Crypt` profiles since #272.

The practical consequence is narrow and unpleasant: `AGENTS.md` points agents at `--json`, and a lost Crypt binding is one of the symptoms reported in #736 - so an agent verifying that symptom through the interface the docs recommend **could not see it at all**. A verification surface that cannot show the thing being verified is worse than no surface.

Two fields are added to all four surfaces:

| field | value |
|---|---|
| `cryptOverlay` | `"aerocrypt"` / `"rclone-crypt"` / `null` - the kind of an enabled binding, read the way the overlay resolver reads it |
| `protocolClass` | what the table renders, via `profile_protocol_class()` |

The kind rather than a boolean: the interop and native lanes are different answers, and `true` hides which one you are looking at.

**`protocol` is deliberately untouched.** Consumers read it for the transport; rewriting it to match the table would break every one of them. Both new fields are always emitted and `null` when unbound, so no reader has to tell "absent" apart from "no overlay" - the same shape rule `CLI-JSON-01` already states for `providerId` a few lines above.

They survive `--redact-identifiers`: PRIV-01 hides **who** an account is (host, username), while these describe **how** the connection is shaped. They identify nobody, and omitting them would reopen the blind spot exactly where agents look first.

`agent_info` propagates the two values instead of recomputing them, so the surfaces cannot disagree about the same profile.

### What review changed (second commit)

Two gaps, both fixed at the source rather than at the symptom:

- **A binding with no `kind`** (CodeRabbit). An enabled overlay without `kind` printed `"cryptOverlay": null` next to `"protocolClass": "Crypt"`, while every path that opens the overlay reads a missing kind as `aerocrypt`. That rule was restated in four readers - `overlay_binding_from_profile`, `mcp::pool::resolve_overlay_secrets` and two CLI chokepoints - and the new field was a fifth copy that answered differently. It now lives once, as `crypt_overlay_provider::overlay_kind` with `DEFAULT_OVERLAY_KIND`, and all five call it. It is `pub` because the resolver is `pub(crate)` and the binary cannot reach it, which is why the copies existed. The gate reuses `profile_has_crypt_overlay`, the same predicate that makes `profile_protocol_class` answer `Crypt`, so the two fields cannot contradict each other.
- **`server_list_saved` was not covered.** The first version of this description said the tool reads `safe_vault_profiles`. It does not: it goes through `safe_vault_profiles_for_agent`, which assembled its own eight-field record, so the new fields never reached the tool agents call most. Both functions now build records through one `safe_profile_records`. Every field the tool emitted before keeps its value and default (`name` `"unnamed"`, `initialPath` `"/"`, `providerId` read from the profile). The one addition beyond the two new fields is `auth_state`, which `agent-bootstrap` and `agent-info` already carried, derived from a single listing of vault keys as before.

**One edge, stated rather than hidden.** `getServerCryptOverlay` in `src/types.ts` returns the stored `kind` as is. `kind` is a required field of `AeroCryptOverlayBinding` and the GUI always writes it, so for every profile the GUI produces, the CLI and the table agree. For a binding that lacks it (hand-edited or imported), the helper returns `undefined` while the CLI reports `"aerocrypt"`: the CLI follows the backend, which is what actually opens the overlay. The class is `Crypt` on both sides.

**One agent surface not covered, on purpose.** The unified tool `aeroftp_list_servers` (`ai_core/remote_tools.rs`), which MCP clients call and to which `server_list_saved` is aliased in the unified registry, builds its records from the typed `ai_core::ServerProfile`. That struct carries no binding, and three implementations fill it (`tauri_impl`, `cli_impl`, `mcp_impl`). Covering it means adding the binding to the struct and to all three, a change to the library's agent core rather than to this CLI shape, so it is left to a follow-up instead of being folded into a reviewed PR. Until then an MCP client still cannot see the overlay.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

Additive only: no field changes type or meaning, so existing consumers keep working. `server_list_saved` gains three fields and loses none.

## Checklist
- [x] My code follows the project's code style (`cargo fmt --all -- --check` clean)
- [x] I have tested my changes
- [x] I have updated the documentation (if needed)
- [x] My changes generate no new warnings
- [x] Every commit is signed off (`git commit -s`)

Notes on the evidence behind those boxes, so they can be checked rather than trusted:

- **Tests: seen red first, in both rounds.** The first two tests failed on `contains_key("cryptOverlay")` against the unfixed code. They pin the key being *present*, not its value: a missing key reads as `null` for a permissive consumer, so asserting `cryptOverlay == null` would have passed against the very code this fixes. In the review round, `safe_profile_record_reads_missing_kind_as_aerocrypt` was run against the first head and was the only failure (`left: None`, `right: Some("aerocrypt")`) before the fix.
- **Added in review**: `safe_profile_record_reads_missing_kind_as_aerocrypt`; `safe_profile_record_ignores_the_kind_of_a_disabled_overlay`, which guards the gate (the kind is read only once the overlay is enabled); and, in the library, `overlay_kind_reads_a_missing_kind_as_the_native_lane` (an explicit kind is kept, a missing or non-string one falls back).
- **Full binary suite**: `532 passed; 0 failed`. **Library tests** filtered on `overlay_kind` and `binding_`: `8 passed; 0 failed`, including the new `overlay_kind` test and the existing binding and export round-trip tests.
- **How the library tests were run, since it is not the obvious way**: from a copy of the test binary with a Common-Controls v6 manifest embedded. On Windows 10 the library test binary as built does not start at all (`0xC0000139`, no test output): it imports `TaskDialogIndirect`, which only comctl32 v6 exports, and without a manifest the loader binds `System32\comctl32.dll` 5.82. The CLI test binary does not import comctl32, which is why it runs. The code under test is the same binary; CI runs the full suite on Linux.
- **No new warnings**: compared against a baseline taken before the change. The remaining `never used` warnings are pre-existing in `src/aerorsync/xattr_fs.rs`.
- **Local build limitation, stated up front**: compiled and tested on Windows 10 with `--no-default-features --features aerorsync`, the fallback documented in `CONTRIBUTING.md`, because this machine lacks libclang for the `whisper-rs-sys` bindgen step. A green obtained that way does not cover code under `#[cfg(feature = "local-stt")]`, which this change does not touch. CI compiles with defaults.
- **Coverage is honest about its edges**: the unit tests cover `safe_profile_record` and `overlay_kind`. `safe_profile_records`, the `profiles --json` and `agent-info` call sites and the four overlay readers are covered by compilation and by sharing those helpers, not by assertions of their own: opening a real vault in a unit test is what the extraction exists to avoid.

## Related Issues

Refs #736 - found while retesting that issue on Windows 10, not a fix for it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JSON profile listings now include `initialPath`, `cryptOverlay`, and `protocolClass`.
  * Profile metadata is also available through `agent-bootstrap --json`, `agent-info --json`, and saved-profile listings.
  * `cryptOverlay` identifies native or interoperable encryption, while `protocolClass` reflects the connection type shown in the interface.
  * These fields remain available when identifiers are redacted, without exposing account details.

* **Documentation**
  * Added guidance on interpreting the new fields and accounting for transparent encryption when accessing paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
