### PR TITLE
fix(ai): the local agent tools report what they could not read

### DIFF
--- a/src-tauri/src/ai_core/local_tools.rs
+++ b/src-tauri/src/ai_core/local_tools.rs
@@ -238,27 +238,42 @@ pub async fn local_list(ctx: &dyn ToolCtx, args: &Value) -> Result<Value, ToolEr
     // is told the real total and whether the 100-entry listing was capped,
     // mirroring remote list_files. Metadata is only read for the kept entries.
     const LIST_CAP: usize = 100;
-    let all: Vec<std::fs::DirEntry> = std::fs::read_dir(&path)
-        .map_err(|e| {
-            ToolError::Exec(format!(
-                "Failed to read directory '{}' (resolved from '{}'): {}",
-                path, raw, e
-            ))
-        })?
-        .filter_map(|e| e.ok())
-        .collect();
+    // An entry the listing could not read is not a zero-byte file. A dirent the
+    // directory refuses to yield, and one whose metadata cannot be read, are
+    // counted in `unreadable`, and the row carries the error instead of a size
+    // and a type that were never learned: `is_dir: false, size: 0` reads as a
+    // fact about the file, and it was a fact about the failure.
+    let mut unreadable: u64 = 0;
+    let mut all: Vec<std::fs::DirEntry> = Vec::new();
+    for entry in std::fs::read_dir(&path).map_err(|e| {
+        ToolError::Exec(format!(
+            "Failed to read directory '{}' (resolved from '{}'): {}",
+            path, raw, e
+        ))
+    })? {
+        match entry {
+            Ok(entry) => all.push(entry),
+            Err(_) => unreadable += 1,
+        }
+    }
     let total = all.len();
     let truncated = total > LIST_CAP;
     let entries: Vec<Value> = all
         .into_iter()
         .take(LIST_CAP)
         .map(|e| {
-            let meta = e.metadata().ok();
-            json!({
-                "name": e.file_name().to_string_lossy(),
-                "is_dir": meta.as_ref().map(|m| m.is_dir()).unwrap_or(false),
-                "size": meta.as_ref().map(|m| m.len()).unwrap_or(0),
-            })
+            let mut row = json!({ "name": e.file_name().to_string_lossy() });
+            match e.metadata() {
+                Ok(meta) => {
+                    row["is_dir"] = json!(meta.is_dir());
+                    row["size"] = json!(meta.len());
+                }
+                Err(error) => {
+                    unreadable += 1;
+                    row["error"] = json!(error.to_string());
+                }
+            }
+            row
         })
         .collect();
 
@@ -266,6 +281,7 @@ pub async fn local_list(ctx: &dyn ToolCtx, args: &Value) -> Result<Value, ToolEr
         "entries": entries,
         "total": total,
         "truncated": truncated,
+        "unreadable": unreadable,
     }))
 }
 
@@ -295,28 +311,44 @@ pub async fn local_search(ctx: &dyn ToolCtx, args: &Value) -> Result<Value, Tool
     // count, and `truncated` must flag when the 100-result cap was hit, so the
     // agent never reasons over a partial listing as if it were complete.
     const SEARCH_CAP: usize = 100;
-    let all_matches: Vec<std::fs::DirEntry> = std::fs::read_dir(&path)
-        .map_err(|e| {
-            ToolError::Exec(format!(
-                "Failed to read directory '{}' (resolved from '{}'): {}",
-                path, raw, e
-            ))
-        })?
-        .filter_map(|e| e.ok())
-        .filter(|e| matcher(&e.file_name().to_string_lossy().to_lowercase()))
-        .collect();
+    // Same reading as `local_list`: a name that could not be read is reported,
+    // not rendered as an empty file. A dirent the directory refuses to yield
+    // cannot be matched against the pattern either, so it is counted even
+    // though nothing can say whether it would have matched.
+    let mut unreadable: u64 = 0;
+    let mut all_matches: Vec<std::fs::DirEntry> = Vec::new();
+    for entry in std::fs::read_dir(&path).map_err(|e| {
+        ToolError::Exec(format!(
+            "Failed to read directory '{}' (resolved from '{}'): {}",
+            path, raw, e
+        ))
+    })? {
+        match entry {
+            Ok(entry) if matcher(&entry.file_name().to_string_lossy().to_lowercase()) => {
+                all_matches.push(entry)
+            }
+            Ok(_) => {}
+            Err(_) => unreadable += 1,
+        }
+    }
     let total = all_matches.len();
     let truncated = total > SEARCH_CAP;
     let results: Vec<Value> = all_matches
         .into_iter()
         .take(SEARCH_CAP)
         .map(|e| {
-            let meta = e.metadata().ok();
-            json!({
-                "name": e.file_name().to_string_lossy(),
-                "is_dir": meta.as_ref().map(|m| m.is_dir()).unwrap_or(false),
-                "size": meta.as_ref().map(|m| m.len()).unwrap_or(0),
-            })
+            let mut row = json!({ "name": e.file_name().to_string_lossy() });
+            match e.metadata() {
+                Ok(meta) => {
+                    row["is_dir"] = json!(meta.is_dir());
+                    row["size"] = json!(meta.len());
+                }
+                Err(error) => {
+                    unreadable += 1;
+                    row["error"] = json!(error.to_string());
+                }
+            }
+            row
         })
         .collect();
 
@@ -324,6 +356,7 @@ pub async fn local_search(ctx: &dyn ToolCtx, args: &Value) -> Result<Value, Tool
         "results": results,
         "total": total,
         "truncated": truncated,
+        "unreadable": unreadable,
     }))
 }
 
@@ -882,18 +915,35 @@ pub async fn local_disk_usage(ctx: &dyn ToolCtx, args: &Value) -> Result<Value, 
         let mut entry_count: u64 = 0;
         let base = std::path::Path::new(&path_for_walk);
 
+        // A total that leaves out a directory the walk could not open, or a file
+        // whose size it could not read, is smaller than the tree and says
+        // nothing about it. Both are counted, and the cap is reported, so the
+        // number is readable as a lower bound rather than as the answer.
+        let mut unreadable: u64 = 0;
+        let mut truncated = false;
+
         for entry in walkdir::WalkDir::new(&path_for_walk)
             .follow_links(false)
             .max_depth(100)
             .into_iter()
-            .filter_map(|e| e.ok())
         {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(_) => {
+                    unreadable += 1;
+                    continue;
+                }
+            };
             entry_count += 1;
             if entry_count > MAX_ENTRIES {
+                truncated = true;
                 break;
             }
             if entry.file_type().is_file() {
-                total_bytes += entry.metadata().map(|m| m.len()).unwrap_or(0);
+                match entry.metadata() {
+                    Ok(meta) => total_bytes += meta.len(),
+                    Err(_) => unreadable += 1,
+                }
                 file_count += 1;
             } else if entry.file_type().is_dir() && entry.path() != base {
                 dir_count += 1;
@@ -906,6 +956,8 @@ pub async fn local_disk_usage(ctx: &dyn ToolCtx, args: &Value) -> Result<Value, 
             "total_human": format!("{:.1} MB", total_bytes as f64 / 1_048_576.0),
             "file_count": file_count,
             "dir_count": dir_count,
+            "unreadable": unreadable,
+            "truncated": truncated,
         })
     })
     .await
@@ -940,7 +992,7 @@ pub async fn local_find_duplicates(ctx: &dyn ToolCtx, args: &Value) -> Result<Va
 
     let path_for_scan = path.clone();
     tokio::task::spawn_blocking(move || -> Result<Value, ToolError> {
-        let engine_groups = crate::dedupe::find_similar_in_dir(
+        let (engine_groups, health) = crate::dedupe::find_similar_in_dir_checked(
             std::path::Path::new(&path_for_scan),
             sim_mode,
             distance,
@@ -984,12 +1036,18 @@ pub async fn local_find_duplicates(ctx: &dyn ToolCtx, args: &Value) -> Result<Va
             .map(|d| d["wasted_bytes"].as_u64().unwrap_or(0))
             .sum();
 
+        // This list is the one an agent deletes from, so an empty answer has to
+        // be readable as "nothing matched" and never as "nothing was left out".
+        // The two counters are always present, zero included: a caller that has
+        // to check for a missing key will not check.
         let mut resp = json!({
             "groups": duplicates.len(),
             "total_wasted_bytes": total_wasted,
             "total_wasted_human": format!("{:.1} MB", total_wasted as f64 / 1_048_576.0),
             "duplicates": duplicates,
             "similarity": sim_mode.as_str(),
+            "unreadable": health.unreadable,
+            "truncated": health.truncated,
         });
         if let Some(d) = distance {
             resp["distance"] = json!(d);
@@ -1095,18 +1153,34 @@ pub async fn local_grep(_ctx: &dyn ToolCtx, args: &Value) -> Result<Value, ToolE
         let mut files_searched: u32 = 0;
         const MAX_FILE_SIZE: u64 = 10_485_760;
 
+        // "No match" has to mean the file was read and did not match. A file the
+        // walk could not reach, could not stat or could not open was never
+        // searched, and is counted instead of being folded into the same answer.
+        // A binary file or one that is not UTF-8 is not an error: it was read,
+        // and this tool does not search it.
+        let mut unreadable: u64 = 0;
+
         for entry in walkdir::WalkDir::new(&path_for_grep)
             .follow_links(false)
             .into_iter()
-            .filter_map(|e| e.ok())
         {
             if matches.len() >= max_results {
                 break;
             }
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(_) => {
+                    unreadable += 1;
+                    continue;
+                }
+            };
             let entry_path = entry.path();
             let meta = match entry.metadata() {
                 Ok(m) => m,
-                Err(_) => continue,
+                Err(_) => {
+                    unreadable += 1;
+                    continue;
+                }
             };
             if !meta.is_file() || meta.len() > MAX_FILE_SIZE {
                 continue;
@@ -1122,7 +1196,10 @@ pub async fn local_grep(_ctx: &dyn ToolCtx, args: &Value) -> Result<Value, ToolE
 
             let bytes = match std::fs::read(entry_path) {
                 Ok(b) => b,
-                Err(_) => continue,
+                Err(_) => {
+                    unreadable += 1;
+                    continue;
+                }
             };
             let check_len = bytes.len().min(8192);
             if bytes[..check_len].contains(&0) {
@@ -1166,6 +1243,7 @@ pub async fn local_grep(_ctx: &dyn ToolCtx, args: &Value) -> Result<Value, ToolE
             "pattern": pattern_for_result,
             "total_matches": matches.len(),
             "files_searched": files_searched,
+            "unreadable": unreadable,
             "matches": matches,
         }))
     })
@@ -1484,15 +1562,31 @@ pub async fn local_tree(ctx: &dyn ToolCtx, args: &Value) -> Result<Value, ToolEr
         file_count: &mut u32,
         dir_count: &mut u32,
         total_size: &mut u64,
+        unreadable: &mut u64,
         max_entries: usize,
     ) {
         if depth >= max_depth || lines.len() >= max_entries {
             return;
         }
-        let mut entries: Vec<_> = match std::fs::read_dir(dir) {
-            Ok(e) => e.filter_map(|e| e.ok()).collect(),
-            Err(_) => return,
-        };
+        // A directory that cannot be opened is drawn as if it were empty, which
+        // is the one thing the tree must not say about it. Count it, and the
+        // entries inside a directory that lists but cannot be entered, so the
+        // shape the agent reads is not quietly smaller than the tree.
+        let mut entries: Vec<_> = Vec::new();
+        match std::fs::read_dir(dir) {
+            Ok(read) => {
+                for entry in read {
+                    match entry {
+                        Ok(entry) => entries.push(entry),
+                        Err(_) => *unreadable += 1,
+                    }
+                }
+            }
+            Err(_) => {
+                *unreadable += 1;
+                return;
+            }
+        }
         entries.sort_by_key(|e| {
             let is_dir = e.file_type().map(|t| t.is_dir()).unwrap_or(false);
             (!is_dir, e.file_name().to_string_lossy().to_lowercase())
@@ -1525,7 +1619,10 @@ pub async fn local_tree(ctx: &dyn ToolCtx, args: &Value) -> Result<Value, ToolEr
 
             let meta = match entry.metadata() {
                 Ok(m) => m,
-                Err(_) => continue,
+                Err(_) => {
+                    *unreadable += 1;
+                    continue;
+                }
             };
 
             if meta.is_dir() {
@@ -1542,6 +1639,7 @@ pub async fn local_tree(ctx: &dyn ToolCtx, args: &Value) -> Result<Value, ToolEr
                     file_count,
                     dir_count,
                     total_size,
+                    unreadable,
                     max_entries,
                 );
             } else if meta.is_file() {
@@ -1564,6 +1662,7 @@ pub async fn local_tree(ctx: &dyn ToolCtx, args: &Value) -> Result<Value, ToolEr
         }
     }
 
+    let mut unreadable: u64 = 0;
     build_tree(
         base_path,
         "",
@@ -1575,6 +1674,7 @@ pub async fn local_tree(ctx: &dyn ToolCtx, args: &Value) -> Result<Value, ToolEr
         &mut file_count,
         &mut dir_count,
         &mut total_size,
+        &mut unreadable,
         MAX_ENTRIES,
     );
 
@@ -1590,6 +1690,7 @@ pub async fn local_tree(ctx: &dyn ToolCtx, args: &Value) -> Result<Value, ToolEr
             "total_size_human": total_human,
         },
         "truncated": tree_lines.len() >= MAX_ENTRIES,
+        "unreadable": unreadable,
     }))
 }
 

--- a/src-tauri/src/ai_core/tools.rs
+++ b/src-tauri/src/ai_core/tools.rs
@@ -2454,6 +2454,160 @@ mod tests {
         }
     }
 
+    /// A scratch tree for the read-error tests: `a.txt`, a directory the
+    /// current user cannot read at all (`locked/`, mode 000) and one it can
+    /// list but not enter (`sealed/`, mode 0400, where every stat fails), each
+    /// holding `keep.txt`. Permissions are restored on drop so the tree can be
+    /// removed.
+    #[cfg(unix)]
+    struct ReadErrorTree {
+        dir: tempfile::TempDir,
+    }
+
+    #[cfg(unix)]
+    impl ReadErrorTree {
+        fn new() -> Self {
+            use std::os::unix::fs::PermissionsExt;
+            let dir = tempfile::tempdir().expect("scratch directory");
+            std::fs::write(dir.path().join("a.txt"), vec![b'a'; 2048]).expect("a.txt");
+            for (name, mode) in [("locked", 0o000), ("sealed", 0o400)] {
+                let sub = dir.path().join(name);
+                std::fs::create_dir(&sub).expect("subdirectory");
+                std::fs::write(sub.join("keep.txt"), vec![b'k'; 2048]).expect("keep.txt");
+                std::fs::set_permissions(&sub, std::fs::Permissions::from_mode(mode))
+                    .expect("set permissions");
+            }
+            let tree = Self { dir };
+            assert!(
+                std::fs::read_dir(tree.dir.path().join("locked")).is_err()
+                    && std::fs::symlink_metadata(tree.dir.path().join("sealed").join("keep.txt"))
+                        .is_err(),
+                "these tests need a user that cannot read a 000 directory or enter a 0400 one, and root does both"
+            );
+            tree
+        }
+
+        fn path(&self) -> String {
+            self.dir.path().to_string_lossy().into_owned()
+        }
+
+        fn sealed(&self) -> String {
+            self.dir
+                .path()
+                .join("sealed")
+                .to_string_lossy()
+                .into_owned()
+        }
+    }
+
+    #[cfg(unix)]
+    impl Drop for ReadErrorTree {
+        fn drop(&mut self) {
+            use std::os::unix::fs::PermissionsExt;
+            for name in ["locked", "sealed"] {
+                let _ = std::fs::set_permissions(
+                    self.dir.path().join(name),
+                    std::fs::Permissions::from_mode(0o755),
+                );
+            }
+        }
+    }
+
+    /// Run a tool the way an agent on the CLI does, and return its output.
+    async fn run_cli_tool(name: &str, args: Value) -> Value {
+        dispatch_tool(&mock_ctx(Surfaces::CLI), name, &args)
+            .await
+            .unwrap_or_else(|e| panic!("{name} failed: {e}"))
+    }
+
+    /// `local_list` over a directory whose entries cannot be statted must say
+    /// so: an entry it could not read is not a zero-byte file. The listing
+    /// counts it and marks the entry.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn local_list_reports_entries_it_cannot_stat() {
+        let tree = ReadErrorTree::new();
+
+        let out = run_cli_tool("local_list", json!({ "path": tree.sealed() })).await;
+
+        assert_eq!(out["unreadable"], 1, "output: {out}");
+        let entry = &out["entries"][0];
+        assert_eq!(entry["name"], "keep.txt");
+        assert!(
+            entry["error"].is_string(),
+            "the entry carries its error: {out}"
+        );
+    }
+
+    /// `local_search` has the same listing and must report the same way.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn local_search_reports_matches_it_cannot_stat() {
+        let tree = ReadErrorTree::new();
+
+        let out = run_cli_tool(
+            "local_search",
+            json!({ "path": tree.sealed(), "pattern": "keep" }),
+        )
+        .await;
+
+        assert_eq!(out["unreadable"], 1, "output: {out}");
+        assert!(out["results"][0]["error"].is_string(), "output: {out}");
+    }
+
+    /// `local_disk_usage` must not present a total that silently leaves out a
+    /// directory it could not read and a file it could not stat.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn local_disk_usage_reports_what_it_could_not_read() {
+        let tree = ReadErrorTree::new();
+
+        let out = run_cli_tool("local_disk_usage", json!({ "path": tree.path() })).await;
+
+        assert_eq!(out["unreadable"], 2, "output: {out}");
+        assert_eq!(out["truncated"], false, "output: {out}");
+    }
+
+    /// `local_grep` must not present "no match" for files it never read.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn local_grep_reports_files_it_could_not_read() {
+        let tree = ReadErrorTree::new();
+
+        let out = run_cli_tool("local_grep", json!({ "path": tree.path(), "pattern": "k" })).await;
+
+        assert_eq!(out["unreadable"], 2, "output: {out}");
+    }
+
+    /// `local_tree` must not draw a directory it could not read as empty, nor
+    /// drop an entry it could not stat, without saying so.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn local_tree_reports_what_it_could_not_read() {
+        let tree = ReadErrorTree::new();
+
+        let out = run_cli_tool("local_tree", json!({ "path": tree.path() })).await;
+
+        assert_eq!(out["unreadable"], 2, "output: {out}");
+    }
+
+    /// `local_find_duplicates` is the list an agent may delete from: it must
+    /// say when files were left out because they could not be read.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn local_find_duplicates_reports_files_it_could_not_read() {
+        let tree = ReadErrorTree::new();
+
+        let out = run_cli_tool(
+            "local_find_duplicates",
+            json!({ "path": tree.path(), "min_size": 1 }),
+        )
+        .await;
+
+        assert_eq!(out["unreadable"], 2, "output: {out}");
+        assert_eq!(out["truncated"], false, "output: {out}");
+    }
+
     #[tokio::test]
     async fn dispatch_unknown_tool_returns_unknown_error() {
         let ctx = mock_ctx(Surfaces::GUI);

--- a/src-tauri/src/dedupe/mod.rs
+++ b/src-tauri/src/dedupe/mod.rs
@@ -303,7 +303,21 @@ pub fn find_similar_local(
     distance: Option<u32>,
     min_size: Option<u64>,
 ) -> Vec<DuplicateGroup> {
-    find_similar_local_with_progress(paths, mode, distance, min_size, &mut |_| {})
+    find_similar_local_checked(paths, mode, distance, min_size, &mut |_| {}).0
+}
+
+/// What a duplicate scan could not read, alongside the groups it found.
+///
+/// A group list is the input to a delete: what it leaves out therefore matters
+/// as much as what it holds. `unreadable` counts the files whose size or
+/// content the pass could not read, so they were never compared with anything;
+/// `truncated` says the pass stopped before the end (the walk's file cap, or
+/// the read budget of the signature pass). Neither is a failure of the scan,
+/// and both make its answer a lower bound.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct DedupeHealth {
+    pub unreadable: u64,
+    pub truncated: bool,
 }
 
 /// `find_similar_local` with a progress callback, called once per file whose
@@ -317,22 +331,44 @@ pub fn find_similar_local_with_progress(
     min_size: Option<u64>,
     on_progress: &mut dyn FnMut(DedupeProgress),
 ) -> Vec<DuplicateGroup> {
+    find_similar_local_checked(paths, mode, distance, min_size, on_progress).0
+}
+
+/// `find_similar_local_with_progress` and the health of the pass that produced
+/// the groups. The two functions above are the same call with the health
+/// dropped, kept because their callers do not report it yet: the GUI dedupe
+/// panel, which needs translated strings to say it, and two callers that scan
+/// files they have just written themselves.
+pub fn find_similar_local_checked(
+    paths: &[PathBuf],
+    mode: SimilarityMode,
+    distance: Option<u32>,
+    min_size: Option<u64>,
+    on_progress: &mut dyn FnMut(DedupeProgress),
+) -> (Vec<DuplicateGroup>, DedupeHealth) {
     let min = min_size.unwrap_or(1);
     let files_total = paths.len() as u64;
     let mut files_processed: u64 = 0;
     let mut bytes_processed: u64 = 0;
     let mut files_skipped: u64 = 0;
+    let mut health = DedupeHealth::default();
 
-    match mode {
+    let result = match mode {
         SimilarityMode::Exact => {
             // Size prefilter + blake3 (matches GUI current shape)
             let mut size_groups: HashMap<u64, Vec<PathBuf>> = HashMap::new();
             for p in paths {
-                if let Ok(meta) = std::fs::metadata(p) {
-                    let sz = meta.len();
-                    if sz >= min {
-                        size_groups.entry(sz).or_default().push(p.clone());
+                // A file below `min` was read and left out on purpose. One whose
+                // size cannot be read was not left out, it was never seen, and
+                // only the second is a gap in the answer.
+                match std::fs::metadata(p) {
+                    Ok(meta) => {
+                        let sz = meta.len();
+                        if sz >= min {
+                            size_groups.entry(sz).or_default().push(p.clone());
+                        }
                     }
+                    Err(_) => health.unreadable += 1,
                 }
             }
             let mut hash_groups: HashMap<String, (u64, Vec<String>)> = HashMap::new();
@@ -341,12 +377,16 @@ pub fn find_similar_local_with_progress(
                     continue;
                 }
                 for f in files {
-                    if let Ok(h) = compute_blake3(&f) {
-                        hash_groups
+                    // A file that cannot be hashed cannot be grouped, so it is
+                    // absent from every group: the same absence as a file that
+                    // has no duplicate, and not the same fact.
+                    match compute_blake3(&f) {
+                        Ok(h) => hash_groups
                             .entry(h)
                             .or_insert_with(|| (sz, Vec::new()))
                             .1
-                            .push(f.to_string_lossy().to_string());
+                            .push(f.to_string_lossy().to_string()),
+                        Err(_) => health.unreadable += 1,
                     }
                     files_processed += 1;
                     bytes_processed += sz;
@@ -412,7 +452,20 @@ pub fn find_similar_local_with_progress(
             for p in paths {
                 let sz = match std::fs::metadata(p) {
                     Ok(meta) if meta.len() >= min => meta.len(),
-                    _ => {
+                    // Same distinction as the exact pass: below `min` is a
+                    // choice, a size that cannot be read is a gap.
+                    Ok(_) => {
+                        files_processed += 1;
+                        on_progress(DedupeProgress {
+                            files_processed,
+                            bytes_processed,
+                            files_total,
+                            files_skipped,
+                        });
+                        continue;
+                    }
+                    Err(_) => {
+                        health.unreadable += 1;
                         files_processed += 1;
                         on_progress(DedupeProgress {
                             files_processed,
@@ -442,6 +495,7 @@ pub fn find_similar_local_with_progress(
                 let bytes = match std::fs::read(p) {
                     Ok(b) => b,
                     Err(_) => {
+                        health.unreadable += 1;
                         // Counted whether or not the read succeeded: the tick
                         // tracks how far through the list we are, not how many
                         // files worked.
@@ -711,17 +765,18 @@ pub fn find_similar_local_with_progress(
 
             result
         }
-    }
+    };
+    (result, health)
 }
 
 /// Convenience: scan a directory (local) and find duplicates. Mirrors the 2-phase
 /// shape of existing find_duplicate_files but adds non-identical path.
-pub fn find_similar_in_dir(
+pub fn find_similar_in_dir_checked(
     root: &Path,
     mode: SimilarityMode,
     distance: Option<u32>,
     min_size: Option<u64>,
-) -> Result<Vec<DuplicateGroup>, String> {
+) -> Result<(Vec<DuplicateGroup>, DedupeHealth), String> {
     if !root.is_dir() {
         return Err("Path is not a directory".to_string());
     }
@@ -729,24 +784,40 @@ pub fn find_similar_in_dir(
     const MAX_FILES: u64 = 100_000;
     let mut collected: Vec<PathBuf> = Vec::new();
     let mut count = 0u64;
+    let mut walk_unreadable: u64 = 0;
+    let mut truncated = false;
 
     for entry in walkdir::WalkDir::new(root)
         .follow_links(false)
         .max_depth(100)
         .into_iter()
-        .filter_map(|e| e.ok())
     {
+        // A directory the walk cannot open, or a file it cannot stat, never
+        // reaches the comparison: it is not a file without duplicates, it is a
+        // file nothing was compared against.
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(_) => {
+                walk_unreadable += 1;
+                continue;
+            }
+        };
         if !entry.file_type().is_file() {
             continue;
         }
         count += 1;
         if count > MAX_FILES {
+            truncated = true;
             break;
         }
         collected.push(entry.into_path());
     }
 
-    Ok(find_similar_local(&collected, mode, distance, min_size))
+    let (groups, mut health) =
+        find_similar_local_checked(&collected, mode, distance, min_size, &mut |_| {});
+    health.unreadable += walk_unreadable;
+    health.truncated = health.truncated || truncated;
+    Ok((groups, health))
 }
 
 #[cfg(test)]

--- a/src-tauri/src/filesystem.rs
+++ b/src-tauri/src/filesystem.rs
@@ -1958,8 +1958,9 @@ pub async fn find_duplicate_files(
 
     // Phase 0: one walk for both modes, so the progress the user sees is the
     // same shape whichever mode they picked. Non-identical used to let the
-    // engine do its own walk (find_similar_in_dir); it now gets the file list
-    // from here and reports its own analysis pass through the callback below.
+    // engine do its own walk (`find_similar_in_dir_checked`, which the agent
+    // tool still uses); it now gets the file list from here and reports its own
+    // analysis pass through the callback below.
     let walk_started = std::time::Instant::now();
     let mut last_emit = walk_started;
     let mut walked: Vec<(PathBuf, u64)> = Vec::new();


### PR DESCRIPTION
## The defect

Six tools an agent runs over a local tree answered as if every directory had opened and every file had been statted. Each wrong answer had exactly the shape of a right one, which is what makes this worth fixing rather than logging.

Run against a tree holding `a.txt`, a directory the user cannot read at all (mode 000) and one it can list but not enter (mode 0400, where every stat fails), the tools said:

```
local_list    {"entries":[{"is_dir":false,"name":"keep.txt","size":0}],"total":1,"truncated":false}
local_tree    {"tree":"...\n├── locked/\n├── sealed/\n└── a.txt (2.0 KB)","stats":{"dirs":2,"files":1,...}}
local_grep    {"files_searched":1,"matches":[],"total_matches":0,...}
local_disk_usage      {"dir_count":2,"file_count":2,"total_bytes":2048,...}
local_search  {"results":[{"is_dir":false,"name":"keep.txt","size":0}],"total":1,...}
local_find_duplicates {"duplicates":[],"groups":0,"total_wasted_bytes":0,...}
```

`local_list` presented an entry it could not read as a zero-byte file. `local_tree` drew a directory it could not open as an empty one. `local_grep` answered "no match" over files it never opened. And `local_find_duplicates`, whose output is the list an agent deletes from, answered "no duplicates" having skipped two files: there an empty answer is not missing information, it reads as permission to proceed.

## Fix

Every tool now reports what it could not read, in its output rather than only in a log.

- `local_list` and `local_search` count the dirents the directory would not yield and the entries they could not stat, and the row carries the error instead of `is_dir: false, size: 0`, which reads as a fact about the file when it was a fact about the failure.
- `local_disk_usage` counts walk errors and sizes it could not read, and gains `truncated` for its 500k entry cap, so its total is readable as a lower bound.
- `local_grep` counts what it could not reach, stat or open. A binary file, or one that is not UTF-8, is NOT in that count: it was read, and this tool does not search it.
- `local_tree` counts the directories it could not open and the entries it could not stat, through a counter threaded into the recursive walk.
- `local_find_duplicates` gains `unreadable` and `truncated`, always present, zero included, because a caller that has to check for a missing key will not check.

### Why `local_find_duplicates` reports rather than refuses

It is the most dangerous of the six, so it is worth saying why it still answers. The groups it finds are true, and the files it could not read are absent from every group, so nothing in the list is unsafe to act on. What was missing was any way for the caller to know the list was partial, and that is what the two counters restore. Refusing would also withdraw the true groups, which is a worse trade for a read-only tool whose caller can now see the gap.

### The engine

`src/dedupe/mod.rs` grew `DedupeHealth { unreadable, truncated }`, with `find_similar_local_checked` and `find_similar_in_dir_checked` as the entry points that return it. They count the walk errors, the sizes that could not be read, the files that could not be hashed, the reads that failed in the signature pass, and the two caps (100k files in the walk, the read budget of the signature pass).

A file below `min_size` is deliberately NOT counted: it was read and left out on purpose, which is not the same as never seen. The two are one `_` arm apart in the original code, and separating them is most of the point.

`find_similar_local` and `find_similar_local_with_progress` remain as the same call with the health dropped, for the three callers that cannot report it yet: the GUI dedupe panel, which would need translated strings to say it, and two callers that scan files they have just written themselves.

One commit rather than the two the plan called for: the engine's entry point is renamed and its only caller is in the other file, so splitting them would leave a commit that does not compile.

## Tests

Six, driving the tools through `dispatch_tool` on the CLI surface, the path an agent actually takes, over the tree described above.

### Seen red on the test commit

```
test ai_core::tools::tests::local_list_reports_entries_it_cannot_stat ... FAILED
test ai_core::tools::tests::local_search_reports_matches_it_cannot_stat ... FAILED
test ai_core::tools::tests::local_disk_usage_reports_what_it_could_not_read ... FAILED
test ai_core::tools::tests::local_grep_reports_files_it_could_not_read ... FAILED
test ai_core::tools::tests::local_tree_reports_what_it_could_not_read ... FAILED
test ai_core::tools::tests::local_find_duplicates_reports_files_it_could_not_read ... FAILED

test result: FAILED. 0 passed; 6 failed
```

In all six the assertion is `left: Null, right: 1` or `2`: the field did not exist. The outputs quoted at the top of this description are from that run.

The branch was rebased onto the current base BEFORE that run, not after, so the red is on this lineage and not on the one the tests were written against.

### Green after the fix

```
ai_core::tools::tests::local_   6 passed; 0 failed
dedupe::                        8 passed; 0 failed
ai_core::                      65 passed; 0 failed
filesystem::                    8 passed; 0 failed
```

### Declared coverage limits

- The six tests are `#[cfg(unix)]` and need a non-root user: the fixture asserts that the 000 directory really cannot be read and the 0400 one really cannot be entered, so under root they fail with that message instead of passing without exercising anything.
- The GUI dedupe panel (`filesystem.rs`) and `sync_preview` (`gui_tools.rs`) have the same class of gap and are NOT in this change: the first needs translated strings to show a partial result, and the second cannot be driven through `dispatch_tool`, so a red test for it needs GUI state. Both are tracked separately.
- The three callers that keep the health-dropping wrappers are unchanged by design, named above.

## Documentation

No public document describes the output fields of these tools: `docs/AEROAGENT.md` and `docs/AEROAGENT-CAPABILITIES.md` list them by name, safety class and one-line description only. So there is no contract text to update here, unlike the CLI guide, which spells out the JSON of `check` and `sync-doctor`. The new fields are additive in any case: nothing is renamed or removed.

## Gates

- `cargo fmt --all -- --check`: rc 0
- `cargo test --lib` on the four filters above: 87 passed, 0 failed
- `cargo clippy --lib --tests -- -D warnings`: rc 0, run after `cargo clean -p aeroftp` so the lint pass recompiled the crate instead of answering from cache
- Frontend gates were not re-run and are not required by this head: Rust only, with no TypeScript, locale or provider catalog touched.

No CHANGELOG entry: the release notes are written from the tracker at release time.
