### PR TITLE
fix(metainfo): declare the old identifier as replaced

### DIFF
--- a/app.aeroftp.AeroFTP.metainfo.xml
+++ b/app.aeroftp.AeroFTP.metainfo.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
   <id>app.aeroftp.AeroFTP</id>
+  <replaces>
+    <id>com.aeroftp.AeroFTP</id>
+  </replaces>
 
   <name>AeroFTP</name>
   <summary>Modern Multi-Protocol File Client with AI, Encryption and Cloud Storage</summary>


### PR DESCRIPTION
## The change

Three lines in the metainfo, and nothing else in the file:

```xml
  <replaces>
    <id>com.aeroftp.AeroFTP</id>
  </replaces>
```

## Why

The application identifier changed recently. The metainfo declares the new `<id>` but never says that it succeeds the previous one: `<replaces>` was absent, and `<provides>` carried only a binary and a mediatype, so nothing in the file connected the two components.

A software center that sees both has no way to learn they are the same application. It lists the app twice, and the "installed" association stays on the component the user does not have. `<replaces>` is the declaration that answers that question.

The impact is small today, because the three root files were renamed together and the package removes the old path itself. It becomes real wherever an old metainfo survives the rename: a copy placed by hand, or a mirror that has not caught up.

## What is deliberately not touched

The historical `<release>` blocks. They describe what shipped, and rewriting them would make the record describe something that did not happen. They also carry the two warnings discussed below, which are out of scope here.

## How this was validated, because the obvious check is misleading

`appstreamcli` exits non-zero on this file **before** any change, over two `description-has-plaintext-url` warnings inside those historical release blocks. Read as a verdict, its exit code would say this change does not validate, which is false: it says the file already did not validate, for reasons that predate the change and are tracked separately.

So the criterion is not the exit code. It is the diff of the normalised findings against a baseline captured before the edit. The findings are identical, the diff is empty, and none of them names `replaces`. Normalising the line numbers is not cosmetic: the three added lines shift both warnings by three, and a raw comparison would report two brand new findings that are the same two.

The baseline failing is also the positive control. A validator that passed the unmodified file would not be reading it, and an empty diff against a green baseline would prove nothing.

Two further checks: the file parses as XML after the edit, with `replaces` exposing the previous identifier and `provides` unchanged; and `<replaces>` appears exactly once.

## On the provenance of the content

A prepared candidate for this change existed. It was not copied: the edit was constructed independently against today's tree, anchored on the `<id>` element, and the result then compared byte for byte with that candidate. They are identical. Copying it would have made the comparison vacuous, since it would have compared a file with itself.

The premise was re-measured rather than assumed: on today's tree `<replaces>` is absent and `<provides>` holds exactly a binary and a mediatype, so this adds a declaration rather than duplicating one.

No CHANGELOG entry: the release notes are written from the tracker at release time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added application metadata to support recognition of the app under its former identifier during transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->