### PR TITLE
docs(scan): state the fast-path symlink contract

### DIFF
--- a/src-tauri/src/used_scan.rs
+++ b/src-tauri/src/used_scan.rs
@@ -202,6 +202,11 @@ fn relative_component_count(abs_path: &str, root: &str) -> Option<usize> {
 /// path: directories count against the cap with files, and a cancel raised
 /// while the listing ran is read on the way out, keeping the sums.
 ///
+/// Unlike the BFS, this reducer has no symlink guard: its only production
+/// sources are S3 and WebDAV, whose listing parsers always set `is_symlink`
+/// to false. A provider that reports links must preserve the BFS's skip rule
+/// before it can use this path.
+///
 /// `max_depth` is applied only when it is `Some` (the caller asked) and the
 /// listing carries structured paths. The parachute (`None`) does not filter
 /// a list the provider already delivered. A requested depth that is


### PR DESCRIPTION
Document why the used-storage fast-path reducer has no symlink guard: its current production sources are S3 and WebDAV, and both listing parsers set is_symlink to false. A future provider that reports links must preserve the BFS skip rule before using this reducer.

This records the current contract without adding an ineffective guard or claiming an observed difference in byte counts. No runtime change. Validated with `cargo fmt --all` and `cargo clippy --all-targets -- -D warnings` after `cargo clean -p aeroftp`, retaining the source-naming dependency artifacts and Clippy arguments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification for providers using the fast-path listing reduction, including symlink-handling expectations and compatibility with BFS behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->