### PR TITLE
fix(sftp): stop treating every exists() error as missing

### DIFF
--- a/src-tauri/src/providers/sftp.rs
+++ b/src-tauri/src/providers/sftp.rs
@@ -99,6 +99,51 @@ fn classify_russh_err(
     }
 }
 
+/// Map `SftpSession::try_exists` onto [`StorageProvider::exists`].
+///
+/// russh-sftp converts `SSH_FX_NO_SUCH_FILE` into `Ok(false)` and returns
+/// every other failure as `Err`. Absence stays `Ok(false)`; permission,
+/// session and I/O failures stay `Err`, so a root under an unreadable
+/// parent is a gap rather than a missing source.
+fn map_sftp_try_exists(
+    result: Result<bool, russh_sftp::client::error::Error>,
+) -> Result<bool, ProviderError> {
+    match result {
+        Ok(exists) => Ok(exists),
+        Err(russh_sftp::client::error::Error::Status(status))
+            if status.status_code == russh_sftp::protocol::StatusCode::NoSuchFile =>
+        {
+            Ok(false)
+        }
+        Err(e) => Err(classify_sftp_exists_err(e)),
+    }
+}
+
+fn classify_sftp_exists_err(e: russh_sftp::client::error::Error) -> ProviderError {
+    if let russh_sftp::client::error::Error::Status(status) = &e {
+        match status.status_code {
+            russh_sftp::protocol::StatusCode::PermissionDenied => {
+                let message = if status.error_message.is_empty() {
+                    status.status_code.to_string()
+                } else {
+                    status.error_message.clone()
+                };
+                return ProviderError::PermissionDenied(message);
+            }
+            russh_sftp::protocol::StatusCode::ConnectionLost => {
+                return ProviderError::ConnectionLost(status.error_message.clone());
+            }
+            russh_sftp::protocol::StatusCode::NoConnection => {
+                return ProviderError::NotConnected;
+            }
+            _ => {}
+        }
+    }
+    classify_russh_err(e, |s| {
+        ProviderError::ServerError(format!("Failed to check existence: {s}"))
+    })
+}
+
 /// Shared, lock-protected handle to the underlying russh SSH session.
 /// Used by sibling modules (e.g. rsync-over-SSH) to open additional channels
 /// (exec, direct-tcpip) without re-authenticating.
@@ -2494,11 +2539,7 @@ impl StorageProvider for SftpProvider {
     async fn exists(&mut self, path: &str) -> Result<bool, ProviderError> {
         let sftp = self.get_sftp()?;
         let full_path = self.normalize_path(path);
-
-        match sftp.try_exists(&full_path).await {
-            Ok(exists) => Ok(exists),
-            Err(_) => Ok(false),
-        }
+        map_sftp_try_exists(sftp.try_exists(&full_path).await)
     }
 
     fn supports_checksum(&self) -> bool {
@@ -4490,6 +4531,60 @@ mod tests {
         assert_eq!(
             plan_resume_upload(120, 120, 100),
             ResumeUploadPlan::AlreadyComplete
+        );
+    }
+
+    fn sftp_status(
+        code: russh_sftp::protocol::StatusCode,
+        message: &str,
+    ) -> russh_sftp::client::error::Error {
+        russh_sftp::client::error::Error::Status(russh_sftp::protocol::Status {
+            id: 1,
+            status_code: code,
+            error_message: message.to_string(),
+            language_tag: "en".into(),
+        })
+    }
+
+    #[test]
+    fn exists_maps_a_present_path_to_true() {
+        assert!(map_sftp_try_exists(Ok(true)).unwrap());
+    }
+
+    #[test]
+    fn exists_maps_a_missing_path_to_false() {
+        // russh-sftp::try_exists converts SSH_FX_NO_SUCH_FILE into Ok(false).
+        assert!(!map_sftp_try_exists(Ok(false)).unwrap());
+        // Defensive: if a future russh-sftp leaves that status as Err, absence
+        // must still be Ok(false) so a sync into a directory not yet created
+        // keeps scanning it as an empty tree.
+        let err = sftp_status(russh_sftp::protocol::StatusCode::NoSuchFile, "No such file");
+        assert!(!map_sftp_try_exists(Err(err)).unwrap());
+    }
+
+    #[test]
+    fn exists_maps_permission_denied_to_err_not_absent() {
+        let err = sftp_status(
+            russh_sftp::protocol::StatusCode::PermissionDenied,
+            "Permission denied",
+        );
+        match map_sftp_try_exists(Err(err)) {
+            Err(ProviderError::PermissionDenied(message)) => {
+                assert!(
+                    message.to_ascii_lowercase().contains("permission"),
+                    "got {message:?}"
+                );
+            }
+            other => panic!("permission denied must stay an error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn exists_maps_an_io_failure_to_err_not_absent() {
+        let err = russh_sftp::client::error::Error::IO("broken pipe".into());
+        assert!(
+            map_sftp_try_exists(Err(err)).is_err(),
+            "an I/O failure must stay an error, not Ok(false)"
         );
     }
 }

--- a/src-tauri/src/sync_core/scan.rs
+++ b/src-tauri/src/sync_core/scan.rs
@@ -2571,6 +2571,11 @@ pub(crate) mod tests {
         /// which is how SFTP reports any listing failure it does not classify,
         /// while `stat` finds them.
         pub(crate) unlistable: std::collections::HashSet<String>,
+        /// Directories whose `exists` check itself fails (permission, I/O).
+        /// Distinct from `unlistable`: that path answers `Ok(true)`, this one
+        /// answers `Err`, which is how SFTP must report a root under a parent
+        /// the account cannot traverse.
+        pub(crate) exists_denied: std::collections::HashSet<String>,
         /// The directory whose listing raises `cancel`, the way a user's cancel
         /// lands in the middle of a listing.
         pub(crate) cancel_on: Option<String>,
@@ -2588,6 +2593,7 @@ pub(crate) mod tests {
             Self {
                 dirs,
                 unlistable: std::collections::HashSet::new(),
+                exists_denied: std::collections::HashSet::new(),
                 cancel_on: None,
                 cancel: Arc::new(std::sync::atomic::AtomicBool::new(false)),
                 writes: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
@@ -2630,6 +2636,7 @@ pub(crate) mod tests {
             Ok(Box::new(Self {
                 dirs: self.dirs.clone(),
                 unlistable: self.unlistable.clone(),
+                exists_denied: self.exists_denied.clone(),
                 cancel_on: self.cancel_on.clone(),
                 cancel: Arc::clone(&self.cancel),
                 writes: Arc::clone(&self.writes),
@@ -2726,6 +2733,9 @@ pub(crate) mod tests {
             Ok(0)
         }
         async fn exists(&mut self, path: &str) -> Result<bool, ProviderError> {
+            if self.exists_denied.contains(path) {
+                return Err(ProviderError::PermissionDenied(path.to_string()));
+            }
             Ok(self.dirs.contains_key(path) || self.unlistable.contains(path))
         }
         async fn keep_alive(&mut self) -> Result<(), ProviderError> {
@@ -2851,6 +2861,31 @@ pub(crate) mod tests {
                 boundaries.unbounded,
                 Some("list_error"),
                 "an unlisted root is a gap with no name (pool={pool})"
+            );
+        }
+    }
+
+    /// G51: a root whose `exists` check fails (permission on a parent the
+    /// account cannot traverse) must not be read as missing. `root_is_absent`
+    /// takes only `Ok(false)` as absence; any other answer leaves the root a
+    /// gap, so a run that reads from it is refused as an incomplete scan
+    /// rather than as `source_root_missing`.
+    #[tokio::test]
+    async fn a_root_whose_exists_check_fails_is_a_gap_not_a_missing_source() {
+        for pool in [false, true] {
+            let mut tree = WalkTreeProvider::new(std::collections::HashMap::new(), pool);
+            tree.exists_denied.insert("/root".to_string());
+            let (rows, completeness, boundaries) = walk_tree(tree, None).await;
+            assert!(rows.is_empty(), "(pool={pool})");
+            assert!(!completeness.is_complete(), "(pool={pool})");
+            assert!(
+                !boundaries.root_missing,
+                "a permission failure is not a missing source (pool={pool})"
+            );
+            assert_eq!(
+                boundaries.unbounded,
+                Some("list_error"),
+                "the root stays a gap with no name (pool={pool})"
             );
         }
     }


### PR DESCRIPTION
## The defect

`SftpProvider::exists` mapped every `try_exists` failure to `Ok(false)`:

```
match sftp.try_exists(&full_path).await {
    Ok(exists) => Ok(exists),
    Err(_) => Ok(false),
}
```

A permission error, a dropped session or an I/O failure all read as "that path is not there". `scan.rs` asks `exists` only after a listing fails, and takes solely `Ok(false)` as a missing root: any other answer leaves the root a gap. The swallow turned a root that exists under a parent the account cannot traverse into `source_root_missing`, which sends the user looking for a wrong path instead of a denied permission, and let a run that writes toward that root plan copies that then all fail the same way.

## Library, read before writing

russh-sftp 2.4.0 `SftpSession::try_exists` (`client/session.rs`) already splits the cases:

- `Ok(true)` when `metadata` succeeds
- `Ok(false)` on `SSH_FX_NO_SUCH_FILE`
- `Err` for everything else, including `SSH_FX_PERMISSION_DENIED`

A missing path is therefore `Ok(false)` from the library. The wrapper was the part that threw the `Err` away. The mapping keeps absence as `Ok(false)`, with a defensive arm if a future russh-sftp stops converting `NoSuchFile`, so a sync into a directory not yet created still scans it as an empty tree.

## Fix

Local to `exists`. The trait already returns `Result<bool, ProviderError>`, so no signature change and no other provider had to move. Absence stays `Ok(false)`. Other failures are classified with the variants the rest of the provider already uses: `PermissionDenied`, `ConnectionLost` / `NotConnected`, `classify_russh_err` for a closed session, `ServerError` as the fallback. No new variant.

## Tests

Against the mapper, not a live SFTP session. Red before the fix, with the previous `Err(_) => Ok(false)` still in place:

```
exists_maps_permission_denied_to_err_not_absent
  permission denied must stay an error, got Ok(false)
exists_maps_an_io_failure_to_err_not_absent
  an I/O failure must stay an error, not Ok(false)
exists_maps_a_present_path_to_true ... ok
exists_maps_a_missing_path_to_false ... ok
FAILED. 2 passed; 2 failed
```

Green after: those four, plus `a_root_whose_exists_check_fails_is_a_gap_not_a_missing_source` on both walks, which pins that an `exists` `Err` leaves the root a gap rather than `root_missing`. The two neighbours stay green: a root that does not exist is still an empty tree, and a root that exists and does not list is still a gap.

## Same swallow elsewhere, not this PR

`grep -rn 'Err(_) => Ok(false)' src-tauri/src/providers/` finds one other `exists`: `providers/mega.rs` still matches `NotFound` then `Err(_) => Ok(false)`. Every other provider already propagates a non-`NotFound` error. That MEGA arm is a gate of its own.

## Behaviour change

`exists` on SFTP now returns `Err` when the check fails for permission, session or I/O, instead of `Ok(false)`. Callers that treated every non-true as missing will see an error where they used to see absence. `root_is_absent` already takes only `Ok(false)`, so a scan of a forbidden root becomes an incomplete scan (gap) rather than `source_root_missing`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - SFTP checks now distinguish missing paths from permission, connection, and I/O failures.
  - Permission and other access errors are reported accurately instead of being treated as missing files.
  - Sync scans now correctly handle failures when checking whether a root path exists.
  - Sync runs are refused when root access errors prevent reliable scanning.

- **Tests**
  - Added coverage for existing, missing, permission-denied, and I/O-error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->