### PR TITLE
fix(ftp): bound a resume's data open, and drop a session with a queued reply

### DIFF
--- a/src-tauri/src/providers/ftp.rs
+++ b/src-tauri/src/providers/ftp.rs
@@ -1791,7 +1791,7 @@ impl StorageProvider for FtpProvider {
         offset: u64,
         on_progress: Option<Box<dyn Fn(u64, u64) + Send>>,
     ) -> Result<(), ProviderError> {
-        use tokio::io::AsyncSeekExt;
+        use tokio::io::{AsyncReadExt, AsyncSeekExt};
 
         let total_size = tokio::fs::metadata(local_path)
             .await
@@ -1815,8 +1815,66 @@ impl StorageProvider for FtpProvider {
         // No TYPE I here: connect() already put the session in binary mode
         // (the same invariant upload_single relies on).
 
+        // Open the data channel under the cap every other open on this provider
+        // already had. `append_file` did the open AND the whole transfer in one
+        // call, so there was nowhere for the cap to sit, and an `APPE` the
+        // server takes without answering waited for as long as the process
+        // lived: the one transfer entry point still unbounded. Same shape as
+        // `upload_single`, one verb apart.
+        let opened = match Self::open_with_cap(stream.append_with_stream(remote_path)).await {
+            Ok(opened) => opened,
+            Err(err) => return Err(self.refused_store(remote_path, err)),
+        };
+        let mut data_stream = match opened {
+            Some(data_stream) => data_stream,
+            None => {
+                return Err(self
+                    .after_timed_out_open("resuming the upload of", remote_path)
+                    .await)
+            }
+        };
+
+        let mut chunk = [0u8; 65536];
+        let mut sent = offset;
+        loop {
+            let n = file
+                .read(&mut chunk)
+                .await
+                .map_err(ProviderError::IoError)?;
+            if n == 0 {
+                break;
+            }
+            crate::transfer_dag::throttle::charge(
+                crate::transfer_dag::governor::TransferDirection::Upload,
+                n as u64,
+            )
+            .await;
+            data_stream
+                .write_all(&chunk[..n])
+                .await
+                .map_err(|e| ProviderError::TransferFailed(format!("Data write error: {}", e)))?;
+            sent += n as u64;
+            if let Some(ref progress) = on_progress {
+                progress(sent, total_size);
+            }
+        }
+
+        data_stream
+            .flush()
+            .await
+            .map_err(|e| ProviderError::TransferFailed(format!("Flush error: {}", e)))?;
+        // The same end-of-data signal as `upload_single`: our close, then the
+        // server's, bounded so a server that never closes cannot hang the resume
+        // where it can no longer hang the upload.
+        data_stream
+            .shutdown()
+            .await
+            .map_err(|e| ProviderError::TransferFailed(format!("Data close error: {}", e)))?;
+        let _ = tokio::time::timeout(DATA_DRAIN_BUDGET, drain_to_eof(&mut data_stream)).await;
+
+        let stream = self.stream.as_mut().ok_or(ProviderError::NotConnected)?;
         stream
-            .append_file(remote_path, &mut file)
+            .finalize_put_stream(AlreadyShutDown(data_stream))
             .await
             .map_err(|e| ProviderError::TransferFailed(e.to_string()))?;
 

--- a/src-tauri/src/providers/ftp.rs
+++ b/src-tauri/src/providers/ftp.rs
@@ -1380,9 +1380,10 @@ impl StorageProvider for FtpProvider {
         // (the same invariant upload_single relies on).
 
         // Download using retr_as_stream
-        let opened = Self::open_with_cap(stream.retr_as_stream(remote_path))
-            .await
-            .map_err(|e| Self::classify_data_failure("reading", remote_path, e))?;
+        let opened = match Self::open_with_cap(stream.retr_as_stream(remote_path)).await {
+            Ok(opened) => opened,
+            Err(err) => return Err(self.refused_data_open("reading", remote_path, err)),
+        };
         let data_stream = match opened {
             Some(data_stream) => data_stream,
             None => return Err(self.after_timed_out_open("reading", remote_path).await),
@@ -1719,9 +1720,10 @@ impl StorageProvider for FtpProvider {
             .map_err(|e| ProviderError::TransferFailed(format!("REST failed: {}", e)))?;
 
         // Retrieve from offset
-        let opened = Self::open_with_cap(stream.retr_as_stream(remote_path))
-            .await
-            .map_err(|e| Self::classify_data_failure("resuming", remote_path, e))?;
+        let opened = match Self::open_with_cap(stream.retr_as_stream(remote_path)).await {
+            Ok(opened) => opened,
+            Err(err) => return Err(self.refused_data_open("resuming", remote_path, err)),
+        };
         let data_stream = match opened {
             Some(data_stream) => data_stream,
             None => return Err(self.after_timed_out_open("resuming", remote_path).await),
@@ -2018,9 +2020,10 @@ impl StorageProvider for FtpProvider {
             .await
             .map_err(|e| ProviderError::TransferFailed(format!("REST failed: {}", e)))?;
 
-        let opened = Self::open_with_cap(stream.retr_as_stream(path))
-            .await
-            .map_err(|e| Self::classify_data_failure("reading a range of", path, e))?;
+        let opened = match Self::open_with_cap(stream.retr_as_stream(path)).await {
+            Ok(opened) => opened,
+            Err(err) => return Err(self.refused_data_open("reading a range of", path, err)),
+        };
         let data_stream = match opened {
             Some(data_stream) => data_stream,
             None => return Err(self.after_timed_out_open("reading a range of", path).await),
@@ -2592,55 +2595,38 @@ impl FtpProvider {
                 // owed. FTP carries no identifier, so nothing distinguishes
                 // them.
                 //
-                // AND ON A SECOND ONE, mute for a different reason: whether
-                // ANOTHER reply follows the one just read. `read_response_in`
-                // consumes exactly one, and a server that refuses and then hangs
-                // up sends `550` and then `421`, in that order, because the
-                // refusal answers the command and the goodbye comes after. Read
-                // the `550` and this arm keeps the session with the `421` still
-                // queued.
-                // It is named rather than fixed because the fix that suggests
-                // itself does not work: a second peek looks at `get_ref()`,
-                // which is the bare socket UNDER the `BufReader`, so when both
-                // replies arrive in one segment the `421` is already in the
-                // buffer and the socket shows nothing. The peek would report
-                // "aligned" in exactly the case it was added to catch, and a
-                // fixture sending the two in separate writes would make that
-                // green. Segmentation is not ours to control.
-                // What the reader holds is no longer invisible:
-                // `buffered_reply_bytes` exists now and the data-channel watch
-                // uses it. Whether a second reply is queued could be answered
-                // here with it; the decision that answer feeds, keep or drop
-                // the session, is still tracked separately and is not part of
-                // the change that added the accessor.
-                // THE COST IS NOT BOUNDED, and an earlier version of this
-                // comment said it was. Measured, not reasoned: a server
-                // answering `RETR` with `550` and `421` in ONE write leaves
-                // nothing on the socket, and the next command, a `PWD`, receives
-                // "421 Service not available" as ITS OWN reply. An operation
-                // fails citing an answer caused by the command before it, which
-                // IS the phantom-files class, the one this whole line of work
-                // exists to remove.
-                // The first version of that claim checked the VALUE (an error,
-                // not data) and not the ATTRIBUTION (the error of the wrong
-                // command), which is the same mistake in prose that the code is
-                // here to prevent on the wire.
-                // Tracked separately rather than patched here: the fix is not a
-                // comment, and it does not belong in a change about bounding the
-                // open.
+                // AND ON A SECOND ONE, now answered: whether ANOTHER reply
+                // follows the one just read. `read_response_in` consumes exactly
+                // one, and a server that refuses and then hangs up sends `550`
+                // and then `421`, in that order, because the refusal answers the
+                // command and the goodbye comes after. Read the `550` and this
+                // arm used to keep the session with the `421` still queued,
+                // which the next command then took as ITS OWN reply: measured, a
+                // `PWD` after a refused `RETR` came back "421 Service not
+                // available". That is the phantom-files class entering through
+                // the branch that exists to prevent it.
+                // A second peek cannot see it: `get_ref()` is the bare socket
+                // UNDER the `BufReader`, so when both replies arrive in one
+                // segment the `421` is already in the buffer and the socket
+                // shows nothing. The reader's own buffer is what can, and
+                // `buffered_reply_bytes` reports it, so the session is given up
+                // below whenever a reply is still queued, whatever the
+                // segmentation was.
                 //
-                // Both are named rather than claimed closed: a condition that
-                // looks total has been wrong four times, and each time it was
-                // total with respect to one property.
+                // The first property is still only named: a condition that looks
+                // total has been wrong four times, and each time it was total
+                // with respect to one property.
                 Ok(FtpError::UnexpectedResponse(reply))
                     if (400..600).contains(&reply.status.code())
                         && reply.status != Status::NotAvailable =>
                 {
-                    return Self::classify_data_failure(
+                    let classified = Self::classify_data_failure(
                         operation,
                         path,
                         FtpError::UnexpectedResponse(reply),
-                    )
+                    );
+                    self.drop_session_if_a_reply_is_queued();
+                    return classified;
                 }
                 // EVERYTHING else, and the catch-all is the point rather than a
                 // shorthand. It now holds two kinds of case. Some say nothing
@@ -2672,6 +2658,47 @@ impl FtpProvider {
             path,
             OPEN_BUDGET.as_secs()
         ))
+    }
+
+    /// Give up the session when the control reader is still holding a reply.
+    ///
+    /// A server that refuses and then hangs up sends `550` and `421`, and on one
+    /// write they arrive together: the refusal answers the command that asked,
+    /// the goodbye stays in the reader, and the next command reads it as its own
+    /// reply. A peek at the socket cannot see it, because both replies are
+    /// already off the wire and inside the `BufReader`; `buffered_reply_bytes`
+    /// is what reports them. Dropping the session costs a re-dial on a path that
+    /// has already failed, and keeps the next question from taking this one's
+    /// answer.
+    fn drop_session_if_a_reply_is_queued(&mut self) {
+        let queued = self
+            .stream
+            .as_ref()
+            .map(|stream| !stream.buffered_reply_bytes().is_empty())
+            .unwrap_or(false);
+        if queued {
+            self.stream = None;
+        }
+    }
+
+    /// A refused data open, classified, with the session given up when the
+    /// server queued another reply behind the refusal.
+    fn refused_data_open(
+        &mut self,
+        operation: &'static str,
+        path: &str,
+        err: FtpError,
+    ) -> ProviderError {
+        let classified = Self::classify_data_failure(operation, path, err);
+        self.drop_session_if_a_reply_is_queued();
+        classified
+    }
+
+    /// The same for a refused `STOR` or `APPE`, which keeps its own mapping.
+    fn refused_store(&mut self, path: &str, err: FtpError) -> ProviderError {
+        let classified = Self::map_store_error(path, err);
+        self.drop_session_if_a_reply_is_queued();
+        classified
     }
 
     /// Read the refusal the server has queued, without waiting for one that
@@ -2902,9 +2929,10 @@ impl FtpProvider {
         let stream = self.stream_mut()?;
 
         // Download using retr_as_stream: stream directly to disk (no full-file RAM buffer)
-        let opened = Self::open_with_cap(stream.retr_as_stream(remote_path))
-            .await
-            .map_err(|e| Self::classify_data_failure("downloading", remote_path, e))?;
+        let opened = match Self::open_with_cap(stream.retr_as_stream(remote_path)).await {
+            Ok(opened) => opened,
+            Err(err) => return Err(self.refused_data_open("downloading", remote_path, err)),
+        };
         let data_stream = match opened {
             Some(data_stream) => data_stream,
             None => return Err(self.after_timed_out_open("downloading", remote_path).await),
@@ -2984,9 +3012,10 @@ impl FtpProvider {
         // Open streaming upload channel (PASV + STOR), under the same cap as the
         // reads: the two unbounded awaits live in `data_command`, which every
         // verb goes through.
-        let opened = Self::open_with_cap(stream.put_with_stream(remote_path))
-            .await
-            .map_err(|e| Self::map_store_error(remote_path, e))?;
+        let opened = match Self::open_with_cap(stream.put_with_stream(remote_path)).await {
+            Ok(opened) => opened,
+            Err(err) => return Err(self.refused_store(remote_path, err)),
+        };
         let mut data_stream = match opened {
             Some(data_stream) => data_stream,
             None => return Err(self.after_timed_out_open("uploading", remote_path).await),
@@ -3182,11 +3211,13 @@ async fn ftp_download_one_range(
 
     let opened = {
         let stream = worker.stream_mut()?;
-        FtpProvider::open_with_cap(stream.retr_as_stream(&remote_path))
-            .await
-            .map_err(|e| {
-                FtpProvider::classify_data_failure("downloading a range of", &remote_path, e)
-            })?
+        FtpProvider::open_with_cap(stream.retr_as_stream(&remote_path)).await
+    };
+    let opened = match opened {
+        Ok(opened) => opened,
+        Err(err) => {
+            return Err(worker.refused_data_open("downloading a range of", &remote_path, err))
+        }
     };
     let mut data_stream = match opened {
         Some(data_stream) => data_stream,

--- a/src-tauri/src/providers/ftp.rs
+++ b/src-tauri/src/providers/ftp.rs
@@ -2668,8 +2668,13 @@ impl FtpProvider {
                 // segment the `421` is already in the buffer and the socket
                 // shows nothing. The reader's own buffer is what can, and
                 // `buffered_reply_bytes` reports it, so the session is given up
-                // below whenever a reply is still queued, whatever the
-                // segmentation was.
+                // below whenever a reply is ALREADY queued. Measured on the
+                // fake server: written together with the refusal, the goodbye
+                // is 55 bytes in the reader and nothing on the socket; written
+                // after it, both are empty when the check runs and it lands
+                // some 50 ms later. So the segmentation this covers is the one
+                // that queues the reply in time, and the other one is a named
+                // limit with a test of its own in `tests/ftp_resume_and_421.rs`.
                 //
                 // The first property is still only named: a condition that looks
                 // total has been wrong four times, and each time it was total
@@ -2728,6 +2733,16 @@ impl FtpProvider {
     /// is what reports them. Dropping the session costs a re-dial on a path that
     /// has already failed, and keeps the next question from taking this one's
     /// answer.
+    ///
+    /// What this covers is a reply ALREADY queued when the refusal is
+    /// classified. A server that writes the goodbye afterwards, in a write of
+    /// its own, has sent nothing at this point: measured, the reader's buffer
+    /// and a peek at the socket are both empty here, and the goodbye lands some
+    /// 50 ms later. So asking the socket as well changes no outcome on this
+    /// path, and it is not asked. Where a wait has already happened the socket
+    /// is worth asking, and `after_timed_out_open` asks it. The uncovered shape
+    /// has a test of its own; what it points at is a check when the NEXT
+    /// command starts, which is a design change and not this one.
     fn drop_session_if_a_reply_is_queued(&mut self) {
         let queued = self
             .stream

--- a/src-tauri/tests/ftp_resume_and_421.rs
+++ b/src-tauri/tests/ftp_resume_and_421.rs
@@ -70,7 +70,9 @@ async fn session(stream: tokio::net::TcpStream, script: Script, commands: Comman
     // A PASV listener lives until the next data command consumes it. It is kept
     // alive deliberately in `SwallowAppe`: the client's connect succeeds and the
     // wait that follows is the one the test is about.
-    let mut pasv: Option<TcpListener> = None;
+    // The binding is never read: holding it is the whole point, so the name
+    // carries an underscore to say so to the unused-variable lints.
+    let mut _pasv: Option<TcpListener> = None;
     while let Ok(Some(line)) = lines.next_line().await {
         commands.lock().unwrap().push(line.clone());
         let verb = line.split_whitespace().next().unwrap_or("").to_uppercase();
@@ -89,7 +91,7 @@ async fn session(stream: tokio::net::TcpStream, script: Script, commands: Comman
                     }
                 };
                 let port = listener.local_addr().unwrap().port();
-                pasv = Some(listener);
+                _pasv = Some(listener);
                 let msg = format!(
                     "227 Entering Passive Mode (127,0,0,1,{},{})\r\n",
                     port / 256,

--- a/src-tauri/tests/ftp_resume_and_421.rs
+++ b/src-tauri/tests/ftp_resume_and_421.rs
@@ -175,6 +175,50 @@ async fn connected(port: u16) -> FtpProvider {
     provider
 }
 
+/// A resume whose `APPE` is never answered has to end by itself.
+///
+/// Every other data open on this provider is bounded; `resume_upload` reached
+/// the server through `append_file`, which opens and transfers in one call with
+/// no cap of its own, so this wait had no end. The assertion is that the call
+/// returns at all: the error it returns is the server's business, the hang is
+/// ours. The outer timeout is the test's own limit and is far above the
+/// provider's, so it only fires when nothing bounds the wait.
+#[tokio::test]
+async fn a_resume_whose_append_is_never_answered_gives_up() {
+    let server = start_fake_ftp(Script::SwallowAppe).await;
+    let mut provider = connected(server.port).await;
+
+    let local = std::env::temp_dir().join(format!("aeroftp-resume-{}.bin", std::process::id()));
+    std::fs::File::create(&local)
+        .unwrap()
+        .write_all(&vec![b'x'; 4096])
+        .unwrap();
+
+    let outcome = tokio::time::timeout(
+        Duration::from_secs(90),
+        provider.resume_upload(local.to_str().unwrap(), "/resume.bin", 1024, None),
+    )
+    .await;
+    let _ = std::fs::remove_file(&local);
+
+    let ended = outcome.expect(
+        "the resume never came back: an APPE the server does not answer must be bounded like \
+         every other data open on this provider",
+    );
+    assert!(
+        ended.is_err(),
+        "a resume the server never answered must fail, not report success"
+    );
+    let commands = server.commands.lock().unwrap().clone();
+    assert!(
+        commands
+            .iter()
+            .any(|c| c.to_uppercase().starts_with("APPE")),
+        "the test drove the path it is about: {:?}",
+        commands
+    );
+}
+
 /// A refusal followed by a goodbye must not answer the next command.
 ///
 /// The server sends `550` and `421` in one write. The `550` answers the `RETR`;

--- a/src-tauri/tests/ftp_resume_and_421.rs
+++ b/src-tauri/tests/ftp_resume_and_421.rs
@@ -1,0 +1,207 @@
+//! Two FTP defects that need a server to show, against a scripted fake one.
+//!
+//! 1. `resume_upload` opens its data channel with `append_file`, which is the
+//!    one transfer entry point never brought under the deadline that bounds
+//!    every other open: a server that takes the `APPE` and never answers leaves
+//!    the resume waiting for as long as the process lives.
+//! 2. A server that refuses and then hangs up sends `550` and `421` in that
+//!    order, and on one write they arrive together. The `550` answers the
+//!    command; the `421` stays in the control reader, and the NEXT command
+//!    reads it as its own reply, so an operation fails citing an answer caused
+//!    by the command before it.
+//!
+//! Neither needs the Docker fixture: the server below is a scripted fake on
+//! loopback, enough FTP for connect plus the one command each test drives.
+
+use std::io::Write as _;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use ftp_client_gui_lib::providers::types::{FtpConfig, FtpTlsMode};
+use ftp_client_gui_lib::providers::{FtpProvider, StorageProvider};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpListener;
+
+/// What the fake server does with the command each test is about.
+#[derive(Clone, Copy)]
+enum Script {
+    /// Answer `PASV`, then take `APPE` and never say anything about it: the
+    /// shape of a server that accepts the command and stops.
+    SwallowAppe,
+    /// Answer `RETR` with a refusal and a goodbye in ONE write, so both replies
+    /// reach the client in the same segment.
+    RefuseThenHangUp,
+}
+
+/// Every control command the fake server received, in order.
+type Commands = Arc<Mutex<Vec<String>>>;
+
+async fn serve(
+    mut stop: tokio::sync::watch::Receiver<bool>,
+    listener: TcpListener,
+    script: Script,
+    commands: Commands,
+) {
+    loop {
+        let accepted = tokio::select! {
+            _ = stop.changed() => return,
+            a = listener.accept() => a,
+        };
+        let (stream, _) = match accepted {
+            Ok(v) => v,
+            Err(_) => return,
+        };
+        let commands = Arc::clone(&commands);
+        tokio::spawn(async move { session(stream, script, commands).await });
+    }
+}
+
+async fn session(stream: tokio::net::TcpStream, script: Script, commands: Commands) {
+    let (read, mut write) = stream.into_split();
+    let mut lines = BufReader::new(read).lines();
+    if write.write_all(b"220 FakeFTP ready\r\n").await.is_err() {
+        return;
+    }
+    // A PASV listener lives until the next data command consumes it. It is kept
+    // alive deliberately in `SwallowAppe`: the client's connect succeeds and the
+    // wait that follows is the one the test is about.
+    let mut pasv: Option<TcpListener> = None;
+    while let Ok(Some(line)) = lines.next_line().await {
+        commands.lock().unwrap().push(line.clone());
+        let verb = line.split_whitespace().next().unwrap_or("").to_uppercase();
+        match verb.as_str() {
+            "USER" => reply(&mut write, b"331 Password required\r\n").await,
+            "PASS" => reply(&mut write, b"230 Logged in\r\n").await,
+            "TYPE" => reply(&mut write, b"200 Type set\r\n").await,
+            "FEAT" => reply(&mut write, b"211-Features:\r\n MLST\r\n211 End\r\n").await,
+            "PWD" => reply(&mut write, b"257 \"/\"\r\n").await,
+            "PASV" => {
+                let listener = match TcpListener::bind("127.0.0.1:0").await {
+                    Ok(l) => l,
+                    Err(_) => {
+                        reply(&mut write, b"425 Cannot listen\r\n").await;
+                        continue;
+                    }
+                };
+                let port = listener.local_addr().unwrap().port();
+                pasv = Some(listener);
+                let msg = format!(
+                    "227 Entering Passive Mode (127,0,0,1,{},{})\r\n",
+                    port / 256,
+                    port % 256
+                );
+                reply(&mut write, msg.as_bytes()).await;
+            }
+            "APPE" => match script {
+                // Not a reply, not a close: the command is taken and nothing
+                // comes back, which is what leaves an unbounded open waiting.
+                Script::SwallowAppe => {
+                    // The PASV listener stays alive on purpose: the client's
+                    // connect succeeds, so what it waits on is the reply to
+                    // APPE, which never comes. Dropping the listener here would
+                    // refuse the connection and end the wait for the wrong
+                    // reason.
+                    continue;
+                }
+                Script::RefuseThenHangUp => reply(&mut write, b"550 Not allowed\r\n").await,
+            },
+            "RETR" => match script {
+                Script::RefuseThenHangUp => {
+                    // ONE write, so the refusal and the goodbye arrive in the
+                    // same segment: a second peek at the socket would see
+                    // nothing, which is why the reader's own buffer is what has
+                    // to be asked.
+                    reply(
+                        &mut write,
+                        b"550 Failed to open file\r\n421 Service not available, closing control connection\r\n",
+                    )
+                    .await;
+                }
+                Script::SwallowAppe => reply(&mut write, b"550 Not found\r\n").await,
+            },
+            "QUIT" => {
+                reply(&mut write, b"221 Goodbye\r\n").await;
+                return;
+            }
+            _ => reply(&mut write, b"502 Not implemented\r\n").await,
+        }
+    }
+}
+
+async fn reply(write: &mut tokio::net::tcp::OwnedWriteHalf, bytes: &[u8]) {
+    let _ = write.write_all(bytes).await;
+}
+
+struct FakeFtp {
+    port: u16,
+    commands: Commands,
+    stop: tokio::sync::watch::Sender<bool>,
+}
+
+async fn start_fake_ftp(script: Script) -> FakeFtp {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let commands: Commands = Arc::new(Mutex::new(Vec::new()));
+    let (stop, rx) = tokio::sync::watch::channel(false);
+    tokio::spawn(serve(rx, listener, script, Arc::clone(&commands)));
+    FakeFtp {
+        port,
+        commands,
+        stop,
+    }
+}
+
+impl Drop for FakeFtp {
+    fn drop(&mut self) {
+        let _ = self.stop.send(true);
+    }
+}
+
+async fn connected(port: u16) -> FtpProvider {
+    let config = FtpConfig {
+        host: "127.0.0.1".to_string(),
+        port,
+        username: "testuser".to_string(),
+        password: secrecy::SecretString::from("testpass".to_string()),
+        tls_mode: FtpTlsMode::None,
+        verify_cert: false,
+        initial_path: Some("/".to_string()),
+    };
+    let mut provider = FtpProvider::new(config);
+    provider
+        .connect()
+        .await
+        .expect("connect to the fake server");
+    provider
+}
+
+/// A refusal followed by a goodbye must not answer the next command.
+///
+/// The server sends `550` and `421` in one write. The `550` answers the `RETR`;
+/// the `421` is then sitting in the control reader, and a session kept in that
+/// state hands the next command somebody else's reply. What the next command
+/// may do is fail or reconnect; what it may not do is come back carrying the
+/// goodbye that belonged to the command before it.
+#[tokio::test]
+async fn a_refusal_followed_by_a_goodbye_does_not_answer_the_next_command() {
+    let server = start_fake_ftp(Script::RefuseThenHangUp).await;
+    let mut provider = connected(server.port).await;
+
+    let local = std::env::temp_dir().join(format!("aeroftp-421-{}.bin", std::process::id()));
+    let refused = provider
+        .download("/missing.bin", local.to_str().unwrap(), None)
+        .await;
+    let _ = std::fs::remove_file(&local);
+    assert!(refused.is_err(), "the server refused the download");
+
+    let next = provider.pwd().await;
+    let text = match &next {
+        Ok(dir) => dir.clone(),
+        Err(err) => err.to_string(),
+    };
+    assert!(
+        !text.contains("421") && !text.to_lowercase().contains("service not available"),
+        "the next command was answered with the goodbye owed to the refused one: {:?}",
+        next
+    );
+}

--- a/src-tauri/tests/ftp_resume_and_421.rs
+++ b/src-tauri/tests/ftp_resume_and_421.rs
@@ -17,7 +17,7 @@ use std::io::Write as _;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use ftp_client_gui_lib::providers::types::{FtpConfig, FtpTlsMode};
+use ftp_client_gui_lib::providers::types::{FtpConfig, FtpTlsMode, ProviderError};
 use ftp_client_gui_lib::providers::{FtpProvider, StorageProvider};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpListener;
@@ -31,6 +31,11 @@ enum Script {
     /// Answer `RETR` with a refusal and a goodbye in ONE write, so both replies
     /// reach the client in the same segment.
     RefuseThenHangUp,
+    /// The same two replies in TWO writes, with a deliberate pause between them:
+    /// the goodbye goes out after the client has already taken the refusal, so
+    /// at the moment the refusal is classified it has not been sent at all. The
+    /// pause is what makes that deterministic instead of a race.
+    RefuseThenHangUpLater,
 }
 
 /// Every control command the fake server received, in order.
@@ -103,7 +108,9 @@ async fn session(stream: tokio::net::TcpStream, script: Script, commands: Comman
                     // reason.
                     continue;
                 }
-                Script::RefuseThenHangUp => reply(&mut write, b"550 Not allowed\r\n").await,
+                Script::RefuseThenHangUp | Script::RefuseThenHangUpLater => {
+                    reply(&mut write, b"550 Not allowed\r\n").await
+                }
             },
             "RETR" => match script {
                 Script::RefuseThenHangUp => {
@@ -114,6 +121,19 @@ async fn session(stream: tokio::net::TcpStream, script: Script, commands: Comman
                     reply(
                         &mut write,
                         b"550 Failed to open file\r\n421 Service not available, closing control connection\r\n",
+                    )
+                    .await;
+                }
+                Script::RefuseThenHangUpLater => {
+                    // Two writes with a pause between them: the client takes the
+                    // refusal and classifies it, and only then does the goodbye
+                    // go out, so at the moment of the check there is nothing to
+                    // find, in the reader's buffer or on the socket.
+                    reply(&mut write, b"550 Failed to open file\r\n").await;
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                    reply(
+                        &mut write,
+                        b"421 Service not available, closing control connection\r\n",
                     )
                     .await;
                 }
@@ -247,5 +267,69 @@ async fn a_refusal_followed_by_a_goodbye_does_not_answer_the_next_command() {
         !text.contains("421") && !text.to_lowercase().contains("service not available"),
         "the next command was answered with the goodbye owed to the refused one: {:?}",
         next
+    );
+    // On the wire, not on a guess: the command under test really was sent, and
+    // what came back is the refusal of a path, not a transport failure.
+    let commands = server.commands.lock().unwrap().clone();
+    assert!(
+        commands
+            .iter()
+            .any(|line| line.to_uppercase().starts_with("RETR")),
+        "the test drove the path it is about: {commands:?}"
+    );
+    assert!(
+        matches!(refused, Err(ProviderError::InvalidPath(_))),
+        "a 550 about the file is a refusal of the path: {refused:?}"
+    );
+}
+
+/// What the queued-reply check does NOT cover, written down as a test.
+///
+/// The server refuses, waits, and only then says goodbye, so when the refusal is
+/// classified the `421` has not been sent yet. Measured on this fixture: the
+/// reader's buffer holds nothing there and a peek at the socket returns nothing,
+/// and the goodbye lands about 50 ms later. No check made at that moment can see
+/// a reply that has not arrived, whatever it looks at, so the session is kept and
+/// the next command reads the goodbye as its own reply, as it did before the
+/// check existed. That is why the check asks the reader's buffer and not the
+/// socket as well: on this path the socket has nothing to add.
+///
+/// The boundary is pinned here rather than left to a sentence in a comment,
+/// because the property it bounds ("a queued reply gives up the session") reads
+/// as total and is not. What it points at is a check when the NEXT command
+/// starts, which is a design change and not this one: whoever makes it should
+/// flip this test, not delete it, since the shape it drives has to keep working.
+#[tokio::test]
+async fn a_goodbye_written_after_the_refusal_is_not_caught_by_this_check() {
+    let server = start_fake_ftp(Script::RefuseThenHangUpLater).await;
+    let mut provider = connected(server.port).await;
+
+    let local = std::env::temp_dir().join(format!("aeroftp-421-late-{}.bin", std::process::id()));
+    let refused = provider
+        .download("/missing.bin", local.to_str().unwrap(), None)
+        .await;
+    let _ = std::fs::remove_file(&local);
+    assert!(
+        matches!(refused, Err(ProviderError::InvalidPath(_))),
+        "a 550 about the file is a refusal of the path: {refused:?}"
+    );
+    let commands = server.commands.lock().unwrap().clone();
+    assert!(
+        commands
+            .iter()
+            .any(|line| line.to_uppercase().starts_with("RETR")),
+        "the test drove the path it is about: {commands:?}"
+    );
+
+    let next = provider.pwd().await;
+    let text = match &next {
+        Ok(dir) => dir.clone(),
+        Err(err) => err.to_string(),
+    };
+    assert!(
+        text.contains("421"),
+        "the boundary moved: a goodbye written after the refusal no longer reaches the next \
+         command, so the session is given up in a case this test says it is not. Flip it \
+         instead of deleting it: {next:?}"
     );
 }


### PR DESCRIPTION
## Summary

Two defects on the FTP provider, one commit each.

1. `fix(ftp): give up a session that still holds a queued reply`
2. `fix(ftp): bound the data open of a resumed upload`

Both are shown with a scripted fake server on loopback (`tests/ftp_resume_and_421.rs`), so neither needs the Docker fixture.

## A resumed upload that could wait forever

`resume_upload` reached the server through `append_file`, which opens the data channel and transfers in one call. The cap that every other data open on this provider got when the opens were bounded had nowhere to sit there, so it was the one transfer entry point still unbounded: a server that takes the `APPE` and never answers left the resume waiting for as long as the process lived.

Red, against a server that answers `PASV` and then takes `APPE` in silence: the call never came back, and the test's own 90 second limit fired (`Elapsed`).

The fix opens with `append_with_stream` under the same cap and keeps the upload path's ending: our close, the server's close bounded by the drain budget, then the `226`. No new number, and a refusal is classified as a store refusal exactly as before. It is `upload_single`, one verb apart.

Green: the call ends in 30.00 s, inside the open budget, with an error.

## A refusal followed by a goodbye

A server that refuses and then hangs up sends `550` and then `421`, in that order, because the refusal answers the command and the goodbye comes after; on one write they arrive together. The `550` answered the command that asked, and the `421` stayed in the control reader. The session was kept in that state, so the next command read the goodbye as its own reply.

Red, after a refused `RETR` on such a server, the next `pwd()` returned:

```
Err(ServerError("Invalid response: [421] 421 Service not available, closing control connection"))
```

An operation failing with an answer caused by the command before it is the class this line of work exists to remove.

A peek at the socket cannot see it: both replies are already off the wire and inside the `BufReader`, so when they arrive in one segment the socket shows nothing. Measured on the fake server, at the moment the refusal is classified: 55 bytes in the reader's buffer, nothing on the socket. The buffer is what reports them, through `buffered_reply_bytes()`. That method comes from the suppaftp fork this repository **already pins** (`src-tauri/Cargo.toml`: the v10.0.2 release commit plus that one method, added for the data-channel watch), so this change adds no dependency.

The fix classifies the refusal as before and then gives up the session whenever a reply is already queued. It is applied at the seven refused opens (reading, resumed download, ranged read, download, pooled ranged download, store, and the resumed upload's store) and in the branch that reads a refusal after an open that timed out. Those sites rather than that one branch because the defect shows on a fast refusal too: the red above needed no timeout at all.

**What it does not cover, measured rather than argued.** A goodbye the server writes after the refusal, in a write of its own, has not been sent at all when the refusal is classified: the reader's buffer and a peek at the socket are both empty there, and it lands some 50 ms later, in time for the next command to read it. No check made at that moment can see a reply that has not arrived, whichever place it looks at, so a second peek beside the buffer was written, measured, and dropped again for changing no outcome on this path. Asking the socket is worth it where a wait has already happened, and that is what the branch after a timed-out open does. What this limit points at is a check when the NEXT command starts, a design change and not this one. A fixture drives the shape and a test states the boundary, so it is a limit with a name rather than a sentence in a comment.

The comment that called this "tracked separately" is gone, because it no longer is. What stays named there is the other property, still open: whose reply a queued one is. FTP carries no request identifier, so a reply waiting here could in principle belong to an earlier command whose answer came late.

Green: the next command no longer carries the goodbye.

## Tests

`tests/ftp_resume_and_421.rs`, both red before their fix and green after:

- `a_resume_whose_append_is_never_answered_gives_up`
- `a_refusal_followed_by_a_goodbye_does_not_answer_the_next_command`

Both assert on the server's transcript as well: that the command under test was really sent, and that what came back was a refusal of the path rather than a transport failure.

A third test states a boundary instead of a fix, so it was never red: `a_goodbye_written_after_the_refusal_is_not_caught_by_this_check`. Its server refuses, pauses, and only then says goodbye, which makes the uncovered shape deterministic instead of a race.

Regression: `ftp_put_floor` (2 tests) stays green.

## Gates

- `cargo fmt --all` is clean.
- `cargo test --test ftp_resume_and_421 --test ftp_put_floor`: 5 passed, 0 failed. The resume test costs 30 s by design: it waits out the open budget.
- Tier 1 green: `npm run typecheck`, `i18n:validate`, `i18n:diacritics`, `i18n:untranslated`, `check:provider-inventory`, `test:unit` (916).
- Only the head of this branch was compiled and tested. The first commit's tree exists for review order.
- Not run locally: `cargo clippy --all-targets -- -D warnings` and the full library suite; for a PR branch both are left to CI.
- No CHANGELOG entry: the changelog is written at release time, not per pull request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FTP transfer reliability by preventing stale server responses from affecting subsequent commands.
  * Improved handling of refused, interrupted, resumed, and ranged transfers.
  * Resumed uploads now provide controlled progress reporting and complete shutdown handling.

* **Tests**
  * Added coverage for interrupted resume uploads and combined FTP server responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->