### PR TITLE
ci: retry apt and docker with GNU timeout, not nick-fields/retry

### DIFF
--- a/.github/workflows/delta-sync-integration.yml
+++ b/.github/workflows/delta-sync-integration.yml
@@ -128,31 +128,43 @@ jobs:
           restore-keys: |
             apt-delta-sync-keyauth-${{ runner.os }}-
 
-      # Bounded and retried. The budget is what makes the signal honest: a slow
-      # mirror now fails *this step*, with its name in the log, instead of
-      # cancelling the whole job and leaving every test marked `skipped`.
-      # 5 minutes is ~3.5x the slowest healthy run measured (86s; the other
-      # four sampled runs were 20-66s) and two attempts still fit under the
-      # job cap. The step-level `timeout-minutes` is a backstop in case the
-      # retry wrapper itself wedges.
+      # Bounded and retried by GNU timeout run as root, not nick-fields/retry.
+      # That wrapper (v3 pin ad98453, also tagged v4) dies with `kill EPERM`
+      # when the child is sudo/apt (issue #124, still open; PR #161 unmerged),
+      # so max_attempts never started attempt 2. Measured on #789 run
+      # 34603359227 attempts 1 and 2: both spent ~4m54s in Attempt 1, then
+      # EPERM, cache miss, 178 packages / 59.7 MB. Warm runs are 20-86s; 300s
+      # per attempt is a cold 59.7 MB fetch at ~200 kB/s plus unpack.
+      # Acquire::http::Timeout=30 and Retries=2 cut a hung mirror from 4.5 min
+      # of silence to 30s. timeout must run as root: kill(2) allows a signal
+      # only if the sender is privileged or the uids match, so a runner-user
+      # timeout cannot TERM/KILL apt and dpkg, which would leave the dpkg/apt
+      # locks held into attempt 2. uid/gid are captured before sudo because
+      # inside, id -u is 0 and chown would make the cache unsavable. Two
+      # attempts + 30s kill-after + 2s reap + 15s pause = 677s, so the step
+      # cap is 13 minutes.
       - name: Install system dependencies
-        timeout-minutes: 12
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v3
-        with:
-          timeout_minutes: 5
-          max_attempts: 2
-          retry_wait_seconds: 15
-          command: |
+        timeout-minutes: 13
+        run: |
+          set -euo pipefail
+          export RUNNER_UID RUNNER_GID
+          RUNNER_UID=$(id -u)
+          RUNNER_GID=$(id -g)
+          run_attempt() {
             set -euo pipefail
             # An attempt killed mid-unpack leaves dpkg half-configured, and the
             # next apt-get would refuse to run until it is told to finish.
-            sudo dpkg --configure -a || true
+            dpkg --configure -a || true
             mkdir -p "$HOME/apt-archives/partial"
             # Runner-image extras: the preinstalled microsoft*, azure-cli* and google-chrome*
             # apt repos fail often enough to redden a run (403 on InRelease, Hash Sum
             # mismatch on Packages.gz), and nothing here installs from any of them.
-            sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
-            sudo apt-get update
+            rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
+            apt-get update \
+              -o Acquire::Retries=2 \
+              -o Acquire::http::Timeout=30 \
+              -o Acquire::https::Timeout=30 \
+              -o DPkg::Lock::Timeout=30
             # rsync + ssh client for the host side of the integration test.
             # Webkit/GTK stack is needed because compiling the aeroftp
             # library pulls Tauri deps even when we only run one test binary.
@@ -160,9 +172,13 @@ jobs:
             # repo (cli-smoke, aerorsync-protocol, portal-chooser,
             # nightly-telemetry), which compile the same crate with the same
             # three -dev packages.
-            sudo apt-get install -y --no-install-recommends \
+            apt-get install -y --no-install-recommends \
               -o Dir::Cache::archives="$HOME/apt-archives/" \
               -o APT::Keep-Downloaded-Packages=true \
+              -o Acquire::Retries=2 \
+              -o Acquire::http::Timeout=30 \
+              -o Acquire::https::Timeout=30 \
+              -o DPkg::Lock::Timeout=30 \
               rsync \
               openssh-client \
               acl \
@@ -172,9 +188,31 @@ jobs:
               libwebkit2gtk-4.1-dev \
               libappindicator3-dev \
               librsvg2-dev
-            # apt ran as root; hand the archives back so the cache save (which
-            # runs as the runner user) can read them.
-            sudo chown -R "$(id -u):$(id -g)" "$HOME/apt-archives"
+            # apt ran as root (sudo timeout); hand the archives back so the
+            # cache save (which runs as the runner user) can read them.
+            chown -R "${RUNNER_UID}:${RUNNER_GID}" "$HOME/apt-archives"
+          }
+          ok=0
+          for attempt in 1 2; do
+            echo "Install system dependencies: attempt ${attempt}/2"
+            if sudo --preserve-env=HOME,RUNNER_UID,RUNNER_GID \
+                 timeout --signal=TERM --kill-after=30s 300s \
+                 bash -euo pipefail -c "$(declare -f run_attempt); run_attempt"; then
+              ok=1
+              break
+            fi
+            echo "attempt ${attempt} failed (timeout or apt error)" >&2
+            sudo pkill -9 -x apt-get || true
+            sudo pkill -9 -x dpkg || true
+            sleep 2
+            if [ "$attempt" -lt 2 ]; then
+              sleep 15
+            fi
+          done
+          if [ "$ok" -ne 1 ]; then
+            echo "Install system dependencies failed after 2 attempts" >&2
+            exit 1
+          fi
 
       - name: Generate fixture SSH key
         working-directory: src-tauri/tests/fixtures/sftp-rsync
@@ -339,25 +377,35 @@ jobs:
       - name: Install system dependencies
         # sshpass needed to poll the password-auth fixture readiness
         # (the integration test itself uses russh via SftpProvider -
-        # sshpass is just a scripting convenience).
-        timeout-minutes: 12
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v3
-        with:
-          timeout_minutes: 5
-          max_attempts: 2
-          retry_wait_seconds: 15
-          command: |
+        # sshpass is just a scripting convenience). Same sudo-timeout loop as
+        # the key-auth job: 300s per attempt, 13-minute step cap. See that
+        # job's comment for kill(2) and why nick-fields/retry is gone.
+        timeout-minutes: 13
+        run: |
+          set -euo pipefail
+          export RUNNER_UID RUNNER_GID
+          RUNNER_UID=$(id -u)
+          RUNNER_GID=$(id -g)
+          run_attempt() {
             set -euo pipefail
-            sudo dpkg --configure -a || true
+            dpkg --configure -a || true
             mkdir -p "$HOME/apt-archives/partial"
             # Runner-image extras: the preinstalled microsoft*, azure-cli* and google-chrome*
             # apt repos fail often enough to redden a run (403 on InRelease, Hash Sum
             # mismatch on Packages.gz), and nothing here installs from any of them.
-            sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
-            sudo apt-get update
-            sudo apt-get install -y --no-install-recommends \
+            rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
+            apt-get update \
+              -o Acquire::Retries=2 \
+              -o Acquire::http::Timeout=30 \
+              -o Acquire::https::Timeout=30 \
+              -o DPkg::Lock::Timeout=30
+            apt-get install -y --no-install-recommends \
               -o Dir::Cache::archives="$HOME/apt-archives/" \
               -o APT::Keep-Downloaded-Packages=true \
+              -o Acquire::Retries=2 \
+              -o Acquire::http::Timeout=30 \
+              -o Acquire::https::Timeout=30 \
+              -o DPkg::Lock::Timeout=30 \
               rsync \
               openssh-client \
               sshpass \
@@ -365,17 +413,53 @@ jobs:
               libwebkit2gtk-4.1-dev \
               libappindicator3-dev \
               librsvg2-dev
-            sudo chown -R "$(id -u):$(id -g)" "$HOME/apt-archives"
+            chown -R "${RUNNER_UID}:${RUNNER_GID}" "$HOME/apt-archives"
+          }
+          ok=0
+          for attempt in 1 2; do
+            echo "Install system dependencies: attempt ${attempt}/2"
+            if sudo --preserve-env=HOME,RUNNER_UID,RUNNER_GID \
+                 timeout --signal=TERM --kill-after=30s 300s \
+                 bash -euo pipefail -c "$(declare -f run_attempt); run_attempt"; then
+              ok=1
+              break
+            fi
+            echo "attempt ${attempt} failed (timeout or apt error)" >&2
+            sudo pkill -9 -x apt-get || true
+            sudo pkill -9 -x dpkg || true
+            sleep 2
+            if [ "$attempt" -lt 2 ]; then
+              sleep 15
+            fi
+          done
+          if [ "$ok" -ne 1 ]; then
+            echo "Install system dependencies failed after 2 attempts" >&2
+            exit 1
+          fi
 
       - name: Build & start password-auth docker fixture
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v3
-        with:
-          timeout_minutes: 5
-          max_attempts: 2
-          retry_wait_seconds: 10
-          command: |
-            cd src-tauri/tests/fixtures/sftp-rsync
-            docker compose -f docker-compose.password.yml up -d --build
+        timeout-minutes: 13
+        run: |
+          set -euo pipefail
+          ok=0
+          for attempt in 1 2; do
+            echo "Build & start password-auth docker fixture: attempt ${attempt}/2"
+            if timeout --signal=TERM --kill-after=30s 300s bash -euo pipefail -c '
+              cd src-tauri/tests/fixtures/sftp-rsync
+              docker compose -f docker-compose.password.yml up -d --build
+            '; then
+              ok=1
+              break
+            fi
+            echo "attempt ${attempt} failed (timeout or docker error)" >&2
+            if [ "$attempt" -lt 2 ]; then
+              sleep 10
+            fi
+          done
+          if [ "$ok" -ne 1 ]; then
+            echo "Build & start password-auth docker fixture failed after 2 attempts" >&2
+            exit 1
+          fi
 
       - name: Wait for password fixture SSH
         run: |

--- a/.github/workflows/ftp-mlsd.yml
+++ b/.github/workflows/ftp-mlsd.yml
@@ -77,36 +77,67 @@ jobs:
 
       # The test target links the Tauri crate, so the GTK/WebKit stack has to be
       # present or the glib-sys build script fails before a single test runs.
-      # Bounded and retried for the same reason as the sibling lane: a slow
-      # mirror should fail THIS step, with its name in the log, rather than
-      # cancel the job and leave every test reported as skipped.
+      # Bounded and retried by GNU timeout run as root, not nick-fields/retry:
+      # that wrapper dies with `kill EPERM` on sudo/apt and never starts
+      # attempt 2 (issue #124; same pin as v4). Same numbers as
+      # delta-sync-integration.yml: 300s per attempt, Acquire timeouts 30s,
+      # 13-minute step cap. timeout runs as root because kill(2) will not
+      # deliver TERM/KILL to apt/dpkg from the runner user.
       - name: Install system dependencies
-        timeout-minutes: 12
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v3
-        with:
-          timeout_minutes: 5
-          max_attempts: 2
-          retry_wait_seconds: 15
-          command: |
+        timeout-minutes: 13
+        run: |
+          set -euo pipefail
+          export RUNNER_UID RUNNER_GID
+          RUNNER_UID=$(id -u)
+          RUNNER_GID=$(id -g)
+          run_attempt() {
             set -euo pipefail
             # An attempt killed mid-unpack leaves dpkg half-configured, and the
             # next apt-get would refuse to run until it is told to finish.
-            sudo dpkg --configure -a || true
+            dpkg --configure -a || true
             mkdir -p "$HOME/apt-archives/partial"
             # Runner-image extras: the preinstalled microsoft*, azure-cli* and google-chrome*
             # apt repos fail often enough to redden a run (403 on InRelease, Hash Sum
             # mismatch on Packages.gz), and nothing here installs from any of them.
-            sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
-            sudo apt-get update
-            sudo apt-get install -y --no-install-recommends \
+            rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
+            apt-get update \
+              -o Acquire::Retries=2 \
+              -o Acquire::http::Timeout=30 \
+              -o Acquire::https::Timeout=30 \
+              -o DPkg::Lock::Timeout=30
+            apt-get install -y --no-install-recommends \
               -o Dir::Cache::archives="$HOME/apt-archives/" \
               -o APT::Keep-Downloaded-Packages=true \
+              -o Acquire::Retries=2 \
+              -o Acquire::http::Timeout=30 \
+              -o Acquire::https::Timeout=30 \
+              -o DPkg::Lock::Timeout=30 \
               libwebkit2gtk-4.1-dev \
               libappindicator3-dev \
               librsvg2-dev
-            # apt ran as root; hand the archives back so the cache save (which
-            # runs as the runner user) can read them.
-            sudo chown -R "$(id -u):$(id -g)" "$HOME/apt-archives"
+            chown -R "${RUNNER_UID}:${RUNNER_GID}" "$HOME/apt-archives"
+          }
+          ok=0
+          for attempt in 1 2; do
+            echo "Install system dependencies: attempt ${attempt}/2"
+            if sudo --preserve-env=HOME,RUNNER_UID,RUNNER_GID \
+                 timeout --signal=TERM --kill-after=30s 300s \
+                 bash -euo pipefail -c "$(declare -f run_attempt); run_attempt"; then
+              ok=1
+              break
+            fi
+            echo "attempt ${attempt} failed (timeout or apt error)" >&2
+            sudo pkill -9 -x apt-get || true
+            sudo pkill -9 -x dpkg || true
+            sleep 2
+            if [ "$attempt" -lt 2 ]; then
+              sleep 15
+            fi
+          done
+          if [ "$ok" -ne 1 ]; then
+            echo "Install system dependencies failed after 2 attempts" >&2
+            exit 1
+          fi
 
       # It pulls a base image from Docker Hub, which this repo has seen time
       # out before (see aerorsync-protocol.yml).
@@ -230,27 +261,58 @@ jobs:
             apt-ftp-mlsd-${{ runner.os }}-
 
       - name: Install system dependencies
-        timeout-minutes: 12
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v3
-        with:
-          timeout_minutes: 5
-          max_attempts: 2
-          retry_wait_seconds: 15
-          command: |
+        timeout-minutes: 13
+        run: |
+          set -euo pipefail
+          export RUNNER_UID RUNNER_GID
+          RUNNER_UID=$(id -u)
+          RUNNER_GID=$(id -g)
+          run_attempt() {
             set -euo pipefail
-            sudo dpkg --configure -a || true
+            dpkg --configure -a || true
             mkdir -p "$HOME/apt-archives/partial"
             # Runner-image extras: the preinstalled microsoft*, azure-cli* and google-chrome*
             # apt repos fail often enough to redden a run (403 on InRelease, Hash Sum
             # mismatch on Packages.gz), and nothing here installs from any of them.
-            sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
-            sudo apt-get update
-            sudo apt-get install -y --no-install-recommends \
+            rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/azure-cli* /etc/apt/sources.list.d/google-chrome*
+            apt-get update \
+              -o Acquire::Retries=2 \
+              -o Acquire::http::Timeout=30 \
+              -o Acquire::https::Timeout=30 \
+              -o DPkg::Lock::Timeout=30
+            apt-get install -y --no-install-recommends \
               -o Dir::Cache::archives="$HOME/apt-archives/" \
               -o APT::Keep-Downloaded-Packages=true \
+              -o Acquire::Retries=2 \
+              -o Acquire::http::Timeout=30 \
+              -o Acquire::https::Timeout=30 \
+              -o DPkg::Lock::Timeout=30 \
               libwebkit2gtk-4.1-dev \
               libappindicator3-dev \
               librsvg2-dev
+            chown -R "${RUNNER_UID}:${RUNNER_GID}" "$HOME/apt-archives"
+          }
+          ok=0
+          for attempt in 1 2; do
+            echo "Install system dependencies: attempt ${attempt}/2"
+            if sudo --preserve-env=HOME,RUNNER_UID,RUNNER_GID \
+                 timeout --signal=TERM --kill-after=30s 300s \
+                 bash -euo pipefail -c "$(declare -f run_attempt); run_attempt"; then
+              ok=1
+              break
+            fi
+            echo "attempt ${attempt} failed (timeout or apt error)" >&2
+            sudo pkill -9 -x apt-get || true
+            sudo pkill -9 -x dpkg || true
+            sleep 2
+            if [ "$attempt" -lt 2 ]; then
+              sleep 15
+            fi
+          done
+          if [ "$ok" -ne 1 ]; then
+            echo "Install system dependencies failed after 2 attempts" >&2
+            exit 1
+          fi
 
       # 420s of hanging, not 90: the fixture must outlast the 300s budget under
       # test. At the old default of 90 the fixture gave up first, and a test that


### PR DESCRIPTION
## Summary

CI apt and docker retries actually retry after a timeout. nick-fields/retry@v3 died with `kill EPERM` when the child was sudo/apt, so `max_attempts: 2` never started a second try.

The four apt steps loop `sudo timeout --kill-after=30s 300s`. timeout runs as root so TERM/KILL reach apt and dpkg: `kill(2)` delivers a signal only if the sender is privileged or the uids match, so a runner-user timeout cannot stop a root apt and would leave the dpkg/apt locks held into attempt 2. The runner uid/gid are captured before sudo, because inside `id -u` is 0 and `chown` would make the cache unsavable. The docker fixture step loops `timeout` without sudo, because docker does not run as root.

After a failed apt attempt, leftover `apt-get` and `dpkg` are reaped with `sudo pkill -9 -x apt-get || true` and `sudo pkill -9 -x dpkg || true` (`pkill -x` is exact-name; `killall -x` is not a valid option and exited 1, hidden by `2>/dev/null`). `pkill` exits 1 when nothing matches, which `|| true` covers; a real error stays visible. `DPkg::Lock::Timeout=30` waits on the dpkg lock; the apt lists lock is a different file, which is why the reap stays.

The inner bash is `bash -euo pipefail` and `run_attempt` starts with `set -euo pipefail`, so an `apt-get install` failure fails the attempt instead of returning the `chown` exit code.

Apt also sets `Acquire::http::Timeout=30` and `Retries=2` so a hung Azure mirror does not eat the whole attempt.

The pin was not bumped: nick-fields/retry issue #124 is still open, PR #161 is unmerged, and v4.0.0 is the same SHA as the v3 pin (`ad98453`).

## Evidence (PR #789, run 34603359227)

Attempt 1 job 103275794377 and attempt 2 job 103283480584, both "Install system dependencies":

- `Cache not found for input keys: apt-delta-sync-keyauth-Linux-2026-W37, apt-delta-sync-keyauth-Linux-`
- `0 upgraded, 178 newly installed` / `Need to get 59.7 MB of archives.`
- `##[group]Attempt 1` then `Error: kill EPERM` at `killPid` in nick-fields/retry; no Attempt 2 group
- step duration ~5m01s against `timeout_minutes: 5`

```
gh api 'repos/axpdev-lab/aeroftp/actions/caches?key=apt-delta-sync'
# total_count: 0

gh api repos/axpdev-lab/aeroftp/actions/cache/usage
# active_caches_size_in_bytes: 7656807389  (12 caches; whisper blobs)
```

## Numbers

300s per attempt covers a cold 59.7 MB fetch at about 200 kB/s plus unpack. Warm runs were 20-86s. Two attempts + 30s kill-after + 2s reap + 15s pause = 677s, so the step cap is 13 minutes.

## Local proofs of the retry loop

Same shape as the workflow, stub in place of apt, 2s timeout / 1s kill-after.

Without `set -e` in the inner bash, a failing command does not fail the attempt:

```
run_attempt() { false; echo "after false, still running"; true; }
timeout ... bash -c "$(declare -f run_attempt); run_attempt"
# prints "after false, still running", rc=0
```

With `set -euo pipefail` as the first line of `run_attempt` and `bash -euo pipefail -c`:

```
fixed_rc=1
```

(a) stub `exit 1`: attempt 1 fails, attempt 2 runs, final rc=1

```
attempt 1/2
attempt 1 failed
attempt 2/2
attempt 2 failed
failed after 2 attempts
a_rc=1
```

(b) stub `sleep 10` (exceeds 2s): attempt 2 runs, final rc=1

```
attempt 1/2
attempt 1 failed
attempt 2/2
attempt 2 failed
failed after 2 attempts
b_rc=1
```

(c) stub `true`: only attempt 1, rc=0

```
attempt 1/2
c_rc=0
```

(d) `pkill -9 -x` reaps an exact-name leftover (the recovery between apt attempts):

```
cp /bin/sleep /tmp/aptstub
/tmp/aptstub 60 &
pkill -9 -x aptstub
wait
# wait_rc=137 (SIGKILL), process gone
pkill -9 -x __no_such_proc__; echo rc=$?
# rc=1, error printed to stderr (no 2>/dev/null)
```
