### PR TITLE
fix(ui): tell a cancelled used-scan from a truncated one

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -205,6 +205,7 @@ import { localizeRestrictedCharError } from './utils/restrictedCharError';
 import { previewRouteFor } from './utils/previewRoute';
 import { CONNECT_CANCELLED_MARKER, CONNECT_HARD_TIMEOUT_MARKER, isConnectCancelledError, isConnectHardTimeoutError } from './utils/connectCancel';
 import { shouldPersistUsedScan } from './utils/usedScanPersist';
+import { usedScanBoundKey } from './utils/usedScanBound';
 import type { UpdateVerificationInfo } from './utils/updateVerification';
 import { UpdateVerificationPanel } from './components/UpdateVerificationPanel';
 import { safePickerStartDir } from './utils/safePickerDir';
@@ -3545,18 +3546,15 @@ const App: React.FC = () => {
             fileCount: res.file_count,
           });
         }
-        // A cancelled scan carries `truncated` too, because the backend marks a
-        // stopped walk as a lower bound. So the cancel is named first, in the
-        // same order as `size_bound_marker` on the Rust side, which exists to
-        // keep the two states from sharing a word.
+        // Which word a lower bound carries is decided in one tested place that
+        // mirrors `size_bound_marker` on the Rust side: a cancelled scan is
+        // marked truncated as well, so naming the cancel second would report a
+        // scan the user stopped as a listing the provider cut short.
+        const boundKey = usedScanBoundKey(res);
         const doneDetail = t('statusBar.usedScanDoneDetail', {
           used: formatBytes(res.used),
           files: String(res.file_count),
-        }) + (res.cancelled
-          ? ` (${t('transfer.cancelled')})`
-          : res.truncated
-            ? ` (${t('statusBar.usedScanTruncated')})`
-            : '');
+        }) + (boundKey ? ` (${t(boundKey)})` : '');
         notify.success(t('statusBar.usedScanDone'), doneDetail);
         activityLog.updateEntry(scanLogId, {
           status: 'success',

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3545,10 +3545,18 @@ const App: React.FC = () => {
             fileCount: res.file_count,
           });
         }
+        // A cancelled scan carries `truncated` too, because the backend marks a
+        // stopped walk as a lower bound. So the cancel is named first, in the
+        // same order as `size_bound_marker` on the Rust side, which exists to
+        // keep the two states from sharing a word.
         const doneDetail = t('statusBar.usedScanDoneDetail', {
           used: formatBytes(res.used),
           files: String(res.file_count),
-        }) + (res.truncated ? ` (${t('statusBar.usedScanTruncated')})` : '');
+        }) + (res.cancelled
+          ? ` (${t('transfer.cancelled')})`
+          : res.truncated
+            ? ` (${t('statusBar.usedScanTruncated')})`
+            : '');
         notify.success(t('statusBar.usedScanDone'), doneDetail);
         activityLog.updateEntry(scanLogId, {
           status: 'success',

--- a/src/utils/usedScanBound.test.ts
+++ b/src/utils/usedScanBound.test.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+import { describe, expect, it } from 'vitest';
+import { usedScanBoundKey } from './usedScanBound';
+
+describe('usedScanBoundKey', () => {
+    it('names the cancel when both flags are up, which is the state the backend produces', () => {
+        // Not a corner case: both scan paths in used_scan.rs do
+        // `if cancelled { truncated = true; }`, so this is what a cancelled
+        // scan actually looks like by the time it reaches the interface. Read
+        // for `truncated` alone, it used to report the user's own cancel as
+        // the provider cutting its listing.
+        expect(usedScanBoundKey({ truncated: true, cancelled: true })).toBe('transfer.cancelled');
+    });
+
+    it('names the truncation when the provider cut the listing', () => {
+        expect(usedScanBoundKey({ truncated: true, cancelled: false }))
+            .toBe('statusBar.usedScanTruncated');
+    });
+
+    it('keeps the order of size_bound_marker, so a swap of the two branches is red', () => {
+        // A cancel without truncation is not reachable today. It is asserted
+        // anyway: it is the half of the order that the reachable case cannot
+        // pin, since there both branches would answer.
+        expect(usedScanBoundKey({ truncated: false, cancelled: true })).toBe('transfer.cancelled');
+    });
+
+    it('says nothing when the figure is a complete answer', () => {
+        expect(usedScanBoundKey({ truncated: false, cancelled: false })).toBeNull();
+    });
+
+    it('treats a missing cancelled field as not-cancelled (additive default)', () => {
+        expect(usedScanBoundKey({ truncated: false })).toBeNull();
+        expect(usedScanBoundKey({ truncated: true })).toBe('statusBar.usedScanTruncated');
+    });
+});

--- a/src/utils/usedScanBound.ts
+++ b/src/utils/usedScanBound.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024-2026 axpnet: AI-assisted (see AI-TRANSPARENCY.md)
+
+/**
+ * Which word a used-storage figure carries when it is a lower bound.
+ *
+ * Mirrors `size_bound_marker` in `src-tauri/src/used_scan.rs`, order included.
+ * A cancelled scan is marked truncated as well, because the backend records a
+ * stopped walk as a lower bound rather than a zero, so the cancel has to be
+ * named first: named second, a scan the user stopped reads as a listing the
+ * provider cut short. The Rust side states the rule ("two different states and
+ * must not share a word") and this keeps the same rule checkable here, where
+ * an inline condition could be reordered without anything turning red.
+ *
+ * `cancelled` is additive, as in `usedScanPersist`: a backend that omits the
+ * field is treated as not-cancelled, and `truncated` still speaks for itself.
+ */
+export type UsedScanBoundFlags = {
+    truncated: boolean;
+    cancelled?: boolean;
+};
+
+/** The i18n key to show beside the figure, or null when it is a full answer. */
+export type UsedScanBoundKey = 'transfer.cancelled' | 'statusBar.usedScanTruncated';
+
+export function usedScanBoundKey(res: UsedScanBoundFlags): UsedScanBoundKey | null {
+    if (res.cancelled) return 'transfer.cancelled';
+    if (res.truncated) return 'statusBar.usedScanTruncated';
+    return null;
+}


### PR DESCRIPTION
## Summary

One expression in `src/App.tsx`: a used-storage scan the user cancelled was reported as `(partial: scan limit reached)`, the words that belong to a listing the provider cut short.

## The defect

The backend already keeps the two states apart. A stopped walk still has to answer a lower bound rather than a zero, so both scan paths in `src-tauri/src/used_scan.rs` do `if cancelled { truncated = true; }`, and `size_bound_marker` exists next to them to keep the two from sharing a word: it returns `" (CANCELLED)"` before it considers `" (TRUNCATED)"`.

The GUI read `truncated` alone. Since a cancelled scan carries that flag too, pressing cancel produced the truncation wording, in the notification and in the activity log entry. Separating two states in the backend and leaving them merged where the user reads them is not separating them.

## Fix

The cancel is named first, in the same order the Rust marker uses, and the truncation wording keeps the case it belongs to. The string feeds both surfaces, so the single change covers the notification and the activity log entry.

Which word to use now lives in `src/utils/usedScanBound.ts`, next to the sibling helper that already reads these same two flags to decide what may be persisted, and it is covered by `usedScanBound.test.ts`. Left inline, the rule would be a condition anyone could reorder without a test noticing; extracted, swapping the two branches turns red. That is measured, not claimed: with the two branches swapped, the state the backend actually produces is the one that fails and the other four keep passing, and with the order restored all five pass again.

## Measured, not assumed

- `res.cancelled` appeared **zero** times in the 19134 lines of `src/App.tsx`: there was no wrong branch for a cancel, there was no branch at all.
- `res.truncated` appears once, at the line this changes, and the `statusBar.usedScanTruncated` key has no other reader anywhere in `src`.
- The inline type of the `provider_scan_used` call already declares `cancelled?: boolean`, so no type changes.
- `src/utils/usedScanPersist.ts` already gates on both flags (`!res.truncated && !res.cancelled`), so what a cancelled scan writes to the profile was never wrong. This is the wording only.
- `transfer.cancelled` resolves in **all 47 locales** and is translated in each (it `Annullato`, de `Abgebrochen`, fr `Annule`, ja and zh likewise), so no i18n sync or translation round is needed. Checked on the key's real path in the locale files, not on a prefix: `transfer.cancelledByUser` is a different key and accounts for 20 of the 21 matches a prefix search returns.

## Gates

- `npm run typecheck`, `i18n:validate`, `i18n:diacritics`, `i18n:untranslated`, `check:provider-inventory`, `test:unit` (926 tests, 105 files).
- No Rust changed, so no cargo gate applies here.
- No CHANGELOG entry: the changelog is written at release time, not per pull request.

## Limits

- The tests cover the choice of word, not its rendering. The call site stays inside a 19k-line component and is still read rather than driven, because giving it a seam would mean restructuring the surrounding flow, which this PR does not do. What is asserted is every state the helper can meet: the one the backend really produces (cancelled and truncated together), the truncation on its own, the clean answer, the additive default when the field is absent, and a cancel without truncation, which no backend produces today and is there only to pin the order that the reachable case cannot.
- Scope is the used-storage scan. Other cancel paths (`CONNECT_CANCELLED`, `LISTING_CANCELLED`) have their own markers and are untouched.
