### PR TITLE
fix(sync): make conflict-mode newer symmetric when no timestamp can decide

### DIFF
--- a/src-tauri/src/sync.rs
+++ b/src-tauri/src/sync.rs
@@ -1743,6 +1743,10 @@ pub(crate) fn decide_download(
     }
 }
 
+fn newer_without_timestamp_skip(winner: &str) -> String {
+    format!("timestamp missing or unreadable, size decides: {winner}")
+}
+
 fn decide_upload_by_size(
     local_size: u64,
     remote_size: u64,
@@ -1752,9 +1756,13 @@ fn decide_upload_by_size(
         SyncTreeAction::Skip("identical size".to_string())
     } else {
         match mode {
-            ConflictMode::Larger if local_size > remote_size => SyncTreeAction::Copy,
+            ConflictMode::Larger | ConflictMode::Newer if local_size > remote_size => {
+                SyncTreeAction::Copy
+            }
             ConflictMode::Larger => SyncTreeAction::Skip("remote is larger".to_string()),
-            ConflictMode::Newer => SyncTreeAction::Copy,
+            ConflictMode::Newer => {
+                SyncTreeAction::Skip(newer_without_timestamp_skip("remote is larger"))
+            }
             ConflictMode::Skip => SyncTreeAction::Skip("conflict skip".to_string()),
         }
     };
@@ -1773,10 +1781,12 @@ fn decide_download_by_size(
         SyncTreeAction::Skip("identical size".to_string())
     } else {
         match mode {
-            ConflictMode::Larger if remote_size > local_size => SyncTreeAction::Copy,
+            ConflictMode::Larger | ConflictMode::Newer if remote_size > local_size => {
+                SyncTreeAction::Copy
+            }
             ConflictMode::Larger => SyncTreeAction::Skip("local is larger".to_string()),
             ConflictMode::Newer => {
-                SyncTreeAction::Skip("newer mode prefers existing local".to_string())
+                SyncTreeAction::Skip(newer_without_timestamp_skip("local is larger"))
             }
             ConflictMode::Skip => SyncTreeAction::Skip("conflict skip".to_string()),
         }
@@ -6965,6 +6975,206 @@ mod tests {
             .action,
             SyncTreeAction::Skip(_)
         ));
+    }
+
+    fn skip_reason(action: &SyncTreeAction) -> &str {
+        match action {
+            SyncTreeAction::Skip(reason) => reason,
+            SyncTreeAction::Copy => panic!("expected skip, got copy"),
+        }
+    }
+
+    /// G44 / D28: with no usable timestamp, Newer must pick the larger file
+    /// in both directions. Before the fix, upload copied and download skipped,
+    /// so a two-way run silently preferred the local side.
+    #[test]
+    fn newer_without_timestamp_picks_the_larger_file_in_both_directions() {
+        let larger_local = local_entry(20, None, None);
+        let smaller_local = local_entry(5, None, None);
+        let remote = remote_entry(10, None, None);
+
+        for policy in [DeltaPolicy::SizeOnly, DeltaPolicy::Mtime] {
+            let upload_when_local_larger =
+                decide_upload(&larger_local, Some(&remote), policy, ConflictMode::Newer);
+            let download_when_local_larger = decide_download(
+                &remote,
+                Some(&larger_local),
+                policy,
+                ConflictMode::Newer,
+                false,
+            );
+            assert!(
+                matches!(upload_when_local_larger.action, SyncTreeAction::Copy),
+                "{policy:?}"
+            );
+            assert_eq!(
+                skip_reason(&download_when_local_larger.action),
+                "timestamp missing or unreadable, size decides: local is larger",
+                "{policy:?}"
+            );
+
+            let upload_when_remote_larger =
+                decide_upload(&smaller_local, Some(&remote), policy, ConflictMode::Newer);
+            let download_when_remote_larger = decide_download(
+                &remote,
+                Some(&smaller_local),
+                policy,
+                ConflictMode::Newer,
+                false,
+            );
+            assert_eq!(
+                skip_reason(&upload_when_remote_larger.action),
+                "timestamp missing or unreadable, size decides: remote is larger",
+                "{policy:?}"
+            );
+            assert!(
+                matches!(download_when_remote_larger.action, SyncTreeAction::Copy),
+                "{policy:?}"
+            );
+        }
+    }
+
+    /// Same pair on a two-way run: the upload skip must not suppress the
+    /// download that should win, and the upload copy must still suppress
+    /// the download of the smaller remote.
+    #[test]
+    fn newer_without_timestamp_two_way_legs_do_not_contradict() {
+        let local_larger = local_entry(20, None, None);
+        let local_smaller = local_entry(5, None, None);
+        let remote = remote_entry(10, None, None);
+
+        let upload = decide_upload(
+            &local_larger,
+            Some(&remote),
+            DeltaPolicy::Mtime,
+            ConflictMode::Newer,
+        );
+        assert!(matches!(upload.action, SyncTreeAction::Copy));
+        let download_after_upload = decide_download(
+            &remote,
+            Some(&local_larger),
+            DeltaPolicy::Mtime,
+            ConflictMode::Newer,
+            true,
+        );
+        assert!(matches!(
+            download_after_upload.action,
+            SyncTreeAction::Skip(_)
+        ));
+
+        let upload = decide_upload(
+            &local_smaller,
+            Some(&remote),
+            DeltaPolicy::Mtime,
+            ConflictMode::Newer,
+        );
+        assert!(matches!(upload.action, SyncTreeAction::Skip(_)));
+        let download_after_skip = decide_download(
+            &remote,
+            Some(&local_smaller),
+            DeltaPolicy::Mtime,
+            ConflictMode::Newer,
+            false,
+        );
+        assert!(matches!(download_after_skip.action, SyncTreeAction::Copy));
+    }
+
+    /// With timestamps present, Newer still decides by mtime. Larger and Skip
+    /// on a pair with no timestamps stay as they were.
+    #[test]
+    fn newer_with_timestamps_still_decides_by_mtime_and_other_modes_stay() {
+        let local = local_entry(5, Some("2026-04-22T10:00:00Z"), None);
+        let remote = remote_entry(20, Some("2026-04-21T10:00:00Z"), None);
+
+        let upload = decide_upload(
+            &local,
+            Some(&remote),
+            DeltaPolicy::Mtime,
+            ConflictMode::Newer,
+        );
+        let download = decide_download(
+            &remote,
+            Some(&local),
+            DeltaPolicy::Mtime,
+            ConflictMode::Newer,
+            false,
+        );
+        assert!(matches!(upload.action, SyncTreeAction::Copy));
+        assert_eq!(skip_reason(&download.action), "local is newer");
+
+        let local = local_entry(5, None, None);
+        let remote = remote_entry(20, None, None);
+        assert!(matches!(
+            decide_upload(
+                &local,
+                Some(&remote),
+                DeltaPolicy::SizeOnly,
+                ConflictMode::Larger
+            )
+            .action,
+            SyncTreeAction::Skip(_)
+        ));
+        assert!(matches!(
+            decide_download(
+                &remote,
+                Some(&local),
+                DeltaPolicy::SizeOnly,
+                ConflictMode::Larger,
+                false
+            )
+            .action,
+            SyncTreeAction::Copy
+        ));
+        assert_eq!(
+            skip_reason(
+                &decide_upload(
+                    &local,
+                    Some(&remote),
+                    DeltaPolicy::SizeOnly,
+                    ConflictMode::Skip
+                )
+                .action
+            ),
+            "conflict skip"
+        );
+        assert_eq!(
+            skip_reason(
+                &decide_download(
+                    &remote,
+                    Some(&local),
+                    DeltaPolicy::SizeOnly,
+                    ConflictMode::Skip,
+                    false
+                )
+                .action
+            ),
+            "conflict skip"
+        );
+    }
+
+    /// Limit: without a timestamp and without a size difference there is
+    /// nothing to decide, so the pair stays a skip.
+    #[test]
+    fn newer_without_timestamp_or_size_difference_stays_a_skip() {
+        let local = local_entry(10, None, None);
+        let remote = remote_entry(10, None, None);
+        for policy in [DeltaPolicy::SizeOnly, DeltaPolicy::Mtime] {
+            assert_eq!(
+                skip_reason(
+                    &decide_upload(&local, Some(&remote), policy, ConflictMode::Newer).action
+                ),
+                "identical size",
+                "{policy:?}"
+            );
+            assert_eq!(
+                skip_reason(
+                    &decide_download(&remote, Some(&local), policy, ConflictMode::Newer, false)
+                        .action
+                ),
+                "identical size",
+                "{policy:?}"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/transfer_dag_sync.rs
+++ b/src-tauri/src/transfer_dag_sync.rs
@@ -1895,9 +1895,9 @@ mod tests {
 
     #[test]
     fn plan_both_direction_resolves_conflict_via_upload_then_skips_download() {
-        // A file on both sides with different sizes: the upload pass resolves
-        // it (ConflictMode::Newer always copies), and the download pass must
-        // then skip it as already handled.
+        // A file on both sides with different sizes and no timestamp: the
+        // upload pass copies because the local file is larger, and the
+        // download pass then skips it as already handled.
         let locals = vec![local("conflict.txt", 100)];
         let remotes = vec![remote("conflict.txt", 50)];
         let plan = plan_sync_dag(&locals, &remotes, &opts(SyncDirection::Both));
@@ -1908,6 +1908,27 @@ mod tests {
         assert_eq!(plan.skips.len(), 1);
         assert_eq!(plan.skips[0].apply_op, "download");
         assert_eq!(plan.skips[0].rel, "conflict.txt");
+    }
+
+    #[test]
+    fn plan_both_direction_downloads_when_the_remote_is_larger_without_timestamp() {
+        // The other half of the pair: Newer with no timestamp used to copy
+        // on upload and skip on download even when the remote was larger.
+        let locals = vec![local("conflict.txt", 50)];
+        let remotes = vec![remote("conflict.txt", 100)];
+        let plan = plan_sync_dag(&locals, &remotes, &opts(SyncDirection::Both));
+
+        assert_eq!(plan.transfers.len(), 1);
+        assert_eq!(plan.transfers[0].op, "download");
+        assert_eq!(plan.transfers[0].rel, "conflict.txt");
+        assert_eq!(plan.skips.len(), 1);
+        assert_eq!(plan.skips[0].apply_op, "upload");
+        assert_eq!(plan.skips[0].rel, "conflict.txt");
+        assert!(
+            plan.skips[0].reason.contains("timestamp"),
+            "{}",
+            plan.skips[0].reason
+        );
     }
 
     #[test]


### PR DESCRIPTION
## The defect

`--conflict-mode newer` with no usable timestamp fell through to the size decision, where the two directions disagreed:

- `decide_upload_by_size`: `ConflictMode::Newer => Copy` (always)
- `decide_download_by_size`: `ConflictMode::Newer => Skip("newer mode prefers existing local")` (never)

The same pair then resolved in opposite directions. A two-way run preferred the local file in silence. The skip text named the effect, not the cause. That path is the normal one on backends that return `modified: None` (FileLu is named in the same file).

## Fix (D28)

House rule: the newer file wins, and on a tie the larger one. With no timestamp the first half does not apply, so Newer now follows Larger in both directions. The skip names the cause: the timestamp was missing or unreadable, and size decided.

Equal timestamps still fall back to size, as they did and as the `ConflictMode::Larger` comment from #794 already describes. Newer on that path is the same Larger rule, so a tied pair is no longer direction-dependent.

Larger and Skip are untouched.

## Limit, not solved here

When the sizes are equal too, there is nothing to decide and the pair stays a skip (`identical size`).

## Behaviour change

On a provider without mtime, `--conflict-mode newer` used to mean "local always wins". It now means "the larger file wins", in both directions. Anyone depending on the old effect will see downloads of a larger remote that used to be skipped.

## Tests

Red before the fix, with the previous arms still in place:

```
newer_without_timestamp_picks_the_larger_file_in_both_directions
  left: "newer mode prefers existing local"
  right: "timestamp missing or unreadable, size decides: local is larger"
newer_without_timestamp_two_way_legs_do_not_contradict
  assertion failed: matches!(upload.action, SyncTreeAction::Skip(_))
  (upload of the smaller local still copied)
newer_without_timestamp_or_size_difference_stays_a_skip ... ok
FAILED. 1 passed; 2 failed
```

Green after: those three, `newer_with_timestamps_still_decides_by_mtime_and_other_modes_stay` (mtime still wins when present; Larger and Skip unchanged), `plan_both_direction_downloads_when_the_remote_is_larger_without_timestamp` (DAG two-way run), and the existing local-larger DAG neighbour.