### PR TITLE
docs(privacy): name the keyring entry deletion leaves behind

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -26,6 +26,16 @@ All local data can be deleted by removing the AeroFTP application data directori
 - **macOS**: `~/Library/Application Support/aeroftp/`
 - **Windows**: `%APPDATA%\aeroftp\`
 
+One thing is kept outside those directories and is not removed with them. If your vault is protected by the system keyring rather than by a master password, the key that opens it is held by the operating system's own credential store, and deleting the directories above leaves it there. AeroFTP removes it only when you switch the vault to a master password; no other action in the app deletes it.
+
+It is stored under the service name `com.aeroftp.AeroFTP`. That name is deliberately unchanged from an earlier version of the app, so that existing vaults keep working, and it is correct even though the application identifier is now different. The account name follows how AeroFTP was installed: `vault-passphrase` for a normal installation, or `vault-passphrase-portable`, `vault-passphrase-flatpak` or `vault-passphrase-snap` for those. Development builds use the same names with a `-dev` suffix. One installation stores one entry, so there is a single item to find. The commands below use the normal name; substitute the one for your installation.
+
+- **Linux**: in "Passwords and Keys" (Seahorse) or your desktop's keyring application, or from a terminal: `secret-tool clear service com.aeroftp.AeroFTP username vault-passphrase`
+- **macOS**: in Keychain Access, where the entry is listed under the name `com.aeroftp.AeroFTP`, or from a terminal: `security delete-generic-password -s com.aeroftp.AeroFTP -a vault-passphrase`
+- **Windows**: in Credential Manager, under Windows Credentials, where the entry is listed as `vault-passphrase.com.aeroftp.AeroFTP`
+
+If the vault is protected by a master password instead, nothing is kept in the keyring: the key is stored encrypted inside the data directory and is removed along with it.
+
 ## External Connections
 
 AeroFTP connects to external services **only when you explicitly initiate a connection**:


### PR DESCRIPTION
## The defect

`PRIVACY.md` promised that removing the AeroFTP application data directories deletes all local data, and listed the directories. When the vault is protected by the system keyring rather than by a master password, the key that opens the vault is held by the operating system's credential store, outside every directory the document lists. Deleting them leaves it in place, and nothing in the app removes it as part of deleting data: the only code path that clears the entry runs when the user switches the vault to a master password, which is a different operation.

A reader who followed the document exactly would believe their local data was gone while a credential remained.

## Why it exists, which is not an oversight

The keyring service name was deliberately kept on its previous value when the application identifier changed, because renaming it would orphan the vault passphrase of every existing installation. That decision is right in the code, and it is precisely what makes the sentence in this document wrong. The defect is in the promise, not in the storage.

## The choice between the two remedies

The finding offered either documenting the removal or narrowing the promise to the directories listed. This takes the first.

Narrowing would make the sentence true by saying less. A reader who asked to delete everything would still be left with a stored credential and no way to learn of it, which is the incomplete cleanup the finding is about. Completing the text makes the sentence true by making it whole, and costs the reader three lines.

## What was measured, and what it changed

Each instruction was derived from the code and the keyring library's source. Three of them would otherwise have been wrong, in the same way: plausible, and matching nothing.

The account is stored in the `username` attribute on the Secret Service, not `account`. A command written with `account` finds no entry, and the reader concludes there is nothing stored.

Keychain Access does not display the account attribute, so on macOS the entry is found under the service name rather than under the account name the code uses.

The Windows credential target name is the account and the service joined, `vault-passphrase.com.aeroftp.AeroFTP`, so a reader told to look for the service name alone would not find it in Credential Manager.

Two further facts shape the text. The account name follows the install scope, and the code writes only its own scope, so one installation holds exactly one entry rather than the eight names that exist in the source. And with a master password there is no keyring entry at all, so the paragraph says when it applies instead of sending half the readers to look for something that is not there.

## Declared limit

The three commands are verified from the library's source, not by execution. Running the Linux one would delete a real credential on this machine, and the other two platforms are not available here. What is verified is that the names and attributes the commands use are the ones the code writes.

## Scope

Ten lines added to one document. No code changes, and the existing directory list is unchanged.

No CHANGELOG entry: the release notes are written from the tracker at release time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that system-keyring vault keys remain outside AeroFTP data directories when those directories are deleted.
  - Added platform-specific instructions for removing keyring entries on Linux, macOS, and Windows.
  - Documented the difference between system-keyring vaults and master-password vaults when local data is removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->