### PR TITLE
test(ftp): time the put settle on the server, not the process

### DIFF
--- a/src-tauri/tests/ftp_put_floor.rs
+++ b/src-tauri/tests/ftp_put_floor.rs
@@ -13,8 +13,8 @@
 //!
 //! Neither needs the Docker fixture: the server below is a scripted fake on
 //! loopback, enough FTP for connect + PASV + STOR + RETR + MFMT + QUIT, and
-//! it records every command so the wire itself is asserted on, not a
-//! constant.
+//! it records every command, with the moment it arrived, so the wire itself
+//! is asserted on, not a constant.
 
 use std::collections::HashMap;
 use std::io::Write as _;
@@ -26,10 +26,28 @@ use ftp_client_gui_lib::providers::{FtpProvider, StorageProvider};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpListener;
 
+/// One control command as the fake server received it.
+#[derive(Clone, Debug)]
+struct Received {
+    line: String,
+    at: Instant,
+}
+
+impl Received {
+    fn verb(&self) -> String {
+        self.line
+            .split_whitespace()
+            .next()
+            .unwrap_or("")
+            .to_uppercase()
+    }
+}
+
 /// What the fake server saw (and holds), asserted on by the tests.
 #[derive(Clone, Default)]
 struct Wire {
-    commands: Arc<Mutex<Vec<String>>>,
+    /// Every control command, with the moment it arrived.
+    commands: Arc<Mutex<Vec<Received>>>,
     stored: Arc<Mutex<Vec<u8>>>,
     files: Arc<Mutex<HashMap<String, Vec<u8>>>>,
 }
@@ -60,7 +78,10 @@ async fn session(stream: tokio::net::TcpStream, wire: Wire) {
     // A PASV listener lives until the next data command consumes it.
     let mut pasv: Option<TcpListener> = None;
     while let Ok(Some(line)) = lines.next_line().await {
-        wire.commands.lock().unwrap().push(line.clone());
+        wire.commands.lock().unwrap().push(Received {
+            line: line.clone(),
+            at: Instant::now(),
+        });
         let verb = line.split_whitespace().next().unwrap_or("").to_uppercase();
         let arg = line
             .split_once(' ')
@@ -235,33 +256,50 @@ async fn transfer_session_sends_type_exactly_once() {
 
     assert_eq!(std::fs::read(&down_local).unwrap(), payload);
     let commands = server.wire.commands.lock().unwrap();
-    let types: Vec<&String> = commands
+    let lines: Vec<&str> = commands.iter().map(|c| c.line.as_str()).collect();
+    let types: Vec<&str> = lines
         .iter()
+        .copied()
         .filter(|c| c.to_uppercase().starts_with("TYPE"))
         .collect();
     assert_eq!(
         types.len(),
         1,
         "the session must pay TYPE once (at connect), not once per transfer: {:?}",
-        commands.as_slice()
+        lines
     );
     assert_eq!(types[0].to_uppercase(), "TYPE I");
     std::fs::remove_file(&up_local).ok();
     std::fs::remove_file(&down_local).ok();
 }
 
+/// The commands the fake server has received once it has seen QUIT, or when
+/// five seconds have passed without it.
+async fn commands_through_quit(wire: &Wire) -> Vec<Received> {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let commands = wire.commands.lock().unwrap().clone();
+        if commands.iter().any(|c| c.verb() == "QUIT") || Instant::now() >= deadline {
+            return commands;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
 /// The 500 ms post-upload settle exists for russh's buffered SFTP writes; it
 /// used to run for every provider. This drives the COMMAND itself
-/// (`aeroftp-cli put` against a URL, no profile, no vault) and times it
-/// end to end against a loopback server, where the whole exchange is a few
-/// milliseconds: before the fix the process cannot come back in under half a
-/// second, after it the floor is process startup. 400 ms leaves >100 ms of
-/// margin on both sides of the old and new behaviour.
+/// (`aeroftp-cli put` against a URL, no profile, no vault) and measures the
+/// interval where that sleep sits: `cmd_put` settles after the upload and
+/// before it disconnects, so the fake server times the gap between the last
+/// command it receives before QUIT (MFMT, or the STOR itself when there is no
+/// MFMT) and QUIT. On loopback that gap is a few milliseconds; with the
+/// settle on the FTP path it is at least 500 ms. 300 ms tells them apart.
 ///
-/// It has to be the process wall clock, not the CLI's own number: `cmd_put`
-/// closes its `elapsed_secs` BEFORE the settle sleep, so a test asserting on
-/// the JSON's `elapsed_secs` would be green both before and after the fix
-/// and would prove nothing. The bench times the process for the same reason.
+/// Neither the process wall clock nor the CLI's own number can carry this.
+/// The wall clock includes starting a debug binary, which on a loaded CI
+/// runner can take longer than any threshold below the 500 ms signal.
+/// `cmd_put` closes its `elapsed_secs` before the settle sleep, so that
+/// number is the same with and without the sleep.
 #[tokio::test]
 async fn cli_put_to_ftp_has_no_half_second_settle() {
     let server = start_fake_ftp().await;
@@ -273,7 +311,6 @@ async fn cli_put_to_ftp_has_no_half_second_settle() {
         .unwrap();
 
     let url = format!("ftp://testuser:testpass@127.0.0.1:{}/", server.port);
-    let start = Instant::now();
     // tokio::process, not std: the fake server lives on this same runtime, so
     // a blocking wait would starve the very tasks the child is talking to.
     let child = tokio::process::Command::new(env!("CARGO_BIN_EXE_aeroftp-cli"))
@@ -289,20 +326,32 @@ async fn cli_put_to_ftp_has_no_half_second_settle() {
         Ok(o) => o.expect("spawn aeroftp-cli put"),
         Err(_) => panic!("aeroftp-cli put to a loopback server did not finish in 30 s"),
     };
-    let elapsed = start.elapsed();
 
     assert!(
         output.status.success(),
         "put failed: {}",
         String::from_utf8_lossy(&output.stderr)
     );
-    // Give the server task a moment to record the tail of the session.
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    // The child can exit before the server task has read its QUIT.
+    let commands = commands_through_quit(&server.wire).await;
+    let lines: Vec<&str> = commands.iter().map(|c| c.line.as_str()).collect();
     assert_eq!(server.wire.stored.lock().unwrap().as_slice(), payload);
+    let quit = commands
+        .iter()
+        .position(|c| c.verb() == "QUIT")
+        .unwrap_or_else(|| panic!("the put never sent QUIT: {:?}", lines));
     assert!(
-        elapsed < Duration::from_millis(400),
-        "a localhost put took {:?}; the SFTP-only settle sleep is back on the FTP path",
-        elapsed
+        commands[..quit].iter().any(|c| c.verb() == "STOR"),
+        "QUIT has to follow the upload: {:?}",
+        lines
+    );
+    let before_quit = &commands[quit - 1];
+    let gap = commands[quit].at.duration_since(before_quit.at);
+    assert!(
+        gap < Duration::from_millis(300),
+        "{:?} passed between `{}` and QUIT; the SFTP-only settle sleep is back on the FTP path",
+        gap,
+        before_quit.line
     );
     std::fs::remove_file(&local).ok();
 }


### PR DESCRIPTION
## The failure

`cli_put_to_ftp_has_no_half_second_settle` (in `src-tauri/tests/ftp_put_floor.rs`) failed on a pull request that changes only comments:

```
a localhost put took 655.742524ms; the SFTP-only settle sleep is back on the FTP path
```

The same test is green on `main`. The PR could not have moved the FTP path, so the test was measuring something else.

## Why

The test timed the whole `aeroftp-cli put` process against a loopback server and required it to finish under 400 ms. That wall clock includes starting a debug binary, and on a loaded CI runner startup alone can take longer than 400 ms with no sleep anywhere. The signal the test looks for is a 500 ms sleep, so a 400 ms bound on the whole process leaves no reliable margin between the two.

## Change

The test now measures the interval where the sleep sits, on the server side:

- The fake FTP server records the moment each control command arrives (`Wire::commands` holds `Received { line, at }` instead of the text alone).
- `cmd_put` settles after the upload and before it disconnects. The test asserts that the gap between the last command before `QUIT` (`MFMT` when the server offers it, otherwise the `STOR`) and `QUIT` is under 300 ms, against a signal of at least 500 ms.
- It still checks that `QUIT` arrives, now by waiting for it (up to 5 s) instead of a fixed 50 ms pause, and that it follows the upload.
- The test name is unchanged; its comment no longer reasons about 400 ms and process startup. The other test in the file reads the new command type and is otherwise unchanged.

No production code changes.

## Proof that the test still tells the two apart

With the settle temporarily extended to FTP in `cmd_put` (`if provider.provider_type() == ProviderType::Sftp || provider.provider_type() == ProviderType::Ftp`), a local change that is not part of this PR:

```
test cli_put_to_ftp_has_no_half_second_settle ... FAILED
503.109094ms passed between `MFMT 20260911190903 /floor.bin` and QUIT; the SFTP-only settle sleep is back on the FTP path
```

With that change reverted, on the code of this PR:

```
test transfer_session_sends_type_exactly_once ... ok
test cli_put_to_ftp_has_no_half_second_settle ... ok
test result: ok. 2 passed; 0 failed
```

## Gates

- `cargo fmt --all -- --check`: clean
- `cargo test --test ftp_put_floor`: 2 passed
- `cargo clippy --test ftp_put_floor -- -D warnings`: clean

No CHANGELOG entry: the release notes are written from the tracker at release time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved FTP upload test coverage by validating command sequencing, successful uploads, and orderly connection shutdown.
  - Added more precise timing checks for the delay before disconnecting, reducing reliance on overall process timing and making test results more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->