### PR TITLE
fix(ai): let the CLI reach the two tools it offers and refused

### DIFF
--- a/src-tauri/src/ai_core/tools.rs
+++ b/src-tauri/src/ai_core/tools.rs
@@ -2480,6 +2480,13 @@ mod tests {
     /// `NotOnSurface`, which the caller does not treat as a fallback, so the
     /// legacy arm that would have answered is never reached and the agent is
     /// told the tool it was just offered does not exist here.
+    ///
+    /// The assertion is deliberately the negative one, "not `NotOnSurface`",
+    /// and it must stay that way. Asserting success would be wrong twice: on a
+    /// mock context `hash_file` fails on a path that does not exist, and the
+    /// day these two are migrated into the dispatcher for real the answer stops
+    /// being the legacy handler's and the test would break for a change that is
+    /// an improvement. What is pinned here is reachability, not the reply.
     #[tokio::test]
     async fn the_cli_can_reach_every_tool_it_offers() {
         for name in ["app_info", "hash_file"] {

--- a/src-tauri/src/ai_core/tools.rs
+++ b/src-tauri/src/ai_core/tools.rs
@@ -1906,7 +1906,11 @@ pub static TOOL_DEFINITIONS: LazyLock<Vec<ToolDef>> = LazyLock::new(|| {
             description: "Get application version, OS, and connection status.",
             input_schema: json!({ "type": "object" }),
             danger: DangerLevel::Safe,
-            surfaces: Surfaces::GUI,
+            // The CLI offers this one to the model as well, so the CLI surface
+            // has to reach it: the dispatcher refuses a surface it does not
+            // declare, and that refusal is not a fallback, so the answer never
+            // arrives.
+            surfaces: local_surfaces,
         },
         ToolDef {
             name: "sync_control",
@@ -1941,7 +1945,9 @@ pub static TOOL_DEFINITIONS: LazyLock<Vec<ToolDef>> = LazyLock::new(|| {
             description: "Compute the hash of a local file.",
             input_schema: json!({ "type": "object" }),
             danger: DangerLevel::Safe,
-            surfaces: Surfaces::GUI,
+            // Offered by the CLI too, over a file `local_read` can already
+            // open. Same reason as `app_info` above.
+            surfaces: local_surfaces,
         },
         ToolDef {
             name: "generate_transfer_plan",

--- a/src-tauri/src/ai_core/tools.rs
+++ b/src-tauri/src/ai_core/tools.rs
@@ -2466,6 +2466,30 @@ mod tests {
         }
     }
 
+    /// A tool the CLI offers to the model has to be one the CLI can run.
+    ///
+    /// `app_info` and `hash_file` are advertised in the CLI's own tool list and
+    /// classified as read-only, but the registry declares them `Surfaces::GUI`
+    /// alone. On the CLI surface the dispatcher therefore answers
+    /// `NotOnSurface`, which the caller does not treat as a fallback, so the
+    /// legacy arm that would have answered is never reached and the agent is
+    /// told the tool it was just offered does not exist here.
+    #[tokio::test]
+    async fn the_cli_can_reach_every_tool_it_offers() {
+        for name in ["app_info", "hash_file"] {
+            let outcome = dispatch_tool(
+                &mock_ctx(Surfaces::CLI),
+                name,
+                &json!({ "path": "/nonexistent" }),
+            )
+            .await;
+            assert!(
+                !matches!(outcome, Err(ToolError::NotOnSurface { .. })),
+                "{name} is offered to the model on the CLI, so refusing it for the CLI surface leaves an advertised tool unusable: {outcome:?}"
+            );
+        }
+    }
+
     // NOTE: dispatch_on_wrong_surface / dispatch_missing_required /
     // dispatch_returns_not_migrated are intentionally deferred to
     // Gate 2 because they require at least one populated ToolDef.


### PR DESCRIPTION
## The defect

`aeroftp-cli` offers `app_info` and `hash_file` to the model in its own tool list, and classifies both as read-only with danger level 0. The tool registry declares them `Surfaces::GUI` alone.

The dispatcher refuses a tool for a surface it does not declare, and the caller treats only `Unknown` and `NotMigrated` as a reason to fall back to its legacy handler. `NotOnSurface` is neither, so it is returned to the agent: a tool that had just been advertised answers that it is not available here, while the code that would have served it sits unreachable a few hundred lines below.

```
NotOnSurface { tool: "app_info", surface: Surfaces(2) }
```

## Fix

Both entries now declare the same surfaces as the other local tools, `Surfaces::GUI | Surfaces::CLI`, each with a comment saying why: the CLI offers them, so the CLI surface has to reach them.

Widening the surface is the right direction here rather than dropping the advertisement, and the reasons are checkable rather than a matter of taste:

- `app_info` returns the version, the platform, the architecture and the working directory. Nothing leaves the machine.
- `hash_file` hashes a local file that `local_read` can already open.
- The CLI's own classification of both is `LocalReadonly` with danger level 0, so its own judgement is that they are harmless.

Nothing in the history shows a deliberate narrowing: `git log -S` finds no commit that restricted either name, and the CLI advertisement predates the registry entry that declares them. That is compatible with an oversight when the registry was populated, and it is not proof of intent, so it is stated as the former.

### Explicitly out of scope

`vault_peek` and `cross_profile_transfer` are also `Surfaces::GUI` in the registry, and they are NOT changed here. They are not in the set this fixes: the CLI does not advertise them, so the defect above does not apply to them. Widening the surface of a tool that reads the vault, or moves data between profiles, is a decision about the security perimeter rather than a maintenance line, and it is left to the owner.

The measurement that produced the set of two is worth stating, because a first attempt at it was wrong: the names the CLI advertises come from its own `tool!` list, and each one's surfaces come from the registry with the aliases resolved from their definitions (`local_surfaces` and `remote_surfaces` both contain `Surfaces::CLI`). A filter that looked for the string "CLI" inside the alias NAME returned all 39 advertised tools, which is the starting set wearing the costume of a result. With the aliases resolved, exactly two names are advertised without the CLI surface, and they are the two fixed here.

A second list, in `tool_exposure_kind`, looks like an inventory of offered tools and is not one: its callers classify a name that arrives, for approval and telemetry, and offer nothing. The six names that appear only there are not affected.

## Tests

One, committed before the fix and seen failing there.

`the_cli_can_reach_every_tool_it_offers` states the property rather than the two names' current state: a tool the CLI offers has to be one the CLI can reach. It calls the dispatcher on the CLI surface and asserts the answer is not `NotOnSurface`. Nothing is executed: with the fix in place the call gets as far as `NotMigrated`, which is the legacy handler's cue, and the test says so by what it does not assert.

### Seen red on the test commit

```
test ai_core::tools::tests::the_cli_can_reach_every_tool_it_offers ... FAILED
  app_info is offered to the model on the CLI, so refusing it for the CLI surface leaves an
  advertised tool unusable: Err(NotOnSurface { tool: "app_info", surface: Surfaces(2) })
```

### Green after the fix

```
ai_core::tools::tests::   11 passed; 0 failed
ai_core::                 60 passed; 0 failed
```

## Documentation

`docs/AEROAGENT.md`, `docs/AEROAGENT-CAPABILITIES.md`, `docs/PROTOCOL-FEATURES.md` and `docs/COMMAND-INVENTORY.json` all list both tools as available to an agent, with the safety class they have. Those documents described the intended behaviour all along: this change makes the code match them, so none of them needs an edit.

## Gates

- `cargo fmt --all -- --check`: rc 0
- `cargo test --lib` on the two filters above: 71 passed, 0 failed
- `cargo clippy --lib --tests -- -D warnings`: rc 0, run after `cargo clean -p aeroftp` so the lint pass recompiled the crate instead of answering from cache
- Frontend gates were not re-run and are not required by this head: one Rust file, with no TypeScript, locale or provider catalog touched.

No CHANGELOG entry: the release notes are written from the tracker at release time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Made the `app_info` and `hash_file` tools available through both the graphical interface and command-line interface.

* **Tests**
  * Added coverage confirming these tools are accepted when used from the command-line interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->