### PR TITLE
fix(sync): decrypt compare boundaries and fix the used-scan fast path

### DIFF
--- a/src-tauri/src/crypt_overlay_provider.rs
+++ b/src-tauri/src/crypt_overlay_provider.rs
@@ -182,8 +182,35 @@ impl OverlayKeys {
         }
     }
 
-    /// Decrypt one on-wire path component back to plaintext, or `None` when it is
-    /// not a valid name for this overlay (foreign entry, wrong key, sentinel).
+    /// Decrypt a whole relative path back to plaintext, telling the overlay
+    /// what the last segment is.
+    ///
+    /// Every segment above the last one names a directory, whatever sits at the
+    /// end, so only the leaf needs `is_dir`. That distinction is the contract:
+    /// rclone spells a directory name without the `Off` suffix and, with
+    /// `directory_name_encryption` off, leaves it in the clear, so decoding a
+    /// directory as if it were a file strips a suffix that was never added, and
+    /// decoding a cleartext directory name as ciphertext fails outright. A
+    /// caller that knows only the path cannot tell the two apart without
+    /// guessing from the spelling, which is circular.
+    pub(crate) fn decode_rel_path(&self, rel_path: &str, is_dir: bool) -> Option<String> {
+        let segments: Vec<&str> = rel_path.split('/').collect();
+        let last = segments.len().saturating_sub(1);
+        let mut out = Vec::with_capacity(segments.len());
+        for (index, segment) in segments.iter().enumerate() {
+            if segment.is_empty() {
+                out.push(String::new());
+                continue;
+            }
+            let segment_is_dir = index < last || is_dir;
+            out.push(self.decode_name(segment, segment_is_dir)?);
+        }
+        Some(out.join("/"))
+    }
+
+    /// Decrypt one on-wire path component back to plaintext, or `None` when it
+    /// is not a valid name for this overlay (foreign entry, wrong key,
+    /// sentinel).
     fn decode_name(&self, encoded: &str, is_dir: bool) -> Option<String> {
         match self {
             Self::AeroCrypt { master_key, .. } => names::decrypt_filename(master_key, encoded),

--- a/src-tauri/src/mcp/tools.rs
+++ b/src-tauri/src/mcp/tools.rs
@@ -2086,6 +2086,7 @@ mod tests {
                 .map(|i| crate::sync_core::SkippedLink {
                     rel_path: format!("link{i}"),
                     link_target: None,
+                    is_dir: true,
                 })
                 .collect(),
             ..Default::default()
@@ -2121,11 +2122,13 @@ mod tests {
                 .map(|i| crate::sync_core::SkippedLink {
                     rel_path: format!("link{i}"),
                     link_target: None,
+                    is_dir: true,
                 })
                 .collect(),
             unseen_paths: vec![crate::sync_core::UnseenPath {
                 rel_path: "d1".to_string(),
                 reason: "list_error",
+                is_dir: Some(true),
             }],
             ..Default::default()
         };
@@ -2156,6 +2159,7 @@ mod tests {
             unseen_paths: vec![crate::sync_core::UnseenPath {
                 rel_path: "d1".to_string(),
                 reason: "list_error",
+                is_dir: Some(true),
             }],
             ..Default::default()
         };

--- a/src-tauri/src/provider_commands.rs
+++ b/src-tauri/src/provider_commands.rs
@@ -12952,6 +12952,8 @@ async fn walk_compare_remote_serially(
                 skipped_links.push(crate::sync_core::SkippedLink {
                     rel_path: relative_path,
                     link_target: entry.link_target.clone(),
+                    // The arm above matched on `entry.is_dir && is_symlink`.
+                    is_dir: true,
                 });
                 continue;
             }
@@ -13092,10 +13094,12 @@ mod tests {
             links: vec![crate::sync_core::SkippedLink {
                 rel_path: format!("{}/{}", encrypt("parent"), encrypt("link")),
                 link_target: None,
+                is_dir: true,
             }],
             unseen: vec![crate::sync_core::scan::UnseenPath {
                 rel_path: encrypt("blocked"),
                 reason: "list_error",
+                is_dir: Some(true),
             }],
             ..Default::default()
         };
@@ -13118,6 +13122,7 @@ mod tests {
             links: vec![crate::sync_core::SkippedLink {
                 rel_path: "not-base32-!!!".to_string(),
                 link_target: None,
+                is_dir: true,
             }],
             ..Default::default()
         };
@@ -13174,6 +13179,7 @@ mod tests {
                 links: vec![crate::sync_core::SkippedLink {
                     rel_path: "parent/link".to_string(),
                     link_target: Some("target".to_string()),
+                    is_dir: true,
                 }],
                 ..Default::default()
             },
@@ -13317,6 +13323,7 @@ mod tests {
             vec![crate::sync_core::SkippedLink {
                 rel_path: "link".to_string(),
                 link_target: Some("/root/real".to_string()),
+                is_dir: true,
             }]
         );
     }

--- a/src-tauri/src/provider_commands.rs
+++ b/src-tauri/src/provider_commands.rs
@@ -6807,21 +6807,31 @@ fn normalize_remote_boundaries_for_compare(
     keys: &crate::crypt_overlay_provider::OverlayKeys,
     boundaries: &mut crate::sync_core::ScanBoundaries,
 ) -> Result<(), String> {
-    let decrypt = |rel: &str| -> Option<String> {
-        match keys {
-            crate::crypt_overlay_provider::OverlayKeys::Rclone(k) => decrypt_rel_rclone(k, rel),
-            crate::crypt_overlay_provider::OverlayKeys::AeroCrypt { master_key, .. } => {
-                decrypt_rel_aerocrypt(master_key, rel)
-            }
-        }
-    };
+    // Most boundaries are directories, and an overlay spells a directory
+    // differently from a file: rclone leaves it without the `Off` suffix and,
+    // with `directory_name_encryption` off, in the clear. The walk recorded
+    // which it is, so the decode is told; reading the type back out of the path
+    // would be a guess, and a wrong guess anchors the bound to a path that does
+    // not exist, which no one sees.
     let paths = boundaries
         .links
         .iter_mut()
-        .map(|link| &mut link.rel_path)
-        .chain(boundaries.unseen.iter_mut().map(|path| &mut path.rel_path));
-    for rel_path in paths {
-        let Some(plain_rel_path) = decrypt(rel_path.as_str()) else {
+        .map(|link| (&mut link.rel_path, Some(link.is_dir)))
+        .chain(
+            boundaries
+                .unseen
+                .iter_mut()
+                .map(|path| (&mut path.rel_path, path.is_dir)),
+        );
+    for (rel_path, is_dir) in paths {
+        let Some(is_dir) = is_dir else {
+            return Err(format!(
+                "the scan left out the remote path {rel_path} without recording whether it is a \
+                 directory, and a crypt overlay spells a directory and a file differently, so the \
+                 run cannot be bounded around it"
+            ));
+        };
+        let Some(plain_rel_path) = keys.decode_rel_path(rel_path.as_str(), is_dir) else {
             return Err(
                 "a remote path the scan left out could not be read through the crypt overlay, \
                  so the run cannot be bounded around it: check the overlay password"

--- a/src-tauri/src/provider_commands.rs
+++ b/src-tauri/src/provider_commands.rs
@@ -6793,6 +6793,46 @@ fn normalize_aerocrypt_remote_files_for_compare(
     out
 }
 
+/// Rewrite the remote boundary paths the way the remote rows are rewritten, so
+/// a bound built from them can reach the plaintext local rows.
+///
+/// Unlike the row normalizers above, a path that fails to decrypt is NOT
+/// dropped and the run is refused instead. A boundary is what keeps a plan off
+/// a part of the tree: dropping one widens the plan silently, which is the
+/// opposite of what it is for. Refusing is also honest about which of the two
+/// things went wrong, where reusing the scan's `unbounded` verdict would report
+/// a tree the scan did not see when the scan saw it and the name could not be
+/// read.
+fn normalize_remote_boundaries_for_compare(
+    keys: &crate::crypt_overlay_provider::OverlayKeys,
+    boundaries: &mut crate::sync_core::ScanBoundaries,
+) -> Result<(), String> {
+    let decrypt = |rel: &str| -> Option<String> {
+        match keys {
+            crate::crypt_overlay_provider::OverlayKeys::Rclone(k) => decrypt_rel_rclone(k, rel),
+            crate::crypt_overlay_provider::OverlayKeys::AeroCrypt { master_key, .. } => {
+                decrypt_rel_aerocrypt(master_key, rel)
+            }
+        }
+    };
+    let paths = boundaries
+        .links
+        .iter_mut()
+        .map(|link| &mut link.rel_path)
+        .chain(boundaries.unseen.iter_mut().map(|path| &mut path.rel_path));
+    for rel_path in paths {
+        let Some(plain_rel_path) = decrypt(rel_path.as_str()) else {
+            return Err(
+                "a remote path the scan left out could not be read through the crypt overlay, \
+                 so the run cannot be bounded around it: check the overlay password"
+                    .to_string(),
+            );
+        };
+        *rel_path = plain_rel_path;
+    }
+    Ok(())
+}
+
 // Single source of truth for the crypt-compare crypto lives in
 // `crate::crypt_compare`; the GUI's FileInfo-map normalizers above reuse the
 // pure rel-path decrypt and size mapping so the CLI / MCP `RemoteEntry` path and
@@ -7078,19 +7118,17 @@ pub async fn provider_compare_directories(
         }
     }
 
-    // What the scans did not see stays out of the compare on both sides: the
-    // bounded paths and, because a preset copies or deletes a directory row as a
-    // whole, every directory row above them (see `bound_compare_rows`). Under an
-    // unwrapped crypt overlay the remote link paths are still ciphertext here and
-    // cannot match plaintext rows.
-    let bound = bound_compare_rows(
-        &local_path,
-        &mut local_files,
-        &mut remote_files,
-        remote_boundaries,
-    );
-    if let Some(reason) = bound.refusal() {
-        return Err(format!("{}: {}", crate::SCAN_INCOMPLETE_MARKER, reason));
+    // A scan that missed a part of the tree it cannot name refuses the run, and
+    // that verdict does not depend on how the paths are spelled: it stays here,
+    // ahead of the crypt work below, so the cheap hard failure keeps happening
+    // first. The path-dependent half, withdrawing the rows behind each
+    // boundary, runs after the paths have been decrypted.
+    if let Some(reason) = remote_boundaries.unbounded {
+        return Err(format!(
+            "{}: {}",
+            crate::SCAN_INCOMPLETE_MARKER,
+            crate::sync_core::scan::unbounded_refusal("remote", reason)
+        ));
     }
 
     // The remote scan above ran through `state.provider`, which IS the crypt
@@ -7153,6 +7191,12 @@ pub async fn provider_compare_directories(
             .await?;
             let raw_len = remote_files.len();
             remote_files = normalize_remote_files_for_compare(&keys, remote_files);
+            // The boundaries carry remote paths too, and the bound below
+            // matches them against local rows that are plaintext. Rewriting the
+            // rows and leaving the boundaries in ciphertext is what let a
+            // bounded remote subtree keep its local rows in the compare.
+            normalize_remote_boundaries_for_compare(&keys, &mut remote_boundaries)
+                .map_err(|reason| format!("{}: {}", crate::SCAN_INCOMPLETE_MARKER, reason))?;
             // rclone-crypt has no config MAC: a wrong overlay password derives
             // valid-shaped keys that decrypt nothing, so a non-empty remote that
             // normalizes to zero rows is a wrong-key signal. Fail closed rather
@@ -7167,6 +7211,32 @@ pub async fn provider_compare_directories(
                 );
             }
         }
+    }
+
+    // What the scans did not see stays out of the compare on both sides: the
+    // bounded paths and, because a preset copies or deletes a directory row as
+    // a whole, every directory row above them (see `bound_compare_rows`).
+    //
+    // This runs AFTER the crypt normalization above, not before it. Under an
+    // unwrapped overlay the remote rows and the remote boundaries both arrive
+    // as ciphertext while the local rows are plaintext, so a bound built at
+    // that point withdrew the remote rows behind a boundary and left their
+    // local counterparts in the compare. Those rows then read as present on one
+    // side only, and a Mirror preset planned exactly the delete the boundary
+    // exists to prevent. Both sides speak plaintext by the time we get here.
+    let bound = bound_compare_rows(
+        &local_path,
+        &mut local_files,
+        &mut remote_files,
+        remote_boundaries,
+    );
+    // The only refusal `for_sync` builds for this caller comes from the remote
+    // `unbounded` verdict, which the check above already answered, so this one
+    // cannot fire today. It stays as the guard for a future refusal source: if
+    // one is added and nothing reads it here, a compare would run on a bound
+    // that had already refused itself.
+    if let Some(reason) = bound.refusal() {
+        return Err(format!("{}: {}", crate::SCAN_INCOMPLETE_MARKER, reason));
     }
 
     let _ = app.emit(
@@ -12990,6 +13060,76 @@ fn bound_compare_rows(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn rclone_keys_for_test() -> crate::rclone_crypt::RcloneCryptKeys {
+        let (name_key, data_key, name_tweak) =
+            crate::rclone_crypt::derive_keys_with_tweak("compare-pass", "compare-salt")
+                .expect("derive the test keys");
+        crate::rclone_crypt::RcloneCryptKeys {
+            name_key,
+            data_key,
+            name_tweak,
+            filename_encryption: crate::rclone_crypt::FilenameEncryption::Standard,
+            off_suffix: ".bin".to_string(),
+            directory_name_encryption: true,
+        }
+    }
+
+    /// Under an overlay that is not unwrapped, the remote boundaries arrive as
+    /// ciphertext exactly like the remote rows. They are rewritten with the
+    /// same keys, so the bound built from them can reach the plaintext local
+    /// rows; left in ciphertext, the bound withdrew the remote rows and left
+    /// the local ones in the compare, where a Mirror preset read them as
+    /// present on one side only.
+    #[test]
+    fn remote_boundaries_are_decrypted_with_the_remote_rows() {
+        let keys = rclone_keys_for_test();
+        let encrypt = |segment: &str| {
+            crate::rclone_crypt::encrypt_name(&keys.name_key, &keys.name_tweak, segment)
+                .expect("encrypt the segment")
+        };
+        let mut boundaries = crate::sync_core::ScanBoundaries {
+            links: vec![crate::sync_core::SkippedLink {
+                rel_path: format!("{}/{}", encrypt("parent"), encrypt("link")),
+                link_target: None,
+            }],
+            unseen: vec![crate::sync_core::scan::UnseenPath {
+                rel_path: encrypt("blocked"),
+                reason: "list_error",
+            }],
+            ..Default::default()
+        };
+        let overlay = crate::crypt_overlay_provider::OverlayKeys::Rclone(rclone_keys_for_test());
+
+        normalize_remote_boundaries_for_compare(&overlay, &mut boundaries)
+            .expect("the boundary paths decrypt");
+
+        assert_eq!(boundaries.links[0].rel_path, "parent/link");
+        assert_eq!(boundaries.unseen[0].rel_path, "blocked");
+    }
+
+    /// A boundary path that does not decrypt refuses the run instead of being
+    /// dropped: a lost boundary widens the plan in silence, which is the
+    /// opposite of what the boundary is for.
+    #[test]
+    fn a_remote_boundary_that_does_not_decrypt_refuses_the_run() {
+        let overlay = crate::crypt_overlay_provider::OverlayKeys::Rclone(rclone_keys_for_test());
+        let mut boundaries = crate::sync_core::ScanBoundaries {
+            links: vec![crate::sync_core::SkippedLink {
+                rel_path: "not-base32-!!!".to_string(),
+                link_target: None,
+            }],
+            ..Default::default()
+        };
+
+        let err = normalize_remote_boundaries_for_compare(&overlay, &mut boundaries)
+            .expect_err("a path that cannot be read refuses the run");
+
+        assert!(
+            err.contains("could not be read through the crypt overlay"),
+            "got: {err}"
+        );
+    }
 
     fn compare_row(rel: &str, is_dir: bool) -> crate::sync::FileInfo {
         crate::sync::FileInfo {

--- a/src-tauri/src/provider_commands.rs
+++ b/src-tauri/src/provider_commands.rs
@@ -13063,6 +13063,188 @@ fn bound_compare_rows(
 mod tests {
     use super::*;
 
+    /// The same derived keys under another naming mode. The mode is what
+    /// decides how a directory is spelled on the wire, which is what the two
+    /// cases below are about.
+    fn rclone_keys_in_mode(
+        mode: crate::rclone_crypt::FilenameEncryption,
+        directory_name_encryption: bool,
+    ) -> crate::rclone_crypt::RcloneCryptKeys {
+        let (name_key, data_key, name_tweak) =
+            crate::rclone_crypt::derive_keys_with_tweak("compare-pass", "compare-salt")
+                .expect("derive the test keys");
+        crate::rclone_crypt::RcloneCryptKeys {
+            name_key,
+            data_key,
+            name_tweak,
+            filename_encryption: mode,
+            off_suffix: ".bin".to_string(),
+            directory_name_encryption,
+        }
+    }
+
+    /// `Off` mode spells a file with the configured suffix and a directory
+    /// without one, so reading a directory boundary as if it were a file looks
+    /// for a suffix that was never added. That refuses a compare which works,
+    /// and on a directory whose own name happens to end in the suffix it
+    /// quietly anchors the bound to a path that does not exist. The boundary
+    /// carries its type, so the decode can ask for a directory.
+    #[test]
+    fn an_off_mode_directory_boundary_bounds_the_compare_it_was_meant_to() {
+        let overlay = crate::crypt_overlay_provider::OverlayKeys::Rclone(rclone_keys_in_mode(
+            crate::rclone_crypt::FilenameEncryption::Off,
+            true,
+        ));
+        // On the wire in `Off` mode a directory keeps its plaintext name, so
+        // the link and the directory above it are spelled as they read.
+        let mut boundaries = crate::sync_core::ScanBoundaries {
+            links: vec![crate::sync_core::SkippedLink {
+                rel_path: "parent/link".to_string(),
+                link_target: None,
+                is_dir: true,
+            }],
+            ..Default::default()
+        };
+
+        normalize_remote_boundaries_for_compare(&overlay, &mut boundaries)
+            .expect("a directory name carries no file suffix to strip");
+
+        assert_eq!(boundaries.links[0].rel_path, "parent/link");
+
+        let mut local = HashMap::from([
+            ("parent".to_string(), compare_row("parent", true)),
+            ("parent/link".to_string(), compare_row("parent/link", true)),
+            (
+                "parent/link/x.txt".to_string(),
+                compare_row("parent/link/x.txt", false),
+            ),
+            (
+                "parent/y.txt".to_string(),
+                compare_row("parent/y.txt", false),
+            ),
+        ]);
+        let mut remote = HashMap::new();
+        bound_compare_rows(
+            "/nonexistent-local-root",
+            &mut local,
+            &mut remote,
+            boundaries,
+        );
+
+        let mut left: Vec<_> = local.keys().cloned().collect();
+        left.sort();
+        assert_eq!(
+            left,
+            vec!["parent/y.txt"],
+            "the link's subtree and the directory above it are withdrawn, and the sibling file is still compared"
+        );
+    }
+
+    /// With `directory_name_encryption` off, rclone leaves directory names in
+    /// the clear and encrypts only file names. A directory boundary is then
+    /// cleartext, and reading it as ciphertext fails: a compare that works was
+    /// refused, with a message that sent the user to the overlay password.
+    #[test]
+    fn cleartext_directory_names_do_not_refuse_a_directory_boundary() {
+        let keys = rclone_keys_in_mode(crate::rclone_crypt::FilenameEncryption::Standard, false);
+        let wire_link = format!(
+            "parent/{}",
+            crate::rclone_crypt::encrypt_name(&keys.name_key, &keys.name_tweak, "link.txt")
+                .expect("encrypt the file name")
+        );
+        let overlay = crate::crypt_overlay_provider::OverlayKeys::Rclone(keys);
+        let mut boundaries = crate::sync_core::ScanBoundaries {
+            links: vec![crate::sync_core::SkippedLink {
+                rel_path: wire_link,
+                link_target: None,
+                is_dir: false,
+            }],
+            unseen: vec![crate::sync_core::scan::UnseenPath {
+                rel_path: "parent/blocked".to_string(),
+                reason: "list_error",
+                is_dir: Some(true),
+            }],
+            ..Default::default()
+        };
+
+        normalize_remote_boundaries_for_compare(&overlay, &mut boundaries)
+            .expect("a cleartext directory name is not ciphertext to be refused");
+
+        assert_eq!(boundaries.links[0].rel_path, "parent/link.txt");
+        assert_eq!(boundaries.unseen[0].rel_path, "parent/blocked");
+    }
+
+    /// AeroCrypt encrypts every name the same way, directory or not, so the
+    /// type-aware decode has to leave it exactly as it was: a nested boundary
+    /// still round trips, and a name that is not an AeroCrypt name still
+    /// refuses the run instead of being dropped. This one is a guard, green
+    /// before this change as well as after it.
+    #[test]
+    fn an_aerocrypt_nested_boundary_round_trips_and_a_foreign_name_still_refuses() {
+        let master_key = [7u8; 32];
+        let overlay = crate::crypt_overlay_provider::OverlayKeys::AeroCrypt {
+            master_key,
+            // Only the master key decodes a name, so the config is a stub: the
+            // test does not pay for a KDF it never uses.
+            config: crate::aerocrypt::overlay::OverlayConfig::V2 { salt: [0u8; 32] },
+        };
+        let encrypt = |segment: &str| {
+            crate::aerocrypt::names::encrypt_filename(&master_key, segment)
+                .expect("encrypt the segment")
+        };
+        let mut boundaries = crate::sync_core::ScanBoundaries {
+            unseen: vec![crate::sync_core::scan::UnseenPath {
+                rel_path: format!("{}/{}", encrypt("alpha"), encrypt("beta")),
+                reason: "list_error",
+                is_dir: Some(true),
+            }],
+            ..Default::default()
+        };
+
+        normalize_remote_boundaries_for_compare(&overlay, &mut boundaries)
+            .expect("every segment decrypts with the master key");
+        assert_eq!(boundaries.unseen[0].rel_path, "alpha/beta");
+
+        let mut foreign = crate::sync_core::ScanBoundaries {
+            unseen: vec![crate::sync_core::scan::UnseenPath {
+                rel_path: "not-base64-$$$".to_string(),
+                reason: "list_error",
+                is_dir: Some(true),
+            }],
+            ..Default::default()
+        };
+        normalize_remote_boundaries_for_compare(&overlay, &mut foreign)
+            .expect_err("a name that does not decrypt refuses the run instead of being dropped");
+    }
+
+    /// A link whose target did not resolve leaves the walk without a type, and
+    /// the overlay spells a directory differently from a file. Guessing either
+    /// way is how a bound ends up anchored to a path that does not exist, so a
+    /// boundary with no type refuses the run, as a name that does not decrypt
+    /// does.
+    #[test]
+    fn a_boundary_whose_type_is_unknown_refuses_the_run() {
+        let keys = rclone_keys_for_test();
+        let wire = crate::rclone_crypt::encrypt_name(&keys.name_key, &keys.name_tweak, "blocked")
+            .expect("encrypt the segment");
+        let overlay = crate::crypt_overlay_provider::OverlayKeys::Rclone(keys);
+        let mut boundaries = crate::sync_core::ScanBoundaries {
+            unseen: vec![crate::sync_core::scan::UnseenPath {
+                rel_path: wire,
+                reason: "unreadable",
+                is_dir: None,
+            }],
+            ..Default::default()
+        };
+
+        let err = normalize_remote_boundaries_for_compare(&overlay, &mut boundaries)
+            .expect_err("an unknown type is refused, not guessed");
+        assert!(
+            err.contains("whether it is a directory"),
+            "the refusal says what is missing: {err}"
+        );
+    }
+
     fn rclone_keys_for_test() -> crate::rclone_crypt::RcloneCryptKeys {
         let (name_key, data_key, name_tweak) =
             crate::rclone_crypt::derive_keys_with_tweak("compare-pass", "compare-salt")

--- a/src-tauri/src/sync_core/scan.rs
+++ b/src-tauri/src/sync_core/scan.rs
@@ -415,6 +415,18 @@ enum LocalPrefix {
     Unreadable,
 }
 
+/// The refusal a run gets when a scan missed a part of the tree it cannot
+/// name, so nothing can be bounded around it.
+///
+/// Phrased in one place because it has two callers: [`ScanBound::for_sync`]
+/// below, and the compare command, which answers this verdict before it
+/// decrypts the remote paths (the verdict does not depend on how they are
+/// spelled) and would otherwise keep a second copy of the sentence, free to
+/// drift from this one.
+pub fn unbounded_refusal(side: &str, reason: &str) -> String {
+    format!("the {side} scan did not see the whole tree ({reason})")
+}
+
 impl ScanBound {
     /// Bound a sync by what its two scans did not see: the remote links and
     /// unseen paths, the local unseen paths, and the local links above any path
@@ -435,13 +447,9 @@ impl ScanBound {
     ) -> Self {
         let mut bound = Self::default();
         if let Some(reason) = remote.unbounded {
-            bound.refusal = Some(format!(
-                "the remote scan did not see the whole tree ({reason})"
-            ));
+            bound.refusal = Some(unbounded_refusal("remote", reason));
         } else if let Some(reason) = local.unbounded {
-            bound.refusal = Some(format!(
-                "the local scan did not see the whole tree ({reason})"
-            ));
+            bound.refusal = Some(unbounded_refusal("local", reason));
         }
         for link in remote.links {
             bound.add_link(link);
@@ -1690,6 +1698,30 @@ pub(crate) mod tests {
     use super::*;
     use std::fs;
     use tempfile::tempdir;
+
+    /// The compare command answers the unbounded verdict on its own, before it
+    /// decrypts the remote paths, so it never reaches `for_sync` for that case.
+    /// Both say it with `unbounded_refusal`, and this pins them to one
+    /// sentence: a second copy of the format string would drift from the one
+    /// the compare shows, and the two surfaces would disagree on what stopped
+    /// the run.
+    #[test]
+    fn the_unbounded_refusal_is_phrased_in_one_place() {
+        let expected = unbounded_refusal("remote", "the scan was cancelled");
+
+        let bound = ScanBound::for_sync(
+            "/nonexistent-local-root",
+            Vec::<&str>::new(),
+            Vec::<&str>::new(),
+            &ScanBoundaries::default(),
+            ScanBoundaries {
+                unbounded: Some("the scan was cancelled"),
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(bound.refusal(), Some(expected.as_str()));
+    }
 
     /// CLAUDE-AV-B3-13: the provider-backed remote walk must report that it did
     /// not see the whole tree. Every abort below used to leave a stderr warning

--- a/src-tauri/src/sync_core/scan.rs
+++ b/src-tauri/src/sync_core/scan.rs
@@ -155,6 +155,9 @@ fn adapt_fastpath_entries(
                     unseen.push(UnseenPath {
                         rel_path: stop,
                         reason: "depth_limit",
+                        // The walk stops AT a directory: what it did not see
+                        // sits under it.
+                        is_dir: Some(true),
                     });
                     if results.len() + skipped_links.len() + unseen.len() >= cap {
                         break;
@@ -175,6 +178,9 @@ fn adapt_fastpath_entries(
                 skipped_links.push(SkippedLink {
                     rel_path: rel,
                     link_target: entry.link_target.clone(),
+                    // A flat listing reports links to files as well as to
+                    // directories, so the type comes from the entry.
+                    is_dir: entry.is_dir,
                 });
                 if results.len() + skipped_links.len() + unseen.len() >= cap {
                     break;
@@ -277,7 +283,7 @@ fn fastpath_scan(
     for path in unseen {
         // A limit that stops at the root leaves the whole tree unseen, which
         // `unseen` turns into a gap with no name.
-        boundaries.unseen(&path.rel_path, path.reason);
+        boundaries.unseen(&path.rel_path, path.reason, path.is_dir);
         completeness.truncated = true;
     }
     if raw_truncated {
@@ -333,6 +339,18 @@ pub struct SkippedLink {
     pub rel_path: String,
     /// What the link points to, when it could be read.
     pub link_target: Option<String>,
+    /// Whether the link stands where a directory does. Recorded by the walk,
+    /// which knows: a crypt overlay spells a directory name differently from a
+    /// file name (rclone leaves directories without the `Off` suffix), so a
+    /// consumer that has to decrypt this path cannot tell from the path itself
+    /// without guessing, and guessing is how a bound ends up anchored to a path
+    /// that does not exist.
+    ///
+    /// Not serialized: it helps the decoding inside this process, and the
+    /// boundary lists that reach an agent through the MCP `sync_tree` result
+    /// should not grow a key for that.
+    #[serde(skip)]
+    pub is_dir: bool,
 }
 
 /// A path a scan could not see, so what sits at or under it is unknown.
@@ -342,6 +360,16 @@ pub struct UnseenPath {
     pub rel_path: String,
     /// Why it was not seen: `depth_limit`, `list_error` or `unreadable`.
     pub reason: &'static str,
+    /// Whether the path stands where a directory does, for the same reason
+    /// [`SkippedLink::is_dir`] carries it: only the walk knows, and a consumer
+    /// that decrypts the name needs the type to spell it right.
+    ///
+    /// `None` where the walk genuinely could not tell, as for a link whose
+    /// target did not resolve. A consumer that needs the type must refuse such
+    /// a path rather than assume one: assuming "file" is what strips a suffix a
+    /// directory never carried. Not serialized, like the field above.
+    #[serde(skip)]
+    pub is_dir: Option<bool>,
 }
 
 /// What a tree scan skipped or could not see, beyond the entries it returned.
@@ -372,7 +400,7 @@ impl ScanBoundaries {
     /// Record a path the scan did not see. The scan root has no path to bound a
     /// run around: a root the scan did not see leaves the whole tree unseen, a
     /// gap with no name.
-    fn unseen(&mut self, rel_path: &str, reason: &'static str) {
+    fn unseen(&mut self, rel_path: &str, reason: &'static str, is_dir: Option<bool>) {
         if rel_path.is_empty() {
             tracing::warn!("[scan] not seen: the scan root ({})", reason);
             self.unbounded.get_or_insert(reason);
@@ -381,6 +409,7 @@ impl ScanBoundaries {
             self.unseen.push(UnseenPath {
                 rel_path: rel_path.to_string(),
                 reason,
+                is_dir,
             });
         }
     }
@@ -491,6 +520,14 @@ impl ScanBound {
                                 bound.add_link(SkippedLink {
                                     rel_path: prefix.to_string(),
                                     link_target,
+                                    // A path prefix stands where a directory
+                                    // does: something on the remote sits under
+                                    // it. The loop also offers the whole path,
+                                    // where that would not hold, but a local
+                                    // link to a FILE is listed as a file, so it
+                                    // is in `local_set` and the loop skipped it
+                                    // before reaching here.
+                                    is_dir: true,
                                 });
                                 LocalPrefix::Link
                             }
@@ -513,6 +550,11 @@ impl ScanBound {
                                 bound.add_unseen(UnseenPath {
                                     rel_path: prefix.to_string(),
                                     reason: "unreadable",
+                                    // Same as the link above: a prefix with
+                                    // remote entries under it is a directory
+                                    // position, and the leaf case cannot reach
+                                    // here for the same reason.
+                                    is_dir: Some(true),
                                 });
                                 LocalPrefix::Unreadable
                             }
@@ -690,6 +732,9 @@ pub fn scan_local_tree_checked(
                             &mut completeness,
                             &relative_of(path),
                             "unreadable",
+                            // The walk names a path here when it could not open
+                            // a directory to read it.
+                            Some(true),
                             cap.saturating_sub(entries.len()),
                         ),
                         None => {
@@ -722,6 +767,9 @@ pub fn scan_local_tree_checked(
                     boundaries.links.push(SkippedLink {
                         rel_path,
                         link_target,
+                        // Only a link to a directory is recorded here: the arm
+                        // above matched on the target being one.
+                        is_dir: true,
                     });
                 }
                 Ok(_) => {}
@@ -736,6 +784,11 @@ pub fn scan_local_tree_checked(
                         &mut completeness,
                         &relative_of(walk_entry.path()),
                         "unreadable",
+                        // The link did not resolve, so the walk does not know
+                        // what it stands for. Not "a file": a consumer that
+                        // needs the type has to refuse this path rather than
+                        // assume one.
+                        None,
                         cap.saturating_sub(entries.len()),
                     );
                 }
@@ -751,6 +804,8 @@ pub fn scan_local_tree_checked(
                 &mut completeness,
                 &relative_of(walk_entry.path()),
                 "depth_limit",
+                // The arm above matched on the entry being a directory.
+                Some(true),
                 cap.saturating_sub(entries.len()),
             );
             continue;
@@ -790,6 +845,9 @@ pub fn scan_local_tree_checked(
                     &mut completeness,
                     &relative,
                     "unreadable",
+                    // Every stat failed, and the directory entry still reports
+                    // the type, which is the whole point of the case above.
+                    Some(walk_entry.file_type().is_dir()),
                     cap.saturating_sub(entries.len()),
                 );
                 None
@@ -981,6 +1039,8 @@ pub async fn scan_remote_tree_with_provider_lock_checked(
                     &mut completeness,
                     &dir.rel_prefix,
                     "depth_limit",
+                    // A queued walk entry is a directory the walk meant to list.
+                    Some(true),
                     cap.saturating_sub(results.len()),
                 );
                 continue;
@@ -1050,6 +1110,9 @@ pub async fn scan_remote_tree_with_provider_lock_checked(
                         &mut completeness,
                         &failure.rel_prefix,
                         "list_error",
+                        // Only a directory is listed, so only a directory can
+                        // fail to list.
+                        Some(true),
                         cap.saturating_sub(results.len()),
                     );
                 }
@@ -1144,6 +1207,8 @@ async fn scan_remote_tree_locked(
                 &mut completeness,
                 &dir.rel_prefix,
                 "depth_limit",
+                // A queued entry is a directory the walk meant to list.
+                Some(true),
                 cap.saturating_sub(results.len()),
             );
             continue;
@@ -1221,6 +1286,9 @@ async fn scan_remote_tree_locked(
                         &mut completeness,
                         &failure.rel_prefix,
                         "list_error",
+                        // Only a directory is listed, so only a directory can
+                        // fail to list.
+                        Some(true),
                         cap.saturating_sub(results.len()),
                     );
                 }
@@ -1281,13 +1349,14 @@ fn record_unseen(
     completeness: &mut ScanCompleteness,
     rel_path: &str,
     reason: &'static str,
+    is_dir: Option<bool>,
     room: usize,
 ) {
     if !rel_path.is_empty() && boundaries.len() >= room {
         completeness.truncated = true;
         boundaries.unbounded.get_or_insert("entry_cap");
     } else {
-        boundaries.unseen(rel_path, reason);
+        boundaries.unseen(rel_path, reason, is_dir);
     }
 }
 
@@ -1507,6 +1576,9 @@ async fn scan_remote_dir(
                 skipped_links.push(SkippedLink {
                     rel_path: entry_rel,
                     link_target: entry.link_target.clone(),
+                    // This arm sits inside `entry.is_dir`: the link stands
+                    // where a directory does.
+                    is_dir: true,
                 });
             } else {
                 // Past the budget the walk's cap leaves: counted, not kept.
@@ -1904,6 +1976,7 @@ pub(crate) mod tests {
             vec![SkippedLink {
                 rel_path: "link".to_string(),
                 link_target: Some("real".to_string()),
+                is_dir: true,
             }]
         );
     }
@@ -2086,6 +2159,8 @@ pub(crate) mod tests {
             vec![SkippedLink {
                 rel_path: "link.txt".to_string(),
                 link_target: Some("target.txt".to_string()),
+                // The listing said file, and the fast path repeats what it said.
+                is_dir: false,
             }]
         );
     }
@@ -2237,6 +2312,7 @@ pub(crate) mod tests {
             vec![SkippedLink {
                 rel_path: "loop".to_string(),
                 link_target: None,
+                is_dir: true,
             }]
         );
     }
@@ -2245,6 +2321,9 @@ pub(crate) mod tests {
         SkippedLink {
             rel_path: rel.to_string(),
             link_target: None,
+            // These tests are about what a bound covers, which is a subtree, so
+            // the link stands where a directory does.
+            is_dir: true,
         }
     }
 
@@ -2293,6 +2372,7 @@ pub(crate) mod tests {
             &[SkippedLink {
                 rel_path: "link".to_string(),
                 link_target: Some("real".to_string()),
+                is_dir: true,
             }]
         );
         assert!(bound.covers("link/x.txt"));
@@ -2373,6 +2453,7 @@ pub(crate) mod tests {
             &[UnseenPath {
                 rel_path: "locked/link".to_string(),
                 reason: "unreadable",
+                is_dir: Some(true),
             }]
         );
     }
@@ -2484,6 +2565,7 @@ pub(crate) mod tests {
             vec![UnseenPath {
                 rel_path: "d1".to_string(),
                 reason: "depth_limit",
+                is_dir: Some(true),
             }]
         );
         assert_eq!(
@@ -3066,6 +3148,7 @@ pub(crate) mod tests {
             vec![UnseenPath {
                 rel_path: "d1/d2".to_string(),
                 reason: "depth_limit",
+                is_dir: Some(true),
             }],
             "what the walk stops at"
         );

--- a/src-tauri/src/transfer_dag_sync.rs
+++ b/src-tauri/src/transfer_dag_sync.rs
@@ -2654,6 +2654,7 @@ mod tests {
             vec![crate::sync_core::SkippedLink {
                 rel_path: "link".to_string(),
                 link_target: Some("real".to_string()),
+                is_dir: true,
             }],
             "the report names the remote link it left alone"
         );
@@ -2728,6 +2729,7 @@ mod tests {
             vec![crate::sync_core::SkippedLink {
                 rel_path: "link".to_string(),
                 link_target: Some("real".to_string()),
+                is_dir: true,
             }],
             "the report names the local link it left alone"
         );
@@ -2770,6 +2772,7 @@ mod tests {
             vec![crate::sync_core::SkippedLink {
                 rel_path: "link".to_string(),
                 link_target: Some("real".to_string()),
+                is_dir: true,
             }]
         );
     }
@@ -2894,6 +2897,7 @@ mod tests {
             vec![crate::sync_core::UnseenPath {
                 rel_path: "d1".to_string(),
                 reason: "list_error",
+                is_dir: Some(true),
             }],
             "the report names the directory it left alone"
         );

--- a/src-tauri/src/used_scan.rs
+++ b/src-tauri/src/used_scan.rs
@@ -182,10 +182,8 @@ pub async fn scan_used_bytes(
         let mut truncated = fast.truncated;
         let mut hit_cap = fast.truncated;
         // The provider handed us a complete single-shot listing, so there is no
-        // per-directory walk here: nothing can be unreadable and nothing polls
-        // cancellation. Fixed at their empty values rather than tracked.
+        // per-directory walk here and nothing can be unreadable.
         let unreadable_dirs: u64 = 0;
-        let cancelled = false;
         for e in fast.entries {
             // Directories count against the cap alongside files, as they do in
             // `bfs_used_bytes`, so the two ways of walking the same tree cut at
@@ -203,6 +201,18 @@ pub async fn scan_used_bytes(
             }
             used = used.saturating_add(e.size);
             files += 1;
+        }
+        // One call, but not an instant one: a cancel raised while the listing
+        // ran is a cancel this scan has to honour. The BFS polls the flag
+        // between directories; this path has no walk to poll inside, so it
+        // polls on the way out. The figure keeps what was already summed, as
+        // the BFS does when it breaks out of its queue: `df --scan` and `size`
+        // print this number, so a stopped scan has to answer a lower bound and
+        // not a zero. A cancel is not a cap, so `hit_cap` stays as the
+        // provider left it.
+        let cancelled = cancel.load(Ordering::Relaxed);
+        if cancelled {
+            truncated = true;
         }
         on_progress(files, used);
         return Ok(UsedScan {

--- a/src-tauri/src/used_scan.rs
+++ b/src-tauri/src/used_scan.rs
@@ -187,14 +187,19 @@ pub async fn scan_used_bytes(
         let unreadable_dirs: u64 = 0;
         let cancelled = false;
         for e in fast.entries {
-            if e.is_dir {
-                dirs += 1;
-                continue;
-            }
-            if files >= max_entries as u64 {
+            // Directories count against the cap alongside files, as they do in
+            // `bfs_used_bytes`, so the two ways of walking the same tree cut at
+            // the same place. Counting files alone let a listing made mostly of
+            // directory markers (which the recursive listing keeps since #796)
+            // run past `max_entries` without ever reaching this check.
+            if (files + dirs) >= max_entries as u64 {
                 truncated = true;
                 hit_cap = true;
                 break;
+            }
+            if e.is_dir {
+                dirs += 1;
+                continue;
             }
             used = used.saturating_add(e.size);
             files += 1;

--- a/src-tauri/src/used_scan.rs
+++ b/src-tauri/src/used_scan.rs
@@ -306,3 +306,109 @@ async fn bfs_used_bytes(
         method: "bfs",
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::providers::types::S3Config;
+
+    /// An S3 provider connected to a fake endpoint that answers every request
+    /// with `body`, so `scan_used_bytes` takes the single-shot fast path. The
+    /// handle returned is the server's: abort it at the end of the test.
+    async fn s3_fast_path(
+        body: &'static str,
+    ) -> (Box<dyn StorageProvider>, tokio::task::JoinHandle<()>) {
+        let app = axum::Router::new().fallback(axum::routing::any(
+            move |_req: axum::extract::Request| async move {
+                axum::http::Response::new(axum::body::Body::from(body))
+            },
+        ));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        let mut provider = S3Provider::new(S3Config {
+            endpoint: Some(format!("http://{addr}")),
+            region: "us-east-1".to_string(),
+            access_key_id: "key".to_string(),
+            secret_access_key: secrecy::SecretString::from("secret".to_string()),
+            session_token: None,
+            role_arn: None,
+            role_external_id: None,
+            role_session_name: None,
+            role_duration_seconds: None,
+            role_mfa_serial: None,
+            role_mfa_token_code: None,
+            bucket: "test-bucket".to_string(),
+            prefix: None,
+            path_style: true,
+            storage_class: None,
+            sse_mode: None,
+            sse_kms_key_id: None,
+            verify_cert: true,
+            allow_cleartext_endpoint: true,
+        })
+        .expect("build the S3 provider");
+        provider
+            .connect()
+            .await
+            .expect("connect to the fake endpoint");
+        (Box::new(provider), server)
+    }
+
+    /// Directory markers count against the entry cap, as they do in the BFS,
+    /// so both ways of walking a tree cut at the same place. Counting only
+    /// files against the cap let a listing of markers run past `max_entries`.
+    #[tokio::test]
+    async fn fast_path_counts_directories_against_the_entry_cap() {
+        let (mut provider, server) = s3_fast_path(
+            "<ListBucketResult><Contents><Key>d1/</Key><Size>0</Size></Contents><Contents><Key>d2/</Key><Size>0</Size></Contents><Contents><Key>d3/</Key><Size>0</Size></Contents><Contents><Key>f.txt</Key><Size>7</Size></Contents></ListBucketResult>",
+        )
+        .await;
+        let cancel = AtomicBool::new(false);
+
+        let scan = scan_used_bytes(&mut provider, "/", 100, 2, &cancel, |_, _| {})
+            .await
+            .expect("the scan answers");
+        server.abort();
+
+        assert_eq!(
+            scan.file_count + scan.dir_count,
+            2,
+            "the cap counts files and directories together: {scan:?}"
+        );
+        assert!(scan.truncated, "a cut figure is a lower bound: {scan:?}");
+        assert!(scan.hit_cap, "the cap is what cut it: {scan:?}");
+    }
+
+    /// A cancel raised while the single listing runs is honoured on the way out
+    /// of the await, and the figure keeps what was already summed, as the BFS
+    /// does when it breaks out of its queue. A stopped scan is a partial
+    /// figure, not a zero one: `df --scan` and `size` print it.
+    #[tokio::test]
+    async fn fast_path_honours_a_cancel_and_keeps_the_partial_figure() {
+        let (mut provider, server) = s3_fast_path(
+            "<ListBucketResult><Contents><Key>a.txt</Key><Size>3</Size></Contents><Contents><Key>b.txt</Key><Size>4</Size></Contents></ListBucketResult>",
+        )
+        .await;
+        let cancel = AtomicBool::new(true);
+
+        let scan = scan_used_bytes(&mut provider, "/", 100, 500_000, &cancel, |_, _| {})
+            .await
+            .expect("the scan answers");
+        server.abort();
+
+        assert!(scan.cancelled, "the cancel is reported: {scan:?}");
+        assert!(
+            scan.truncated,
+            "a cancelled figure is a lower bound: {scan:?}"
+        );
+        assert!(!scan.hit_cap, "a cancel is not a cap: {scan:?}");
+        assert_eq!(
+            (scan.file_count, scan.used_bytes),
+            (2, 7),
+            "the sums already in hand are reported, not zeros: {scan:?}"
+        );
+    }
+}


### PR DESCRIPTION
## What this is

The three findings left open by the full review of #796, as a patch designed elsewhere and finished here, plus a fourth defect found in the patch's own fix while reviewing it. The design came from a session that could not compile this crate: `cargo check` there dies on a missing `gdk-3.0.pc` (Tauri looking for GTK), so when the patch arrived no compiler had seen the code and it carried no tests. It applied cleanly on `ba8c7414b`, and its shape was verified and then corrected here on three points before anything was committed.

Base `ba8c7414b`. One commit per finding, plus the test commits.

## (a) The compare bound ran on encrypted paths

`bound_compare_rows` ran BEFORE the crypt block. Under an overlay that is not unwrapped, the remote rows and the remote boundaries are both ciphertext while the local rows are plaintext, so the bound withdrew the remote rows behind a boundary and left their local counterparts in the compare. Those rows then read as present on one side only, and a Mirror preset planned exactly the delete the boundary exists to prevent.

- `bound_compare_rows` now runs after the crypt normalization, where both sides speak plaintext.
- `normalize_remote_boundaries_for_compare` rewrites `links[].rel_path` and `unseen[].rel_path` with the keys used for the rows. A path that does not decrypt refuses the run rather than being dropped: a dropped boundary widens the plan in silence, which is the opposite of what a boundary is for.
- The verdict that does not depend on how paths are spelled, the refusal for a gap the scan cannot name, stays ahead of the crypt work.
- That early refusal and `ScanBound::for_sync` now phrase the sentence through one function, `sync_core::scan::unbounded_refusal`, so the two surfaces cannot drift apart.
- The second `bound.refusal()` after the move cannot fire today, because the only refusal `for_sync` builds for this caller is the one already answered above. It stays as the guard for a future refusal source, with a comment that says so, rather than reading as dead code.

**Behaviour change worth stating**: `raw_len`, the row count the rclone wrong-key check compares against, is now taken before the bound withdraws rows instead of after. This is an improvement (before, a bound that withdrew every remote row left `raw_len` at 0 and the wrong-key check never fired), but it is a change.

## (b) Directory markers escaped the fast path entry cap

The single-shot listing checked the cap on the file count alone, and skipped directory markers before reaching the check. The BFS over the same tree stops at `(files + dirs) >= max_entries`. The fast path now checks the cap first and counts both, so the two ways of walking a tree cut at the same place.

**Behaviour change worth stating**: on trees with many directories the figure is reported as truncated earlier than before.

The original framing of this finding, that the markers made the byte figure read as whole while the listing had been cut, does not hold: markers are zero bytes and were skipped before the check, and a provider-side cut was already reported through `fast.truncated`. The comment in the code gives the real reason.

## (c) The fast path never looked at the cancel flag

`cancelled` was hard coded to false, so a scan the user stopped came back looking like a completed one. The flag is now polled on the way out of the listing, where the BFS polls it between directories.

The figure keeps the sums already in hand, as the BFS does when it breaks out of its queue. Both callers of `scan_used_bytes` are in the CLI and both print the number even when it is partial: `df --scan` prints the used figure and the percentage, and `size` does not look at `cancelled` at all. Returning zeros on a cancel would have reported an empty tree for one that had just been listed. A cancel is not a cap, so `hit_cap` stays as the provider left it.

## (d) The boundary decode read every boundary as a file

Found while reviewing the fix for (a), which it regressed. `normalize_remote_boundaries_for_compare` decoded a boundary path with the row decoder, which always treats the last segment as a file name. Most boundaries are not files: a skipped link stands where a directory does, a directory at the depth limit is a directory, a directory that failed to list is a directory. A crypt overlay spells the two differently, so the decode was wrong wherever the spellings differ.

- rclone `Off` mode with a suffix spells a file with the suffix and a directory without one. Looking for a suffix that was never added fails, so a compare that works was refused with a message that sends the user to the overlay password. Worse, and narrower: a directory whose own name ends in the suffix (a folder called `archive.bin`) strips it successfully and the bound anchors to a path that does not exist, with nothing said.
- `Standard` with `directory_name_encryption = false` leaves directory names in the clear. Reading a cleartext directory boundary as ciphertext fails, so the same refusal fired on another compare that works.

The fix carries the type instead of inferring it. `SkippedLink` gains `is_dir`, `UnseenPath` gains `is_dir: Option<bool>`, every recording site sets it from what that site already knows (the arm that matched on the target being a directory, the entry type the walk still holds after a failed stat, the queued directory the walk meant to list, the listing's own answer on the flat fast path), and the decode goes through `OverlayKeys::decode_rel_path`, which is told what the last segment is. Every segment above the last one names a directory whatever sits at the end.

`None` is the honest answer where the walk could not tell, as for a link whose target did not resolve, and a boundary with no type refuses the run and says what is missing. Guessing "file" is what strips a suffix a directory never carried, and a bound that misses is worse than a run that stops.

Both fields are `#[serde(skip)]`: they help the decoding inside this process, and the boundary lists that reach an agent through the MCP `sync_tree` result do not grow a key for that. AeroCrypt is unchanged, because it spells every name the same way.

## Tests

The two `used_scan` tests drive `scan_used_bytes` through the S3 single-shot fast path against a fake endpoint, the way the recursive-listing tests of the S3 provider do. The four crypt boundary tests drive `normalize_remote_boundaries_for_compare`, and the first of them carries on into `bound_compare_rows` to show what the decoded boundary is for. Both sets were committed before their fixes and run there.

### Seen red, on the test commits

```
test used_scan::tests::fast_path_counts_directories_against_the_entry_cap ... FAILED
  the cap counts files and directories together:
  UsedScan { used_bytes: 7, file_count: 1, dir_count: 3, truncated: false, hit_cap: false, cancelled: false, method: "s3-list-recursive" }
  left: 4   right: 2

test used_scan::tests::fast_path_honours_a_cancel_and_keeps_the_partial_figure ... FAILED
  the cancel is reported:
  UsedScan { used_bytes: 7, file_count: 2, dir_count: 0, truncated: false, hit_cap: false, cancelled: false, method: "s3-list-recursive" }

test provider_commands::tests::an_off_mode_directory_boundary_bounds_the_compare_it_was_meant_to ... FAILED
  a directory name carries no file suffix to strip: "a remote path the scan left out could not be read
  through the crypt overlay, so the run cannot be bounded around it: check the overlay password"

test provider_commands::tests::cleartext_directory_names_do_not_refuse_a_directory_boundary ... FAILED
  a cleartext directory name is not ciphertext to be refused: "a remote path the scan left out could not
  be read through the crypt overlay, so the run cannot be bounded around it: check the overlay password"

test provider_commands::tests::a_boundary_whose_type_is_unknown_refuses_the_run ... FAILED
  an unknown type is refused, not guessed: ()
```

The `used_scan` cancel failure also shows what correction (c) is about: the figure already had 2 files and 7 bytes in hand at that point, which is what the fix now reports. The third crypt failure is the fail-closed case: before the fix the run did not refuse at all, it read the path as a file and carried on.

### Green after the fixes

```
provider_commands::tests   66 passed; 0 failed
sync_core::scan::tests     41 passed; 0 failed
used_scan::tests            2 passed; 0 failed
transfer_dag_sync::tests   34 passed; 0 failed
sync_tree_result            3 passed; 0 failed
```

`sync_tree_result_lists_the_unseen_paths` asserts the exact JSON of the `unseen_paths` array and was not touched: it is the check that the two new fields stay out of the MCP payload.

### Declared coverage limits

- The behavioural test for (a), a compare with the overlay not unwrapped where a local row under a bounded remote path has to disappear from the compare, is not reachable without refactoring `provider_compare_directories`: it is a Tauri command that takes `app` and `state`. What is covered instead is the unit behaviour of the normalizer, on both `links` and `unseen`, and its refusal on a path that does not decrypt. What is NOT covered by a test is the ordering itself: that the bound runs after the normalization inside that command. The same limit applies to (d), so the case "armed overlay, nothing to normalize" is not a test either; the non-crypt compare is covered by `compare_rows_withdraw_the_directories_above_a_skipped_link`, which runs without an overlay.
- Three of the four crypt boundary tests are red-then-green, and the fourth is a guard that is green before the fix as well as after it: AeroCrypt spells every name the same way, so a type-aware decode has to leave it exactly as it was, refusal on a foreign name included. It cannot be seen red without inventing a case the code does not have.
- The two normalizer tests added with (a), and the one that pins the refusal sentence, are tests of code this branch adds, so they are green from their first run.
- With the overlay unwrapped the boundaries are plaintext already and are normalized once, in the same block that normalizes the rows; the path is unchanged from before this branch.

## Gates

- `cargo fmt --all -- --check`: rc 0
- `cargo test --lib` on the five module filters above: 146 passed, 0 failed
- `cargo clippy --all-targets -- -D warnings`: rc 0, run after `cargo clean -p aeroftp` so the lint pass actually recompiled the crate instead of answering from cache

No CHANGELOG entry: the release notes are written from the tracker at release time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved comparisons for encrypted directories by correctly handling skipped and undiscovered paths.
  - Comparisons now stop safely when required path information cannot be decrypted, instead of silently continuing.
  - Scan entry limits now consistently include directories, preventing results from exceeding the configured cap.
  - Canceled scans preserve partial results and accurately indicate truncation without incorrectly reporting that the entry limit was reached.
- **Reliability**
  - Improved consistency when detecting incomplete scans during synchronization and comparison operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
