### PR TITLE
refactor(cli): share the scan refusal wording

### DIFF
--- a/src-tauri/src/bin/aeroftp_cli.rs
+++ b/src-tauri/src/bin/aeroftp_cli.rs
@@ -57191,8 +57191,12 @@ fn scan_gap_with_no_name(
 }
 
 fn gap_with_no_name_message(side: &str, reason: &str) -> String {
+    let mut refusal = ftp_client_gui_lib::sync_core::scan::unbounded_refusal(side, reason);
+    if let Some(initial) = refusal.get_mut(..1) {
+        initial.make_ascii_uppercase();
+    }
     format!(
-        "The {side} scan did not see the whole tree ({reason}) and cannot name what it missed, so there is nothing to say which part of the tree a verdict would cover."
+        "{refusal} and cannot name what it missed, so there is nothing to say which part of the tree a verdict would cover."
     )
 }
 


### PR DESCRIPTION
When check or cryptcheck refuses an unnamed scan gap, the CLI now takes the common sentence from `unbounded_refusal` and appends its explanation of the comparison scope. It capitalizes the initial character at the CLI call site, preserving the sentence's original capitalization.

The library helper is also used by `ScanBound::for_sync` and the GUI compare command. Keeping the verdict-specific explanation in the CLI preserves those callers' wording and leaves one definition of the common phrase.

Validation: the source check failed before the change with two definitions and passes with one. The focused library refusal test passes (1 test). A focused Rust harness using the two formatter functions failed on the lowercase CLI sentence and passes with call-site capitalization. `cargo fmt --all` and `cargo clippy --all-targets -- -D warnings` pass after `cargo clean -p aeroftp`; the CLI dependency artifacts identify the checked source and Clippy arguments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in messages shown when a scan cannot inspect the complete directory tree.
  * Scan refusal messages now use standardized wording while preserving the relevant side and reason details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->