### PR TITLE
fix(ftp): do not hand on a session that owes a reply

### DIFF
--- a/src-tauri/src/providers/ftp.rs
+++ b/src-tauri/src/providers/ftp.rs
@@ -2753,7 +2753,9 @@ impl FtpProvider {
                 // after it, both are empty when the check runs and it lands
                 // some 50 ms later. So the segmentation this covers is the one
                 // that queues the reply in time, and the other one is a named
-                // limit with a test of its own in `tests/ftp_resume_and_421.rs`.
+                // limit stated on the helper below. It has no test of its own:
+                // the one that drove it went through the refusal path, and that
+                // path now discards without asking.
                 //
                 // The first property is still only named: a condition that looks
                 // total has been wrong four times, and each time it was total
@@ -2804,24 +2806,28 @@ impl FtpProvider {
 
     /// Give up the session when the control reader is still holding a reply.
     ///
+    /// One caller now, the open that timed out and then found an answer waiting.
+    /// The two refusal helpers used to share this and no longer do: there the
+    /// question "is another reply queued" had an answer that depended on how the
+    /// server split its writes, so they discard without asking. Here a wait has
+    /// already happened before the check runs, which is what makes the question
+    /// worth asking at all.
+    ///
+    /// What it covers is a reply ALREADY queued when the failure is classified.
     /// A server that refuses and then hangs up sends `550` and `421`, and on one
     /// write they arrive together: the refusal answers the command that asked,
-    /// the goodbye stays in the reader, and the next command reads it as its own
-    /// reply. A peek at the socket cannot see it, because both replies are
-    /// already off the wire and inside the `BufReader`; `buffered_reply_bytes`
-    /// is what reports them. Dropping the session costs a re-dial on a path that
-    /// has already failed, and keeps the next question from taking this one's
-    /// answer.
+    /// the goodbye stays in the reader, and the next command would read it as
+    /// its own reply. A peek at the socket cannot see it, because both replies
+    /// are already off the wire and inside the `BufReader`;
+    /// `buffered_reply_bytes` is what reports them.
     ///
-    /// What this covers is a reply ALREADY queued when the refusal is
-    /// classified. A server that writes the goodbye afterwards, in a write of
-    /// its own, has sent nothing at this point: measured, the reader's buffer
-    /// and a peek at the socket are both empty here, and the goodbye lands some
-    /// 50 ms later. So asking the socket as well changes no outcome on this
-    /// path, and it is not asked. Where a wait has already happened the socket
-    /// is worth asking, and `after_timed_out_open` asks it. The uncovered shape
-    /// has a test of its own; what it points at is a check when the NEXT
-    /// command starts, which is a design change and not this one.
+    /// What it does NOT cover is a goodbye written afterwards, in a write of its
+    /// own: nothing has been sent at this point, so this keeps the session and
+    /// the next command reads the goodbye. That limit is real and is stated here
+    /// rather than in a test, because the test that used to drive it went
+    /// through the refusal path, which no longer reaches this function. What it
+    /// points at is a check when the NEXT command starts, which is a design
+    /// change and not this one.
     fn drop_session_if_a_reply_is_queued(&mut self) {
         let queued = self
             .stream

--- a/src-tauri/src/providers/ftp.rs
+++ b/src-tauri/src/providers/ftp.rs
@@ -1840,7 +1840,7 @@ impl StorageProvider for FtpProvider {
             Ok(opened) => opened,
             Err(err) => return Err(self.refused_store(remote_path, err)),
         };
-        let mut data_stream = match opened {
+        let data_stream = match opened {
             Some(data_stream) => data_stream,
             None => {
                 return Err(self
@@ -1848,6 +1848,15 @@ impl StorageProvider for FtpProvider {
                     .await)
             }
         };
+        // From here the server considers the data channel open, and every exit
+        // below has to leave the session in a state the next command can trust.
+        // The guard owns the channel: an error propagated with `?` drops it, and
+        // `Drop` takes the session rather than handing on one whose data channel
+        // was never closed. That covers the exit this type never sees as well,
+        // the failure reading the LOCAL file below, which is not a channel
+        // operation and still leaves the channel open behind it.
+        let mut channel =
+            DataChannel::new(self, data_stream, "resuming the upload of", remote_path);
 
         let mut chunk = [0u8; 65536];
         let mut sent = offset;
@@ -1864,34 +1873,33 @@ impl StorageProvider for FtpProvider {
                 n as u64,
             )
             .await;
-            data_stream
-                .write_all(&chunk[..n])
-                .await
-                .map_err(|e| ProviderError::TransferFailed(format!("Data write error: {}", e)))?;
+            channel.write_all(&chunk[..n]).await?;
             sent += n as u64;
             if let Some(ref progress) = on_progress {
                 progress(sent, total_size);
             }
         }
 
-        data_stream
-            .flush()
-            .await
-            .map_err(|e| ProviderError::TransferFailed(format!("Flush error: {}", e)))?;
+        channel.flush().await?;
         // The same end-of-data signal as `upload_single`: our close, then the
         // server's, bounded so a server that never closes cannot hang the resume
         // where it can no longer hang the upload.
-        data_stream
-            .shutdown()
-            .await
-            .map_err(|e| ProviderError::TransferFailed(format!("Data close error: {}", e)))?;
+        channel.shutdown().await?;
+
+        let mut data_stream = channel.finish()?;
         let _ = tokio::time::timeout(DATA_DRAIN_BUDGET, drain_to_eof(&mut data_stream)).await;
 
         let stream = self.stream.as_mut().ok_or(ProviderError::NotConnected)?;
-        stream
+        if let Err(e) = stream
             .finalize_put_stream(AlreadyShutDown(data_stream))
             .await
-            .map_err(|e| ProviderError::TransferFailed(e.to_string()))?;
+        {
+            // The finalise is the last word on the transfer. A failure here
+            // leaves the control channel mid-sentence, and the guard is already
+            // settled, so nothing else would discard it: do it here.
+            self.stream = None;
+            return Err(ProviderError::TransferFailed(e.to_string()));
+        }
 
         if let Some(progress) = on_progress {
             progress(total_size, total_size);
@@ -2516,6 +2524,62 @@ where
     }
 }
 
+/// The write half of the same channel, for the one transfer that sends instead
+/// of receiving.
+///
+/// `read` above closes the channel on every failure, so a caller that
+/// propagates with `?` has already had its session dealt with. These do the
+/// same for the upload path, which until now had five exits that returned
+/// while the server still considered the data channel open.
+///
+/// The bound adds `AsyncWrite` to the one `read` already needs, and the upload
+/// stream satisfies both: the resume path reads from it too, to drain the tail
+/// after its own shutdown. That is why this half could always have existed.
+impl<'p, S> DataChannel<'p, S>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + 'static,
+{
+    async fn write_all(&mut self, buf: &[u8]) -> Result<(), ProviderError> {
+        let outcome = match self.data.as_mut() {
+            Some(data) => data.write_all(buf).await,
+            None => return Err(ProviderError::NotConnected),
+        };
+        self.settle_write(outcome, "Data write error").await
+    }
+
+    async fn flush(&mut self) -> Result<(), ProviderError> {
+        let outcome = match self.data.as_mut() {
+            Some(data) => data.flush().await,
+            None => return Err(ProviderError::NotConnected),
+        };
+        self.settle_write(outcome, "Flush error").await
+    }
+
+    async fn shutdown(&mut self) -> Result<(), ProviderError> {
+        let outcome = match self.data.as_mut() {
+            Some(data) => data.shutdown().await,
+            None => return Err(ProviderError::NotConnected),
+        };
+        self.settle_write(outcome, "Data close error").await
+    }
+
+    /// One place decides what a write failure does, so the three above cannot
+    /// drift apart: give the channel away, then report.
+    async fn settle_write(
+        &mut self,
+        outcome: std::io::Result<()>,
+        what: &'static str,
+    ) -> Result<(), ProviderError> {
+        match outcome {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                self.abandon().await;
+                Err(ProviderError::TransferFailed(format!("{}: {}", what, e)))
+            }
+        }
+    }
+}
+
 impl<'p, S> Drop for DataChannel<'p, S> {
     fn drop(&mut self) {
         if !self.settled {
@@ -2769,8 +2833,14 @@ impl FtpProvider {
         }
     }
 
-    /// A refused data open, classified, with the session given up when the
-    /// server queued another reply behind the refusal.
+    /// A refused data open, classified, with the session given up.
+    ///
+    /// Unconditionally, and that is the fix rather than an excess. A server can
+    /// send the refusal and a goodbye in two writes, and at the moment the
+    /// refusal is classified the second one may not have been sent at all: a
+    /// check for a queued reply is then looking for something that arrives
+    /// later, and the NEXT command reads it as its own answer. Discarding costs
+    /// one reconnect; keeping costs an answer attributed to the wrong command.
     fn refused_data_open(
         &mut self,
         operation: &'static str,
@@ -2778,14 +2848,14 @@ impl FtpProvider {
         err: FtpError,
     ) -> ProviderError {
         let classified = Self::classify_data_failure(operation, path, err);
-        self.drop_session_if_a_reply_is_queued();
+        self.stream = None;
         classified
     }
 
     /// The same for a refused `STOR` or `APPE`, which keeps its own mapping.
     fn refused_store(&mut self, path: &str, err: FtpError) -> ProviderError {
         let classified = Self::map_store_error(path, err);
-        self.drop_session_if_a_reply_is_queued();
+        self.stream = None;
         classified
     }
 

--- a/src-tauri/tests/ftp_resume_and_421.rs
+++ b/src-tauri/tests/ftp_resume_and_421.rs
@@ -1,4 +1,4 @@
-//! Two FTP defects that need a server to show, against a scripted fake one.
+//! Three FTP defects that need a server to show, against a scripted fake one.
 //!
 //! 1. `resume_upload` opens its data channel with `append_file`, which is the
 //!    one transfer entry point never brought under the deadline that bounds
@@ -9,9 +9,13 @@
 //!    command; the `421` stays in the control reader, and the NEXT command
 //!    reads it as its own reply, so an operation fails citing an answer caused
 //!    by the command before it.
+//! 3. The same stale reply reached through a transfer rather than a refusal: a
+//!    server that answers `APPE` and then cuts the data connection owes a
+//!    closing reply, and every exit after the open used to leave the session
+//!    holding it.
 //!
-//! Neither needs the Docker fixture: the server below is a scripted fake on
-//! loopback, enough FTP for connect plus the one command each test drives.
+//! None of them needs the Docker fixture: the server below is a scripted fake
+//! on loopback, enough FTP for connect plus the one command each test drives.
 
 use std::io::Write as _;
 use std::sync::{Arc, Mutex};
@@ -36,6 +40,12 @@ enum Script {
     /// at the moment the refusal is classified it has not been sent at all. The
     /// pause is what makes that deterministic instead of a race.
     RefuseThenHangUpLater,
+    /// Answer `APPE` with a `150`, take the data connection and drop it, then
+    /// write the `426` the aborted transfer owes. The open SUCCEEDS here, which
+    /// is what separates this from `SwallowAppe`: the failure arrives after the
+    /// point where the server considers the channel open, and the reply left on
+    /// the control connection is the one the next command would read as its own.
+    AcceptAppeThenKillData,
 }
 
 /// Every control command the fake server received, in order.
@@ -113,6 +123,20 @@ async fn session(stream: tokio::net::TcpStream, script: Script, commands: Comman
                 Script::RefuseThenHangUp | Script::RefuseThenHangUpLater => {
                     reply(&mut write, b"550 Not allowed\r\n").await
                 }
+                Script::AcceptAppeThenKillData => {
+                    reply(&mut write, b"150 Opening data connection\r\n").await;
+                    // Take the data connection and drop it at once. The client
+                    // is then writing into a socket whose peer is gone, which
+                    // fails partway through rather than at the open.
+                    if let Some(listener) = _pasv.take() {
+                        if let Ok((data, _)) = listener.accept().await {
+                            drop(data);
+                        }
+                    }
+                    // The reply the aborted transfer owes. A session kept in
+                    // this state hands it to whatever command comes next.
+                    reply(&mut write, b"426 Transfer aborted\r\n").await;
+                }
             },
             "RETR" => match script {
                 Script::RefuseThenHangUp => {
@@ -139,7 +163,9 @@ async fn session(stream: tokio::net::TcpStream, script: Script, commands: Comman
                     )
                     .await;
                 }
-                Script::SwallowAppe => reply(&mut write, b"550 Not found\r\n").await,
+                Script::SwallowAppe | Script::AcceptAppeThenKillData => {
+                    reply(&mut write, b"550 Not found\r\n").await
+                }
             },
             "QUIT" => {
                 reply(&mut write, b"221 Goodbye\r\n").await;
@@ -285,24 +311,27 @@ async fn a_refusal_followed_by_a_goodbye_does_not_answer_the_next_command() {
     );
 }
 
-/// What the queued-reply check does NOT cover, written down as a test.
+/// The case the queued-reply check could not cover, now covered by not asking.
 ///
-/// The server refuses, waits, and only then says goodbye, so when the refusal is
-/// classified the `421` has not been sent yet. Measured on this fixture: the
-/// reader's buffer holds nothing there and a peek at the socket returns nothing,
-/// and the goodbye lands about 50 ms later. No check made at that moment can see
-/// a reply that has not arrived, whatever it looks at, so the session is kept and
-/// the next command reads the goodbye as its own reply, as it did before the
-/// check existed. That is why the check asks the reader's buffer and not the
-/// socket as well: on this path the socket has nothing to add.
+/// This test used to assert the opposite, and it is flipped rather than deleted
+/// because the shape it drives has to keep working. What it recorded was a real
+/// boundary: the server refuses, waits, and only then says goodbye, so when the
+/// refusal is classified the `421` has not been sent at all. Measured on this
+/// fixture, the reader's buffer holds nothing there and a peek at the socket
+/// returns nothing, and the goodbye lands about 50 ms later. That is still true,
+/// and no check made at that moment can see a reply that has not arrived.
 ///
-/// The boundary is pinned here rather than left to a sentence in a comment,
-/// because the property it bounds ("a queued reply gives up the session") reads
-/// as total and is not. What it points at is a check when the NEXT command
-/// starts, which is a design change and not this one: whoever makes it should
-/// flip this test, not delete it, since the shape it drives has to keep working.
+/// What changed is that the refusal path no longer asks. Giving up the session
+/// on every refused open costs one reconnection in the case that used to be
+/// reused, and in exchange the outcome stops depending on whether the server's
+/// second write happened to arrive before the classification. The timing that
+/// used to decide this no longer decides anything.
+///
+/// So the assertion is the same property the two tests above pin, reached
+/// through the path that timing previously excluded: the next command is not
+/// answered from a session carrying a reply it did not earn.
 #[tokio::test]
-async fn a_goodbye_written_after_the_refusal_is_not_caught_by_this_check() {
+async fn a_goodbye_written_after_the_refusal_no_longer_reaches_the_next_command() {
     let server = start_fake_ftp(Script::RefuseThenHangUpLater).await;
     let mut provider = connected(server.port).await;
 
@@ -329,9 +358,82 @@ async fn a_goodbye_written_after_the_refusal_is_not_caught_by_this_check() {
         Err(err) => err.to_string(),
     };
     assert!(
-        text.contains("421"),
-        "the boundary moved: a goodbye written after the refusal no longer reaches the next \
-         command, so the session is given up in a case this test says it is not. Flip it \
-         instead of deleting it: {next:?}"
+        !text.contains("421") && !text.to_lowercase().contains("service not available"),
+        "the next command was answered with the goodbye owed to the refused one: {next:?}"
+    );
+    assert!(
+        matches!(next, Err(ProviderError::NotConnected)),
+        "a session given up reports no connection, and anything else means it was kept: {next:?}"
+    );
+}
+
+/// A resumed upload that fails AFTER the data channel is open gives up the session.
+///
+/// Every exit before the open is already covered: the refusal and the timeout
+/// each end with the session in a state the next command can trust. The exits
+/// after it were not. Once the server has answered `APPE` with a `150` it
+/// considers the channel open and owes a closing reply, so a failure partway
+/// through leaves that reply on the control connection. A session kept in that
+/// state hands it to whatever command comes next, which is the same defect the
+/// `421` tests above describe, reached through the transfer instead of through
+/// a refusal.
+///
+/// The observable property is the session, not the error: after this the
+/// provider must report that it has no connection rather than answer from one
+/// carrying somebody else's reply. `NotConnected` is what a discarded session
+/// produces, since nothing here reconnects on its own.
+///
+/// The payload is deliberately larger than a socket buffer. The first writes
+/// into a socket whose peer has gone land in the send buffer and succeed; the
+/// failure arrives on a later one, which is the shape being pinned. Should the
+/// whole payload be swallowed without an error, the finalise reads the `426`
+/// and fails there instead, and the property under test is the same: both exits
+/// kept the session before this change and give it up after it.
+#[tokio::test]
+async fn a_resume_that_fails_after_the_open_gives_up_the_session() {
+    let server = start_fake_ftp(Script::AcceptAppeThenKillData).await;
+    let mut provider = connected(server.port).await;
+
+    let local = std::env::temp_dir().join(format!("aeroftp-resume-cut-{}.bin", std::process::id()));
+    std::fs::File::create(&local)
+        .unwrap()
+        .write_all(&vec![b'x'; 4 * 1024 * 1024])
+        .unwrap();
+
+    let outcome = tokio::time::timeout(
+        Duration::from_secs(90),
+        provider.resume_upload(local.to_str().unwrap(), "/resume-cut.bin", 1024, None),
+    )
+    .await;
+    let _ = std::fs::remove_file(&local);
+
+    let ended = outcome
+        .expect("the resume never came back: a data channel cut mid transfer must end the call");
+    assert!(
+        ended.is_err(),
+        "a transfer the server cut must fail, not report success: {ended:?}"
+    );
+
+    // On the wire, not on a guess: the test drove the path it is about.
+    let commands = server.commands.lock().unwrap().clone();
+    assert!(
+        commands
+            .iter()
+            .any(|line| line.to_uppercase().starts_with("APPE")),
+        "the test drove the path it is about: {commands:?}"
+    );
+
+    let next = provider.pwd().await;
+    let text = match &next {
+        Ok(dir) => dir.clone(),
+        Err(err) => err.to_string(),
+    };
+    assert!(
+        !text.contains("426") && !text.to_lowercase().contains("transfer aborted"),
+        "the next command was answered with the reply owed to the cut transfer: {next:?}"
+    );
+    assert!(
+        matches!(next, Err(ProviderError::NotConnected)),
+        "a session given up reports no connection, and anything else means it was kept: {next:?}"
     );
 }


### PR DESCRIPTION
## The defect

Once a server answers `APPE` with a `150` it considers the data channel open and owes a closing reply. `resume_upload` had exits after that point which returned without closing the channel and without giving up the session, so the reply the transfer still owed stayed on the control connection and the NEXT command read it as its own answer.

Reproduced on the wire before the change, against the scripted fake server in this PR: a `PWD` issued after a resumed upload whose data connection was cut came back `Err(ServerError("Invalid response: [426] 426 Transfer aborted"))`. The command was answered by a reply caused by the command before it, which is the same class the `421` tests in that file already describe, reached through a transfer instead of a refusal.

## The shape of the fix

`DataChannel` already existed as a guard that owns the stream and takes the session when it is dropped unsettled. It gained a write half, so `resume_upload` is driven through it rather than through the raw stream: `write_all`, `flush` and `shutdown` each settle the guard on failure, and `settle_write` is the single place that decides what a failed channel operation does.

That is why this is one guard rather than five cleanup calls at five exits. It also covers the exit the guard never sees as an error of its own, the failure reading the LOCAL file, which is not a channel operation and still leaves the channel open behind it. The finalise is the one exit the guard cannot cover, because by then it is already settled, so that path discards the session explicitly.

## Three numbers, for three different things

There is **one** conditional helper, `drop_session_if_a_reply_is_queued`, which gives up the session only when the control reader already holds a reply.

It had **three** callers on the base tree. **Two** of them are the refusal helpers changed here, `refused_data_open` and `refused_store`, which now discard unconditionally. The **third**, the arm inside `after_timed_out_open`, is deliberately untouched: there a wait has already happened before the check runs, which is what makes the question worth asking at all. After this change that helper has exactly one caller.

Those two refusal helpers are reached from **seven** call sites, so seven refusal paths change behaviour. On this branch they are at lines 1400, 1740, 1841, 2106, 3098, 3181 and 3383 of `src-tauri/src/providers/ftp.rs`; on the base tree the same seven sit at 1400, 1740, 1841, 2098, 3022, 3105 and 3307. Both lists are the output of `grep -nE 'refused_data_open\(|refused_store\(' src-tauri/src/providers/ftp.rs | grep -v 'fn refused'`, and the positions differ only because the patch shifts them.

## The cost, stated rather than implied

One extra reconnection, on exactly the paths where the session used to be reused because no reply happened to be queued at the moment of the check. Every one of those paths has already failed when this runs, so the reconnection is paid on an error path and never on a successful transfer. What it buys is that the outcome no longer depends on how the server split its writes.

## A test that was already there, flipped rather than deleted

`a_goodbye_written_after_the_refusal_is_not_caught_by_this_check` recorded a boundary as a test instead of a sentence, and asked in its own text to be flipped rather than deleted if the boundary ever moved. This moves it.

It drives a server that refuses, waits, and only then says goodbye, so at the moment the refusal is classified the `421` has not been sent at all. That is still true, and no check made at that instant can see a reply that has not arrived. What changed is that the refusal path no longer asks, so the case that timing used to exclude is now covered by not depending on timing. It keeps the same fixture and drives the same shape, with the assertion and the name changed to what it now pins.

## Evidence

Both new assertions fail against the parent tree and pass here, and the two unrelated tests in the same file pass against both, so the fixture is not what moved.

The first clippy run of this branch reported green while the package was still fresh in the cache and never compiled the patch. The gate below was re-run after `cargo clean -p aeroftp`, and the artifacts were checked afterwards: the lib and the CLI binary metadata are newer than the edited source, and the source is listed among the declared dependencies of the lib. `--all-targets` and not the narrower lib-and-tests form, because this crate ships a binary.

- `cargo fmt --all -- --check`: rc 0
- `cargo clippy --all-targets -- -D warnings`: rc 0, 0 errors
- `cargo test --test ftp_resume_and_421`: rc 0, 4 passed

Each rc was written to a file rather than read from a pipeline.

## Two comments corrected, because the change made them false

The doc on `drop_session_if_a_reply_is_queued` was written around the refusal scenario that no longer reaches it. It now says it has one caller, and states its uncovered case (a goodbye written after the refusal, in a write of its own) as a named limit rather than claiming a test for it. The comment at the timed-out arm said that limit had a test of its own in the test file, which stopped being true when the test that drove it was flipped.

No CHANGELOG entry: the release notes are written from the tracker at release time.
