### PR TITLE
fix: close the plausible findings from the v4.1.9 audits

### DIFF
--- a/.github/scripts/pre-push-gate.sh
+++ b/.github/scripts/pre-push-gate.sh
@@ -47,5 +47,7 @@ cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
 cargo test --manifest-path src-tauri/Cargo.toml
 (
     cd src-tauri
-    cargo audit
+    # Same strictness as checks.yml: a yanked crate or an unrun yank check is
+    # a warning with exit 0 by default, which reads as a pass. Deny them.
+    cargo audit --deny warnings
 )

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -150,5 +150,11 @@ jobs:
         # Non-blocking on PRs: a newly published advisory on a transitive
         # dependency must not red-wall an unrelated PR. On push to main and on
         # the weekly schedule the step is authoritative and fails the job.
+        # `--deny warnings`: without it a yanked crate, and a registry timeout
+        # that leaves the yank check unrun, both end as a printed warning with
+        # exit 0, indistinguishable from a pass (#661 declared that gap; the
+        # v4.1.9 audit measured it still open). The dependency tree is
+        # warning-clean today, so an unavailable check now fails red here
+        # instead of being read as clean.
         continue-on-error: ${{ github.event_name == 'pull_request' }}
-        run: cargo audit
+        run: cargo audit --deny warnings

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -53,7 +53,9 @@ jobs:
                 shown="$expected"
                 ;;
             esac
-            if git show -s --format='%B' "$sha" | grep -qiF "$expected"; then
+            # Anchor on real sign-off LINES before the substring match: a commit
+            # that quotes "Signed-off-by: ..." inside prose must not pass.
+            if git show -s --format='%B' "$sha" | grep -i '^Signed-off-by:' | grep -qiF "$expected"; then
               continue
             fi
             echo "::error::commit $sha is missing '$shown'"

--- a/scripts/assert-linux-acl-packaging.sh
+++ b/scripts/assert-linux-acl-packaging.sh
@@ -133,7 +133,6 @@ if require_or_skip "AppImage" "$APPIMAGE"; then
   chmod +x "$APPIMAGE" || true
   offset="$("$APPIMAGE" --appimage-offset)"
   tmp="$(mktemp -d)"
-  trap 'rm -rf "$tmp"' RETURN
   unsquashfs -d "$tmp/root" -o "$offset" "$APPIMAGE" >/dev/null
   inner="$tmp/root/usr/lib/aeroftp/aeroftp-cli"
   if [ ! -f "$inner" ]; then
@@ -146,7 +145,6 @@ if require_or_skip "AppImage" "$APPIMAGE"; then
   else
     echo "OK: AppImage does not bundle libacl.so*"
   fi
-  trap - RETURN
   rm -rf "$tmp"
 fi
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -218,7 +218,7 @@ jsonwebtoken = { version = "10.4", default-features = false, features = ["aws_lc
 aerovault = "0.6.4"                                                    # M7: converged AEROVAULT3 core + standalone/AeroSync EC engine (published on crates.io)
 aes-gcm-siv = "0.11"                                                   # AeroVault v3 AEAD content encryption
 # Keep on 0.10.1 until aerovault publishes a release that accepts
-# chacha20poly1305 0.11; aerovault 0.6.3 depends on 0.10.
+# chacha20poly1305 0.11; aerovault 0.6.4 depends on 0.10.
 chacha20poly1305 = "=0.10.1"                                           # ChaCha20-Poly1305 (used by CryptoLab in cyber_tools)
 hkdf = "0.12"                                                          # HKDF key derivation (used by crypto.rs keystore)
 

--- a/src-tauri/src/providers/ftp.rs
+++ b/src-tauri/src/providers/ftp.rs
@@ -876,6 +876,21 @@ impl FtpProvider {
         ProviderError::TransferFailed(Self::doing(operation, path, err))
     }
 
+    /// The CR/LF refusal on the command paths that never open a data
+    /// connection (delete, rmdir). Same rule as `classify_data_failure`: the
+    /// library reports the unwritable command line as `ConnectionError` with
+    /// kind `InvalidInput`, and that is a property of the NAME, not of the
+    /// session. Everything else keeps the generic server-error typing these
+    /// paths always had.
+    fn classify_command_refusal(operation: &str, path: &str, err: FtpError) -> ProviderError {
+        if let FtpError::ConnectionError(ref io) = err {
+            if io.kind() == std::io::ErrorKind::InvalidInput {
+                return ProviderError::InvalidPath(Self::doing(operation, path, io));
+            }
+        }
+        ProviderError::ServerError(err.to_string())
+    }
+
     /// Turn a permanent upload refusal into one the user can act on.
     ///
     /// The CLI used to check the parent BEFORE every upload and say "Parent
@@ -1532,7 +1547,7 @@ impl StorageProvider for FtpProvider {
         stream
             .rm(path)
             .await
-            .map_err(|e| ProviderError::ServerError(e.to_string()))?;
+            .map_err(|e| Self::classify_command_refusal("delete", path, e))?;
         Ok(())
     }
 
@@ -1541,7 +1556,7 @@ impl StorageProvider for FtpProvider {
         stream
             .rmdir(path)
             .await
-            .map_err(|e| ProviderError::ServerError(e.to_string()))?;
+            .map_err(|e| Self::classify_command_refusal("rmdir", path, e))?;
         Ok(())
     }
 

--- a/src-tauri/src/providers/jottacloud.rs
+++ b/src-tauri/src/providers/jottacloud.rs
@@ -1599,7 +1599,7 @@ impl StorageProvider for JottacloudProvider {
     async fn delete(&mut self, path: &str) -> Result<(), ProviderError> {
         // Soft-delete into Jottacloud Trash (recoverable via View Trash).
         // Hard delete used to fire `?rm=true` / `?rmDir=true` which skipped the
-        // recycle bin entirely — unlike OpenDrive/Google Drive — so folders
+        // recycle bin entirely, unlike OpenDrive/Google Drive, so folders
         // disappeared permanently from AeroFTP. Permanent purge stays on
         // `permanent_delete_from_trash` / `delete_permanent` only (#397).
         self.move_to_trash(path).await
@@ -1915,7 +1915,7 @@ impl JottacloudProvider {
         // or the agent must resolve against the working directory, otherwise it
         // silently targets a same-named entry in the account root (#397).
         let resolved = self.resolve_path(path);
-        // Ask what it is first — see `delete_param`.
+        // Ask what it is first (see `delete_param`).
         let is_dir = self.stat(&resolved).await?.is_dir;
         let url = format!(
             "{}?{}=true",
@@ -1986,7 +1986,7 @@ impl JottacloudProvider {
     }
 
     /// POST `?cphash=true` on the original mountpoint object with the
-    /// TOMBSTONE's size/md5/timestamps — rclone's restore of a trashed file.
+    /// TOMBSTONE's size/md5/timestamps: rclone's restore of a trashed file.
     /// Callers must source the revision from the tombstone, never from a live
     /// object at the same path (F-652-3). A 2xx answer carries the revived
     /// `<file>` (no `deleted` attribute), so success here is server-confirmed.
@@ -2179,7 +2179,7 @@ impl JottacloudProvider {
     /// Parse a folder listing (live or tombstoned) into tombstone-aware
     /// children. Unlike `parse_folder_xml` nothing is filtered out: the
     /// restore walk needs the tombstoned entries, each with its own
-    /// `currentRevision` — reading size/md5 from here is what keeps cphash
+    /// `currentRevision`: reading size/md5 from here is what keeps cphash
     /// away from a live object at the same path (F-652-3).
     fn parse_folder_tombstone_children(xml: &str) -> Vec<TombstoneChild> {
         use quick_xml::events::Event;
@@ -2363,14 +2363,14 @@ impl JottacloudProvider {
         }
     }
 
-    /// Composed folder restore (#397): no JFS verb restores a directory —
+    /// Composed folder restore (#397): no JFS verb restores a directory:
     /// `?restore=true` 500s on both the Trash view and the original path, and
     /// `?mv=`/`?mvDir=` out of Trash 404 because the view is virtual. What
     /// works is reviving each descendant with the primitives that already
     /// carry file restore: walk the original-path tombstone (JFS still serves
     /// the deleted tree, children `deleted`-stamped, revisions intact),
-    /// cphash every tombstoned file — JFS revives the ancestor chain along
-    /// with it — and mkDir only the directories that stay tombstoned because
+    /// cphash every tombstoned file (JFS revives the ancestor chain along
+    /// with it) and mkDir only the directories that stay tombstoned because
     /// no file lives beneath them.
     ///
     /// Partial failure is reported, never hidden: every entry is attempted,
@@ -2581,7 +2581,7 @@ impl JottacloudProvider {
     /// destination. `?restore=true` 500s on both the Trash view and the
     /// original path; `?mv=` against `/Trash/name` 404s.
     /// Folders: no JFS verb restores a directory (same probes, #397), so the
-    /// restore is composed — see `restore_folder_from_trash`.
+    /// restore is composed (see `restore_folder_from_trash`).
     ///
     /// The report counts only server-confirmed work; an incomplete folder
     /// restore is an `Err` carrying the confirmed counts, never a quiet

--- a/src-tauri/src/rsync_over_ssh.rs
+++ b/src-tauri/src/rsync_over_ssh.rs
@@ -1131,7 +1131,7 @@ mod tests {
 
         let seen = calls.lock().unwrap().clone();
 
-        // Exactly three progress calls — no Summary or Warning extras.
+        // Exactly three progress calls: no Summary or Warning extras.
         assert_eq!(seen.len(), 3, "expected 3 sink calls, got: {:?}", seen);
 
         // 50 %: bytes=5_242_880, total = 5_242_880 * 100 / 50 = 10_485_760

--- a/src-tauri/tests/ftp_crlf_refusal.rs
+++ b/src-tauri/tests/ftp_crlf_refusal.rs
@@ -1,0 +1,153 @@
+//! The CR/LF command-injection refusal, pinned end to end.
+//!
+//! A remote path containing CR or LF must never reach the control connection:
+//! written verbatim it would smuggle a second command into the session. The
+//! library (suppaftp) refuses to write such a line, and the provider types the
+//! refusal as `InvalidPath` (decided on the io kind, not on the message text,
+//! so the classification survives the library rephrasing its error).
+//!
+//! Until now the refusal was covered only by a manual reproduction. The
+//! scripted server below records every line it receives, so the test asserts
+//! on the wire itself: the injected verb is not there.
+
+use std::io::Write as _;
+use std::sync::{Arc, Mutex};
+
+use ftp_client_gui_lib::providers::types::{FtpConfig, FtpTlsMode, ProviderError};
+use ftp_client_gui_lib::providers::{FtpProvider, StorageProvider};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpListener;
+
+/// Accept control connections until the listener is dropped: upload re-dials
+/// a fresh control session from the retained connection spec, so the fake
+/// must serve more than one. Each connection gets just enough FTP for
+/// connect(): greeting, USER/PASS login, and a generic 200 for anything else.
+/// Every received line is recorded verbatim for the assertion.
+async fn serve(listener: TcpListener, commands: Arc<Mutex<Vec<String>>>) {
+    loop {
+        let Ok((stream, _)) = listener.accept().await else {
+            return;
+        };
+        let recorded = Arc::clone(&commands);
+        tokio::spawn(async move { session(stream, recorded).await });
+    }
+}
+
+async fn session(stream: tokio::net::TcpStream, commands: Arc<Mutex<Vec<String>>>) {
+    let (read, mut write) = stream.into_split();
+    if write.write_all(b"220 FakeFTP ready\r\n").await.is_err() {
+        return;
+    }
+    let mut lines = BufReader::new(read).lines();
+    while let Ok(Some(line)) = lines.next_line().await {
+        commands.lock().unwrap().push(line.clone());
+        let verb = line.split_whitespace().next().unwrap_or("").to_uppercase();
+        // PASV needs a real 227 with a listen address: the upload path asks
+        // for the data channel before STOR, and the test asserts the STOR
+        // with a CR/LF name is never written.
+        if verb == "PASV" {
+            let Ok(data) = TcpListener::bind("127.0.0.1:0").await else {
+                if write.write_all(b"425 Cannot listen\r\n").await.is_err() {
+                    return;
+                }
+                continue;
+            };
+            let port = data.local_addr().unwrap().port();
+            let msg = format!(
+                "227 Entering Passive Mode (127,0,0,1,{},{})\r\n",
+                port / 256,
+                port % 256
+            );
+            if write.write_all(msg.as_bytes()).await.is_err() {
+                return;
+            }
+            continue;
+        }
+        let response = match verb.as_str() {
+            "USER" => "331 Password required\r\n",
+            "PASS" => "230 Logged in\r\n",
+            "FEAT" => "211-Features:\r\n MFMT\r\n211 End\r\n",
+            "PWD" => "257 \"/\"\r\n",
+            "QUIT" => "221 Goodbye\r\n",
+            _ => "200 Ok\r\n",
+        };
+        if write.write_all(response.as_bytes()).await.is_err() {
+            return;
+        }
+        if verb == "QUIT" {
+            return;
+        }
+    }
+}
+
+async fn connected_provider() -> (FtpProvider, Arc<Mutex<Vec<String>>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let commands = Arc::new(Mutex::new(Vec::new()));
+    let recorded = Arc::clone(&commands);
+    tokio::spawn(serve(listener, commands));
+    let config = FtpConfig {
+        host: "127.0.0.1".to_string(),
+        port,
+        username: "testuser".to_string(),
+        password: secrecy::SecretString::from("testpass".to_string()),
+        tls_mode: FtpTlsMode::None,
+        verify_cert: false,
+        initial_path: Some("/".to_string()),
+    };
+    let mut provider = FtpProvider::new(config);
+    provider.connect().await.expect("connect to fake FTP");
+    (provider, recorded)
+}
+
+fn assert_refused_cleanly(result: Result<(), ProviderError>, commands: &[String]) {
+    let err = result.expect_err("a CR/LF name must be refused");
+    assert!(
+        matches!(err, ProviderError::InvalidPath(_)),
+        "the refusal must be typed InvalidPath, got: {err}"
+    );
+    assert!(
+        !commands
+            .iter()
+            .any(|c| c.to_uppercase().starts_with("DELE")),
+        "the injected verb must not cross the wire: {commands:?}"
+    );
+    assert!(
+        !commands.iter().any(|c| c.contains("ledger")),
+        "no fragment of the injected command may cross the wire: {commands:?}"
+    );
+}
+
+/// The upload path is the one a crafted remote name travels on the way to
+/// STOR; the refusal must fire before any byte of the command line is sent.
+/// The CR/LF sits in the final component, so the CWD to the parent is clean
+/// and only the STOR line would carry the injection.
+#[tokio::test]
+async fn upload_with_a_crlf_name_is_refused_and_never_reaches_the_wire() {
+    let (mut provider, recorded) = connected_provider().await;
+    let local = std::env::temp_dir().join(format!("kimi-crlf-{}.bin", std::process::id()));
+    std::fs::File::create(&local)
+        .unwrap()
+        .write_all(b"x")
+        .unwrap();
+    let result = provider
+        .upload(
+            local.to_str().unwrap(),
+            "/staging/report.bin\r\nDELE ledger.bin",
+            None,
+        )
+        .await;
+    provider.disconnect().await.ok();
+    std::fs::remove_file(&local).ok();
+    assert_refused_cleanly(result, &recorded.lock().unwrap());
+}
+
+/// Same refusal on the delete path, where the injected verb would be the
+/// destructive one outright.
+#[tokio::test]
+async fn delete_with_a_crlf_name_is_refused_and_never_reaches_the_wire() {
+    let (mut provider, recorded) = connected_provider().await;
+    let result = provider.delete("/staging/old.bin\r\nDELE ledger.bin").await;
+    provider.disconnect().await.ok();
+    assert_refused_cleanly(result, &recorded.lock().unwrap());
+}

--- a/src/components/IntroHub/MyServersPanel.tsx
+++ b/src/components/IntroHub/MyServersPanel.tsx
@@ -820,6 +820,10 @@ export function MyServersPanel({
     }, []);
 
     const handleDragEnter = useCallback((idx: number, e: React.DragEvent) => {
+        // Claim only the panel's own reorder drags: without the guard an
+        // external text or file drag gets preventDefault() and dropEffect
+        // and the strip reads as a drop target for content it cannot take.
+        if (dragServerIdRef.current === null) return;
         e.preventDefault();
         e.dataTransfer.dropEffect = 'move';
         maybeAutoScrollWhileDrag(e.clientY);
@@ -827,6 +831,7 @@ export function MyServersPanel({
     }, [maybeAutoScrollWhileDrag]);
 
     const handleDragOver = useCallback((idx: number, e: React.DragEvent) => {
+        if (dragServerIdRef.current === null) return;
         e.preventDefault();
         e.dataTransfer.dropEffect = 'move';
         maybeAutoScrollWhileDrag(e.clientY);
@@ -834,6 +839,7 @@ export function MyServersPanel({
     }, [maybeAutoScrollWhileDrag]);
 
     const handleDrop = useCallback((idx: number, e: React.DragEvent) => {
+        if (dragServerIdRef.current === null) return;
         e.preventDefault();
         const visible = visibleListRef.current;
         if (visible.length === 0) { dragServerIdRef.current = null; setDragIdx(null); setOverIdx(null); return; }

--- a/src/components/IntroHub/MyServersPanel.tsx
+++ b/src/components/IntroHub/MyServersPanel.tsx
@@ -820,10 +820,6 @@ export function MyServersPanel({
     }, []);
 
     const handleDragEnter = useCallback((idx: number, e: React.DragEvent) => {
-        // Claim only the panel's own reorder drags: without the guard an
-        // external text or file drag gets preventDefault() and dropEffect
-        // and the strip reads as a drop target for content it cannot take.
-        if (dragServerIdRef.current === null) return;
         e.preventDefault();
         e.dataTransfer.dropEffect = 'move';
         maybeAutoScrollWhileDrag(e.clientY);
@@ -831,7 +827,6 @@ export function MyServersPanel({
     }, [maybeAutoScrollWhileDrag]);
 
     const handleDragOver = useCallback((idx: number, e: React.DragEvent) => {
-        if (dragServerIdRef.current === null) return;
         e.preventDefault();
         e.dataTransfer.dropEffect = 'move';
         maybeAutoScrollWhileDrag(e.clientY);
@@ -839,7 +834,6 @@ export function MyServersPanel({
     }, [maybeAutoScrollWhileDrag]);
 
     const handleDrop = useCallback((idx: number, e: React.DragEvent) => {
-        if (dragServerIdRef.current === null) return;
         e.preventDefault();
         const visible = visibleListRef.current;
         if (visible.length === 0) { dragServerIdRef.current = null; setDragIdx(null); setOverIdx(null); return; }


### PR DESCRIPTION
## What this is

A sweep of the PLAUSIBLE-grade findings from the v4.1.9 pre-release audits, one commit per finding. Verified against the code of today first; the table at the bottom lists what was confirmed, what was fixed, and what was dismissed.

## Findings

| Finding | Status | Commit |
|---|---|---|
| DCO check matched the sign-off as a substring anywhere in the commit message, so quoting it in prose passed without a trailer | Confirmed; the match now anchors on lines starting with `Signed-off-by:` first | `ci(dco): match the sign-off on trailer lines, not quoted prose` |
| `assert-linux-acl-packaging.sh` set a `RETURN` trap at script top level, which never fires in an executed (not sourced) script | Confirmed; dead trap removed, explicit cleanup kept, matching the .deb and snap branches | `fix(scripts): drop the dead RETURN trap from the AppImage check` |
| The yanked-crate check passed green on a registry timeout: `cargo audit` reports a yanked crate, and an unrun yank check, as a warning with exit 0 | Confirmed; see the policy change below | `ci(security): deny cargo audit warnings so a skipped yank check fails` |
| `Cargo.toml` comment cited "aerovault 0.6.3 depends on 0.10" under the 0.6.4 declaration | Confirmed; one word corrected, the pin itself still holds | `chore(deps): name aerovault 0.6.4 in the chacha20poly1305 pin comment` |
| The CR/LF command-injection refusal existed only as a manual reproduction; the #672 fixture counters were never consumed | Confirmed; new `ftp_crlf_refusal.rs` drives upload and delete with a CR/LF name against a recording loopback server and asserts the refusal is typed `InvalidPath` and the injected verb never crosses the wire | `test(ftp): pin the CR/LF command-injection refusal on the wire` |
| Em-dash in `rsync_over_ssh.rs` and eight in `jottacloud.rs` | Confirmed; replaced with colon or parentheses | `style(aerorsync): ...`, `style(jottacloud): ...` |
| IntroHub reorder sentinels captured external drags: the shared dragenter/dragover/drop handlers called `preventDefault()` and set `dropEffect` unconditionally | Confirmed; the handlers now claim the drag only while the panel's own reorder is in progress (synchronous ref, not `dataTransfer.types`, because the internal drag publishes plain text). What changes for the user: the reorder drop targets no longer accept external drops; an external file or text dragged over the server list no longer lights the targets up. Declared limit: no live GUI test exists for this; the project has no React component test harness, so the change is covered by typecheck and the unit suite only | `fix(introhub): claim only internal reorder drags on drop targets` |

One fix emerged while writing the CR/LF test: `delete` and `rmdir` mapped the library's unwritable-command-line refusal to `ServerError`, so a crafted name on those paths surfaced as "Connection error" and read as retryable by sync's substring classifier, the exact mistyping the transfer paths had already fixed. Both now apply the same narrow io-kind rule via `classify_command_refusal`. The delete test was red before that commit and green after.

## CI policy change: `cargo audit --deny warnings`

`checks.yml` and the local pre-push gate now run `cargo audit --deny warnings`. This is a policy change: from now on a new warning (for example a crate newly declared unmaintained, or a yanked release) and a registry timeout that leaves the yank check unrun both fail red on the authoritative lanes (main pushes, weekly schedule, local gate). The PR lane keeps `continue-on-error`, so a new upstream advisory does not red-wall unrelated pull requests. The dependency tree is warning-clean today (measured: 1243 advisories loaded, 1206 crate dependencies scanned, no warnings).

Remedies when it fires: an accepted warning is justified in the commit and added to the ignore list in `src-tauri/.cargo/audit.toml`; a registry timeout is simply re-run.

## Dismissed or deferred

- The two other em-dashes named in the audit (`rclone_crypt.rs`, `agent_session.rs`) are already gone on current main; nothing to do.
- The dead pCloud trash path noted in the same audit (unreachable `PCloudTrashManager` still wired to live commands) was reported in triage and is deliberately left out of this sweep; it is its own removal.

## Gates

`cargo fmt --all` clean; `cargo test --test ftp_crlf_refusal` 2/2; `cargo test --lib ftp` 125/125 and `--lib jottacloud` 33/33; `cargo clippy --all-targets -- -D warnings` clean; typecheck, i18n validation, provider inventory and the unit suite (916 tests) all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FTP error handling: paths containing invalid command characters are now rejected clearly as invalid paths.
  * Prevented accidental handling of external text or file drags in the server reordering area.
  * Strengthened validation for potentially unsafe FTP path inputs.

* **Quality Improvements**
  * Enhanced automated checks to catch security and validation issues earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Update (2026-09-12)

The IntroHub change is out of this pull request. `80e8a2ddb` guarded `dragenter`, `dragover` and `drop` on the panel's own reorder, and in doing so it removed the unconditional `preventDefault()`. The app disables the native Tauri drag handler, so on Windows WebView2 navigates away from the app when a file is dropped on a card or on one of the sentinels. `eeada1b85` undoes it, and `MyServersPanel.tsx` is now identical to the version on `main`. Claiming only internal reorders is still wanted: it returns as its own change, with a capture-phase guard that keeps external files cancelled, and a check on Windows.
