### PR TITLE
fix(mega): stop exists turning a failure into an absence

### DIFF
--- a/src-tauri/src/providers/mega.rs
+++ b/src-tauri/src/providers/mega.rs
@@ -863,11 +863,7 @@ impl StorageProvider for MegaCmdProvider {
 
     async fn exists(&mut self, p: &str) -> Result<bool, ProviderError> {
         let p = self.resolve_path(p);
-        match self.run_mega_cmd_with_reauth("mega-ls", &[&p]).await {
-            Ok(_) => Ok(true),
-            Err(ProviderError::NotFound(_)) => Ok(false),
-            Err(_) => Ok(false),
-        }
+        map_mega_exists(self.run_mega_cmd_with_reauth("mega-ls", &[&p]).await)
     }
 
     async fn keep_alive(&mut self) -> Result<(), ProviderError> {
@@ -1217,6 +1213,22 @@ impl MegaCmdProvider {
 }
 
 pub type MegaProvider = MegaCmdProvider;
+
+/// Turn a `mega-ls` probe into an existence answer.
+///
+/// Extracted so the decision can be exercised without MEGAcmd installed, the
+/// way the SFTP side is through `map_sftp_try_exists`. It has three arms and no
+/// classifier, which is where this provider differs from that one: MEGAcmd is a
+/// shellout, and `run_mega_cmd` has already turned its stderr into a typed
+/// `ProviderError` by the time the answer gets here. There is nothing left to
+/// classify, only something to keep and something to pass on.
+fn map_mega_exists(result: Result<String, ProviderError>) -> Result<bool, ProviderError> {
+    match result {
+        Ok(_) => Ok(true),
+        Err(ProviderError::NotFound(_)) => Ok(false),
+        Err(_) => Ok(false),
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src-tauri/src/providers/mega.rs
+++ b/src-tauri/src/providers/mega.rs
@@ -1225,8 +1225,16 @@ pub type MegaProvider = MegaCmdProvider;
 fn map_mega_exists(result: Result<String, ProviderError>) -> Result<bool, ProviderError> {
     match result {
         Ok(_) => Ok(true),
+        // The one failure that IS an answer. `ProviderError` documents the
+        // contract on the variant: a genuinely missing path arrives here as
+        // `NotFound`.
         Err(ProviderError::NotFound(_)) => Ok(false),
-        Err(_) => Ok(false),
+        // Everything else is not an answer. A refusal, a dropped session or a
+        // server error told us nothing about whether the path is there, and
+        // reporting `false` would tell the caller it is not: a present but
+        // unreadable root would read as missing, which is how a run decides
+        // there is nothing to keep.
+        Err(e) => Err(e),
     }
 }
 

--- a/src-tauri/src/providers/mega.rs
+++ b/src-tauri/src/providers/mega.rs
@@ -1235,6 +1235,53 @@ mod tests {
     use super::*;
     use crate::providers::MegaConnectionMode;
 
+    /// A listing that answered means the path is there.
+    #[test]
+    fn map_mega_exists_reports_a_listed_path_as_present() {
+        assert!(map_mega_exists(Ok("----  1  0  15Jan2026  14:30  a.txt".to_string())).unwrap());
+    }
+
+    /// And a path the command reported as missing is absent. `ProviderError`
+    /// documents this contract on its own variant: a genuinely missing path
+    /// arrives as `NotFound`, which is why this arm is kept rather than folded
+    /// into the one below.
+    #[test]
+    fn map_mega_exists_reports_a_missing_path_as_absent() {
+        assert!(!map_mega_exists(Err(ProviderError::NotFound("/gone".to_string()))).unwrap());
+    }
+
+    /// A refusal is not an absence. Answering `false` here tells a caller that
+    /// the path is not there, when what happened is that nobody was allowed to
+    /// look, and a preflight that reads a present-but-unreadable root as missing
+    /// is how a run decides there is nothing to keep.
+    ///
+    /// The error is passed on unchanged rather than reclassified: by the time it
+    /// reaches this function, `run_mega_cmd` has already read the command's
+    /// stderr and given it a type.
+    #[test]
+    fn map_mega_exists_does_not_turn_a_refusal_into_an_absence() {
+        let out = map_mega_exists(Err(ProviderError::PermissionDenied("denied".to_string())));
+        assert!(
+            matches!(out, Err(ProviderError::PermissionDenied(_))),
+            "a refusal must reach the caller as a refusal: {out:?}"
+        );
+    }
+
+    /// The same for a session that is gone: the answer is unknown, not "no".
+    #[test]
+    fn map_mega_exists_does_not_turn_a_lost_session_into_an_absence() {
+        let lost = map_mega_exists(Err(ProviderError::ConnectionLost("dropped".to_string())));
+        assert!(
+            matches!(lost, Err(ProviderError::ConnectionLost(_))),
+            "a dropped session must not read as absent: {lost:?}"
+        );
+        let never = map_mega_exists(Err(ProviderError::NotConnected));
+        assert!(
+            matches!(never, Err(ProviderError::NotConnected)),
+            "nor must a session that was never opened: {never:?}"
+        );
+    }
+
     fn test_provider() -> MegaCmdProvider {
         let config = MegaConfig {
             email: "u@example.com".to_string(),


### PR DESCRIPTION
## The defect

`exists()` on the MEGA provider answered `false` for every failure, not only for a missing path. The mapping was a single arm, `Err(_) => Ok(false)`, so a permission refusal, a dropped session and a server error all reached the caller as "the path is not there". A caller could not tell "it is absent" from "nobody was allowed to look", and the two mean opposite things to anything that decides what to keep.

## Why it matters: the call site that asks the question

`sync_core::scan::root_is_absent` exists precisely to tell those two apart, and its own comment says so: a listing failure does not distinguish them (SFTP reports every listing failure it does not classify as `NotFound`, and FTP answers 550 for a missing and for a forbidden directory alike), so the provider is asked directly, and "any answer but no leaves the root a gap".

That check asks exactly the right question. MEGA answered an easier one. The guard was written to be defeated only by a provider that genuinely knows the path is gone, and instead it was defeated by a provider that knew nothing.

Both directions of `ScanBoundaries::root_missing` are then wrong, in different ways. On the side a run writes to, a missing root is documented as an empty tree, so a sync into a directory it has yet to create can run: a MEGA destination whose root is present but unreadable is therefore planned against an empty picture of a directory that is actually populated. On the side a run reads from, `refuse_missing_source_roots` marks the scan unbounded as `source_root_missing` and refuses the run, which is a safe outcome reached for a false reason, and it sends whoever reads the refusal looking for a directory that is there.

The listing error itself is also suppressed on the way: `root_is_absent` returning true is what declares that the failed listing is "no gap", so the evidence that something went wrong is dropped at the same moment the wrong conclusion is drawn.

## The class, measured

Across the 55 provider files, an `Err(_)` arm that answers a yes/no question with `false` occurs exactly once, and it is this one; after the fix that count is zero.

Widening the shape to include `Ok(None)` finds two more arms, both in `ftp.rs`, and both are excluded for a reason rather than by inspection of the line. Their `Err(_)` is the `Elapsed` of `tokio::time::timeout`, not a provider error at all: nothing is being swallowed, a budget expired. And `Ok(None)` there is a deliberate third state, documented at both sites, precisely so the compiler forces every caller to say what it does with an expiry instead of reading it as an ordinary failure. That is the opposite of this defect: one gives the caller a state it cannot ignore, the other takes a state away from it.

The neighbouring occurrences of `if let Ok(..)` in this file were read one by one rather than counted: an account probe, a `symlink_metadata` on a local path, and two integer parses of a quota line. None of them turns a failure into a negative answer, so the fix stays the single function it belongs to.

## Fix

The mapping is a named function with three arms, one sentence of comment each, because the point of the change is which failure is an answer and which is not.

`Ok(_)` is presence: a listing that answered means the path is there. `Err(NotFound)` is the one failure that IS an answer, and it is kept rather than folded into the others, because by the time a result reaches this mapping `run_mega_cmd` has already read the command's stderr and given the error a type. `ProviderError` documents that contract on the variant itself. Everything else is passed on unchanged, deliberately not reclassified: there is nothing left to classify here, only something to keep and something to hand on.

The error reaches the caller as it was raised, so a refusal still reads as a refusal at the surface that reports it.

Callers that genuinely want an error treated as absence keep saying so themselves: several already write `unwrap_or(false)` at the call site. After this change that decision stays where it is visible and local, instead of being taken inside the provider on behalf of every caller, including the one that was asking the opposite question.

## Tests

Four, on the mapping itself, which is why the refactor that named it is a separate commit that changes no behaviour.

### Seen red

Two failed before the fix, both with `Ok(false)` where an error was required. The run is the tests commit against the unfixed mapping, so the line numbers it printed no longer point at these assertions and are left out; the panic text is the stable anchor:

```
test providers::mega::tests::map_mega_exists_does_not_turn_a_lost_session_into_an_absence ... FAILED
test providers::mega::tests::map_mega_exists_does_not_turn_a_refusal_into_an_absence ... FAILED

panicked at src/providers/mega.rs:
a refusal must reach the caller as a refusal: Ok(false)

panicked at src/providers/mega.rs:
a dropped session must not read as absent: Ok(false)

test result: FAILED. 2 passed; 2 failed; 0 ignored
```

The other two pin what must NOT change, and passed from the start: a listing that answered means present, and a `NotFound` stays an absence. They are the half of the test that keeps the fix from being "propagate everything".

### Declared limit

These tests cover the mapping, not the shell-out that feeds it. That `run_mega_cmd` classifies a genuinely missing path as `NotFound` is the premise the `NotFound` arm rests on, and it is asserted by that function's own contract rather than re-measured here against a live account.

## Gates

- `cargo fmt --all -- --check`: rc 0, no output
- `cargo test --lib providers::mega`: rc 0, 50 passed, 0 failed, with the four tests above green
- `cargo test --lib providers::`: rc 0, 1058 passed, 0 failed, 12 ignored
- `cargo clippy --lib --tests -- -D warnings`: rc 0, run after `cargo clean -p aeroftp` so the lint pass recompiled the crate instead of answering from cache
- Frontend gates were not re-run and are not required by this head: Rust only, with no TypeScript, locale or provider catalog touched.

Each rc was written to a file rather than read from a pipeline, so no step could report a green that belonged to a later command.

No CHANGELOG entry: the release notes are written from the tracker at release time.
