### PR TITLE
fix(sync): refuse watch and reconcile deletes on unreadable local trees

### DIFF
--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -73947,25 +73947,48 @@ mod tests {
     /// A remote tree held in memory, for driving `sync` and `sync-doctor` end
     /// to end: `list` answers from a map, and every mutation is refused, so a
     /// run that tried to change the tree fails instead of passing on a no-op.
+    /// Deletes are also recorded, refused or not, so a test can tell a delete
+    /// the run attempted from one it never planned.
     struct MemTreeProvider {
         dirs: HashMap<String, Vec<RemoteEntry>>,
+        delete_attempts: Arc<Mutex<Vec<String>>>,
     }
 
     impl MemTreeProvider {
         /// Files directly under `/root`, as `(name, size)`, stamped with
         /// [`FIXTURE_MTIME`].
         fn root_files(files: &[(&str, u64)]) -> Self {
-            let entries = files
-                .iter()
-                .map(|(name, size)| {
-                    let mut entry =
-                        RemoteEntry::file(name.to_string(), format!("/root/{name}"), *size);
-                    entry.modified = Some(FIXTURE_MTIME.to_string());
-                    entry
-                })
-                .collect();
+            Self::tree(files)
+        }
+
+        /// Files under `/root` at any depth, as `(relative path, size)`,
+        /// stamped with [`FIXTURE_MTIME`]; the directories on their way are
+        /// listed too.
+        fn tree(files: &[(&str, u64)]) -> Self {
+            let mut dirs: HashMap<String, Vec<RemoteEntry>> =
+                HashMap::from([("/root".to_string(), Vec::new())]);
+            for (path, size) in files {
+                let mut parent = "/root".to_string();
+                let mut parts = path.split('/').peekable();
+                while let Some(part) = parts.next() {
+                    let full = format!("{parent}/{part}");
+                    if parts.peek().is_some() {
+                        let listing = dirs.entry(parent.clone()).or_default();
+                        if !listing.iter().any(|entry| entry.path == full) {
+                            listing.push(RemoteEntry::directory(part.to_string(), full.clone()));
+                        }
+                        dirs.entry(full.clone()).or_default();
+                    } else {
+                        let mut entry = RemoteEntry::file(part.to_string(), full.clone(), *size);
+                        entry.modified = Some(FIXTURE_MTIME.to_string());
+                        dirs.entry(parent.clone()).or_default().push(entry);
+                    }
+                    parent = full;
+                }
+            }
             Self {
-                dirs: HashMap::from([("/root".to_string(), entries)]),
+                dirs,
+                delete_attempts: Arc::default(),
             }
         }
     }
@@ -74030,7 +74053,11 @@ mod tests {
         async fn mkdir(&mut self, _path: &str) -> Result<(), ProviderError> {
             Err(ProviderError::NotSupported("mkdir".to_string()))
         }
-        async fn delete(&mut self, _path: &str) -> Result<(), ProviderError> {
+        async fn delete(&mut self, path: &str) -> Result<(), ProviderError> {
+            self.delete_attempts
+                .lock()
+                .expect("delete log")
+                .push(path.to_string());
             Err(ProviderError::NotSupported("delete".to_string()))
         }
         async fn rmdir(&mut self, _path: &str) -> Result<(), ProviderError> {
@@ -74140,19 +74167,44 @@ mod tests {
         precomputed_local: Option<SyncScan>,
         from_reconcile: Option<&str>,
     ) -> SyncCycleStats {
+        run_sync_with_delete(
+            remote,
+            local,
+            direction,
+            true,
+            cli,
+            precomputed_local,
+            from_reconcile,
+        )
+    }
+
+    /// The real `cmd_sync` with `--delete` against `remote`, as a dry run or
+    /// not. A run that is not dry reaches the scan guards (TX-01) and the
+    /// deletes themselves, which the remote records and refuses.
+    fn run_sync_with_delete(
+        remote: MemTreeProvider,
+        local: &str,
+        direction: &str,
+        dry_run: bool,
+        cli: &Cli,
+        precomputed_local: Option<SyncScan>,
+        from_reconcile: Option<&str>,
+    ) -> SyncCycleStats {
         run_against_remote(remote, move || {
             cmd_sync(
                 "memory://",
                 local,
                 "/root",
                 direction,
-                true, // dry_run
+                dry_run,
                 true, // delete
                 &[],
                 None,
                 0,
                 false,
-                None,
+                // An unattended live --delete must state its cap (DEL-01); a
+                // wide one keeps the cap out of what the tests observe.
+                Some("1000"),
                 None,
                 "",
                 false,
@@ -74432,6 +74484,354 @@ mod tests {
             !saved.files.contains_key("b.txt"),
             "a run without a list replaces the snapshot whole"
         );
+    }
+
+    /// Makes a directory unreadable for the rest of a test and gives it back
+    /// its permissions when dropped, pass or panic, so the scratch tree can be
+    /// removed.
+    #[cfg(unix)]
+    struct UnreadableDir(std::path::PathBuf);
+
+    #[cfg(unix)]
+    impl UnreadableDir {
+        fn lock(path: std::path::PathBuf) -> Self {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o000))
+                .expect("lock the directory");
+            let guard = Self(path);
+            assert!(
+                std::fs::read_dir(&guard.0).is_err(),
+                "this test needs a directory the current user cannot read, and root reads every directory"
+            );
+            guard
+        }
+    }
+
+    #[cfg(unix)]
+    impl Drop for UnreadableDir {
+        fn drop(&mut self) {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(&self.0, std::fs::Permissions::from_mode(0o755));
+        }
+    }
+
+    /// A local tree with `a.txt` and `locked/keep.txt`, both also on the
+    /// remote with the same size and mtime, so nothing is left to upload and
+    /// any delete the run attempts is a wrong one.
+    #[cfg(unix)]
+    fn watch_fixture() -> (FilesFromFixture, MemTreeProvider) {
+        let fixture = FilesFromFixture::new();
+        std::fs::create_dir(Path::new(&fixture.local()).join("locked")).expect("locked directory");
+        fixture.local_file("a.txt", 1);
+        fixture.local_file("locked/keep.txt", 1);
+        let remote = MemTreeProvider::tree(&[("a.txt", 1), ("locked/keep.txt", 1)]);
+        (fixture, remote)
+    }
+
+    /// A watch snapshot taken while a local directory cannot be read must not
+    /// let an incremental `--delete` cycle take the files behind it for remote
+    /// orphans. The snapshot cannot see into `locked/` and the watcher reports
+    /// `a.txt`: the cycle must refuse its deletes, with the exit code of a full
+    /// scan that hits the same directory (4), and must not delete
+    /// `locked/keep.txt` from the remote.
+    #[cfg(unix)]
+    #[test]
+    fn watch_cycle_deletes_nothing_behind_a_directory_the_snapshot_could_not_read() {
+        let (fixture, remote) = watch_fixture();
+        let local = fixture.local();
+        let _locked = UnreadableDir::lock(Path::new(&local).join("locked"));
+        let filter = watch_test_filter(&[]);
+        let snapshot = build_watch_local_snapshot(&local, &filter);
+        let scan = incremental_local_scan(
+            Path::new(&local),
+            &[Path::new(&local).join("a.txt")],
+            &snapshot,
+            &filter,
+        );
+        let delete_attempts = Arc::clone(&remote.delete_attempts);
+        let cli = Cli {
+            quiet: true,
+            ..test_cli()
+        };
+
+        let stats = run_sync_with_delete(remote, &local, "upload", false, &cli, Some(scan), None);
+
+        assert_eq!(
+            *delete_attempts.lock().expect("delete log"),
+            Vec::<String>::new(),
+            "no remote delete may be attempted behind the unreadable directory"
+        );
+        assert_eq!(stats.exit_code, 4, "the refusal shows in the exit code");
+    }
+
+    /// The watcher reports a file the cycle cannot stat, because its directory
+    /// became unreadable after the snapshot. A file that cannot be read is not
+    /// a file that was deleted: the cycle must not plan it as a remote orphan.
+    #[cfg(unix)]
+    #[test]
+    fn watch_cycle_does_not_take_a_file_it_cannot_stat_for_a_deleted_one() {
+        let (fixture, remote) = watch_fixture();
+        let local = fixture.local();
+        let filter = watch_test_filter(&[]);
+        let snapshot = build_watch_local_snapshot(&local, &filter);
+        let _locked = UnreadableDir::lock(Path::new(&local).join("locked"));
+        let scan = incremental_local_scan(
+            Path::new(&local),
+            &[Path::new(&local).join("locked").join("keep.txt")],
+            &snapshot,
+            &filter,
+        );
+        let delete_attempts = Arc::clone(&remote.delete_attempts);
+        let cli = Cli {
+            quiet: true,
+            ..test_cli()
+        };
+
+        let stats = run_sync_with_delete(remote, &local, "upload", false, &cli, Some(scan), None);
+
+        assert_eq!(
+            *delete_attempts.lock().expect("delete log"),
+            Vec::<String>::new(),
+            "an unreadable file must not be deleted from the remote"
+        );
+        assert_eq!(stats.exit_code, 4, "the refusal shows in the exit code");
+    }
+
+    /// A watch cycle's local side holds the files a full `sync` scan would:
+    /// the snapshot and the incremental refresh both apply the depth bound and
+    /// the exclude patterns. The snapshot applied neither, so an excluded file
+    /// already on disk reached the planner at the first watcher event.
+    #[test]
+    fn watch_cycle_local_side_applies_the_sync_depth_and_exclude_filters() {
+        let dir = tempfile::tempdir().expect("scratch directory");
+        let root = dir.path();
+        std::fs::write(root.join("a.txt"), b"a").expect("a.txt");
+        std::fs::write(root.join("secret.env"), b"s").expect("secret.env");
+        std::fs::create_dir(root.join("d")).expect("d/");
+        std::fs::write(root.join("d").join("deep.txt"), b"d").expect("d/deep.txt");
+        let exclude = [globset::Glob::new("*.env").expect("glob").compile_matcher()];
+        let filter = SyncLocalFilter {
+            max_depth: 1,
+            exclude: &exclude,
+        };
+
+        let snapshot = build_watch_local_snapshot(root.to_str().expect("utf-8 root"), &filter);
+        let snapshot_files: std::collections::BTreeSet<&str> =
+            snapshot.files.keys().map(String::as_str).collect();
+        assert_eq!(
+            snapshot_files,
+            std::collections::BTreeSet::from(["a.txt"]),
+            "the snapshot keeps only what the sync scan keeps"
+        );
+
+        let scan = incremental_local_scan(
+            root,
+            &[root.join("secret.env"), root.join("d").join("deep.txt")],
+            &snapshot,
+            &filter,
+        );
+        let scan_files: std::collections::BTreeSet<&str> = scan
+            .entries
+            .iter()
+            .map(|(path, _, _)| path.as_str())
+            .collect();
+        assert_eq!(
+            scan_files,
+            std::collections::BTreeSet::from(["a.txt"]),
+            "a watcher event does not bring in a filtered file"
+        );
+    }
+
+    /// `reconcile` walks the local tree with `scan_local_tree_with_progress`.
+    /// A directory it cannot read must leave that scan incomplete: its files
+    /// would otherwise be reported as missing locally.
+    #[cfg(unix)]
+    #[test]
+    fn reconcile_local_scan_is_incomplete_behind_an_unreadable_directory() {
+        let dir = tempfile::tempdir().expect("scratch directory");
+        std::fs::create_dir(dir.path().join("locked")).expect("locked directory");
+        std::fs::write(dir.path().join("locked").join("keep.txt"), b"k").expect("keep.txt");
+        let _locked = UnreadableDir::lock(dir.path().join("locked"));
+
+        let (_, completeness) = scan_local_tree_with_progress(
+            dir.path().to_str().expect("utf-8 root"),
+            &ftp_client_gui_lib::sync_core::ScanOptions::default(),
+            &None,
+        );
+
+        assert!(
+            !completeness.is_complete(),
+            "the unreadable directory must count as a listing error"
+        );
+    }
+
+    /// Write a reconcile plan with one remote-only file, `b.txt`, and the
+    /// given summary.
+    fn write_reconcile_plan(fixture: &FilesFromFixture, summary: serde_json::Value) -> String {
+        let plan = fixture.dir.path().join("reconcile.json");
+        std::fs::write(
+            &plan,
+            serde_json::json!({
+                "status": "differences_found",
+                "summary": summary,
+                "groups": {
+                    "match": [],
+                    "differ": [],
+                    "missing_remote": [],
+                    "missing_local": [{"path": "b.txt", "remote_size": 1}],
+                },
+            })
+            .to_string(),
+        )
+        .expect("write the reconcile plan");
+        plan.to_string_lossy().into_owned()
+    }
+
+    /// `sync --from-reconcile --delete` on a plan whose local scan was
+    /// incomplete must refuse, as a live scan does (exit 4, no delete): the
+    /// files it lists as missing locally may be files the scan could not read.
+    /// A `--files-from` list naming them does not change that.
+    #[test]
+    fn sync_from_reconcile_refuses_delete_on_an_incomplete_local_scan() {
+        for listed in [None, Some("b.txt")] {
+            let fixture = FilesFromFixture::new();
+            let cli = match listed {
+                Some(path) => fixture.cli_listing(&[path]),
+                None => Cli {
+                    quiet: true,
+                    ..test_cli()
+                },
+            };
+            let plan = write_reconcile_plan(
+                &fixture,
+                serde_json::json!({
+                    "remote_scan_incomplete": false,
+                    "remote_scan_errors": 0,
+                    "remote_scan_truncated": false,
+                    "local_scan_incomplete": true,
+                    "local_scan_errors": 1,
+                    "local_scan_truncated": false,
+                }),
+            );
+            let remote = MemTreeProvider::root_files(&[("b.txt", 1)]);
+            let delete_attempts = Arc::clone(&remote.delete_attempts);
+
+            let stats = run_sync_with_delete(
+                remote,
+                &fixture.local(),
+                "upload",
+                false,
+                &cli,
+                None,
+                Some(&plan),
+            );
+
+            assert_eq!(
+                *delete_attempts.lock().expect("delete log"),
+                Vec::<String>::new(),
+                "no remote delete from a plan with an incomplete local scan (list: {listed:?})"
+            );
+            assert_eq!(stats.exit_code, 4, "a TX-01 refusal (list: {listed:?})");
+        }
+    }
+
+    /// Refusing `--delete` on a partial reconcile plan is the TX-01 refusal of
+    /// a live scan, so it exits with the same code (4), not with the code of a
+    /// malformed plan (5).
+    #[test]
+    fn sync_from_reconcile_refusal_of_a_partial_remote_scan_exits_4() {
+        let fixture = FilesFromFixture::new();
+        let cli = Cli {
+            quiet: true,
+            ..test_cli()
+        };
+        let plan = write_reconcile_plan(
+            &fixture,
+            serde_json::json!({
+                "remote_scan_incomplete": true,
+                "remote_scan_errors": 1,
+                "remote_scan_truncated": false,
+            }),
+        );
+        let remote = MemTreeProvider::root_files(&[("b.txt", 1)]);
+        let delete_attempts = Arc::clone(&remote.delete_attempts);
+
+        let stats = run_sync_with_delete(
+            remote,
+            &fixture.local(),
+            "upload",
+            false,
+            &cli,
+            None,
+            Some(&plan),
+        );
+
+        assert!(delete_attempts.lock().expect("delete log").is_empty());
+        assert_eq!(stats.exit_code, 4);
+    }
+
+    /// A complete reconcile plan driving `sync --from-reconcile --direction
+    /// upload --delete` asks the remote for each orphan once. The plan lists
+    /// its deletes already, and the live orphan pass added the same paths a
+    /// second time, so every delete was attempted twice.
+    #[test]
+    fn sync_from_reconcile_attempts_each_remote_delete_once() {
+        let fixture = FilesFromFixture::new();
+        let cli = Cli {
+            quiet: true,
+            ..test_cli()
+        };
+        let plan = write_reconcile_plan(
+            &fixture,
+            serde_json::json!({
+                "remote_scan_incomplete": false,
+                "remote_scan_errors": 0,
+                "remote_scan_truncated": false,
+            }),
+        );
+        let remote = MemTreeProvider::root_files(&[("b.txt", 1)]);
+        let delete_attempts = Arc::clone(&remote.delete_attempts);
+
+        run_sync_with_delete(
+            remote,
+            &fixture.local(),
+            "upload",
+            false,
+            &cli,
+            None,
+            Some(&plan),
+        );
+
+        assert_eq!(
+            *delete_attempts.lock().expect("delete log"),
+            vec!["/root/b.txt".to_string()]
+        );
+    }
+
+    /// A reconcile file written before the summary carried the local scan
+    /// fields still loads, and still drives `--delete` when its scans were
+    /// complete.
+    #[test]
+    fn reconcile_summary_without_the_local_scan_fields_still_drives_delete() {
+        let fixture = FilesFromFixture::new();
+        let plan = write_reconcile_plan(
+            &fixture,
+            serde_json::json!({
+                "match_count": 0,
+                "differ_count": 0,
+                "missing_remote_count": 0,
+                "missing_local_count": 1,
+                "remote_scan_incomplete": false,
+                "remote_scan_errors": 0,
+                "remote_scan_truncated": false,
+                "elapsed_secs": 0.1,
+            }),
+        );
+
+        let loaded = load_sync_plan_from_reconcile(&plan, "upload", true, None)
+            .unwrap_or_else(|_| panic!("a summary in the earlier format must load"));
+
+        assert_eq!(loaded.to_delete_remote, vec!["b.txt"]);
     }
 
     struct CliEditFakeProvider {

--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -74606,6 +74606,30 @@ mod tests {
     }
 
     #[cfg(unix)]
+    impl UnreadableDir {
+        /// Leave the directory listable but not enterable (0400): its entries
+        /// can still be enumerated, with their type, while a stat of any of
+        /// them fails.
+        fn seal(path: std::path::PathBuf) -> Self {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o400))
+                .expect("seal the directory");
+            let guard = Self(path);
+            let child = std::fs::read_dir(&guard.0)
+                .expect("a 0400 directory still lists")
+                .filter_map(Result::ok)
+                .next()
+                .expect("the sealed directory holds an entry")
+                .path();
+            assert!(
+                std::fs::symlink_metadata(&child).is_err(),
+                "this test needs a directory the current user can list but not enter, and root enters every directory"
+            );
+            guard
+        }
+    }
+
+    #[cfg(unix)]
     impl Drop for UnreadableDir {
         fn drop(&mut self) {
             use std::os::unix::fs::PermissionsExt;
@@ -74930,6 +74954,117 @@ mod tests {
             .unwrap_or_else(|_| panic!("a summary in the earlier format must load"));
 
         assert_eq!(loaded.to_delete_remote, vec!["b.txt"]);
+    }
+
+    /// A file under a directory the walk can list but not enter (0400) comes
+    /// back from the walk with its type but without metadata. The watch
+    /// snapshot must count that as a read error, or it stays usable for
+    /// incremental `--delete` cycles, and must keep the file, or it reads as
+    /// deleted.
+    #[cfg(unix)]
+    #[test]
+    fn watch_snapshot_counts_a_file_it_can_list_but_not_stat() {
+        let dir = tempfile::tempdir().expect("scratch directory");
+        std::fs::create_dir(dir.path().join("sealed")).expect("sealed directory");
+        std::fs::write(dir.path().join("sealed").join("keep.txt"), b"k").expect("keep.txt");
+        let _sealed = UnreadableDir::seal(dir.path().join("sealed"));
+
+        let snapshot = build_watch_local_snapshot(
+            dir.path().to_str().expect("utf-8 root"),
+            &watch_test_filter(&[]),
+        );
+
+        assert!(
+            !snapshot.completeness.is_complete(),
+            "a file that cannot be statted leaves the snapshot incomplete"
+        );
+        assert!(
+            snapshot.files.contains_key("sealed/keep.txt"),
+            "the file stays in the snapshot, so it does not read as deleted"
+        );
+    }
+
+    /// `sync --direction upload --delete` over a local tree with a file it can
+    /// list but not stat must refuse its deletes (exit 4): the scan did not
+    /// read the whole tree. Here the delete it would otherwise make is of
+    /// `gone.txt`, a file present only on the remote.
+    #[cfg(unix)]
+    #[test]
+    fn sync_upload_delete_refuses_when_a_local_file_cannot_be_statted() {
+        let fixture = FilesFromFixture::new();
+        let local = fixture.local();
+        std::fs::create_dir(Path::new(&local).join("sealed")).expect("sealed directory");
+        fixture.local_file("a.txt", 1);
+        fixture.local_file("sealed/keep.txt", 1);
+        let _sealed = UnreadableDir::seal(Path::new(&local).join("sealed"));
+        let remote =
+            MemTreeProvider::tree(&[("a.txt", 1), ("sealed/keep.txt", 1), ("gone.txt", 1)]);
+        let delete_attempts = Arc::clone(&remote.delete_attempts);
+        let cli = Cli {
+            quiet: true,
+            ..test_cli()
+        };
+
+        let stats = run_sync_with_delete(remote, &local, "upload", false, &cli, None, None);
+
+        assert_eq!(
+            *delete_attempts.lock().expect("delete log"),
+            Vec::<String>::new(),
+            "no remote delete while a local file could not be statted"
+        );
+        assert_eq!(stats.exit_code, 4, "the refusal shows in the exit code");
+    }
+
+    /// The reconcile local scan over a file it can list but not stat must be
+    /// incomplete, keep the file, and so make `sync --from-reconcile --delete`
+    /// refuse (exit 4). The plan carries the summary fields `reconcile`
+    /// writes from that scan.
+    #[cfg(unix)]
+    #[test]
+    fn sync_from_reconcile_refuses_delete_when_reconcile_could_not_stat_a_local_file() {
+        let fixture = FilesFromFixture::new();
+        let local = fixture.local();
+        std::fs::create_dir(Path::new(&local).join("sealed")).expect("sealed directory");
+        fixture.local_file("sealed/keep.txt", 1);
+        let _sealed = UnreadableDir::seal(Path::new(&local).join("sealed"));
+
+        let (locals, local_health) = scan_local_tree_with_progress(
+            &local,
+            &ftp_client_gui_lib::sync_core::ScanOptions::default(),
+            &None,
+        );
+        assert!(
+            locals
+                .iter()
+                .any(|entry| entry.rel_path == "sealed/keep.txt"),
+            "the file stays listed"
+        );
+        let plan = write_reconcile_plan(
+            &fixture,
+            serde_json::json!({
+                "remote_scan_incomplete": false,
+                "remote_scan_errors": 0,
+                "remote_scan_truncated": false,
+                "local_scan_incomplete": !local_health.is_complete(),
+                "local_scan_errors": local_health.list_errors,
+                "local_scan_truncated": local_health.truncated,
+            }),
+        );
+        let remote = MemTreeProvider::root_files(&[("b.txt", 1)]);
+        let delete_attempts = Arc::clone(&remote.delete_attempts);
+        let cli = Cli {
+            quiet: true,
+            ..test_cli()
+        };
+
+        let stats = run_sync_with_delete(remote, &local, "upload", false, &cli, None, Some(&plan));
+
+        assert_eq!(
+            *delete_attempts.lock().expect("delete log"),
+            Vec::<String>::new(),
+            "no remote delete from a reconcile whose local scan could not stat a file"
+        );
+        assert_eq!(stats.exit_code, 4, "the refusal shows in the exit code");
     }
 
     struct CliEditFakeProvider {

--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -8225,7 +8225,10 @@ fn scan_local_tree_with_progress(
     root: &str,
     opts: &ftp_client_gui_lib::sync_core::ScanOptions,
     spinner: &Option<ProgressBar>,
-) -> Vec<ftp_client_gui_lib::sync_core::scan::LocalEntry> {
+) -> (
+    Vec<ftp_client_gui_lib::sync_core::scan::LocalEntry>,
+    ftp_client_gui_lib::sync_core::ScanCompleteness,
+) {
     let matchers: Vec<globset::GlobMatcher> = opts
         .exclude_patterns
         .iter()
@@ -8310,7 +8313,7 @@ fn scan_local_tree_with_progress(
         pb.set_message(format!("Scanning local... {} files", entries.len()));
     }
 
-    entries
+    (entries, Default::default())
 }
 
 /// Health of a remote BFS scan: how many `list()` calls failed and whether the
@@ -45846,6 +45849,209 @@ async fn cmd_sync_local_to_local(
     stats
 }
 
+/// One side of a sync as its scan saw it: the files the walk kept and whether
+/// it read the whole tree. A `--delete` pass plans orphans off `entries`, so
+/// `completeness` has to travel with them (TX-01).
+#[derive(Default, Clone)]
+struct SyncScan {
+    entries: Vec<(String, u64, Option<String>)>,
+    completeness: ftp_client_gui_lib::sync_core::ScanCompleteness,
+}
+
+/// Which local files `sync` scans: walk depth and `--exclude`. `--files-from`
+/// is not part of it: `cmd_sync` bounds every entry that reaches the planner
+/// by the list, whatever produced it.
+struct SyncLocalFilter<'a> {
+    max_depth: usize,
+    exclude: &'a [globset::GlobMatcher],
+}
+
+impl SyncLocalFilter<'_> {
+    /// Whether the local file at `relative` (forward slashes, no leading
+    /// slash) takes part in the sync. A walk bounded at `max_depth` yields
+    /// files at most that many components deep; the depth check repeats that
+    /// bound for paths that do not come from a walk.
+    fn keeps(&self, relative: &str, file_name: &str) -> bool {
+        relative.split('/').count() <= self.max_depth
+            && !self
+                .exclude
+                .iter()
+                .any(|m| m.is_match(relative) || m.is_match(file_name))
+    }
+}
+
+/// A local file's modification time in the form `sync` compares.
+fn sync_local_mtime(meta: &std::fs::Metadata) -> Option<String> {
+    meta.modified().ok().map(|t| {
+        let dt: chrono::DateTime<chrono::Utc> = t.into();
+        dt.format("%Y-%m-%dT%H:%M:%S").to_string()
+    })
+}
+
+/// Walk the local tree for `sync`, capped at 500,000 entries. An entry the
+/// walker cannot read counts as a listing error: the files below it are
+/// unseen, not absent.
+fn scan_sync_local(local: &str, filter: &SyncLocalFilter) -> SyncScan {
+    let mut scan = SyncScan::default();
+    let walker = walkdir::WalkDir::new(local)
+        .follow_links(false)
+        .max_depth(filter.max_depth);
+    for entry in walker {
+        if scan.entries.len() >= 500_000 {
+            eprintln!("Warning: local scan capped at 500,000 entries");
+            scan.completeness.truncated = true;
+            break;
+        }
+        let entry = match entry {
+            Ok(e) => e,
+            Err(_) => {
+                scan.completeness.list_errors += 1;
+                continue;
+            }
+        };
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let relative = entry
+            .path()
+            .strip_prefix(local)
+            .unwrap_or(entry.path())
+            .to_string_lossy()
+            .replace('\\', "/");
+        if relative.is_empty() || relative == BISYNC_SNAPSHOT_FILE {
+            continue;
+        }
+        if !filter.keeps(&relative, &entry.file_name().to_string_lossy()) {
+            continue;
+        }
+
+        let meta = entry.metadata().ok();
+        let size = meta.as_ref().map(|m| m.len()).unwrap_or(0);
+        let mtime = meta.as_ref().and_then(sync_local_mtime);
+        scan.entries.push((relative, size, mtime));
+    }
+    scan
+}
+
+/// Path-keyed view of scan entries, the shape `sync` plans from.
+fn sync_entry_map(entries: &[(String, u64, Option<String>)]) -> HashMap<&str, (u64, Option<&str>)> {
+    entries
+        .iter()
+        .map(|(p, s, m)| (p.as_str(), (*s, m.as_deref())))
+        .collect()
+}
+
+/// The orphan deletes of a `sync --delete` pass, one list per side.
+#[derive(Default)]
+struct SyncOrphanDeletes<'a> {
+    /// Remote files with no local counterpart (upload).
+    remote: Vec<&'a str>,
+    /// Local files with no remote counterpart (download).
+    local: Vec<&'a str>,
+}
+
+/// The orphan deletes a `sync` pass plans from its two scans, or the reason it
+/// must plan none.
+///
+/// `guarded` is false for a dry run, which stays read-only and reports its
+/// plan, and for a `--from-reconcile` plan, which the user supplied as the
+/// source of truth. Orphans are planned for the one-way directions only:
+/// `both` decides its deletes from the bisync snapshot.
+fn plan_sync_orphan_deletes<'a>(
+    direction: &str,
+    delete: bool,
+    guarded: bool,
+    local_scan: &ftp_client_gui_lib::sync_core::ScanCompleteness,
+    remote_scan: &ftp_client_gui_lib::sync_core::ScanCompleteness,
+    local_map: &HashMap<&'a str, (u64, Option<&'a str>)>,
+    remote_map: &HashMap<&'a str, (u64, Option<&'a str>)>,
+) -> Result<SyncOrphanDeletes<'a>, String> {
+    let mut orphans = SyncOrphanDeletes::default();
+    if !delete {
+        return Ok(orphans);
+    }
+    if guarded {
+        // TX-01: refuse --delete when the governing scan is incomplete. Local
+        // orphans are derived from the remote listing (download), remote
+        // orphans from the local listing (upload), and "both" reads both sides.
+        // A partial listing on the governing side would classify intact files
+        // as orphans and delete them, so fail closed with zero deletions.
+        let blocking = match direction {
+            "download" => !remote_scan.is_complete(),
+            "upload" => !local_scan.is_complete(),
+            _ => !(remote_scan.is_complete() && local_scan.is_complete()),
+        };
+        if blocking {
+            return Err(format!(
+                "refusing --delete: source-of-truth scan is incomplete \
+                 (remote: {} list error(s){}, local: {} error(s){}). A partial \
+                 listing would classify intact files as orphans and delete them. \
+                 Re-run without --delete or restore full connectivity.",
+                remote_scan.list_errors,
+                if remote_scan.truncated {
+                    ", truncated"
+                } else {
+                    ""
+                },
+                local_scan.list_errors,
+                if local_scan.truncated {
+                    ", truncated"
+                } else {
+                    ""
+                },
+            ));
+        }
+
+        // The check above refuses a delete pass when the scan reported ERRORS.
+        // It cannot see the other half of the same danger: a listing that
+        // succeeded and came back empty. FTP produced exactly that for a
+        // directory that does not exist, so a mistyped path was
+        // indistinguishable from an emptied one, and nothing here noticed
+        // because there was no error to count.
+        //
+        // The core (`sync.rs`) and the DAG both consult the shared guard for
+        // this; this path did not, so the one surface a person drives by hand
+        // was the one without the protection. Calling the shared guard rather
+        // than restating the rule is the point: a fourth copy of the policy is
+        // how the third one came to be missing.
+        //
+        // Kept even though that FTP defect is fixed: it is depth, not
+        // redundancy. Any provider that answers an empty listing where it
+        // should answer an error would otherwise walk the same path.
+        let sync_direction = match direction {
+            "download" => ftp_client_gui_lib::sync::SyncDirection::Download,
+            "upload" => ftp_client_gui_lib::sync::SyncDirection::Upload,
+            _ => ftp_client_gui_lib::sync::SyncDirection::Both,
+        };
+        ftp_client_gui_lib::sync::orphan_delete_guard_over(
+            sync_direction,
+            local_map.is_empty(),
+            remote_map.is_empty(),
+            local_scan,
+            remote_scan,
+        )
+        .map_err(|reason| format!("refusing --delete: {reason}"))?;
+    }
+    match direction {
+        "upload" => {
+            orphans.remote = remote_map
+                .keys()
+                .filter(|path| !local_map.contains_key(*path))
+                .copied()
+                .collect();
+        }
+        "download" => {
+            orphans.local = local_map
+                .keys()
+                .filter(|path| !remote_map.contains_key(*path))
+                .copied()
+                .collect();
+        }
+        _ => {}
+    }
+    Ok(orphans)
+}
+
 // `use_aerorsync_batch` is only consumed inside an `aerorsync`-gated
 // block below; tolerate the dead argument when the feature is off.
 #[cfg_attr(not(feature = "aerorsync"), allow(unused_variables))]
@@ -45874,7 +46080,7 @@ async fn cmd_sync(
     cli: &Cli,
     format: OutputFormat,
     cancelled: Arc<AtomicBool>,
-    precomputed_local: Option<Vec<(String, u64, Option<String>)>>,
+    precomputed_local: Option<SyncScan>,
     // Z.1.2 lane: when true, attempt to route remote SFTP uploads
     // through the AerorsyncBatch session-reuse path. No-op (warn-only)
     // when the provider does not expose a delta transport.
@@ -45945,280 +46151,229 @@ async fn cmd_sync(
     // scan surfaces in the exit code / JSON status instead of reporting success.
     let mut remote_scan_errors: usize = 0;
     let mut remote_scan_truncated = false;
-    let mut local_scan_errors: usize = 0;
-    let mut local_scan_truncated = false;
 
     let mut reconcile_plan: Option<ReconcileSyncPlan> = None;
-    #[allow(clippy::type_complexity)]
-    let (mut local_entries, mut remote_entries): (
-        Vec<(String, u64, Option<String>)>,
-        Vec<(String, u64, Option<String>)>,
-    ) = if let Some(reconcile_path) = from_reconcile {
-        match load_sync_plan_from_reconcile(
-            reconcile_path,
-            direction,
-            delete,
-            files_from_set.as_ref(),
-        ) {
-            Ok(plan) => {
-                let local_entries = plan.local_entries.clone();
-                let remote_entries = plan.remote_entries.clone();
-                reconcile_plan = Some(plan);
-                (local_entries, remote_entries)
+    let (mut local_scan, mut remote_entries): (SyncScan, Vec<(String, u64, Option<String>)>) =
+        if let Some(reconcile_path) = from_reconcile {
+            match load_sync_plan_from_reconcile(
+                reconcile_path,
+                direction,
+                delete,
+                files_from_set.as_ref(),
+            ) {
+                Ok(plan) => {
+                    let local_scan = SyncScan {
+                        entries: plan.local_entries.clone(),
+                        completeness: Default::default(),
+                    };
+                    let remote_entries = plan.remote_entries.clone();
+                    reconcile_plan = Some(plan);
+                    (local_scan, remote_entries)
+                }
+                Err(err) => {
+                    print_error(format, &err, 5);
+                    let _ = provider.disconnect().await;
+                    return 5.into();
+                }
             }
-            Err(err) => {
-                print_error(format, &err, 5);
+        } else {
+            // Scan local files (bounded: max depth, 500K entries). Incremental
+            // watch mode hands in the scan it keeps between cycles, together with
+            // the completeness of the walk it came from.
+            let local_scan = match precomputed_local {
+                Some(scan) => scan,
+                None => scan_sync_local(
+                    local,
+                    &SyncLocalFilter {
+                        max_depth: scan_depth,
+                        exclude: &exclude_matchers,
+                    },
+                ),
+            };
+
+            if cli.no_check_dest && delete {
+                print_error(format, "--no-check-dest cannot be used with --delete (would mark all destination files as orphans for deletion)", 5);
                 let _ = provider.disconnect().await;
                 return 5.into();
             }
-        }
-    } else {
-        // Scan local files (bounded: max depth, 500K entries)
-        // If precomputed_local is provided (incremental watch mode), skip walkdir entirely.
-        let local_entries: Vec<(String, u64, Option<String>)> = if let Some(pre) = precomputed_local
-        {
-            pre
-        } else {
-            let walker = walkdir::WalkDir::new(local)
-                .follow_links(false)
-                .max_depth(scan_depth);
-            let mut entries = Vec::new();
-            for entry in walker {
-                if entries.len() >= 500_000 {
-                    eprintln!("Warning: local scan capped at 500,000 entries");
-                    local_scan_truncated = true;
-                    break;
-                }
-                let entry = match entry {
-                    Ok(e) => e,
-                    Err(_) => {
-                        local_scan_errors += 1;
-                        continue;
-                    }
-                };
-                if !entry.file_type().is_file() {
-                    continue;
-                }
-                let relative = entry
-                    .path()
-                    .strip_prefix(local)
-                    .unwrap_or(entry.path())
-                    .to_string_lossy()
-                    .replace('\\', "/");
-                if relative.is_empty() || relative == BISYNC_SNAPSHOT_FILE {
-                    continue;
-                }
-
-                let fname = entry.file_name().to_string_lossy();
-                let fname_ref: &str = fname.as_ref();
-                if exclude_matchers
-                    .iter()
-                    .any(|m| m.is_match(&relative) || m.is_match(fname_ref))
-                {
-                    continue;
-                }
-                if let Some(ref set) = files_from_set {
-                    if !set.contains(relative.as_str()) {
-                        continue;
-                    }
-                }
-
-                let meta = entry.metadata().ok();
-                let size = meta.as_ref().map(|m| m.len()).unwrap_or(0);
-                let mtime = meta.and_then(|m| {
-                    m.modified().ok().map(|t| {
-                        let dt: chrono::DateTime<chrono::Utc> = t.into();
-                        dt.format("%Y-%m-%dT%H:%M:%S").to_string()
-                    })
-                });
-                entries.push((relative, size, mtime));
+            if cli.immutable && cli.no_check_dest {
+                print_error(format, "--immutable cannot be used with --no-check-dest (immutable needs remote listing to detect existing files)", 5);
+                let _ = provider.disconnect().await;
+                return 5.into();
             }
-            entries
-        };
-
-        if cli.no_check_dest && delete {
-            print_error(format, "--no-check-dest cannot be used with --delete (would mark all destination files as orphans for deletion)", 5);
-            let _ = provider.disconnect().await;
-            return 5.into();
-        }
-        if cli.immutable && cli.no_check_dest {
-            print_error(format, "--immutable cannot be used with --no-check-dest (immutable needs remote listing to detect existing files)", 5);
-            let _ = provider.disconnect().await;
-            return 5.into();
-        }
-        // KE-A4: --no-traverse is upload-only. With download or both, we
-        // need the remote listing to know what is on the other side.
-        if cli.no_traverse && direction != "upload" {
-            print_error(
+            // KE-A4: --no-traverse is upload-only. With download or both, we
+            // need the remote listing to know what is on the other side.
+            if cli.no_traverse && direction != "upload" {
+                print_error(
                 format,
                 "--no-traverse requires --direction upload (download/both need the remote listing)",
                 5,
             );
-            let _ = provider.disconnect().await;
-            return 5.into();
-        }
-        if cli.no_traverse && delete {
-            print_error(
+                let _ = provider.disconnect().await;
+                return 5.into();
+            }
+            if cli.no_traverse && delete {
+                print_error(
                 format,
                 "--no-traverse cannot be used with --delete (orphan detection needs the remote listing)",
                 5,
             );
-            let _ = provider.disconnect().await;
-            return 5.into();
-        }
-        let no_traverse_active = cli.no_traverse && !cli.no_check_dest;
-
-        let mut remote_entries: Vec<(String, u64, Option<String>)> = Vec::new();
-        if cli.no_check_dest {
-            if !quiet {
-                eprintln!(
-                    "Note: --no-check-dest skipping remote scan (assuming empty destination)"
-                );
+                let _ = provider.disconnect().await;
+                return 5.into();
             }
-        } else if no_traverse_active {
-            if !quiet {
-                eprintln!(
+            let no_traverse_active = cli.no_traverse && !cli.no_check_dest;
+
+            let mut remote_entries: Vec<(String, u64, Option<String>)> = Vec::new();
+            if cli.no_check_dest {
+                if !quiet {
+                    eprintln!(
+                        "Note: --no-check-dest skipping remote scan (assuming empty destination)"
+                    );
+                }
+            } else if no_traverse_active {
+                if !quiet {
+                    eprintln!(
                     "Note: --no-traverse skipping remote scan (per-file stat will run during planning)"
                 );
-            }
-        } else {
-            let mut used_fast_list = false;
-            if cli.fast_list {
-                if let Some(s3) = provider
-                    .as_any_mut()
-                    .downcast_mut::<ftp_client_gui_lib::providers::s3::S3Provider>()
-                {
-                    if !quiet {
-                        eprintln!("Using --fast-list (S3 recursive listing)...");
-                    }
-                    match s3.list_recursive(remote).await {
-                        Ok(entries) => {
-                            let max_depth = cli.max_depth.map(|d| d as usize);
-                            for e in entries {
-                                if e.is_dir {
-                                    continue;
-                                }
-                                if remote_entries.len() >= MAX_SCAN_ENTRIES {
-                                    if !quiet {
-                                        eprintln!(
-                                            "Warning: --fast-list capped at {} entries",
-                                            MAX_SCAN_ENTRIES
-                                        );
-                                    }
-                                    remote_scan_truncated = true;
-                                    break;
-                                }
-                                let relative = e
-                                    .path
-                                    .strip_prefix(remote)
-                                    .unwrap_or(&e.path)
-                                    .trim_start_matches('/')
-                                    .to_string();
-                                if relative.is_empty() || relative == BISYNC_SNAPSHOT_FILE {
-                                    continue;
-                                }
-                                if let Some(max_d) = max_depth {
-                                    let depth = relative.matches('/').count();
-                                    if depth >= max_d {
+                }
+            } else {
+                let mut used_fast_list = false;
+                if cli.fast_list {
+                    if let Some(s3) = provider
+                        .as_any_mut()
+                        .downcast_mut::<ftp_client_gui_lib::providers::s3::S3Provider>(
+                    ) {
+                        if !quiet {
+                            eprintln!("Using --fast-list (S3 recursive listing)...");
+                        }
+                        match s3.list_recursive(remote).await {
+                            Ok(entries) => {
+                                let max_depth = cli.max_depth.map(|d| d as usize);
+                                for e in entries {
+                                    if e.is_dir {
                                         continue;
                                     }
-                                }
-                                if exclude_matchers
-                                    .iter()
-                                    .any(|m| m.is_match(&relative) || m.is_match(&e.name))
-                                {
-                                    continue;
-                                }
-                                if let Some(ref set) = files_from_set {
-                                    if !set.contains(relative.as_str()) {
+                                    if remote_entries.len() >= MAX_SCAN_ENTRIES {
+                                        if !quiet {
+                                            eprintln!(
+                                                "Warning: --fast-list capped at {} entries",
+                                                MAX_SCAN_ENTRIES
+                                            );
+                                        }
+                                        remote_scan_truncated = true;
+                                        break;
+                                    }
+                                    let relative = e
+                                        .path
+                                        .strip_prefix(remote)
+                                        .unwrap_or(&e.path)
+                                        .trim_start_matches('/')
+                                        .to_string();
+                                    if relative.is_empty() || relative == BISYNC_SNAPSHOT_FILE {
                                         continue;
                                     }
+                                    if let Some(max_d) = max_depth {
+                                        let depth = relative.matches('/').count();
+                                        if depth >= max_d {
+                                            continue;
+                                        }
+                                    }
+                                    if exclude_matchers
+                                        .iter()
+                                        .any(|m| m.is_match(&relative) || m.is_match(&e.name))
+                                    {
+                                        continue;
+                                    }
+                                    if let Some(ref set) = files_from_set {
+                                        if !set.contains(relative.as_str()) {
+                                            continue;
+                                        }
+                                    }
+                                    remote_entries.push((relative, e.size, e.modified));
                                 }
-                                remote_entries.push((relative, e.size, e.modified));
+                                used_fast_list = true;
                             }
-                            used_fast_list = true;
-                        }
-                        Err(e) => {
-                            if !quiet {
-                                eprintln!(
-                                    "Warning: --fast-list failed, falling back to BFS scan: {}",
-                                    e
-                                );
+                            Err(e) => {
+                                if !quiet {
+                                    eprintln!(
+                                        "Warning: --fast-list failed, falling back to BFS scan: {}",
+                                        e
+                                    );
+                                }
                             }
                         }
+                    } else if !quiet {
+                        eprintln!("Note: --fast-list only supported for S3; using standard scan");
                     }
-                } else if !quiet {
-                    eprintln!("Note: --fast-list only supported for S3; using standard scan");
+                }
+
+                if !used_fast_list {
+                    // The remote walk runs on the provider's list pool, like
+                    // `check`, `reconcile` and the GUI scan: up to --checkers
+                    // directories at once on a clone-backed provider, one at a
+                    // time on a single-session one. Same filters as the walk this
+                    // replaces: depth, entry cap, excludes, the bisync snapshot
+                    // file, symlinked directories listed but never walked.
+                    let remote_scan_depth =
+                        cli.max_depth.map(|d| d as usize).unwrap_or(MAX_SCAN_DEPTH);
+                    let pooled_opts = ftp_client_gui_lib::sync_core::ScanOptions {
+                        exclude_patterns: effective_exclude.clone(),
+                        max_depth: Some(remote_scan_depth),
+                        checkers: Some(effective_checkers(cli)),
+                        disable_recursive_fastpath: true,
+                        ..Default::default()
+                    };
+                    let (remotes, health, returned) = scan_remote_tree_with_progress(
+                        provider,
+                        remote,
+                        &pooled_opts,
+                        &None,
+                        Some(Arc::clone(&cancelled)),
+                    )
+                    .await;
+                    provider = returned;
+                    if health.truncated && !quiet {
+                        eprintln!("Warning: remote scan truncated (depth or entry cap reached)");
+                    }
+                    remote_scan_errors += health.errors;
+                    remote_scan_truncated |= health.truncated;
+                    // The bisync snapshot is skipped at the root only, as the walk
+                    // this replaces did: a same-named file deeper in the tree is
+                    // the user's.
+                    remote_entries.extend(
+                        remotes
+                            .into_iter()
+                            .filter(|r| {
+                                !r.rel_path.is_empty() && r.rel_path != BISYNC_SNAPSHOT_FILE
+                            })
+                            .map(|r| (r.rel_path, r.size, r.mtime)),
+                    );
                 }
             }
 
-            if !used_fast_list {
-                // The remote walk runs on the provider's list pool, like
-                // `check`, `reconcile` and the GUI scan: up to --checkers
-                // directories at once on a clone-backed provider, one at a
-                // time on a single-session one. Same filters as the walk this
-                // replaces: depth, entry cap, excludes, the bisync snapshot
-                // file, symlinked directories listed but never walked.
-                let remote_scan_depth = cli.max_depth.map(|d| d as usize).unwrap_or(MAX_SCAN_DEPTH);
-                let pooled_opts = ftp_client_gui_lib::sync_core::ScanOptions {
-                    exclude_patterns: effective_exclude.clone(),
-                    max_depth: Some(remote_scan_depth),
-                    checkers: Some(effective_checkers(cli)),
-                    disable_recursive_fastpath: true,
-                    ..Default::default()
-                };
-                let (remotes, health, returned) = scan_remote_tree_with_progress(
-                    provider,
-                    remote,
-                    &pooled_opts,
-                    &None,
-                    Some(Arc::clone(&cancelled)),
-                )
-                .await;
-                provider = returned;
-                if health.truncated && !quiet {
-                    eprintln!("Warning: remote scan truncated (depth or entry cap reached)");
-                }
-                remote_scan_errors += health.errors;
-                remote_scan_truncated |= health.truncated;
-                // The bisync snapshot is skipped at the root only, as the walk
-                // this replaces did: a same-named file deeper in the tree is
-                // the user's.
-                remote_entries.extend(
-                    remotes
-                        .into_iter()
-                        .filter(|r| !r.rel_path.is_empty() && r.rel_path != BISYNC_SNAPSHOT_FILE)
-                        .map(|r| (r.rel_path, r.size, r.mtime)),
-                );
-            }
-        }
-
-        (local_entries, remote_entries)
-    };
+            (local_scan, remote_entries)
+        };
 
     // `--files-from` bounds the run, not one side of it. The planner reads a
     // path present on one side only as a copy or an orphan, so a list applied
     // to one side turns every unlisted file of the other side into one: with
     // `--direction upload --delete` that deleted the remote tree outside the
-    // list. The local walk and the S3 fast-list prune by the list early; the
-    // pooled remote walk, a watch cycle's precomputed local list and a
+    // list. The S3 fast-list prunes by the list early; the local walk, the
+    // pooled remote walk, a watch cycle's precomputed local scan and a
     // reconcile plan do not, and neither will the next scan path. Applying
     // the list here, once, to every entry that reaches the planner is what
     // keeps all of them bounded.
     if let Some(listed) = files_from_set.as_ref() {
-        local_entries.retain(|(path, _, _)| listed.contains(path));
+        local_scan
+            .entries
+            .retain(|(path, _, _)| listed.contains(path));
         remote_entries.retain(|(path, _, _)| listed.contains(path));
     }
+    let local_entries = &local_scan.entries;
 
     // Build comparison maps
-    let local_map: HashMap<&str, (u64, Option<&str>)> = local_entries
-        .iter()
-        .map(|(p, s, m)| (p.as_str(), (*s, m.as_deref())))
-        .collect();
-    let remote_map: HashMap<&str, (u64, Option<&str>)> = remote_entries
-        .iter()
-        .map(|(p, s, m)| (p.as_str(), (*s, m.as_deref())))
-        .collect();
+    let local_map = sync_entry_map(local_entries);
+    let remote_map = sync_entry_map(&remote_entries);
 
     // Load previous snapshot for bisync delta detection (--direction both only)
     let prev_snapshot = if direction == "both" && !resync {
@@ -46233,98 +46388,43 @@ async fn cmd_sync(
     let default_time_val = resolve_default_time(cli);
     let default_time_ref = default_time_val.as_deref();
 
-    // TX-01: refuse --delete when the governing scan is incomplete. Local orphans
-    // are derived from the remote listing (download), remote orphans from the
-    // local listing (upload), and "both" reads both sides. A partial listing on
-    // the governing side would classify intact files as orphans and delete them,
-    // so fail closed (exit 4) with zero deletions. Dry-run stays read-only and
-    // reports the partial state below (SCAN-01). A from-reconcile plan is an
-    // explicit, user-supplied source of truth and is treated as complete.
-    let remote_scan_incomplete = remote_scan_errors > 0 || remote_scan_truncated;
-    let local_scan_incomplete = local_scan_errors > 0 || local_scan_truncated;
-    let scan_incomplete =
-        reconcile_plan.is_none() && (remote_scan_incomplete || local_scan_incomplete);
+    // TX-01 / SCAN-01: a partial scan never drives --delete orphan planning
+    // (`plan_sync_orphan_deletes` refuses, exit 4, zero deletions) and surfaces
+    // in the exit code / JSON status instead of reporting success. A
+    // from-reconcile plan is an explicit, user-supplied source of truth and is
+    // treated as complete.
+    let local_scan_health = local_scan.completeness;
+    let remote_scan_health = ftp_client_gui_lib::sync_core::ScanCompleteness {
+        list_errors: remote_scan_errors,
+        truncated: remote_scan_truncated,
+    };
+    let scan_incomplete = reconcile_plan.is_none()
+        && !(local_scan_health.is_complete() && remote_scan_health.is_complete());
 
-    if delete && !dry_run && reconcile_plan.is_none() {
-        let blocking = match direction {
-            "download" => remote_scan_incomplete,
-            "upload" => local_scan_incomplete,
-            _ => remote_scan_incomplete || local_scan_incomplete,
-        };
-        if blocking {
-            print_error(
-                format,
-                &format!(
-                    "refusing --delete: source-of-truth scan is incomplete \
-                     (remote: {} list error(s){}, local: {} error(s){}). A partial \
-                     listing would classify intact files as orphans and delete them. \
-                     Re-run without --delete or restore full connectivity.",
-                    remote_scan_errors,
-                    if remote_scan_truncated {
-                        ", truncated"
-                    } else {
-                        ""
-                    },
-                    local_scan_errors,
-                    if local_scan_truncated {
-                        ", truncated"
-                    } else {
-                        ""
-                    },
-                ),
-                4,
-            );
+    let orphan_deletes = match plan_sync_orphan_deletes(
+        direction,
+        delete,
+        !dry_run && reconcile_plan.is_none(),
+        &local_scan_health,
+        &remote_scan_health,
+        &local_map,
+        &remote_map,
+    ) {
+        Ok(orphans) => orphans,
+        Err(reason) => {
+            print_error(format, &reason, 4);
             let _ = provider.disconnect().await;
             return 4.into();
         }
-    }
-
-    // The block above refuses a delete pass when the scan reported ERRORS. It
-    // cannot see the other half of the same danger: a listing that succeeded
-    // and came back empty. FTP produced exactly that for a directory that does
-    // not exist, so a mistyped path was indistinguishable from an emptied one,
-    // and nothing here noticed because there was no error to count.
-    //
-    // The core (`sync.rs`) and the DAG both consult the shared guard for this;
-    // this path did not, so the one surface a person drives by hand was the one
-    // without the protection. Calling the shared guard rather than restating
-    // the rule is the point: a fourth copy of the policy is how the third one
-    // came to be missing.
-    //
-    // Kept even though the FTP defect above is fixed in the same change: it is
-    // depth, not redundancy. Any provider that answers an empty listing where
-    // it should answer an error would otherwise walk the same path.
-    if delete && !dry_run && reconcile_plan.is_none() {
-        let sync_direction = match direction {
-            "download" => ftp_client_gui_lib::sync::SyncDirection::Download,
-            "upload" => ftp_client_gui_lib::sync::SyncDirection::Upload,
-            _ => ftp_client_gui_lib::sync::SyncDirection::Both,
-        };
-        let local_scan = ftp_client_gui_lib::sync_core::ScanCompleteness {
-            list_errors: local_scan_errors,
-            truncated: local_scan_truncated,
-        };
-        let remote_scan = ftp_client_gui_lib::sync_core::ScanCompleteness {
-            list_errors: remote_scan_errors,
-            truncated: remote_scan_truncated,
-        };
-        if let Err(reason) = ftp_client_gui_lib::sync::orphan_delete_guard_over(
-            sync_direction,
-            local_map.is_empty(),
-            remote_map.is_empty(),
-            &local_scan,
-            &remote_scan,
-        ) {
-            print_error(format, &format!("refusing --delete: {reason}"), 4);
-            let _ = provider.disconnect().await;
-            return 4.into();
-        }
-    }
+    };
 
     if scan_incomplete && !quiet {
         eprintln!(
             "Warning: scan incomplete (remote errors: {}, local errors: {}, remote truncated: {}, local truncated: {}); results may be partial.",
-            remote_scan_errors, local_scan_errors, remote_scan_truncated, local_scan_truncated
+            remote_scan_errors,
+            local_scan_health.list_errors,
+            remote_scan_truncated,
+            local_scan_health.truncated
         );
     }
 
@@ -46479,22 +46579,8 @@ async fn cmd_sync(
     }
 
     // Orphan deletion (for upload/download-only modes)
-    if delete && direction != "both" {
-        if direction == "upload" {
-            for path in remote_map.keys() {
-                if !local_map.contains_key(path) {
-                    to_delete_remote.push(path);
-                }
-            }
-        }
-        if direction == "download" {
-            for path in local_map.keys() {
-                if !remote_map.contains_key(path) {
-                    to_delete_local.push(path);
-                }
-            }
-        }
-    }
+    to_delete_remote.extend(orphan_deletes.remote);
+    to_delete_local.extend(orphan_deletes.local);
 
     // --track-renames: detect files that were renamed (same hash, different path)
     let mut renames: Vec<(String, String)> = Vec::new(); // (old_remote, new_local)
@@ -54687,17 +54773,71 @@ fn should_exclude_watch_path(path: &std::path::Path) -> bool {
     false
 }
 
-/// Build a local entry list incrementally: refresh metadata only for watcher-reported paths,
-/// and merge with the previous full snapshot for everything else.
+/// The local files a watch loop keeps between cycles, so that a watcher event
+/// only re-reads the paths it names, and the completeness of the walk they
+/// came from.
+#[derive(Default, Clone)]
+struct WatchLocalSnapshot {
+    files: std::collections::HashMap<String, (u64, Option<String>)>,
+    completeness: ftp_client_gui_lib::sync_core::ScanCompleteness,
+}
+
+impl WatchLocalSnapshot {
+    fn from_scan(scan: &SyncScan) -> Self {
+        Self {
+            files: scan
+                .entries
+                .iter()
+                .map(|(path, size, mtime)| (path.clone(), (*size, mtime.clone())))
+                .collect(),
+            completeness: scan.completeness,
+        }
+    }
+}
+
+/// The snapshot a watch loop starts its incremental cycles from.
+fn build_watch_local_snapshot(local_dir: &str, _filter: &SyncLocalFilter) -> WatchLocalSnapshot {
+    let mut snap = std::collections::HashMap::new();
+    let walker = walkdir::WalkDir::new(local_dir)
+        .follow_links(false)
+        .max_depth(100);
+    for entry in walker {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let relative = match entry.path().strip_prefix(local_dir) {
+            Ok(r) => r.to_string_lossy().replace('\\', "/"),
+            Err(_) => continue,
+        };
+        if relative.is_empty() || relative == BISYNC_SNAPSHOT_FILE {
+            continue;
+        }
+        if let Ok(meta) = entry.metadata() {
+            snap.insert(relative, (meta.len(), sync_local_mtime(&meta)));
+        }
+    }
+    WatchLocalSnapshot {
+        files: snap,
+        completeness: Default::default(),
+    }
+}
+
+/// Build the local side of a watch cycle incrementally: refresh metadata only
+/// for watcher-reported paths, and take everything else from the snapshot.
 /// This avoids a full walkdir when only a few files changed.
 fn incremental_local_scan(
     base: &std::path::Path,
     changed_paths: &[std::path::PathBuf],
-    previous_entries: &std::collections::HashMap<String, (u64, Option<String>)>,
-    exclude_matchers: &[globset::GlobMatcher],
-) -> Vec<(String, u64, Option<String>)> {
+    previous: &WatchLocalSnapshot,
+    filter: &SyncLocalFilter,
+) -> SyncScan {
+    let exclude_matchers = filter.exclude;
     let mut result: std::collections::HashMap<String, (u64, Option<String>)> =
-        previous_entries.clone();
+        previous.files.clone();
 
     for changed in changed_paths {
         // Compute relative path
@@ -54720,12 +54860,7 @@ fn incremental_local_scan(
         // Read current metadata: if file was deleted, remove from snapshot
         match std::fs::metadata(changed) {
             Ok(meta) if meta.is_file() => {
-                let size = meta.len();
-                let mtime = meta.modified().ok().map(|t| {
-                    let dt: chrono::DateTime<chrono::Utc> = t.into();
-                    dt.format("%Y-%m-%dT%H:%M:%S").to_string()
-                });
-                result.insert(relative, (size, mtime));
+                result.insert(relative, (meta.len(), sync_local_mtime(&meta)));
             }
             _ => {
                 // File deleted or not a regular file
@@ -54734,10 +54869,13 @@ fn incremental_local_scan(
         }
     }
 
-    result
-        .into_iter()
-        .map(|(path, (size, mtime))| (path, size, mtime))
-        .collect()
+    SyncScan {
+        entries: result
+            .into_iter()
+            .map(|(path, (size, mtime))| (path, size, mtime))
+            .collect(),
+        completeness: previous.completeness,
+    }
 }
 
 /// Start a filesystem watcher and return a boxed handle (dropped to stop).
@@ -55039,43 +55177,14 @@ async fn cmd_sync_watch(
     // - track_renames is off (needs full file set for hash matching)
     let use_incremental = direction != "download" && !track_renames;
 
-    // Local snapshot: populated after each full scan for incremental merging
-    let mut local_snapshot: std::collections::HashMap<String, (u64, Option<String>)> =
-        std::collections::HashMap::new();
+    // The same filters `cmd_sync` applies to its own local walk.
+    let local_filter = SyncLocalFilter {
+        max_depth: cli.max_depth.map(|d| d as usize).unwrap_or(100),
+        exclude: &exclude_matchers,
+    };
 
-    // Helper: build snapshot from a full local walkdir scan
-    let build_snapshot =
-        |local_dir: &str| -> std::collections::HashMap<String, (u64, Option<String>)> {
-            let mut snap = std::collections::HashMap::new();
-            let walker = walkdir::WalkDir::new(local_dir)
-                .follow_links(false)
-                .max_depth(100);
-            for entry in walker {
-                let entry = match entry {
-                    Ok(e) => e,
-                    Err(_) => continue,
-                };
-                if !entry.file_type().is_file() {
-                    continue;
-                }
-                let relative = match entry.path().strip_prefix(local_dir) {
-                    Ok(r) => r.to_string_lossy().replace('\\', "/"),
-                    Err(_) => continue,
-                };
-                if relative.is_empty() || relative == BISYNC_SNAPSHOT_FILE {
-                    continue;
-                }
-                if let Ok(meta) = entry.metadata() {
-                    let size = meta.len();
-                    let mtime = meta.modified().ok().map(|t| {
-                        let dt: chrono::DateTime<chrono::Utc> = t.into();
-                        dt.format("%Y-%m-%dT%H:%M:%S").to_string()
-                    });
-                    snap.insert(relative, (size, mtime));
-                }
-            }
-            snap
-        };
+    // Local snapshot: populated after each full scan for incremental merging
+    let mut local_snapshot = WatchLocalSnapshot::default();
 
     // Initial sync
     if !watch_no_initial {
@@ -55087,7 +55196,7 @@ async fn cmd_sync_watch(
 
     // Build initial snapshot after first sync (or immediately if --watch-no-initial)
     if use_incremental {
-        local_snapshot = build_snapshot(local);
+        local_snapshot = build_watch_local_snapshot(local, &local_filter);
     }
 
     // Watch loop
@@ -55122,26 +55231,14 @@ async fn cmd_sync_watch(
                 let trigger = format!("watcher: {} paths", path_count);
 
                 if use_incremental {
-                    let entries = incremental_local_scan(
+                    let scan = incremental_local_scan(
                         local_path,
                         &changed_paths,
                         &local_snapshot,
-                        &exclude_matchers,
+                        &local_filter,
                     );
-                    // Update snapshot with changes
-                    for (ref rel, size, ref mtime) in &entries {
-                        local_snapshot.insert(rel.clone(), (*size, mtime.clone()));
-                    }
-                    // Remove deleted files from snapshot
-                    for p in &changed_paths {
-                        if let Ok(rel) = p.strip_prefix(local_path) {
-                            let rel_str = rel.to_string_lossy().replace('\\', "/");
-                            if !entries.iter().any(|(r, _, _)| r == &rel_str) {
-                                local_snapshot.remove(&rel_str);
-                            }
-                        }
-                    }
-                    run_sync_cycle!(trigger.as_str(), Some(entries));
+                    local_snapshot = WatchLocalSnapshot::from_scan(&scan);
+                    run_sync_cycle!(trigger.as_str(), Some(scan));
                     if cancelled.load(Ordering::SeqCst) {
                         if !quiet {
                             eprintln!("\nWatch mode stopped. {} sync cycles completed.", cycle_count);
@@ -55166,7 +55263,7 @@ async fn cmd_sync_watch(
                 run_sync_cycle!("rescan");
                 // Rebuild snapshot after full rescan
                 if use_incremental {
-                    local_snapshot = build_snapshot(local);
+                    local_snapshot = build_watch_local_snapshot(local, &local_filter);
                 }
                 if cancelled.load(Ordering::SeqCst) {
                     if !quiet {
@@ -56694,7 +56791,8 @@ async fn cmd_reconcile(
         ..Default::default()
     };
     let local_spinner = maybe_create_scan_spinner(format, cli, "Scanning local...");
-    let locals = scan_local_tree_with_progress(local_path, &scan_opts, &local_spinner);
+    let (locals, _local_health) =
+        scan_local_tree_with_progress(local_path, &scan_opts, &local_spinner);
     if let Some(pb) = local_spinner {
         pb.finish_and_clear();
     }
@@ -71908,8 +72006,14 @@ mod tests {
         let file = dir.join("hello.txt");
         std::fs::write(&file, "hello world").unwrap();
 
-        let previous = std::collections::HashMap::new();
-        let result = incremental_local_scan(&dir, std::slice::from_ref(&file), &previous, &[]);
+        let previous = WatchLocalSnapshot::default();
+        let result = incremental_local_scan(
+            &dir,
+            std::slice::from_ref(&file),
+            &previous,
+            &watch_test_filter(&[]),
+        )
+        .entries;
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].0, "hello.txt");
@@ -71918,20 +72022,29 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    /// The filter a watch loop builds with no `--max-depth`.
+    fn watch_test_filter(exclude: &[globset::GlobMatcher]) -> SyncLocalFilter<'_> {
+        SyncLocalFilter {
+            max_depth: 100,
+            exclude,
+        }
+    }
+
     #[test]
     fn test_incremental_local_scan_deleted_file() {
         let dir = std::env::temp_dir().join("aeroftp_test_incr_del");
         let _ = std::fs::create_dir_all(&dir);
 
-        let mut previous = std::collections::HashMap::new();
-        previous.insert(
+        let mut previous = WatchLocalSnapshot::default();
+        previous.files.insert(
             "gone.txt".to_string(),
             (100u64, Some("2026-01-01T00:00:00".to_string())),
         );
 
         // File does not exist on disk
         let ghost = dir.join("gone.txt");
-        let result = incremental_local_scan(&dir, &[ghost], &previous, &[]);
+        let result =
+            incremental_local_scan(&dir, &[ghost], &previous, &watch_test_filter(&[])).entries;
 
         assert!(result.is_empty()); // deleted file removed from snapshot
 
@@ -71945,13 +72058,19 @@ mod tests {
         let file = dir.join("changed.txt");
         std::fs::write(&file, "new content").unwrap();
 
-        let mut previous = std::collections::HashMap::new();
-        previous.insert(
+        let mut previous = WatchLocalSnapshot::default();
+        previous.files.insert(
             "existing.txt".to_string(),
             (50u64, Some("2026-01-01T00:00:00".to_string())),
         );
 
-        let result = incremental_local_scan(&dir, std::slice::from_ref(&file), &previous, &[]);
+        let result = incremental_local_scan(
+            &dir,
+            std::slice::from_ref(&file),
+            &previous,
+            &watch_test_filter(&[]),
+        )
+        .entries;
 
         // Should contain both: existing (from snapshot) + changed (from disk)
         assert_eq!(result.len(), 2);
@@ -71973,9 +72092,10 @@ mod tests {
         let result = incremental_local_scan(
             &dir,
             std::slice::from_ref(&file),
-            &std::collections::HashMap::new(),
-            &[matcher],
-        );
+            &WatchLocalSnapshot::default(),
+            &watch_test_filter(std::slice::from_ref(&matcher)),
+        )
+        .entries;
 
         assert!(result.is_empty()); // excluded by glob
 
@@ -74017,7 +74137,7 @@ mod tests {
         local: &str,
         direction: &str,
         cli: &Cli,
-        precomputed_local: Option<Vec<(String, u64, Option<String>)>>,
+        precomputed_local: Option<SyncScan>,
         from_reconcile: Option<&str>,
     ) -> SyncCycleStats {
         run_against_remote(remote, move || {
@@ -74148,10 +74268,13 @@ mod tests {
     fn sync_watch_cycle_local_entries_are_bounded_by_the_files_from_list() {
         let fixture = FilesFromFixture::new();
         let cli = fixture.cli_listing(&["a.txt"]);
-        let precomputed_local = vec![
-            ("a.txt".to_string(), 1, Some(FIXTURE_MTIME.to_string())),
-            ("c.txt".to_string(), 1, Some(FIXTURE_MTIME.to_string())),
-        ];
+        let precomputed_local = SyncScan {
+            entries: vec![
+                ("a.txt".to_string(), 1, Some(FIXTURE_MTIME.to_string())),
+                ("c.txt".to_string(), 1, Some(FIXTURE_MTIME.to_string())),
+            ],
+            completeness: Default::default(),
+        };
         let stats = plan_sync_with_delete(
             MemTreeProvider::root_files(&[("a.txt", 1), ("b.txt", 1)]),
             &fixture.local(),

--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -8301,7 +8301,14 @@ fn scan_local_tree_with_progress(
             }
         }
 
-        let meta = walk_entry.metadata().ok();
+        // Listed but not statted: kept, and counted, as in `scan_sync_local`.
+        let meta = match walk_entry.metadata() {
+            Ok(meta) => Some(meta),
+            Err(_) => {
+                completeness.list_errors += 1;
+                None
+            }
+        };
         let size = meta.as_ref().map(|value| value.len()).unwrap_or(0);
         let mtime = meta.and_then(|value| {
             value.modified().ok().map(|timestamp| {
@@ -45988,7 +45995,17 @@ fn scan_sync_local(local: &str, filter: &SyncLocalFilter) -> SyncScan {
             continue;
         }
 
-        let meta = entry.metadata().ok();
+        // A file the walk can list but not stat (its directory can be read but
+        // not entered) comes with its type and nothing else. Keep it, so it
+        // does not read as deleted, and count the failure, so no delete pass
+        // trusts a scan that did not read the whole tree.
+        let meta = match entry.metadata() {
+            Ok(meta) => Some(meta),
+            Err(_) => {
+                scan.completeness.list_errors += 1;
+                None
+            }
+        };
         let size = meta.as_ref().map(|m| m.len()).unwrap_or(0);
         let mtime = meta.as_ref().and_then(sync_local_mtime);
         scan.entries.push((relative, size, mtime));
@@ -57061,7 +57078,7 @@ async fn cmd_reconcile(
     }
 
     let _ = provider.disconnect().await;
-    // "ok" -> 0; "differences_found" and "partial" (incomplete remote scan) -> 4.
+    // "ok" -> 0; "differences_found" and "partial" (an incomplete remote or local scan) -> 4.
     if result.status == "ok" {
         0
     } else {

--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -5570,6 +5570,15 @@ struct StoredReconcileSummary {
     remote_scan_errors: u64,
     #[serde(default)]
     remote_scan_truncated: bool,
+    // The local fields were added after the remote ones; a summary written
+    // before them loads with the local scan read as complete, which is what
+    // that version reported.
+    #[serde(default)]
+    local_scan_incomplete: bool,
+    #[serde(default)]
+    local_scan_errors: u64,
+    #[serde(default)]
+    local_scan_truncated: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -5577,7 +5586,7 @@ struct StoredReconcileResult {
     /// Top-level reconcile verdict: "ok", "differences_found", or "partial".
     #[serde(default)]
     status: Option<String>,
-    /// Scan-health summary; "partial" is keyed on an incomplete remote scan.
+    /// Scan-health summary; "partial" is keyed on an incomplete scan of either side.
     #[serde(default)]
     summary: Option<StoredReconcileSummary>,
     groups: Option<StoredReconcileGroups>,
@@ -8244,14 +8253,24 @@ fn scan_local_tree_with_progress(
         .checked_sub(std::time::Duration::from_millis(500))
         .unwrap_or_else(Instant::now);
     let mut entries = Vec::new();
+    let mut completeness = ftp_client_gui_lib::sync_core::ScanCompleteness::default();
 
-    for walk_entry in walkdir::WalkDir::new(root)
+    for result in walkdir::WalkDir::new(root)
         .follow_links(false)
         .max_depth(depth)
-        .into_iter()
-        .filter_map(|entry| entry.ok())
     {
+        let walk_entry = match result {
+            Ok(entry) => entry,
+            Err(_) => {
+                // A directory the walk could not read hides the files below
+                // it: counted, so `reconcile` reports a partial result instead
+                // of listing those files as missing locally.
+                completeness.list_errors += 1;
+                continue;
+            }
+        };
         if entries.len() >= cap {
+            completeness.truncated = true;
             break;
         }
         if !walk_entry.file_type().is_file() {
@@ -8313,7 +8332,7 @@ fn scan_local_tree_with_progress(
         pb.set_message(format!("Scanning local... {} files", entries.len()));
     }
 
-    (entries, Default::default())
+    (entries, completeness)
 }
 
 /// Health of a remote BFS scan: how many `list()` calls failed and whether the
@@ -8425,45 +8444,89 @@ async fn scan_remote_tree_with_progress(
     )
 }
 
+/// Why a stored reconcile plan cannot drive this `sync`.
+#[derive(Debug)]
+enum ReconcilePlanError {
+    /// `--delete` refused on a plan produced from an incomplete scan: the
+    /// TX-01 refusal of a live scan, with its exit code.
+    DeleteRefused(String),
+    /// The plan cannot be read, parsed or used with these flags.
+    Invalid(String),
+}
+
+impl std::fmt::Display for ReconcilePlanError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.message())
+    }
+}
+
+impl ReconcilePlanError {
+    fn message(&self) -> &str {
+        match self {
+            Self::DeleteRefused(message) | Self::Invalid(message) => message,
+        }
+    }
+
+    fn exit_code(&self) -> i32 {
+        match self {
+            Self::DeleteRefused(_) => 4,
+            Self::Invalid(_) => 5,
+        }
+    }
+}
+
 fn load_sync_plan_from_reconcile(
     path: &str,
     direction: &str,
     delete: bool,
     listed: Option<&std::collections::HashSet<String>>,
-) -> Result<ReconcileSyncPlan, String> {
-    let raw = std::fs::read_to_string(path)
-        .map_err(|err| format!("Cannot read reconcile file '{}': {}", path, err))?;
-    let stored: StoredReconcileResult = serde_json::from_str(&raw)
-        .map_err(|err| format!("Invalid reconcile JSON '{}': {}", path, err))?;
-    // TX-01 (reconcile path): a reconcile produced from an incomplete remote scan
-    // marks "missing_remote"/"missing_local" unreliably. Feeding it into
+) -> Result<ReconcileSyncPlan, ReconcilePlanError> {
+    let raw = std::fs::read_to_string(path).map_err(|err| {
+        ReconcilePlanError::Invalid(format!("Cannot read reconcile file '{}': {}", path, err))
+    })?;
+    let stored: StoredReconcileResult = serde_json::from_str(&raw).map_err(|err| {
+        ReconcilePlanError::Invalid(format!("Invalid reconcile JSON '{}': {}", path, err))
+    })?;
+    // TX-01 (reconcile path): a reconcile produced from an incomplete scan marks
+    // "missing_remote"/"missing_local" unreliably: a file the scan could not see,
+    // on either side, reads as missing there. Feeding it into
     // `sync --from-reconcile --delete` would classify intact files as orphans and
     // delete them, bypassing the live-scan completeness gate (which trusts a
     // user-supplied reconcile as a complete source of truth). Refuse delete when
-    // the stored verdict is "partial" or the summary flags an incomplete remote
-    // scan. Non-delete transfers from a partial reconcile stay allowed (they only
-    // move fewer files, never destroy data).
+    // the stored verdict is "partial" or the summary flags an incomplete scan of
+    // either side. The refusal reads the whole plan, before the `--files-from`
+    // bound below. Non-delete transfers from a partial reconcile stay allowed
+    // (they only move fewer files, never destroy data).
     if delete {
         let status_partial = stored.status.as_deref() == Some("partial");
-        let summary_incomplete = stored.summary.as_ref().is_some_and(|s| {
+        let summary = stored.summary.as_ref();
+        let remote_incomplete = summary.is_some_and(|s| {
             s.remote_scan_incomplete || s.remote_scan_errors > 0 || s.remote_scan_truncated
         });
-        if status_partial || summary_incomplete {
-            return Err(format!(
-                "refusing --delete: reconcile file '{}' was produced from an incomplete remote scan \
+        let local_incomplete = summary.is_some_and(|s| {
+            s.local_scan_incomplete || s.local_scan_errors > 0 || s.local_scan_truncated
+        });
+        if status_partial || remote_incomplete || local_incomplete {
+            let side = match (remote_incomplete, local_incomplete) {
+                (false, true) => "local",
+                (true, true) => "remote and local",
+                _ => "remote",
+            };
+            return Err(ReconcilePlanError::DeleteRefused(format!(
+                "refusing --delete: reconcile file '{}' was produced from an incomplete {} scan \
                  (status=partial). A partial listing would classify intact files as orphans and \
-                 delete them. Re-run reconcile to completion (restore connectivity / raise --max-depth) \
-                 or drop --delete.",
-                path
-            ));
+                 delete them. Re-run reconcile to completion (restore connectivity and local read \
+                 access / raise --max-depth) or drop --delete.",
+                path, side
+            )));
         }
     }
 
     let mut groups = stored.groups.ok_or_else(|| {
-        format!(
+        ReconcilePlanError::Invalid(format!(
             "Reconcile file '{}' does not contain detailed groups. Re-run reconcile without --format summary.",
             path
-        )
+        ))
     })?;
     // A `--files-from` list bounds a stored plan the way it bounds a live
     // scan. The groups are filtered before anything is derived from them, so
@@ -8481,10 +8544,10 @@ fn load_sync_plan_from_reconcile(
     }
 
     if direction == "both" && (delete || !groups.differ.is_empty()) {
-        return Err(
+        return Err(ReconcilePlanError::Invalid(
             "--from-reconcile supports --direction both only when there are no differ entries and --delete is off"
                 .to_string(),
-        );
+        ));
     }
 
     let mut plan = ReconcileSyncPlan::default();
@@ -8558,10 +8621,10 @@ fn load_sync_plan_from_reconcile(
                 .collect();
         }
         other => {
-            return Err(format!(
+            return Err(ReconcilePlanError::Invalid(format!(
                 "--from-reconcile does not support direction '{}'",
                 other
-            ))
+            )))
         }
     }
 
@@ -45953,10 +46016,11 @@ struct SyncOrphanDeletes<'a> {
 /// The orphan deletes a `sync` pass plans from its two scans, or the reason it
 /// must plan none.
 ///
+/// `delete` is false for a run without `--delete` and for a `--from-reconcile`
+/// plan, which carries its own deletes and is guarded when it is loaded.
 /// `guarded` is false for a dry run, which stays read-only and reports its
-/// plan, and for a `--from-reconcile` plan, which the user supplied as the
-/// source of truth. Orphans are planned for the one-way directions only:
-/// `both` decides its deletes from the bisync snapshot.
+/// plan. Orphans are planned for the one-way directions only: `both` decides
+/// its deletes from the bisync snapshot.
 fn plan_sync_orphan_deletes<'a>(
     direction: &str,
     delete: bool,
@@ -46171,9 +46235,9 @@ async fn cmd_sync(
                     (local_scan, remote_entries)
                 }
                 Err(err) => {
-                    print_error(format, &err, 5);
+                    print_error(format, err.message(), err.exit_code());
                     let _ = provider.disconnect().await;
-                    return 5.into();
+                    return err.exit_code().into();
                 }
             }
         } else {
@@ -46401,10 +46465,13 @@ async fn cmd_sync(
     let scan_incomplete = reconcile_plan.is_none()
         && !(local_scan_health.is_complete() && remote_scan_health.is_complete());
 
+    // A reconcile plan carries its own deletes and its own scan guard (in
+    // `load_sync_plan_from_reconcile`): planning orphans from its entries again
+    // would ask the remote for every one of them twice.
     let orphan_deletes = match plan_sync_orphan_deletes(
         direction,
-        delete,
-        !dry_run && reconcile_plan.is_none(),
+        delete && reconcile_plan.is_none(),
+        !dry_run,
         &local_scan_health,
         &remote_scan_health,
         &local_map,
@@ -47547,7 +47614,7 @@ async fn cmd_sync(
     if direction == "both" && errors.is_empty() && !dry_run {
         save_bisync_snapshot(
             local,
-            &local_entries,
+            local_entries,
             &remote_entries,
             files_from_set.as_ref(),
         );
@@ -54795,35 +54862,29 @@ impl WatchLocalSnapshot {
     }
 }
 
-/// The snapshot a watch loop starts its incremental cycles from.
-fn build_watch_local_snapshot(local_dir: &str, _filter: &SyncLocalFilter) -> WatchLocalSnapshot {
-    let mut snap = std::collections::HashMap::new();
-    let walker = walkdir::WalkDir::new(local_dir)
-        .follow_links(false)
-        .max_depth(100);
-    for entry in walker {
-        let entry = match entry {
-            Ok(e) => e,
-            Err(_) => continue,
-        };
-        if !entry.file_type().is_file() {
-            continue;
-        }
-        let relative = match entry.path().strip_prefix(local_dir) {
-            Ok(r) => r.to_string_lossy().replace('\\', "/"),
-            Err(_) => continue,
-        };
-        if relative.is_empty() || relative == BISYNC_SNAPSHOT_FILE {
-            continue;
-        }
-        if let Ok(meta) = entry.metadata() {
-            snap.insert(relative, (meta.len(), sync_local_mtime(&meta)));
-        }
+/// The snapshot a watch loop starts its incremental cycles from: the walk
+/// `cmd_sync` itself runs, so it keeps the same files and counts what it could
+/// not read.
+fn build_watch_local_snapshot(local_dir: &str, filter: &SyncLocalFilter) -> WatchLocalSnapshot {
+    WatchLocalSnapshot::from_scan(&scan_sync_local(local_dir, filter))
+}
+
+/// Say on stderr when a watch snapshot could not read the whole tree: until a
+/// snapshot does, watcher events run full sync cycles instead of incremental
+/// ones.
+fn note_incomplete_watch_snapshot(snapshot: &WatchLocalSnapshot, quiet: bool) {
+    if quiet || snapshot.completeness.is_complete() {
+        return;
     }
-    WatchLocalSnapshot {
-        files: snap,
-        completeness: Default::default(),
-    }
+    eprintln!(
+        "Warning: local snapshot incomplete ({} read error(s){}); watcher events run full sync cycles until the whole tree can be read.",
+        snapshot.completeness.list_errors,
+        if snapshot.completeness.truncated {
+            ", truncated"
+        } else {
+            ""
+        }
+    );
 }
 
 /// Build the local side of a watch cycle incrementally: refresh metadata only
@@ -54835,9 +54896,9 @@ fn incremental_local_scan(
     previous: &WatchLocalSnapshot,
     filter: &SyncLocalFilter,
 ) -> SyncScan {
-    let exclude_matchers = filter.exclude;
     let mut result: std::collections::HashMap<String, (u64, Option<String>)> =
         previous.files.clone();
+    let mut completeness = previous.completeness;
 
     for changed in changed_paths {
         // Compute relative path
@@ -54848,23 +54909,37 @@ fn incremental_local_scan(
         if relative.is_empty() || relative == BISYNC_SNAPSHOT_FILE {
             continue;
         }
-        // Check excludes
-        let fname = changed.file_name().and_then(|n| n.to_str()).unwrap_or("");
-        if exclude_matchers
-            .iter()
-            .any(|m| m.is_match(&relative) || m.is_match(fname))
-        {
+        // The same depth bound and excludes as the walk
+        let fname = changed
+            .file_name()
+            .map(|n| n.to_string_lossy())
+            .unwrap_or_default();
+        if !filter.keeps(&relative, &fname) {
             result.remove(&relative);
             continue;
         }
-        // Read current metadata: if file was deleted, remove from snapshot
         match std::fs::metadata(changed) {
             Ok(meta) if meta.is_file() => {
                 result.insert(relative, (meta.len(), sync_local_mtime(&meta)));
             }
-            _ => {
-                // File deleted or not a regular file
+            Ok(_) => {
+                // Not a regular file (any more)
                 result.remove(&relative);
+            }
+            Err(err)
+                if matches!(
+                    err.kind(),
+                    std::io::ErrorKind::NotFound | std::io::ErrorKind::NotADirectory
+                ) =>
+            {
+                // Deleted, or a directory on its path is gone
+                result.remove(&relative);
+            }
+            Err(_) => {
+                // Unreadable is not absent: keep what the snapshot knew and
+                // count the error, so this cycle plans no orphan deletes
+                // (TX-01) and the next one rescans.
+                completeness.list_errors += 1;
             }
         }
     }
@@ -54874,7 +54949,7 @@ fn incremental_local_scan(
             .into_iter()
             .map(|(path, (size, mtime))| (path, size, mtime))
             .collect(),
-        completeness: previous.completeness,
+        completeness,
     }
 }
 
@@ -55197,6 +55272,7 @@ async fn cmd_sync_watch(
     // Build initial snapshot after first sync (or immediately if --watch-no-initial)
     if use_incremental {
         local_snapshot = build_watch_local_snapshot(local, &local_filter);
+        note_incomplete_watch_snapshot(&local_snapshot, quiet);
     }
 
     // Watch loop
@@ -55230,7 +55306,7 @@ async fn cmd_sync_watch(
                 let path_count = changed_paths.len();
                 let trigger = format!("watcher: {} paths", path_count);
 
-                if use_incremental {
+                if use_incremental && local_snapshot.completeness.is_complete() {
                     let scan = incremental_local_scan(
                         local_path,
                         &changed_paths,
@@ -55246,7 +55322,16 @@ async fn cmd_sync_watch(
                         return 0;
                     }
                 } else {
+                    // A snapshot that could not read the whole tree is no base
+                    // for an incremental cycle: run a full one, whose own walk
+                    // decides whether --delete may proceed (TX-01), and take a
+                    // fresh snapshot for the next event, so a transient error
+                    // heals instead of lasting until the periodic rescan.
                     run_sync_cycle!(trigger.as_str());
+                    if use_incremental {
+                        local_snapshot = build_watch_local_snapshot(local, &local_filter);
+                        note_incomplete_watch_snapshot(&local_snapshot, quiet);
+                    }
                     if cancelled.load(Ordering::SeqCst) {
                         if !quiet {
                             eprintln!("\nWatch mode stopped. {} sync cycles completed.", cycle_count);
@@ -55264,6 +55349,7 @@ async fn cmd_sync_watch(
                 // Rebuild snapshot after full rescan
                 if use_incremental {
                     local_snapshot = build_watch_local_snapshot(local, &local_filter);
+                    note_incomplete_watch_snapshot(&local_snapshot, quiet);
                 }
                 if cancelled.load(Ordering::SeqCst) {
                     if !quiet {
@@ -56791,7 +56877,7 @@ async fn cmd_reconcile(
         ..Default::default()
     };
     let local_spinner = maybe_create_scan_spinner(format, cli, "Scanning local...");
-    let (locals, _local_health) =
+    let (locals, local_health) =
         scan_local_tree_with_progress(local_path, &scan_opts, &local_spinner);
     if let Some(pb) = local_spinner {
         pb.finish_and_clear();
@@ -56826,6 +56912,15 @@ async fn cmd_reconcile(
             "Warning: remote scan incomplete ({} list error(s){}); reconcile result is partial and unsafe to feed into `sync --delete`.",
             remote_health.errors,
             if remote_health.truncated { ", truncated" } else { "" }
+        );
+    }
+    // The same holds for the local side: a directory the walk could not read
+    // lists its files as missing locally.
+    if !local_health.is_complete() && !cli.quiet {
+        eprintln!(
+            "Warning: local scan incomplete ({} read error(s){}); reconcile result is partial and unsafe to feed into `sync --delete`.",
+            local_health.list_errors,
+            if local_health.truncated { ", truncated" } else { "" }
         );
     }
     let diff = compare_trees(&locals, &remotes, one_way);
@@ -56884,7 +56979,7 @@ async fn cmd_reconcile(
     );
 
     let result = CliReconcileResult {
-        status: if remote_health.is_incomplete() {
+        status: if remote_health.is_incomplete() || !local_health.is_complete() {
             "partial"
         } else if differ_group.is_empty()
             && missing_remote_group.is_empty()
@@ -56904,6 +56999,9 @@ async fn cmd_reconcile(
             "remote_scan_incomplete": remote_health.is_incomplete(),
             "remote_scan_errors": remote_health.errors,
             "remote_scan_truncated": remote_health.truncated,
+            "local_scan_incomplete": !local_health.is_complete(),
+            "local_scan_errors": local_health.list_errors,
+            "local_scan_truncated": local_health.truncated,
             "elapsed_secs": elapsed,
         }),
         groups: serde_json::json!({
@@ -71800,7 +71898,7 @@ mod tests {
         let err = load_sync_plan_from_reconcile(path.to_str().unwrap(), "upload", false, None)
             .unwrap_err();
 
-        assert!(err.contains("does not contain detailed groups"));
+        assert!(err.message().contains("does not contain detailed groups"));
     }
 
     #[test]
@@ -71831,7 +71929,7 @@ mod tests {
         let err = load_sync_plan_from_reconcile(path.to_str().unwrap(), "download", true, None)
             .unwrap_err();
         assert!(
-            err.contains("incomplete remote scan"),
+            err.message().contains("incomplete remote scan"),
             "unexpected error: {err}"
         );
 
@@ -71867,7 +71965,7 @@ mod tests {
         let err = load_sync_plan_from_reconcile(path.to_str().unwrap(), "download", true, None)
             .unwrap_err();
         assert!(
-            err.contains("incomplete remote scan"),
+            err.message().contains("incomplete remote scan"),
             "unexpected error: {err}"
         );
     }


### PR DESCRIPTION
## The defect

`aeroftp-cli sync --watch` with `--direction upload --delete` could delete remote files that still exist locally.

The watch loop keeps a snapshot of the local tree between cycles and, on a watcher event, hands `cmd_sync` that snapshot plus the refreshed paths instead of walking the tree again. Three places dropped read errors on the way:

1. The snapshot builder skipped every entry the walker could not read (a directory without permission, a transient I/O error) without counting it, so a whole subtree disappeared from the snapshot.
2. The incremental refresh treated any `metadata` failure on a reported path as a deletion, so a file the cycle could not stat left the snapshot too.
3. `cmd_sync` took the precomputed list without any completeness information, so `local_scan_errors` stayed at 0 and the TX-01 guard, which refuses `--delete` on an incomplete source scan, could not fire. The orphan planner then read every file it could not see as a remote orphan.

## Chain, verified on the code before the change

- The snapshot closure in `cmd_sync_watch` matched `Err(_) => continue` on the walker entry and on `strip_prefix`, and `if let Ok(meta)` had no error arm. No counter.
- `incremental_local_scan` cloned the snapshot and applied the reported paths, so a cycle's local side was exactly the snapshot plus changes; its `match std::fs::metadata(..)` had a single `_ => remove` arm.
- `cmd_sync(.., precomputed_local = Some(entries))` used the list in place of the walk, leaving the local error counter at 0, and the upload orphan loop planned `remote_map - local_map` for deletion.

## Same root, same PR

- **Filters in watch cycles.** The snapshot ignored the depth bound and the exclude patterns that the sync scan applies, so an excluded file already on disk reached the planner at the first watcher event. The snapshot is now built by the same local walk `cmd_sync` uses, and the incremental refresh applies the same filter. The `--files-from` list is left to the single bound `cmd_sync` applies to every entry that reaches the planner.
- **`reconcile` feeding `sync --from-reconcile --delete`.** The CLI local walk of `reconcile` dropped read errors, the reconcile status marked `partial` only for an incomplete remote scan, and the plan loader checked only the remote side. With an unreadable local directory, its files were listed as `missing_local`, and `--direction upload --delete` deleted them on the remote.

Counted and left unchanged, because they plan no deletes: `check` and `cryptcheck` do not report the completeness of either scan.

## Fix

- `SyncScan` carries the entries of one side together with the `ScanCompleteness` of the walk that produced them, from the watch loop into `cmd_sync`. An incremental cycle therefore meets the same TX-01 refusal as a full scan: exit 4, zero deletions, the reason on stderr or in the JSON error.
- The snapshot is built by `scan_sync_local`, the walk `cmd_sync` itself uses, so it counts unreadable entries and applies the same filters.
- The incremental refresh removes a path only when it is gone (`NotFound`, `NotADirectory`). Any other error keeps what the snapshot knew and counts a listing error.
- The watch loop runs an incremental cycle only from a complete snapshot. From an incomplete one it runs a full cycle, which applies TX-01 on a fresh walk, and rebuilds the snapshot, so a transient error heals at the next event instead of blocking every cycle until the periodic rescan.
- `reconcile` counts local walk errors and truncation, reports `status: partial` and adds `local_scan_incomplete`, `local_scan_errors` and `local_scan_truncated` to its summary (additive: no field is renamed or removed). The plan loader refuses `--delete` when either scan was incomplete, before the `--files-from` filter and without changing it. The refusal now exits 4 like the live TX-01 refusal; a malformed plan still exits 5.

- A file the local walk can list but not stat (its directory has read but no execute permission) counts as a listing error and stays in the scan, in `scan_sync_local` and in the `reconcile` walk. Before, it went out with size 0 and no mtime and the scan still read as complete.

Why refuse rather than only fall back to a full scan: the refusal is what makes the guarantee structural, since no path can hand `cmd_sync` a local side without its completeness. The fallback is what keeps a transient error from stalling the watch.

## Tests

The tests drive the real `cmd_sync` against the in-memory remote through the existing test connection seam, not as a dry run, so the scan guards and the deletes are reached; the remote records every delete it is asked for.

### Seen red on the test commit, before the fix

`cargo test --bin aeroftp-cli` on `test(cli): cover unreadable local trees in watch and reconcile deletes`, with the refactor below it and no fix:

```
test tests::watch_cycle_deletes_nothing_behind_a_directory_the_snapshot_could_not_read ... FAILED
test tests::watch_cycle_does_not_take_a_file_it_cannot_stat_for_a_deleted_one ... FAILED
test tests::watch_cycle_local_side_applies_the_sync_depth_and_exclude_filters ... FAILED
test tests::reconcile_local_scan_is_incomplete_behind_an_unreadable_directory ... FAILED
test tests::sync_from_reconcile_refuses_delete_on_an_incomplete_local_scan ... FAILED
test tests::sync_from_reconcile_refusal_of_a_partial_remote_scan_exits_4 ... FAILED
test tests::sync_from_reconcile_attempts_each_remote_delete_once ... FAILED
```

The reasons, as printed:

```
watch_cycle_deletes_nothing_behind_a_directory_the_snapshot_could_not_read
  "errors": ["delete remote locked/keep.txt: Operation not supported: delete"]
  (the in-memory remote refuses deletes and records the attempt)

watch_cycle_does_not_take_a_file_it_cannot_stat_for_a_deleted_one
  left: ["/root/locked/keep.txt"]   right: []

watch_cycle_local_side_applies_the_sync_depth_and_exclude_filters
  left: {"a.txt", "d/deep.txt", "secret.env"}   right: {"a.txt"}

reconcile_local_scan_is_incomplete_behind_an_unreadable_directory
  the unreadable directory must count as a listing error

sync_from_reconcile_refuses_delete_on_an_incomplete_local_scan
  left: ["/root/b.txt", "/root/b.txt"]   right: []

sync_from_reconcile_refusal_of_a_partial_remote_scan_exits_4
  left: 5   right: 4

sync_from_reconcile_attempts_each_remote_delete_once
  left: ["/root/b.txt", "/root/b.txt"]   right: ["/root/b.txt"]
```

A first run of the end-to-end tests stopped earlier, at the non-interactive `--delete` gate that asks for an explicit `--max-delete`, and so proved nothing about the deletes; the test helper now passes a wide cap, and the reasons above are from the run that reached the deletes.

`reconcile_summary_without_the_local_scan_fields_still_drives_delete` is a compatibility pin, green before and after.

### Files the walk can list but not stat, seen red on `86929a0d7`

A directory with read but no execute permission (0400) lists its entries with their type while a stat of any of them fails. These tests were committed on top of `86929a0d7` and run there, before the fix:

```
test tests::watch_snapshot_counts_a_file_it_can_list_but_not_stat ... FAILED
  a file that cannot be statted leaves the snapshot incomplete
test tests::sync_upload_delete_refuses_when_a_local_file_cannot_be_statted ... FAILED
  left: ["/root/gone.txt"]   right: []
test tests::sync_from_reconcile_refuses_delete_when_reconcile_could_not_stat_a_local_file ... FAILED
  left: ["/root/b.txt"]   right: []
```

In the reconcile test the first assertion, that the file stays listed, already held: the defect was the missing refusal, not a false absence.

### Green after the fix

The same run plus the neighbouring tests the change touches (the incremental scan, the reconcile loader, and the `--files-from` tests of `cmd_sync`):

```
test result: ok. 24 passed; 0 failed; 0 ignored; 0 measured; 522 filtered out
```

## Limits

- The watch loop itself, and its fallback from an incomplete snapshot to a full cycle, have no direct test: the loop runs a real filesystem watcher until it is interrupted. The tests cover the pieces it is built from (the snapshot, the incremental refresh, and `cmd_sync` with a precomputed local scan).
- The full output of `cmd_reconcile` is not tested. The tests cover its local scan and the loader reading the summary fields it writes.
- Saving the bisync snapshot after a `--direction both` run without `--delete` has no new completeness guard. That behaviour predates this change.

## Gates

On the head of this branch, after the stat-error fix:

- `cargo fmt --all -- --check`: clean
- `cargo test --bin aeroftp-cli` on the tests above: 27 passed, 0 failed
- `cargo clippy --bin aeroftp-cli --tests -- -D warnings`: clean

Before the last rebase, which brought in a change to `cmd_put` and the FTP provider only (no TypeScript changed since):

- `npm run typecheck`, `npm run i18n:validate`, `npm run i18n:diacritics`, `npm run i18n:untranslated`, `npm run check:provider-inventory`: all pass
- `npm run test:unit`: 916 passed

The tests that make a directory unreadable are `#[cfg(unix)]` and need a non-root user: they assert that the directory really cannot be read, so under root they fail with that message instead of passing without exercising anything.

No CHANGELOG entry: the release notes are written from the tracker at release time.
