### PR TITLE
fix(cli): bound sync and reconcile by what a scan did not see

### DIFF
--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -74751,6 +74751,50 @@ mod tests {
         );
     }
 
+    /// A scan root the walk cannot read leaves the whole tree unseen, and there
+    /// is nothing above a root to bound with, so the run is refused instead of
+    /// planned. Going on there compares against an empty local side, which reads
+    /// every remote file as missing here: in a reconcile that plan says download
+    /// everything on the strength of a reading that never happened.
+    #[cfg(unix)]
+    #[test]
+    fn an_unreadable_scan_root_is_a_gap_with_no_name() {
+        let dir = tempfile::tempdir().expect("scratch directory");
+        let root = dir.path().join("tree");
+        std::fs::create_dir(&root).expect("the tree");
+        std::fs::write(root.join("a.txt"), b"a").expect("a.txt");
+        let _locked = UnreadableDir::lock(root.clone());
+        let root = root.to_str().expect("utf-8 root").to_string();
+
+        let (locals, completeness, boundaries) = scan_local_tree_with_progress(
+            &root,
+            &ftp_client_gui_lib::sync_core::ScanOptions::default(),
+            &None,
+        );
+        assert!(
+            locals.is_empty(),
+            "nothing under it could be read: {locals:?}"
+        );
+        assert!(!completeness.is_complete(), "the walk failed at the root");
+        assert_eq!(
+            boundaries.unbounded,
+            Some("unreadable"),
+            "a root nobody could read is a gap with no name: {boundaries:?}"
+        );
+
+        let bound = ftp_client_gui_lib::sync_core::ScanBound::for_sync(
+            &root,
+            std::iter::empty(),
+            std::iter::empty(),
+            &boundaries,
+            ftp_client_gui_lib::sync_core::ScanBoundaries::default(),
+        );
+        assert!(
+            bound.refusal().is_some(),
+            "the run is refused, not compared against an empty local side"
+        );
+    }
+
     /// Write a reconcile plan with one remote-only file, `b.txt`, and the
     /// given summary.
     fn write_reconcile_plan(fixture: &FilesFromFixture, summary: serde_json::Value) -> String {

--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -45521,7 +45521,7 @@ fn save_bisync_snapshot(
         if let Some(previous) = load_bisync_snapshot(local_dir) {
             for (path, state) in previous.files {
                 let saw =
-                    listed.map_or(true, |listed| listed.contains(&path)) && !bound.covers(&path);
+                    listed.is_none_or(|listed| listed.contains(&path)) && !bound.covers(&path);
                 if !saw {
                     files.entry(path).or_insert(state);
                 }

--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -8450,6 +8450,7 @@ fn scan_local_tree_with_progress(
 ) -> (
     Vec<ftp_client_gui_lib::sync_core::scan::LocalEntry>,
     ftp_client_gui_lib::sync_core::ScanCompleteness,
+    ftp_client_gui_lib::sync_core::ScanBoundaries,
 ) {
     let matchers: Vec<globset::GlobMatcher> = opts
         .exclude_patterns
@@ -8467,6 +8468,7 @@ fn scan_local_tree_with_progress(
         .unwrap_or_else(Instant::now);
     let mut entries = Vec::new();
     let mut completeness = ftp_client_gui_lib::sync_core::ScanCompleteness::default();
+    let mut boundaries = ftp_client_gui_lib::sync_core::ScanBoundaries::default();
 
     for result in walkdir::WalkDir::new(root)
         .follow_links(false)
@@ -8474,11 +8476,47 @@ fn scan_local_tree_with_progress(
     {
         let walk_entry = match result {
             Ok(entry) => entry,
-            Err(_) => {
-                // A directory the walk could not read hides the files below
-                // it: counted, so `reconcile` reports a partial result instead
-                // of listing those files as missing locally.
+            Err(error) => {
+                // A directory the walk could not read hides the files below it.
+                // Counting it was not enough: the comparison never learned the
+                // name of the gap, so the remote entries under that directory
+                // still read as missing here, which is a plan to download files
+                // on the strength of a reading nobody performed. The path is
+                // named as well, and the bound keeps what sits under it out.
                 completeness.list_errors += 1;
+                match error.path() {
+                    // The root itself: there is no path under it to bound
+                    // around, and a local side left empty would read every
+                    // remote file as missing. That is the same defect one level
+                    // up, so the run is refused instead.
+                    Some(path) if path == std::path::Path::new(root) => {
+                        boundaries.unbounded.get_or_insert("unreadable");
+                    }
+                    Some(path) => {
+                        let rel = path
+                            .strip_prefix(root)
+                            .unwrap_or(path)
+                            .to_string_lossy()
+                            .replace('\\', "/");
+                        if rel.is_empty() {
+                            boundaries.unbounded.get_or_insert("unreadable");
+                        } else {
+                            boundaries
+                                .unseen
+                                .push(ftp_client_gui_lib::sync_core::UnseenPath {
+                                    rel_path: rel,
+                                    reason: "unreadable",
+                                    // Raised both by a directory that would not
+                                    // open and by an entry that would not stat,
+                                    // and nothing here tells which.
+                                    is_dir: None,
+                                });
+                        }
+                    }
+                    // An error the walk cannot attribute to a path leaves
+                    // nothing to name, and stays a count, as it was.
+                    None => {}
+                }
                 continue;
             }
         };
@@ -8519,6 +8557,17 @@ fn scan_local_tree_with_progress(
             Ok(meta) => Some(meta),
             Err(_) => {
                 completeness.list_errors += 1;
+                // Its size and mtime were never read, so nothing may be copied
+                // over it on the strength of a size it never had.
+                boundaries
+                    .unseen
+                    .push(ftp_client_gui_lib::sync_core::UnseenPath {
+                        rel_path: relative.clone(),
+                        reason: "unreadable",
+                        // Past the guard that skips everything which is not a
+                        // file: the type is known, the metadata is not.
+                        is_dir: Some(false),
+                    });
                 None
             }
         };
@@ -8552,7 +8601,7 @@ fn scan_local_tree_with_progress(
         pb.set_message(format!("Scanning local... {} files", entries.len()));
     }
 
-    (entries, completeness)
+    (entries, completeness, boundaries)
 }
 
 /// Health of a remote BFS scan: how many `list()` calls failed and whether the
@@ -57878,7 +57927,7 @@ async fn cmd_reconcile(
         ..Default::default()
     };
     let local_spinner = maybe_create_scan_spinner(format, cli, "Scanning local...");
-    let (mut locals, local_health) =
+    let (mut locals, local_health, local_boundaries) =
         scan_local_tree_with_progress(local_path, &scan_opts, &local_spinner);
     if let Some(pb) = local_spinner {
         pb.finish_and_clear();
@@ -57928,14 +57977,15 @@ async fn cmd_reconcile(
     // plan fed to `sync --from-reconcile` cannot copy through a link or read an
     // unlisted subtree as missing. A scan that missed a part of the tree it
     // cannot name leaves nothing to bound around, so the comparison is refused.
-    // The local walk here reports no boundaries of its own; the bound still
-    // checks on disk the ancestors of every path only the remote holds, which is
-    // where a local link would be misread.
+    // The local walk names the paths it could not read, so the remote entries
+    // under them stay out of the comparison; what it still does not name are the
+    // links it skips, and there the bound's on-disk check of the ancestors of
+    // every path only the remote holds is what catches a local link.
     let bound = ftp_client_gui_lib::sync_core::ScanBound::apply(
         local_path,
         &mut locals,
         &mut remotes,
-        &ftp_client_gui_lib::sync_core::ScanBoundaries::default(),
+        &local_boundaries,
         remote_boundaries,
     );
     if let Some(reason) = bound.refusal() {
@@ -74553,7 +74603,7 @@ mod tests {
         std::fs::write(dir.path().join("locked").join("keep.txt"), b"k").expect("keep.txt");
         let _locked = UnreadableDir::lock(dir.path().join("locked"));
 
-        let (_, completeness) = scan_local_tree_with_progress(
+        let (_, completeness, _) = scan_local_tree_with_progress(
             dir.path().to_str().expect("utf-8 root"),
             &ftp_client_gui_lib::sync_core::ScanOptions::default(),
             &None,
@@ -74562,6 +74612,142 @@ mod tests {
         assert!(
             !completeness.is_complete(),
             "the unreadable directory must count as a listing error"
+        );
+    }
+
+    /// The remote children of a local directory the walk could not read must not
+    /// enter `missing_local`.
+    ///
+    /// Measured: this one holds with or without the walk naming the directory,
+    /// because the path is remote-only, so the bound walks its prefixes on disk
+    /// and finds the unreadable one itself. It is kept for that mechanism, not
+    /// for the walk's boundaries: remove the on-disk check and it goes red. The
+    /// case the walk's own naming is the only guard for is the one below, a file
+    /// the walk listed and could not stat, which sits on both sides and so never
+    /// reaches that prefix loop.
+    #[cfg(unix)]
+    #[test]
+    fn remote_children_of_an_unreadable_local_dir_stay_out_of_missing_local() {
+        let dir = tempfile::tempdir().expect("scratch directory");
+        std::fs::write(dir.path().join("a.txt"), b"a").expect("a.txt");
+        std::fs::create_dir(dir.path().join("locked")).expect("locked directory");
+        std::fs::write(dir.path().join("locked").join("keep.txt"), b"k").expect("keep.txt");
+        let _locked = UnreadableDir::lock(dir.path().join("locked"));
+
+        let root = dir.path().to_str().expect("utf-8 root").to_string();
+        let (mut locals, completeness, local_boundaries) = scan_local_tree_with_progress(
+            &root,
+            &ftp_client_gui_lib::sync_core::ScanOptions::default(),
+            &None,
+        );
+        assert!(
+            !completeness.is_complete(),
+            "the walk could not read the directory"
+        );
+        assert!(
+            !local_boundaries.unseen.is_empty(),
+            "the walk names the path it could not read: {local_boundaries:?}"
+        );
+
+        let mut remotes = vec![
+            ftp_client_gui_lib::sync_core::scan::RemoteEntry {
+                rel_path: "a.txt".to_string(),
+                size: 1,
+                mtime: None,
+                checksum_alg: None,
+                checksum_hex: None,
+            },
+            ftp_client_gui_lib::sync_core::scan::RemoteEntry {
+                rel_path: "locked/keep.txt".to_string(),
+                size: 1,
+                mtime: None,
+                checksum_alg: None,
+                checksum_hex: None,
+            },
+        ];
+        let bound = ftp_client_gui_lib::sync_core::ScanBound::apply(
+            &root,
+            &mut locals,
+            &mut remotes,
+            &local_boundaries,
+            ftp_client_gui_lib::sync_core::ScanBoundaries::default(),
+        );
+        assert!(
+            bound.refusal().is_none(),
+            "the gap has a name, so the run is bounded and not refused"
+        );
+        let diff = ftp_client_gui_lib::sync_core::compare_trees(&locals, &remotes, false);
+        assert_eq!(
+            diff.missing_local_count(),
+            0,
+            "a file nobody could read is not a file that is missing"
+        );
+    }
+
+    /// A file the walk listed but could not stat must leave the comparison.
+    ///
+    /// Its size and mtime were never read, so it reaches the planner as zero
+    /// bytes with no timestamp: compared against a remote copy of any other
+    /// size it lands in `differ`, which is a transfer decided on a number
+    /// nobody measured. The bound's on-disk walk cannot save this one, because
+    /// the path IS on both sides and that walk only visits paths the remote
+    /// alone holds. What keeps it out is the walk naming what it could not
+    /// read, which is what this covers.
+    #[cfg(unix)]
+    #[test]
+    fn a_file_the_walk_could_not_stat_leaves_the_comparison() {
+        let dir = tempfile::tempdir().expect("scratch directory");
+        std::fs::write(dir.path().join("a.txt"), b"a").expect("a.txt");
+        std::fs::create_dir(dir.path().join("sealed")).expect("sealed directory");
+        std::fs::write(dir.path().join("sealed").join("keep.txt"), b"k").expect("keep.txt");
+        let _sealed = UnreadableDir::seal(dir.path().join("sealed"));
+
+        let root = dir.path().to_str().expect("utf-8 root").to_string();
+        let (mut locals, _completeness, local_boundaries) = scan_local_tree_with_progress(
+            &root,
+            &ftp_client_gui_lib::sync_core::ScanOptions::default(),
+            &None,
+        );
+        assert!(
+            locals
+                .iter()
+                .any(|entry| entry.rel_path == "sealed/keep.txt" && entry.size == 0),
+            "the walk keeps the file it could not stat, with no size: {locals:?}"
+        );
+
+        let mut remotes = vec![
+            ftp_client_gui_lib::sync_core::scan::RemoteEntry {
+                rel_path: "a.txt".to_string(),
+                size: 1,
+                mtime: None,
+                checksum_alg: None,
+                checksum_hex: None,
+            },
+            ftp_client_gui_lib::sync_core::scan::RemoteEntry {
+                rel_path: "sealed/keep.txt".to_string(),
+                size: 1,
+                mtime: None,
+                checksum_alg: None,
+                checksum_hex: None,
+            },
+        ];
+        let bound = ftp_client_gui_lib::sync_core::ScanBound::apply(
+            &root,
+            &mut locals,
+            &mut remotes,
+            &local_boundaries,
+            ftp_client_gui_lib::sync_core::ScanBoundaries::default(),
+        );
+        assert!(bound.refusal().is_none(), "the gap has a name");
+        assert!(
+            !locals.iter().any(|e| e.rel_path == "sealed/keep.txt"),
+            "the unread file leaves the local side"
+        );
+        let diff = ftp_client_gui_lib::sync_core::compare_trees(&locals, &remotes, false);
+        assert_eq!(
+            diff.differ_count(),
+            0,
+            "a size nobody read is not a difference"
         );
     }
 
@@ -74806,7 +74992,7 @@ mod tests {
         fixture.local_file("sealed/keep.txt", 1);
         let _sealed = UnreadableDir::seal(Path::new(&local).join("sealed"));
 
-        let (locals, local_health) = scan_local_tree_with_progress(
+        let (locals, local_health, _) = scan_local_tree_with_progress(
             &local,
             &ftp_client_gui_lib::sync_core::ScanOptions::default(),
             &None,

--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -45553,6 +45553,7 @@ fn save_bisync_snapshot(
     remote_entries: &[(String, u64, Option<String>)],
     listed: Option<&std::collections::HashSet<String>>,
     bound: &ftp_client_gui_lib::sync_core::ScanBound,
+    left_alone: &[ftp_client_gui_lib::sync_core::SkippedLink],
 ) {
     let mut files = HashMap::new();
     // Merge both sides - after a successful sync they should be equal
@@ -45566,11 +45567,27 @@ fn save_bisync_snapshot(
     // it saw. The previous snapshot's entries for the rest are kept: dropped, the
     // next full run would read those files as never synced and copy back a
     // deletion made on one side instead of propagating it.
-    if listed.is_some() || !bound.is_empty() {
+    //
+    // `bound.covers` does not answer for every path a run left alone. A link on
+    // the LOCAL side enters the bound only when remote entries sit below it, so
+    // a local link with nothing under it on the remote is reported and not
+    // covered: its subtree was skipped all the same, and asking `covers` alone
+    // drops exactly those entries. `left_alone` carries the links the run
+    // reported, and a path at or under one of them is kept like any other.
+    let under_a_reported_link = |path: &str| {
+        left_alone.iter().any(|link| {
+            path == link.rel_path
+                || path
+                    .strip_prefix(&link.rel_path)
+                    .is_some_and(|rest| rest.starts_with('/'))
+        })
+    };
+    if listed.is_some() || !bound.is_empty() || !left_alone.is_empty() {
         if let Some(previous) = load_bisync_snapshot(local_dir) {
             for (path, state) in previous.files {
-                let saw =
-                    listed.is_none_or(|listed| listed.contains(&path)) && !bound.covers(&path);
+                let saw = listed.is_none_or(|listed| listed.contains(&path))
+                    && !bound.covers(&path)
+                    && !under_a_reported_link(&path);
                 if !saw {
                     files.entry(path).or_insert(state);
                 }
@@ -48018,6 +48035,7 @@ async fn cmd_sync(
             &remote_entries,
             files_from_set.as_ref(),
             &bound,
+            &reported_links,
         );
         if !quiet {
             eprintln!(
@@ -74304,6 +74322,7 @@ mod tests {
             &synced,
             Some(&listed),
             &ftp_client_gui_lib::sync_core::ScanBound::default(),
+            &[],
         );
         let saved = load_bisync_snapshot(&local).expect("the snapshot is saved");
         assert_eq!(
@@ -74323,6 +74342,7 @@ mod tests {
             &synced,
             None,
             &ftp_client_gui_lib::sync_core::ScanBound::default(),
+            &[],
         );
         let saved = load_bisync_snapshot(&local).expect("the snapshot is saved");
         assert!(
@@ -74365,7 +74385,7 @@ mod tests {
             },
         );
         let synced = vec![("a.txt".to_string(), 2, Some(FIXTURE_MTIME.to_string()))];
-        save_bisync_snapshot(&local, &synced, &synced, None, &bound);
+        save_bisync_snapshot(&local, &synced, &synced, None, &bound, &[]);
         let saved = load_bisync_snapshot(&local).expect("the snapshot is saved");
         assert_eq!(
             saved.files.get("a.txt"),
@@ -74376,6 +74396,60 @@ mod tests {
             saved.files.get("link/x.txt"),
             Some(&(1, FIXTURE_MTIME.to_string())),
             "the path under the skipped link keeps its previous entry"
+        );
+    }
+
+    /// The same for a link on the LOCAL side with nothing under it on the
+    /// remote. `ScanBound` takes a local link only when remote entries sit below
+    /// it, so this one never enters the bound and `covers` does not answer for
+    /// it: what names it is `reported_links`. Rewritten without that entry, the
+    /// next run that can see the path reads the file as never synced and copies
+    /// it back instead of propagating the deletion made on the other side.
+    #[test]
+    fn a_bisync_snapshot_keeps_the_entries_under_a_local_link() {
+        let dir = tempfile::tempdir().expect("scratch directory");
+        let local = dir.path().to_string_lossy().into_owned();
+        let previous = BisyncSnapshot {
+            synced_at: "2020-01-01T00:00:00Z".to_string(),
+            files: HashMap::from([
+                ("a.txt".to_string(), (1, FIXTURE_MTIME.to_string())),
+                ("link/x.txt".to_string(), (1, FIXTURE_MTIME.to_string())),
+            ]),
+        };
+        std::fs::write(
+            Path::new(&local).join(BISYNC_SNAPSHOT_FILE),
+            serde_json::to_string(&previous).expect("serialize the snapshot"),
+        )
+        .expect("write the snapshot");
+        let local_boundaries = ftp_client_gui_lib::sync_core::ScanBoundaries {
+            links: vec![ftp_client_gui_lib::sync_core::SkippedLink {
+                rel_path: "link".to_string(),
+                link_target: Some("real".to_string()),
+                is_dir: Some(true),
+            }],
+            ..Default::default()
+        };
+        let bound = ftp_client_gui_lib::sync_core::ScanBound::for_sync(
+            &local,
+            std::iter::empty(),
+            std::iter::empty(),
+            &local_boundaries,
+            ftp_client_gui_lib::sync_core::ScanBoundaries::default(),
+        );
+        assert!(
+            !bound.covers("link/x.txt"),
+            "a local link with nothing remote under it does not enter the bound"
+        );
+        let reported = bound.reported_links(&local_boundaries);
+        assert_eq!(reported.len(), 1, "but the run reports it all the same");
+
+        let synced = vec![("a.txt".to_string(), 2, Some(FIXTURE_MTIME.to_string()))];
+        save_bisync_snapshot(&local, &synced, &synced, None, &bound, &reported);
+        let saved = load_bisync_snapshot(&local).expect("the snapshot is saved");
+        assert_eq!(
+            saved.files.get("link/x.txt"),
+            Some(&(1, FIXTURE_MTIME.to_string())),
+            "the path under the local link keeps its previous entry"
         );
     }
 

--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -5435,6 +5435,13 @@ struct CliSyncResult {
     /// output is unchanged for callers that never pass `--dry-run`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     plan: Vec<CliSyncPlanEntry>,
+    /// Additive: the symbolic links the run left alone on both sides, and the
+    /// paths its scans could not see. Absent when there are none, so a tree
+    /// without either answers exactly as before.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    skipped_links: Vec<ftp_client_gui_lib::sync_core::SkippedLink>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    unseen_paths: Vec<ftp_client_gui_lib::sync_core::UnseenPath>,
     /// DAG-P2-07 (block E): engine-level telemetry of the transfer(s) this
     /// result covers (folded DAG metrics + wall clock + process resource
     /// bracket). Present only for real runs on the converged pool-backed engine
@@ -31915,6 +31922,8 @@ async fn cmd_get_recursive(
                 errors,
                 elapsed_secs: elapsed.as_secs_f64(),
                 plan: Vec::new(),
+                skipped_links: Vec::new(),
+                unseen_paths: Vec::new(),
                 stats: engine_stats,
             });
         }
@@ -32152,6 +32161,8 @@ async fn cmd_get_glob(
                 errors,
                 elapsed_secs: elapsed.as_secs_f64(),
                 plan: Vec::new(),
+                skipped_links: Vec::new(),
+                unseen_paths: Vec::new(),
                 stats: engine_stats,
             });
         }
@@ -32823,6 +32834,8 @@ async fn cmd_put_recursive(
                 errors,
                 elapsed_secs: elapsed.as_secs_f64(),
                 plan: Vec::new(),
+                skipped_links: Vec::new(),
+                unseen_paths: Vec::new(),
                 stats: engine_stats,
             });
         }
@@ -45490,6 +45503,7 @@ fn save_bisync_snapshot(
     local_entries: &[(String, u64, Option<String>)],
     remote_entries: &[(String, u64, Option<String>)],
     listed: Option<&std::collections::HashSet<String>>,
+    bound: &ftp_client_gui_lib::sync_core::ScanBound,
 ) {
     let mut files = HashMap::new();
     // Merge both sides - after a successful sync they should be equal
@@ -45498,14 +45512,17 @@ fn save_bisync_snapshot(
             .entry(path.clone())
             .or_insert_with(|| (*size, mtime.as_deref().unwrap_or("").to_string()));
     }
-    // A `--files-from` run saw only the listed paths, so it may rewrite only
-    // those. The previous snapshot's entries for every other path are kept:
-    // dropped, the next full run would read those files as never synced and
-    // copy back a deletion made on one side instead of propagating it.
-    if let Some(listed) = listed {
+    // A `--files-from` run saw only the listed paths, and a bounded run left
+    // every path its scans could not see alone, so either may rewrite only what
+    // it saw. The previous snapshot's entries for the rest are kept: dropped, the
+    // next full run would read those files as never synced and copy back a
+    // deletion made on one side instead of propagating it.
+    if listed.is_some() || !bound.is_empty() {
         if let Some(previous) = load_bisync_snapshot(local_dir) {
             for (path, state) in previous.files {
-                if !listed.contains(&path) {
+                let saw =
+                    listed.map_or(true, |listed| listed.contains(&path)) && !bound.covers(&path);
+                if !saw {
                     files.entry(path).or_insert(state);
                 }
             }
@@ -46087,6 +46104,10 @@ async fn cmd_sync_local_to_local(
 struct SyncScan {
     entries: Vec<(String, u64, Option<String>)>,
     completeness: ftp_client_gui_lib::sync_core::ScanCompleteness,
+    /// What the walk did not see or follow: the symbolic links to directories it
+    /// did not descend into (named whether or not the remote holds anything
+    /// under them), the entries it could not read, and a gap it cannot name.
+    boundaries: ftp_client_gui_lib::sync_core::ScanBoundaries,
 }
 
 /// Which local files `sync` scans: walk depth and `--exclude`. `--files-from`
@@ -46111,6 +46132,14 @@ impl SyncLocalFilter<'_> {
     }
 }
 
+/// A local path as `sync` names it: relative to the scan root, forward slashes.
+fn sync_relative_path(path: &Path, root: &str) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
 /// A local file's modification time in the form `sync` compares.
 fn sync_local_mtime(meta: &std::fs::Metadata) -> Option<String> {
     meta.modified().ok().map(|t| {
@@ -46128,27 +46157,93 @@ fn scan_sync_local(local: &str, filter: &SyncLocalFilter) -> SyncScan {
         .follow_links(false)
         .max_depth(filter.max_depth);
     for entry in walker {
-        if scan.entries.len() >= 500_000 {
+        if scan.entries.len() + scan.boundaries.links.len() + scan.boundaries.unseen.len()
+            >= 500_000
+        {
             eprintln!("Warning: local scan capped at 500,000 entries");
             scan.completeness.truncated = true;
+            // What the walk did not reach past the cap has no name to bound a run
+            // around, so the run is refused rather than planned in part.
+            scan.boundaries.unbounded.get_or_insert("entry_cap");
             break;
         }
         let entry = match entry {
             Ok(e) => e,
-            Err(_) => {
+            Err(error) => {
+                // A directory the walk could not read hides the files under it:
+                // counted, and named so a run can leave that path alone on both
+                // sides. A root that does not exist is the empty tree a download
+                // into a new directory scans, and is marked missing instead; any
+                // other root failure, or an error that names no path, leaves the
+                // whole tree unseen, which refuses the run.
                 scan.completeness.list_errors += 1;
+                let at_root = error.depth() == 0;
+                let missing = error.io_error().is_some_and(|io| {
+                    matches!(
+                        io.kind(),
+                        std::io::ErrorKind::NotFound | std::io::ErrorKind::NotADirectory
+                    )
+                });
+                if at_root && missing {
+                    scan.boundaries.root_missing = true;
+                } else if let Some(path) = error.path().filter(|_| !at_root) {
+                    scan.boundaries
+                        .unseen
+                        .push(ftp_client_gui_lib::sync_core::UnseenPath {
+                            rel_path: sync_relative_path(path, local),
+                            reason: "unreadable",
+                            // The walk failed either opening a directory or
+                            // reading an entry, and nothing here tells which.
+                            is_dir: None,
+                        });
+                } else {
+                    scan.boundaries.unbounded.get_or_insert("unreadable");
+                }
                 continue;
             }
         };
+        if entry.path_is_symlink() && entry.depth() > 0 {
+            // Not followed: what sits behind the link is not part of this side's
+            // tree. A link to a directory is named, so a run can leave its path
+            // alone on both sides; a link to a file is passed over, as before.
+            let relative = sync_relative_path(entry.path(), local);
+            match std::fs::metadata(entry.path()) {
+                Ok(target) if target.is_dir() => {
+                    scan.boundaries
+                        .links
+                        .push(ftp_client_gui_lib::sync_core::SkippedLink {
+                            rel_path: relative,
+                            link_target: std::fs::read_link(entry.path())
+                                .ok()
+                                .map(|target| target.to_string_lossy().into_owned()),
+                            // This arm matched on the target being a directory,
+                            // so the type is certain here.
+                            is_dir: Some(true),
+                        });
+                }
+                Ok(_) => {}
+                // A dangling link points at nothing to load.
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(_) => {
+                    // Listed and not resolved: what it points at is unknown.
+                    scan.completeness.list_errors += 1;
+                    scan.boundaries
+                        .unseen
+                        .push(ftp_client_gui_lib::sync_core::UnseenPath {
+                            rel_path: relative,
+                            reason: "unreadable",
+                            // A link whose target did not resolve: nobody read
+                            // what it stands for, so the type is unknown.
+                            is_dir: None,
+                        });
+                }
+            }
+            continue;
+        }
         if !entry.file_type().is_file() {
             continue;
         }
-        let relative = entry
-            .path()
-            .strip_prefix(local)
-            .unwrap_or(entry.path())
-            .to_string_lossy()
-            .replace('\\', "/");
+        let relative = sync_relative_path(entry.path(), local);
         if relative.is_empty() || relative == BISYNC_SNAPSHOT_FILE {
             continue;
         }
@@ -46164,6 +46259,17 @@ fn scan_sync_local(local: &str, filter: &SyncLocalFilter) -> SyncScan {
             Ok(meta) => Some(meta),
             Err(_) => {
                 scan.completeness.list_errors += 1;
+                // Its size and mtime were never read, so nothing may be copied
+                // over it on the strength of a size it never had.
+                scan.boundaries
+                    .unseen
+                    .push(ftp_client_gui_lib::sync_core::UnseenPath {
+                        rel_path: relative.clone(),
+                        reason: "unreadable",
+                        // Reached past the guard that skips everything which is
+                        // not a file: the type is known, the metadata is not.
+                        is_dir: Some(false),
+                    });
                 None
             }
         };
@@ -46393,6 +46499,9 @@ async fn cmd_sync(
     // scan surfaces in the exit code / JSON status instead of reporting success.
     let mut remote_scan_errors: usize = 0;
     let mut remote_scan_truncated = false;
+    // What the remote walk did not see or follow; the local side travels in its
+    // own scan.
+    let mut remote_boundaries = ftp_client_gui_lib::sync_core::ScanBoundaries::default();
 
     let mut reconcile_plan: Option<ReconcileSyncPlan> = None;
     let (mut local_scan, mut remote_entries): (SyncScan, Vec<(String, u64, Option<String>)>) =
@@ -46407,6 +46516,7 @@ async fn cmd_sync(
                     let local_scan = SyncScan {
                         entries: plan.local_entries.clone(),
                         completeness: Default::default(),
+                        boundaries: Default::default(),
                     };
                     let remote_entries = plan.remote_entries.clone();
                     reconcile_plan = Some(plan);
@@ -46573,7 +46683,7 @@ async fn cmd_sync(
                         disable_recursive_fastpath: true,
                         ..Default::default()
                     };
-                    let (remotes, health, _remote_boundaries, returned) =
+                    let (remotes, health, scanned_boundaries, returned) =
                         scan_remote_tree_with_progress(
                             provider,
                             remote,
@@ -46588,6 +46698,7 @@ async fn cmd_sync(
                     }
                     remote_scan_errors += health.errors;
                     remote_scan_truncated |= health.truncated;
+                    remote_boundaries = scanned_boundaries;
                     // The bisync snapshot is skipped at the root only, as the walk
                     // this replaces did: a same-named file deeper in the tree is
                     // the user's.
@@ -46619,6 +46730,57 @@ async fn cmd_sync(
             .entries
             .retain(|(path, _, _)| listed.contains(path));
         remote_entries.retain(|(path, _, _)| listed.contains(path));
+    }
+
+    // What the scans did not see stays out of the run on both sides: every
+    // skipped link and unseen path, with everything under it, so no copy writes
+    // through a link and no delete pass reads an unlisted subtree as gone. A scan
+    // that missed a part of the tree it cannot name leaves nothing to bound the
+    // run around, so the run is refused instead of planned in part.
+    let mut local_boundaries = std::mem::take(&mut local_scan.boundaries);
+    // A root that does not exist is an empty tree on the side a run writes to,
+    // and a missing source on the side it reads from: read as empty there, it
+    // would turn every file on the other side into an orphan.
+    if matches!(direction, "upload" | "both") && local_boundaries.root_missing {
+        local_boundaries
+            .unbounded
+            .get_or_insert("source_root_missing");
+    }
+    if matches!(direction, "download" | "both") && remote_boundaries.root_missing {
+        remote_boundaries
+            .unbounded
+            .get_or_insert("source_root_missing");
+    }
+    let bound = ftp_client_gui_lib::sync_core::ScanBound::for_sync(
+        local,
+        local_scan.entries.iter().map(|(path, _, _)| path.as_str()),
+        remote_entries.iter().map(|(path, _, _)| path.as_str()),
+        &local_boundaries,
+        remote_boundaries,
+    );
+    if let Some(reason) = bound.refusal() {
+        print_error(
+            format,
+            &format!("sync refused, nothing was planned: {}", reason),
+            4,
+        );
+        let _ = provider.disconnect().await;
+        return 4.into();
+    }
+    let reported_links = bound.reported_links(&local_boundaries);
+    let unseen_paths = bound.unseen().to_vec();
+    if !bound.is_empty() {
+        local_scan
+            .entries
+            .retain(|(path, _, _)| !bound.covers(path));
+        remote_entries.retain(|(path, _, _)| !bound.covers(path));
+    }
+    if !quiet && !(reported_links.is_empty() && unseen_paths.is_empty()) {
+        eprintln!(
+            "Note: leaving {} skipped symlink(s) and {} unseen path(s) alone on both sides",
+            reported_links.len(),
+            unseen_paths.len()
+        );
     }
     let local_entries = &local_scan.entries;
 
@@ -47233,6 +47395,8 @@ async fn cmd_sync(
                     errors: vec![],
                     elapsed_secs: start.elapsed().as_secs_f64(),
                     plan,
+                    skipped_links: reported_links.clone(),
+                    unseen_paths: unseen_paths.clone(),
                     // Dry run performs no transfer, so there is no engine job.
                     stats: None,
                 });
@@ -47804,6 +47968,7 @@ async fn cmd_sync(
             local_entries,
             &remote_entries,
             files_from_set.as_ref(),
+            &bound,
         );
         if !quiet {
             eprintln!(
@@ -47880,6 +48045,8 @@ async fn cmd_sync(
                 errors: errors.clone(),
                 elapsed_secs: elapsed.as_secs_f64(),
                 plan: Vec::new(),
+                skipped_links: reported_links.clone(),
+                unseen_paths: unseen_paths.clone(),
                 stats: engine_stats,
             });
         }
@@ -54964,6 +55131,8 @@ async fn cmd_put_glob(
                 errors,
                 elapsed_secs: elapsed.as_secs_f64(),
                 plan: Vec::new(),
+                skipped_links: Vec::new(),
+                unseen_paths: Vec::new(),
                 stats: engine_stats,
             });
         }
@@ -55034,6 +55203,11 @@ fn should_exclude_watch_path(path: &std::path::Path) -> bool {
 struct WatchLocalSnapshot {
     files: std::collections::HashMap<String, (u64, Option<String>)>,
     completeness: ftp_client_gui_lib::sync_core::ScanCompleteness,
+    /// What the walk that built this snapshot did not see or follow. A link made
+    /// between cycles is not in it; the bound still checks on disk the ancestors
+    /// of every path only the remote holds, which is where a local link would be
+    /// misread.
+    boundaries: ftp_client_gui_lib::sync_core::ScanBoundaries,
 }
 
 impl WatchLocalSnapshot {
@@ -55045,6 +55219,7 @@ impl WatchLocalSnapshot {
                 .map(|(path, size, mtime)| (path.clone(), (*size, mtime.clone())))
                 .collect(),
             completeness: scan.completeness,
+            boundaries: scan.boundaries.clone(),
         }
     }
 }
@@ -55086,6 +55261,7 @@ fn incremental_local_scan(
     let mut result: std::collections::HashMap<String, (u64, Option<String>)> =
         previous.files.clone();
     let mut completeness = previous.completeness;
+    let mut boundaries = previous.boundaries.clone();
 
     for changed in changed_paths {
         // Compute relative path
@@ -55125,8 +55301,18 @@ fn incremental_local_scan(
             Err(_) => {
                 // Unreadable is not absent: keep what the snapshot knew and
                 // count the error, so this cycle plans no orphan deletes
-                // (TX-01) and the next one rescans.
+                // (TX-01) and the next one rescans. Its path is named too, so
+                // nothing is copied over what this cycle could not read.
                 completeness.list_errors += 1;
+                boundaries
+                    .unseen
+                    .push(ftp_client_gui_lib::sync_core::UnseenPath {
+                        rel_path: relative,
+                        reason: "unreadable",
+                        // `metadata` is what failed, and it is what would have
+                        // said the type: the arm above is the one that knows.
+                        is_dir: None,
+                    });
             }
         }
     }
@@ -55137,6 +55323,7 @@ fn incremental_local_scan(
             .map(|(path, (size, mtime))| (path, size, mtime))
             .collect(),
         completeness,
+        boundaries,
     }
 }
 
@@ -57691,14 +57878,14 @@ async fn cmd_reconcile(
         ..Default::default()
     };
     let local_spinner = maybe_create_scan_spinner(format, cli, "Scanning local...");
-    let (locals, local_health) =
+    let (mut locals, local_health) =
         scan_local_tree_with_progress(local_path, &scan_opts, &local_spinner);
     if let Some(pb) = local_spinner {
         pb.finish_and_clear();
     }
 
     let remote_spinner = maybe_create_scan_spinner(format, cli, "Scanning remote...");
-    let (mut remotes, remote_health, _remote_boundaries, returned) =
+    let (mut remotes, remote_health, remote_boundaries, returned) =
         scan_remote_tree_with_progress(provider, remote_path, &scan_opts, &remote_spinner, None)
             .await;
     provider = returned;
@@ -57736,6 +57923,29 @@ async fn cmd_reconcile(
             local_health.list_errors,
             if local_health.truncated { ", truncated" } else { "" }
         );
+    }
+    // What the scans did not see stays out of the comparison on both sides, so a
+    // plan fed to `sync --from-reconcile` cannot copy through a link or read an
+    // unlisted subtree as missing. A scan that missed a part of the tree it
+    // cannot name leaves nothing to bound around, so the comparison is refused.
+    // The local walk here reports no boundaries of its own; the bound still
+    // checks on disk the ancestors of every path only the remote holds, which is
+    // where a local link would be misread.
+    let bound = ftp_client_gui_lib::sync_core::ScanBound::apply(
+        local_path,
+        &mut locals,
+        &mut remotes,
+        &ftp_client_gui_lib::sync_core::ScanBoundaries::default(),
+        remote_boundaries,
+    );
+    if let Some(reason) = bound.refusal() {
+        print_error(
+            format,
+            &format!("reconcile refused, nothing was compared: {}", reason),
+            4,
+        );
+        let _ = provider.disconnect().await;
+        return 4;
     }
     let diff = compare_trees(&locals, &remotes, one_way);
 
@@ -73898,6 +74108,7 @@ mod tests {
                 ("c.txt".to_string(), 1, Some(FIXTURE_MTIME.to_string())),
             ],
             completeness: Default::default(),
+            boundaries: Default::default(),
         };
         let stats = plan_sync_with_delete(
             MemTreeProvider::root_files(&[("a.txt", 1), ("b.txt", 1)]),
@@ -74037,7 +74248,13 @@ mod tests {
         )];
         let listed = std::collections::HashSet::from(["a.txt".to_string()]);
 
-        save_bisync_snapshot(&local, &synced, &synced, Some(&listed));
+        save_bisync_snapshot(
+            &local,
+            &synced,
+            &synced,
+            Some(&listed),
+            &ftp_client_gui_lib::sync_core::ScanBound::default(),
+        );
         let saved = load_bisync_snapshot(&local).expect("the snapshot is saved");
         assert_eq!(
             saved.files.get("a.txt"),
@@ -74050,11 +74267,98 @@ mod tests {
             "the unlisted path keeps its previous entry"
         );
 
-        save_bisync_snapshot(&local, &synced, &synced, None);
+        save_bisync_snapshot(
+            &local,
+            &synced,
+            &synced,
+            None,
+            &ftp_client_gui_lib::sync_core::ScanBound::default(),
+        );
         let saved = load_bisync_snapshot(&local).expect("the snapshot is saved");
         assert!(
             !saved.files.contains_key("b.txt"),
             "a run without a list replaces the snapshot whole"
+        );
+    }
+
+    /// A run that left a path alone may not rewrite the snapshot without it:
+    /// dropped, the next full run would read that file as never synced and copy
+    /// a deletion back over it.
+    #[test]
+    fn a_bisync_snapshot_keeps_the_entries_a_run_left_alone() {
+        let dir = tempfile::tempdir().expect("scratch directory");
+        let local = dir.path().to_string_lossy().into_owned();
+        let previous = BisyncSnapshot {
+            synced_at: "2020-01-01T00:00:00Z".to_string(),
+            files: HashMap::from([
+                ("a.txt".to_string(), (1, FIXTURE_MTIME.to_string())),
+                ("link/x.txt".to_string(), (1, FIXTURE_MTIME.to_string())),
+            ]),
+        };
+        std::fs::write(
+            Path::new(&local).join(BISYNC_SNAPSHOT_FILE),
+            serde_json::to_string(&previous).expect("serialize the snapshot"),
+        )
+        .expect("write the snapshot");
+        let bound = ftp_client_gui_lib::sync_core::ScanBound::for_sync(
+            &local,
+            std::iter::empty(),
+            std::iter::empty(),
+            &ftp_client_gui_lib::sync_core::ScanBoundaries::default(),
+            ftp_client_gui_lib::sync_core::ScanBoundaries {
+                links: vec![ftp_client_gui_lib::sync_core::SkippedLink {
+                    rel_path: "link".to_string(),
+                    link_target: None,
+                    is_dir: Some(true),
+                }],
+                ..Default::default()
+            },
+        );
+        let synced = vec![("a.txt".to_string(), 2, Some(FIXTURE_MTIME.to_string()))];
+        save_bisync_snapshot(&local, &synced, &synced, None, &bound);
+        let saved = load_bisync_snapshot(&local).expect("the snapshot is saved");
+        assert_eq!(
+            saved.files.get("a.txt"),
+            Some(&(2, FIXTURE_MTIME.to_string())),
+            "the path the run saw is rewritten"
+        );
+        assert_eq!(
+            saved.files.get("link/x.txt"),
+            Some(&(1, FIXTURE_MTIME.to_string())),
+            "the path under the skipped link keeps its previous entry"
+        );
+    }
+
+    /// A watch cycle refreshes the paths its watcher named and keeps the rest of
+    /// the snapshot, boundaries included: the links the last full walk did not
+    /// follow still bound the run of that cycle.
+    #[test]
+    fn an_incremental_watch_cycle_keeps_the_boundaries_of_its_snapshot() {
+        let dir = tempfile::tempdir().expect("scratch directory");
+        std::fs::write(dir.path().join("a.txt"), b"a").expect("write a.txt");
+        let scan = SyncScan {
+            entries: vec![("a.txt".to_string(), 1, Some(FIXTURE_MTIME.to_string()))],
+            completeness: Default::default(),
+            boundaries: ftp_client_gui_lib::sync_core::ScanBoundaries {
+                links: vec![ftp_client_gui_lib::sync_core::SkippedLink {
+                    rel_path: "link".to_string(),
+                    link_target: Some("real".to_string()),
+                    is_dir: Some(true),
+                }],
+                ..Default::default()
+            },
+        };
+        let snapshot = WatchLocalSnapshot::from_scan(&scan);
+        let exclude: Vec<globset::GlobMatcher> = Vec::new();
+        let filter = SyncLocalFilter {
+            max_depth: 100,
+            exclude: &exclude,
+        };
+        let cycle =
+            incremental_local_scan(dir.path(), &[dir.path().join("a.txt")], &snapshot, &filter);
+        assert_eq!(
+            cycle.boundaries.links, scan.boundaries.links,
+            "the cycle keeps the links its snapshot knows"
         );
     }
 
@@ -75038,6 +75342,292 @@ mod tests {
 
         assert_eq!(report.status, "attention");
         assert_eq!(report.summary["remote_scan_incomplete"], true);
+    }
+
+    /// `a.txt` at the root, present on both sides, and `link`, a directory
+    /// listed at the root. Under the link's own path the tree holds what SFTP
+    /// answers for it: the entries of its target.
+    fn mem_tree_with_a_link_dir(link_is_symlink: bool) -> MemTreeProvider {
+        let mut a = RemoteEntry::file("a.txt".to_string(), "/root/a.txt".to_string(), 1);
+        a.modified = Some(FIXTURE_MTIME.to_string());
+        let mut link = RemoteEntry::directory("link".to_string(), "/root/link".to_string());
+        if link_is_symlink {
+            link.is_symlink = true;
+            link.link_target = Some("real".to_string());
+        }
+        let mut x = RemoteEntry::file("x.txt".to_string(), "/root/link/x.txt".to_string(), 1);
+        x.modified = Some(FIXTURE_MTIME.to_string());
+        MemTreeProvider {
+            dirs: HashMap::from([
+                ("/root".to_string(), vec![a, link]),
+                ("/root/link".to_string(), vec![x]),
+            ]),
+            delete_attempts: Arc::default(),
+        }
+    }
+
+    /// `a.txt` and a real directory `link` holding `x.txt` in the local tree:
+    /// what an earlier walk that descended into the remote link left on disk.
+    fn fixture_with_a_real_link_dir() -> FilesFromFixture {
+        let fixture = FilesFromFixture::new();
+        fixture.local_file("a.txt", 1);
+        std::fs::create_dir(Path::new(&fixture.local()).join("link")).expect("create link/");
+        fixture.local_file("link/x.txt", 1);
+        fixture
+    }
+
+    /// The remote walk does not descend into a symlinked directory, so the
+    /// link's subtree is absent from the remote side. `sync --direction
+    /// download --delete` must not read the local files at that path as
+    /// deleted on the remote: they are still there, behind the link.
+    #[test]
+    fn sync_download_delete_plans_no_local_delete_under_a_remote_symlinked_dir() {
+        let fixture = fixture_with_a_real_link_dir();
+        let cli = Cli {
+            quiet: true,
+            ..test_cli()
+        };
+        let stats = plan_sync_with_delete(
+            mem_tree_with_a_link_dir(true),
+            &fixture.local(),
+            "download",
+            &cli,
+            None,
+            None,
+        );
+        assert_eq!(stats.exit_code, 0);
+        assert_eq!(
+            stats.deleted, 0,
+            "link/x.txt sits under the skipped link: no local delete"
+        );
+    }
+
+    /// Bidirectional with a snapshot that knows `link/x.txt`: absent from the
+    /// remote scan only because the link was skipped, it must not read as
+    /// deleted remotely (a local delete) nor as new locally (an upload
+    /// written through the link into its target).
+    #[test]
+    fn sync_both_delete_with_a_snapshot_plans_nothing_under_a_remote_symlinked_dir() {
+        let fixture = fixture_with_a_real_link_dir();
+        let snapshot = BisyncSnapshot {
+            synced_at: "2020-01-01T00:00:00Z".to_string(),
+            files: HashMap::from([
+                ("a.txt".to_string(), (1, FIXTURE_MTIME.to_string())),
+                ("link/x.txt".to_string(), (1, FIXTURE_MTIME.to_string())),
+            ]),
+        };
+        std::fs::write(
+            Path::new(&fixture.local()).join(BISYNC_SNAPSHOT_FILE),
+            serde_json::to_string(&snapshot).expect("serialize the snapshot"),
+        )
+        .expect("write the snapshot");
+        let cli = Cli {
+            quiet: true,
+            ..test_cli()
+        };
+        let stats = plan_sync_with_delete(
+            mem_tree_with_a_link_dir(true),
+            &fixture.local(),
+            "both",
+            &cli,
+            None,
+            None,
+        );
+        assert_eq!(stats.exit_code, 0);
+        assert_eq!(
+            stats.deleted, 0,
+            "link/x.txt sits under the skipped link: no delete"
+        );
+        assert_eq!(
+            stats.uploaded, 0,
+            "link/x.txt sits under the skipped link: no upload through it"
+        );
+    }
+
+    /// The mirror case on the local side: the local walk does not follow a
+    /// symlinked directory, so `sync --direction upload --delete` must not
+    /// read the remote files at the link's path as deleted locally.
+    #[cfg(unix)]
+    #[test]
+    fn sync_upload_delete_plans_no_remote_delete_under_a_local_symlinked_dir() {
+        let fixture = FilesFromFixture::new();
+        fixture.local_file("a.txt", 1);
+        std::fs::create_dir(Path::new(&fixture.local()).join("real")).expect("create real/");
+        fixture.local_file("real/x.txt", 1);
+        std::os::unix::fs::symlink("real", Path::new(&fixture.local()).join("link"))
+            .expect("link -> real");
+        let cli = Cli {
+            quiet: true,
+            ..test_cli()
+        };
+        let stats = plan_sync_with_delete(
+            mem_tree_with_a_link_dir(false),
+            &fixture.local(),
+            "upload",
+            &cli,
+            None,
+            None,
+        );
+        assert_eq!(stats.exit_code, 0);
+        assert_eq!(
+            stats.deleted, 0,
+            "link/x.txt sits under the skipped local link: no remote delete"
+        );
+    }
+
+    /// A remote directory that fails to list, with a local tree holding files
+    /// under the same path. What the remote directory holds is unknown (it could
+    /// be a link to elsewhere), so the upload must not plan anything under it:
+    /// the scan's completeness only guarded deletes, and the transfer plan ran on
+    /// the unlisted tree.
+    #[test]
+    fn sync_upload_plans_nothing_under_a_remote_directory_that_did_not_list() {
+        let fixture = FilesFromFixture::new();
+        fixture.local_file("a.txt", 1);
+        std::fs::create_dir_all(Path::new(&fixture.local()).join("d1/link"))
+            .expect("create d1/link/");
+        fixture.local_file("d1/link/x.txt", 1);
+        let mut a = RemoteEntry::file("a.txt".to_string(), "/root/a.txt".to_string(), 1);
+        a.modified = Some(FIXTURE_MTIME.to_string());
+        let remote = MemTreeProvider {
+            dirs: HashMap::from([(
+                "/root".to_string(),
+                vec![
+                    a,
+                    RemoteEntry::directory("d1".to_string(), "/root/d1".to_string()),
+                ],
+            )]),
+            delete_attempts: Arc::default(),
+        };
+        let cli = Cli {
+            quiet: true,
+            ..test_cli()
+        };
+        let stats = plan_sync_with_delete(remote, &fixture.local(), "upload", &cli, None, None);
+        assert_eq!(
+            stats.uploaded, 0,
+            "nothing under the unlisted remote directory may be planned"
+        );
+    }
+
+    /// A remote root that does not exist is an empty tree only for a run that
+    /// writes to it. `--direction download --delete` reads from it, and an empty
+    /// tree there turns every local file into an orphan: the run must be refused
+    /// instead of planning the local folder away.
+    #[test]
+    fn sync_download_delete_refuses_a_remote_root_that_does_not_exist() {
+        let fixture = FilesFromFixture::new();
+        fixture.local_file("a.txt", 1);
+        let cli = Cli {
+            quiet: true,
+            ..test_cli()
+        };
+        let stats = plan_sync_with_delete(
+            MemTreeProvider {
+                dirs: HashMap::new(),
+                delete_attempts: Arc::default(),
+            },
+            &fixture.local(),
+            "download",
+            &cli,
+            None,
+            None,
+        );
+        assert_eq!(
+            stats.deleted, 0,
+            "a source root that does not exist plans no delete"
+        );
+        assert_eq!(stats.exit_code, 4, "the refusal shows in the exit code");
+        assert!(
+            Path::new(&fixture.local()).join("a.txt").exists(),
+            "the local file stays"
+        );
+    }
+
+    /// The other side of that refusal: the same missing remote root is the
+    /// destination of an upload, which is the empty tree a sync into a directory
+    /// it has yet to create scans, so the copies are still planned.
+    #[test]
+    fn sync_upload_into_a_remote_root_that_does_not_exist_plans_its_copies() {
+        let fixture = FilesFromFixture::new();
+        fixture.local_file("a.txt", 1);
+        let cli = Cli {
+            quiet: true,
+            ..test_cli()
+        };
+        let stats = plan_sync_with_delete(
+            MemTreeProvider {
+                dirs: HashMap::new(),
+                delete_attempts: Arc::default(),
+            },
+            &fixture.local(),
+            "upload",
+            &cli,
+            None,
+            None,
+        );
+        assert_eq!(
+            stats.uploaded, 1,
+            "a destination root that does not exist is an empty tree"
+        );
+    }
+
+    /// The real `cmd_sync` as a dry-run upload whose scans start cancelled.
+    fn plan_sync_with_a_cancelled_scan(
+        remote: MemTreeProvider,
+        local: &str,
+        cli: &Cli,
+    ) -> SyncCycleStats {
+        run_against_remote(remote, move || {
+            cmd_sync(
+                "memory://",
+                local,
+                "/root",
+                "upload",
+                true,  // dry_run
+                false, // delete
+                &[],
+                None,
+                0,
+                false,
+                None,
+                None,
+                "",
+                false,
+                None,
+                None,
+                None,
+                "newer",
+                false,
+                false,
+                cli,
+                OutputFormat::Json,
+                Arc::new(AtomicBool::new(true)),
+                None,
+                false,
+            )
+        })
+    }
+
+    /// A cancelled scan stopped at no particular directory, so what it missed
+    /// has no name to bound a plan around. The run must plan nothing rather
+    /// than upload every local file over a remote it never finished listing.
+    #[test]
+    fn sync_plans_nothing_when_its_remote_scan_was_cancelled() {
+        let fixture = FilesFromFixture::new();
+        fixture.local_file("a.txt", 1);
+        fixture.local_file("b.txt", 1);
+        let cli = Cli {
+            quiet: true,
+            ..test_cli()
+        };
+        let stats = plan_sync_with_a_cancelled_scan(
+            MemTreeProvider::root_files(&[("a.txt", 1)]),
+            &fixture.local(),
+            &cli,
+        );
+        assert_eq!(stats.uploaded, 0, "a cancelled scan plans nothing");
+        assert_eq!(stats.exit_code, 4);
     }
 
     struct CliEditFakeProvider {


### PR DESCRIPTION
## Summary

One commit: `fix(cli): bound sync and reconcile by what their scans did not see`.

`aeroftp-cli sync` and `reconcile` plan from their own scans, so the bound that #796 applied to the sync core, the DAG route and the GUI compare did not reach them. **The CLI was the one surface still uncovered**, and this brings it to the same rule.

## The defect

A planner reads a path absent from one side's scan as a copy or an orphan. Three things make a path absent without it being gone:

- a symbolic link to a directory, which no walk follows (the remote walk skips it, the local walk skips it);
- a directory that failed to list, whose files are unknown, not deleted;
- a scan that stopped early (cancelled, cut off at the entry cap) or that read from a root that does not exist.

Before this PR the CLI turned each of those into transfers and deletes: `sync --direction download --delete` planned a local delete for every file under a remote symlinked directory, `--direction upload --delete` planned a remote delete for the files at the path of a local symlinked directory, `--direction both` did either through its snapshot, an upload wrote under a remote directory that never listed, and a cancelled scan uploaded the whole local tree over a remote it never finished reading.

## Fix

- The remote walk carries what it did not see or follow (`RemoteScanHealth::boundaries`), and the local walk does the same (`SyncScan::boundaries`): the symlinked directories it did not descend into, the entries it could not read, a root that does not exist, and a gap it cannot name.
- `cmd_sync` applies `ScanBound` where `--files-from` already bounds the run, so every entry that reaches the planner is bounded whatever produced it: the local walk, the pooled remote walk, a watch cycle's precomputed scan, or a reconcile plan.
- A scan that missed a part of the tree it cannot name refuses the run (exit 4, nothing planned): cancelled, cut off at the entry cap, a root that did not list, or a run that reads from a root that does not exist (`source_root_missing`: the local root of an upload, the remote root of a download, either root of a two-way run). A missing root on the side a run writes to stays an empty tree, so a sync into a directory it has yet to create still runs.
- `cmd_reconcile` applies the same bound after its scans, so a plan fed to `sync --from-reconcile` carries no path its scans could not see.
- The bisync snapshot keeps the previous entry for every path the run left alone, as it already does for a `--files-from` run: rewritten without them, the next full run would read those files as never synced and copy a deletion back over them.
- `--json` gains `skipped_links` and `unseen_paths`, absent when there is nothing to report, so historical output is unchanged. A text run says how many paths it left alone.
- A watch cycle keeps the boundaries of the snapshot it starts from.

## Live, on a local SFTP fixture

Throwaway trees under `g33/`, driven with the binary built from this branch, over a URL (no saved profile, so no vault is touched). `link` is a symbolic link to `real`.

| # | Scenario | Where | Result with this PR |
|---|----------|-------|---------------------|
| 1 | `ls` of the remote folder holding `link -> real` | `g33/dl` | `link` is listed as a directory (SFTP resolves the target), which is what makes the walk skip it |
| 2 | `sync --direction download --delete --dry-run`, local tree holding a real `link/x.txt` | `g33/dl` | `deleted: 0`, `skipped_links: [{"rel_path": "link", "link_target": "real"}]`; only the genuinely remote-only `real/x.txt` is planned |
| 3 | the same, real run | `g33/dl` | `deleted: 0`, local `link/x.txt` still on disk |
| 4 | `sync --direction upload --delete --dry-run`, local `link -> real`, remote real `link/x.txt` | `g33/ul` | `deleted: 0` (the remote file at the link's path is left alone), `skipped_links` names the local link |
| 5 | `sync --direction both --delete --dry-run`, snapshot naming `link/x.txt` | `g33/both` | `deleted: 0`, and the plan holds only `a.txt` and `real/x.txt`: nothing through the link |
| 6 | `sync --direction download --delete --dry-run` from a remote root that does not exist | `g33/not-there` | exit 4, `sync refused, nothing was planned: the remote scan did not see the whole tree (source_root_missing)`, local `a.txt` untouched |
| 7 | `sync --direction upload --dry-run` into a remote root that does not exist | `g33/fresh` | the copy is still planned (`uploaded: 1`): a missing destination is the empty tree a sync into a new directory scans |

## What the review found, and what it changed

A review of this branch raised a Major on the `reconcile` path: `scan_local_tree_with_progress` counted what it could not read and then **discarded the path**, so the comparison never learned the name of the gap. The comment above the call said so itself ("the local walk here reports no boundaries of its own"), which is how a declared limit turns into the defect the pull request claims to close.

The scenario the review described, remote children of an unreadable local directory reaching `missing_local`, does not reproduce: those paths are remote-only, so the bound already walks their prefixes on disk and stops at the unreadable one. That is measured, not argued, and a test says so. What the walk's own naming is the only guard for is a different path: a file the walk **listed** and could not stat. It sits on both sides, so the bound's on-disk walk never visits it, and with its size and mtime unread it reaches the planner as zero bytes and compares as a difference, which is a transfer decided on a number nobody measured.

The walk now names what it could not read: the path of a directory that would not open, and the path of a file it listed but could not stat. Both reach `ScanBound::apply`, which keeps what sits under them out of the comparison. Two consequences are worth stating rather than leaving to be discovered. A walk error that carries no path at all cannot be named and stays a count, as before. And when the failing path is the scan root itself there is no name to bound around either, because nothing sits above a root to bound with. **That case changes behaviour, and the direction is worth naming: before, the run went on and compared against an empty local side; now it refuses (exit 4).** Going on there reads every remote file as missing locally, so in a reconcile the plan says download everything on the strength of a reading that never happened. That is the same defect one level up, where no bound can contain it. `an_unreadable_scan_root_is_a_gap_with_no_name` pins the behaviour, and it was seen red by taking the refusal out: the walk then came back with nothing named at all, which is the state that used to be planned against.

The comment that declared the limit is gone, because it is no longer true.

## Rebased onto main, and what that changed

Two things had moved in `main` under this branch, and this adopts both rather than keeping its own shape.

The boundaries of a remote scan now travel as their own element of what `scan_remote_tree_with_progress` returns, beside `RemoteScanHealth`, instead of inside it. `main` had settled that first and its five call sites already destructure it that way, so this branch follows: `RemoteScanHealth` keeps the two fields and the `Copy` it had, and the two places here that read the boundaries take them from the tuple.

`SkippedLink` and `UnseenPath` gained `is_dir: Option<bool>`, which records whether the path stands where a directory does, with `None` reserved for where the walk genuinely cannot tell (a consumer that needs the type must refuse such a path rather than assume one). The seven construction sites here fill it from what each one actually knows: the link whose target resolved as a directory is `Some(true)`, the file kept past the guard that skips everything which is not a file is `Some(false)`, and the three that cannot tell are `None`: a `walkdir` error that is raised both by a directory it could not open and by an entry it could not stat, a link whose target did not resolve, and a path whose `metadata` call is the thing that failed. The two fixtures stand for a link to a directory and say so.

## Tests

Red before this commit, green after (`cargo test --bin aeroftp-cli`):

- `sync_download_delete_plans_no_local_delete_under_a_remote_symlinked_dir`: before, 1 local delete planned under the link.
- `sync_both_delete_with_a_snapshot_plans_nothing_under_a_remote_symlinked_dir`: before, 1 delete planned from the snapshot.
- `sync_upload_delete_plans_no_remote_delete_under_a_local_symlinked_dir`: before, 1 remote delete planned at the local link's path.
- `sync_upload_plans_nothing_under_a_remote_directory_that_did_not_list`: before, 1 upload planned under the unlisted directory.
- `sync_plans_nothing_when_its_remote_scan_was_cancelled`: before, 2 uploads planned off a cancelled scan.
- `sync_download_delete_refuses_a_remote_root_that_does_not_exist`: before, 1 local delete planned from an empty remote that does not exist.

Controls that pass before and after: `sync_upload_into_a_remote_root_that_does_not_exist_plans_its_copies` (a missing destination still gets its copies) and the `--files-from` tests (a listed run still rewrites only the listed paths).

New with the shapes this commit adds, so they could not be red first: `a_bisync_snapshot_keeps_the_entries_a_run_left_alone` and `an_incremental_watch_cycle_keeps_the_boundaries_of_its_snapshot`.

From the review round, two, because the review's own scenario turned out to be guarded by something else:

- `remote_children_of_an_unreadable_local_dir_stay_out_of_missing_local`: a local directory the walk cannot read, a remote holding a file under it, and the assertion that the file does not reach `missing_local`. Measured, it holds with or without the naming this adds, because that path is remote-only and the bound walks its prefixes on disk, finding the unreadable one itself. It is kept for that mechanism, and it is named as such.
- `a_file_the_walk_could_not_stat_leaves_the_comparison`: the case the naming is the only guard for. The file sits on both sides, so the bound's on-disk walk never visits it, and without a name it reaches the planner as zero bytes and compares as a difference. Checked by mutation rather than by claim: name the path as something that matches nothing and this test fails while the other stays green.

A second review round raised another Major, and this one reproduces. `ScanBound` takes a link on the **local** side only when remote entries sit below it, so a local symbolic link with nothing under it on the remote is reported by the run and never enters the bound. The snapshot asked `bound.covers` alone, so exactly those previous entries were dropped, and a later run that can see the path reads the file as never synced and copies it back instead of propagating the deletion made on the other side. That also made a sentence of this branch's own commit message wider than its code, which said the snapshot keeps the entry for every path a run left alone.

The snapshot now keeps a path at or under a link the run reported, beside the ones the bound covers, and loads the previous snapshot when there are reported links even if the bound is empty, which is the shape this case has. Seen red first, with only the parameter threaded through and the rule unchanged: the entry came back `None` where the previous state was expected, and green with the rule applied. `a_bisync_snapshot_keeps_the_entries_under_a_local_link` covers it, and the two snapshot tests that were already there stay green.

## Known limits

- The local walk of `reconcile` names the paths it could not read, so the remote entries under them stay out of the comparison, but it still does not report the links it skips: a local symbolic link with nothing under it on the remote does not appear in that command's summary. That part is not a risk, because the walk does not descend into links either, so nothing under one reaches the plan, and the bound still checks on disk the ancestors of every path only the remote holds, which is the case that misreads.
- `--fast-list` (the S3 recursive listing of `cmd_sync`) reports no boundaries of its own: it names neither what its depth filter cut nor a listing it had to truncate. What stays protected on that path: the local walk still reports the links and unreadable entries it found, and `ScanBound` still checks on disk the ancestors of every path only the remote holds, which is the case that deletes data (an upload with deletes at the path of a local symbolic link). The flat listing is S3 only, where an object store has no symbolic links to miss, and its depth filter keeps exactly what the local walk keeps at the same limit, so the two sides stop at the same level. A run cut off at its entry cap there is still marked incomplete, which keeps the orphan-delete guard refusing its deletes, but it is not refused.
- `--no-check-dest` and `--no-traverse` skip the remote scan entirely, so there is nothing to bound with and nothing to compare against. Both already refuse `--delete` (exit 5), so neither path deletes anything: the risk they carry is the declared one of the option itself, not a new one.
- A reconcile JSON written before this change is used as stored by `sync --from-reconcile`, as in #796. Its entries are still bounded by the local ancestor check when the run reads them.
- A local symbolic link made between two watch cycles is not in the snapshot's boundaries until the next full walk; the ancestor check covers the dangerous direction in the meantime.

## Gates

- `cargo fmt --all` is clean.
- `cargo test --bin aeroftp-cli`: 584 passed, 0 failed, with each of the tests above named in the run rather than counted.
- The live table above, on the SFTP fixture.
- `cargo clippy --all-targets -- -D warnings` is clean on this head. `--all-targets` is the load-bearing part of that command here: with `--lib --tests` the binary this changes is never compiled, so the lint job's own command would not have seen it. The green was checked for being a cached one rather than a real one: the run's artifacts are newer than the edited source, and their dependency file records both the lint flags it ran under and the manifest directory it compiled, which is this branch's.
- Not run locally: the full library suite, left to CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved synchronization when local directories or file metadata cannot be read.
  - Prevented remote entries beneath inaccessible local paths from being incorrectly reconciled.
  - Preserved existing snapshot entries for local links that are skipped during synchronization.
  - Improved handling of unreadable scan roots and unstatable files.

- **Tests**
  - Added regression coverage for inaccessible directories, files, scan roots, and skipped links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->