### PR TITLE
refactor(compare): hold the decode ahead of the compare bound

### DIFF
--- a/src-tauri/src/provider_commands.rs
+++ b/src-tauri/src/provider_commands.rs
@@ -7157,6 +7157,7 @@ pub async fn provider_compare_directories(
     // Use the wrap flag pinned at scan start. If the badge flipped mid-scan the
     // listing is mixed ciphertext/plaintext and neither branch is safe: fail
     // closed and ask the user to retry.
+    let mut overlay_keys: Option<crate::crypt_overlay_provider::OverlayKeys> = None;
     if let Some(vault_id) = crypt_vault_id.as_deref() {
         let overlay_wrapped_now = state.overlay_wrapped.load(Ordering::SeqCst);
         if overlay_wrapped_now != overlay_wrapped_at_scan_start {
@@ -7194,35 +7195,19 @@ pub async fn provider_compare_directories(
                 crypt_kind.as_deref().unwrap_or("unknown")
             );
         } else {
-            let keys = resolve_compare_overlay_keys(
-                crypt_kind.as_deref(),
-                vault_id,
-                &state,
-                &rclone_state,
-                &aerocrypt_state,
-            )
-            .await?;
-            let raw_len = remote_files.len();
-            remote_files = normalize_remote_files_for_compare(&keys, remote_files);
-            // The boundaries carry remote paths too, and the bound below
-            // matches them against local rows that are plaintext. Rewriting the
-            // rows and leaving the boundaries in ciphertext is what let a
-            // bounded remote subtree keep its local rows in the compare.
-            normalize_remote_boundaries_for_compare(&keys, &mut remote_boundaries)
-                .map_err(|reason| format!("{}: {}", crate::SCAN_INCOMPLETE_MARKER, reason))?;
-            // rclone-crypt has no config MAC: a wrong overlay password derives
-            // valid-shaped keys that decrypt nothing, so a non-empty remote that
-            // normalizes to zero rows is a wrong-key signal. Fail closed rather
-            // than re-flag the whole tree as missing (the #364 symptom).
-            if crypt_kind.as_deref() == Some("rclone-crypt")
-                && raw_len > 0
-                && remote_files.is_empty()
-            {
-                return Err(
-                    "Crypt overlay decrypted no remote entries: wrong overlay password or non-crypt remote."
-                        .to_string(),
-                );
-            }
+            // The keys are resolved here, where `state` is; what they drive
+            // happens in the seam below, so the decode and the bound sit in one
+            // place and in one order that a test can hold them to.
+            overlay_keys = Some(
+                resolve_compare_overlay_keys(
+                    crypt_kind.as_deref(),
+                    vault_id,
+                    &state,
+                    &rclone_state,
+                    &aerocrypt_state,
+                )
+                .await?,
+            );
         }
     }
 
@@ -7237,12 +7222,14 @@ pub async fn provider_compare_directories(
     // local counterparts in the compare. Those rows then read as present on one
     // side only, and a Mirror preset planned exactly the delete the boundary
     // exists to prevent. Both sides speak plaintext by the time we get here.
-    let bound = bound_compare_rows(
+    let bound = normalize_then_bound_compare_rows(
         &local_path,
         &mut local_files,
         &mut remote_files,
         remote_boundaries,
-    );
+        overlay_keys.as_ref(),
+        crypt_kind.as_deref(),
+    )?;
     // The only refusal `for_sync` builds for this caller comes from the remote
     // `unbounded` verdict, which the check above already answered, so this one
     // cannot fire today. It stays as the guard for a future refusal source: if
@@ -13069,6 +13056,58 @@ async fn walk_compare_remote_serially(
 /// bounded path. A preset copies or deletes a directory row as a whole, so a
 /// directory left present on one side only, its bounded contents withdrawn,
 /// would be planned for a recursive delete that reaches the protected files.
+/// Normalize the remote side through the crypt overlay, then bound the compare.
+///
+/// The order is the point of this function existing. Under an overlay that is
+/// armed but not wrapped, the remote rows and the remote boundaries both arrive
+/// as ciphertext while the local rows are plaintext. A bound built before the
+/// decode matches the boundary against the remote spelling only: it withdraws
+/// the remote rows behind it and leaves their local counterparts in the
+/// compare, where they read as present on one side alone, and a Mirror preset
+/// plans exactly the delete the boundary exists to prevent. That was the defect
+/// this path was fixed for; what was missing was anything holding the two steps
+/// in that order, so an inversion stayed green.
+///
+/// `keys` is `None` when there is nothing to decode: no overlay, or an overlay
+/// whose listing already came back plaintext because the live provider is the
+/// wrapped one. The bound still applies there, which is the other half a
+/// reordering could break.
+fn normalize_then_bound_compare_rows(
+    local_root: &str,
+    local_files: &mut HashMap<String, crate::sync::FileInfo>,
+    remote_files: &mut HashMap<String, crate::sync::FileInfo>,
+    mut remote_boundaries: crate::sync_core::ScanBoundaries,
+    keys: Option<&crate::crypt_overlay_provider::OverlayKeys>,
+    crypt_kind: Option<&str>,
+) -> Result<crate::sync_core::ScanBound, String> {
+    if let Some(keys) = keys {
+        let raw_len = remote_files.len();
+        *remote_files = normalize_remote_files_for_compare(keys, std::mem::take(remote_files));
+        // The boundaries carry remote paths too, and the bound below matches
+        // them against local rows that are plaintext. Rewriting the rows and
+        // leaving the boundaries in ciphertext is what let a bounded remote
+        // subtree keep its local rows in the compare.
+        normalize_remote_boundaries_for_compare(keys, &mut remote_boundaries)
+            .map_err(|reason| format!("{}: {}", crate::SCAN_INCOMPLETE_MARKER, reason))?;
+        // rclone-crypt has no config MAC: a wrong overlay password derives
+        // valid-shaped keys that decrypt nothing, so a non-empty remote that
+        // normalizes to zero rows is a wrong-key signal. Fail closed rather
+        // than re-flag the whole tree as missing (the #364 symptom).
+        if crypt_kind == Some("rclone-crypt") && raw_len > 0 && remote_files.is_empty() {
+            return Err(
+                "Crypt overlay decrypted no remote entries: wrong overlay password or non-crypt remote."
+                    .to_string(),
+            );
+        }
+    }
+    Ok(bound_compare_rows(
+        local_root,
+        local_files,
+        remote_files,
+        remote_boundaries,
+    ))
+}
+
 fn bound_compare_rows(
     local_root: &str,
     local_files: &mut HashMap<String, crate::sync::FileInfo>,
@@ -13114,6 +13153,104 @@ mod tests {
             off_suffix: ".bin".to_string(),
             directory_name_encryption,
         }
+    }
+
+    /// The bound runs AFTER the crypt normalization, and this holds it there.
+    /// With the overlay armed but not wrapped the remote side is ciphertext and
+    /// the local side is plaintext, so a bound built before the decode matches
+    /// the boundary against the remote spelling alone: the remote rows go and
+    /// their local counterparts stay, reading as present on one side only,
+    /// which is the row a Mirror preset deletes. Invert the two steps inside
+    /// the seam and this fails on the local rows.
+    #[test]
+    fn the_compare_bound_runs_after_the_crypt_normalization() {
+        let keys = rclone_keys_in_mode(crate::rclone_crypt::FilenameEncryption::Standard, true);
+        let wire = |name: &str| {
+            crate::rclone_crypt::encrypt_name(&keys.name_key, &keys.name_tweak, name)
+                .expect("encrypt the segment")
+        };
+        let wire_dir = wire("link");
+        let wire_file = format!("{}/{}", wire_dir, wire("x.txt"));
+        let overlay = crate::crypt_overlay_provider::OverlayKeys::Rclone(keys);
+
+        let mut local = HashMap::from([
+            ("link".to_string(), compare_row("link", true)),
+            ("link/x.txt".to_string(), compare_row("link/x.txt", false)),
+            ("keep.txt".to_string(), compare_row("keep.txt", false)),
+        ]);
+        let mut remote = HashMap::from([
+            (wire_dir.clone(), compare_row(&wire_dir, true)),
+            (wire_file.clone(), compare_row(&wire_file, false)),
+        ]);
+
+        normalize_then_bound_compare_rows(
+            "/nonexistent-local-root",
+            &mut local,
+            &mut remote,
+            crate::sync_core::ScanBoundaries {
+                links: vec![crate::sync_core::SkippedLink {
+                    rel_path: wire_dir.clone(),
+                    link_target: None,
+                    is_dir: Some(true),
+                }],
+                ..Default::default()
+            },
+            Some(&overlay),
+            Some("rclone-crypt"),
+        )
+        .expect("the boundary decodes and the compare is bounded");
+
+        let mut left: Vec<_> = local.keys().cloned().collect();
+        left.sort();
+        assert_eq!(
+            left,
+            vec!["keep.txt"],
+            "the local rows behind the boundary go too: bounding before the decode leaves them"
+        );
+        assert!(
+            remote.is_empty(),
+            "and the remote rows behind it are withdrawn as well: {:?}",
+            remote.keys().collect::<Vec<_>>()
+        );
+    }
+
+    /// An overlay that is armed and already wrapped hands the compare a
+    /// plaintext listing, so there is nothing to decode. The bound still has to
+    /// apply: skipping it there would leave the rows behind a boundary in the
+    /// compare, which is the same one-sided row by another route.
+    #[test]
+    fn a_compare_with_nothing_to_normalize_is_still_bounded() {
+        let mut local = HashMap::from([
+            ("link".to_string(), compare_row("link", true)),
+            ("link/x.txt".to_string(), compare_row("link/x.txt", false)),
+            ("keep.txt".to_string(), compare_row("keep.txt", false)),
+        ]);
+        let mut remote = HashMap::new();
+
+        normalize_then_bound_compare_rows(
+            "/nonexistent-local-root",
+            &mut local,
+            &mut remote,
+            crate::sync_core::ScanBoundaries {
+                links: vec![crate::sync_core::SkippedLink {
+                    rel_path: "link".to_string(),
+                    link_target: None,
+                    is_dir: Some(true),
+                }],
+                ..Default::default()
+            },
+            None,
+            None,
+        )
+        .expect("nothing to decode, and the bound still applies");
+
+        let mut left: Vec<_> = local.keys().cloned().collect();
+        left.sort();
+        assert_eq!(
+            left,
+            vec!["keep.txt"],
+            "with nothing to normalize the bound is still what withdraws the rows"
+        );
     }
 
     /// `Off` mode spells a file with the configured suffix and a directory


### PR DESCRIPTION
## Summary

The crypt decode already ran ahead of the compare bound, and nothing held it there. This puts both steps in one function, in that order, and adds a test that fails when they are swapped.

## Why an order needs a guard

The defect this path was fixed for was a bound applied before the decode. With the overlay armed but not wrapped, the remote rows and the remote boundaries arrive as ciphertext while the local rows are plaintext, so a bound built at that moment matches the boundary against the remote spelling alone: it withdraws the remote rows behind it and leaves their local counterparts in the compare. Those rows then read as present on one side only, and a Mirror preset plans exactly the delete the boundary exists to prevent.

The fix for that was in place. What was missing was anything that would notice if it came undone: the two calls sat several lines apart inside a Tauri command that takes `app` and `state` and so cannot be instantiated in a test, and no test named both symbols. A refactor that reordered them stayed green.

## The seam

`normalize_then_bound_compare_rows` takes the local root, the two row maps, the remote boundaries, the overlay keys and the crypt kind, and returns the bound. It decodes the rows, decodes the boundaries, applies the wrong-key check that belongs between them, and only then bounds. The command keeps what needs `state`: resolving the keys, the wrapped/unwrapped decision, the size-comparison adjustment, the logging, and the refusal check on the bound it gets back. Its call is one expression.

`keys` is `None` when there is nothing to decode, which is both the no-overlay case and the armed-but-wrapped one, where the listing already came back plaintext. The bound still applies there, and that is the other half a reordering could break.

## Measured, not argued

The order test was seen red by inverting the two steps inside the seam, which reproduces the original defect rather than a stand-in for it:

```
assertion `left == right` failed: the local rows behind the boundary go too
  left: ["keep.txt", "link", "link/x.txt"]
 right: ["keep.txt"]
```

`link` and `link/x.txt` are the local rows that survive a bound built on ciphertext, and they are the rows a Mirror preset would delete. Restored, the test passes again and the file is byte for byte what it was.

Under the same inversion the second test stays green, which is the point of having two: with nothing to decode the order is irrelevant, so each test holds its own mechanism instead of both answering for one.

## Tests

- `the_compare_bound_runs_after_the_crypt_normalization`: rclone-crypt with directory name encryption on, remote rows and boundary in ciphertext, local rows in plaintext. Both sides behind the boundary leave the compare. Red when the steps are swapped.
- `a_compare_with_nothing_to_normalize_is_still_bounded`: no keys, plaintext on both sides, and the bound still withdraws the rows behind the boundary.

## Scope

Only the seam and its tests. The bound logic is untouched, and the command is unchanged apart from resolving the keys into a variable and calling the seam where it used to call the bound.

## Gates

- `cargo test --lib provider_commands::tests::`: 68 passed, 0 failed, with both new tests named in the run.
- `cargo clippy --all-targets -- -D warnings` clean.
- `cargo fmt --all` clean.
- No CHANGELOG entry: the changelog is written at release time, not per pull request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider directory comparisons for encrypted remote listings.
  * Incorrect encryption keys are now rejected instead of producing misleading results.
  * Boundary-limited comparisons now consistently apply filtering after remote entries are normalized.
  * Improved handling of plaintext listings and bounded directory comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->